### PR TITLE
fix(demo): wrap stylized // comments in JSX braces

### DIFF
--- a/apps/demo/slides/harness-engineering/index.tsx
+++ b/apps/demo/slides/harness-engineering/index.tsx
@@ -693,7 +693,9 @@ const ClaudeCodeExample: Page = () => (
         maxWidth: 1500,
       }}
     >
-      {'// a thin TUI wrapping a model with a curated tool surface, a planning loop, and approvals.'}
+      {
+        '// a thin TUI wrapping a model with a curated tool surface, a planning loop, and approvals.'
+      }
     </p>
 
     <div style={{ display: 'flex', gap: 50, flex: 1 }}>

--- a/apps/demo/slides/harness-engineering/index.tsx
+++ b/apps/demo/slides/harness-engineering/index.tsx
@@ -216,7 +216,7 @@ const Cover: Page = () => (
         zIndex: 1,
       }}
     >
-      // the scaffolding around the model is the new bottleneck.
+      {'// the scaffolding around the model is the new bottleneck.'}
     </p>
     <div
       className="h-fadeup"
@@ -693,7 +693,7 @@ const ClaudeCodeExample: Page = () => (
         maxWidth: 1500,
       }}
     >
-      // a thin TUI wrapping a model with a curated tool surface, a planning loop, and approvals.
+      {'// a thin TUI wrapping a model with a curated tool surface, a planning loop, and approvals.'}
     </p>
 
     <div style={{ display: 'flex', gap: 50, flex: 1 }}>
@@ -978,7 +978,7 @@ const Layers: Page = () => (
         maxWidth: 1500,
       }}
     >
-      // each one is a strict subset of the next — and the bottleneck has moved outward.
+      {'// each one is a strict subset of the next — and the bottleneck has moved outward.'}
     </p>
 
     <div style={{ display: 'flex', flexDirection: 'column', gap: 22, flex: 1 }}>

--- a/packages/core/src/app/lib/export-pdf.ts
+++ b/packages/core/src/app/lib/export-pdf.ts
@@ -135,10 +135,7 @@ export async function exportSlideAsPdf(
     // settled, which matches "page X of N is being processed" mental model.
     const deadline = performance.now() + ANIMATION_TIMEOUT_MS;
     while (performance.now() < deadline) {
-      const settled = frames.reduce(
-        (n, frame) => (isFrameAnimationSettled(frame) ? n + 1 : n),
-        0,
-      );
+      const settled = frames.reduce((n, frame) => (isFrameAnimationSettled(frame) ? n + 1 : n), 0);
       onProgress?.({
         phase: 'processing',
         current: settled,


### PR DESCRIPTION
Biome's noCommentText rule flagged three lines in the harness-engineering
slide where stylized "// ..." text was rendered directly as JSX children.
Wrap them as string expressions so the text still renders without
tripping the lint rule.