### PR TITLE
Add dist directory to .gitignore in init command

### DIFF
--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -75,7 +75,7 @@ export async function init(opts: InitOptions): Promise<void> {
     await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
   }
 
-  await writeFile(join(target, '.gitignore'), 'node_modules\n');
+  await writeFile(join(target, '.gitignore'), 'node_modules\ndist\n');
 
   const cdTarget = dir === '.' ? basename(target) : dir;
   process.stdout.write(


### PR DESCRIPTION
## Summary
Updated the `.gitignore` file generated by the init command to include the `dist` directory alongside `node_modules`.

## Changes
- Modified the `.gitignore` template in the init command to exclude both `node_modules` and `dist` directories
- This ensures that build output directories are not accidentally committed to version control

## Details
The `dist` directory is a common output folder for compiled/bundled code in JavaScript projects. Including it in `.gitignore` by default prevents build artifacts from being tracked in the repository, which is a best practice for most projects.

https://claude.ai/code/session_01FkVNd4vTm7kZksPGsBW9th