### PR TITLE
feat(core): add asset manager to slide editor

### DIFF
--- a/packages/core/src/app/components/AssetView.tsx
+++ b/packages/core/src/app/components/AssetView.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowDownToLine,
   File as FileIcon,
   FileImage,
   ImageIcon,
@@ -200,37 +201,15 @@ export function AssetView({ slideId }: Props) {
 
       {dragActive && (
         <div
-          className="pointer-events-none absolute inset-0 z-30 animate-in fade-in-0 duration-150"
+          className="pointer-events-none absolute inset-0 z-30 animate-in fade-in-0 duration-200"
           aria-hidden="true"
         >
-          {/* Marching-ants outline framing the whole view */}
-          <div
-            className="absolute inset-2 rounded-xl"
-            style={{
-              background:
-                'linear-gradient(90deg, var(--color-primary) 50%, transparent 0) 0 0 / 18px 2px repeat-x, linear-gradient(0deg, var(--color-primary) 50%, transparent 0) 100% 0 / 2px 18px repeat-y, linear-gradient(90deg, var(--color-primary) 50%, transparent 0) 0 100% / 18px 2px repeat-x, linear-gradient(0deg, var(--color-primary) 50%, transparent 0) 0 0 / 2px 18px repeat-y',
-              opacity: 0.7,
-              animation: 'asset-marching-ants 0.6s linear infinite',
-            }}
-          />
-          {/* Soft breathing inner glow on the whole view */}
-          <div
-            className="absolute inset-0"
-            style={{ animation: 'asset-breathe 1.8s ease-in-out infinite' }}
-          />
-          {/* Floating pill at the top */}
-          <div className="absolute inset-x-0 top-6 flex justify-center">
-            <div
-              className="flex animate-in items-center gap-2 rounded-full border border-primary/20 bg-card/95 px-4 py-2 shadow-lg backdrop-blur fade-in-0 slide-in-from-top-3 duration-300"
-              style={{ animation: 'asset-pill-bob 2s ease-in-out infinite 300ms' }}
-            >
-              <span className="flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground">
-                <Upload className="size-3" />
-              </span>
-              <span className="text-sm font-medium">Drop to upload</span>
-              <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-                {existingNames.size === 0 ? 'first asset' : `${existingNames.size} files`}
-              </kbd>
+          <div className="absolute inset-0 bg-foreground/[0.03]" />
+          <div className="absolute inset-2 rounded-xl border border-dashed border-foreground/25" />
+          <div className="absolute inset-x-0 bottom-8 flex justify-center">
+            <div className="flex animate-in items-center gap-2 rounded-full border bg-background px-3.5 py-1.5 text-xs font-medium shadow-sm fade-in-0 slide-in-from-bottom-1 duration-300">
+              <ArrowDownToLine className="size-3.5 text-muted-foreground" />
+              <span>Drop to upload</span>
             </div>
           </div>
         </div>

--- a/packages/core/src/app/components/AssetView.tsx
+++ b/packages/core/src/app/components/AssetView.tsx
@@ -3,12 +3,14 @@ import {
   File as FileIcon,
   FileImage,
   ImageIcon,
+  Loader2,
   MoreVertical,
   Pencil,
+  Search,
   Trash2,
   Upload,
 } from 'lucide-react';
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Button, buttonVariants } from '@/components/ui/button';
 import {
@@ -25,7 +27,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { type AssetEntry, useAssets } from '@/lib/assets';
+import {
+  type AssetEntry,
+  fetchSvgAsFile,
+  type SvglItem,
+  searchSvgl,
+  useAssets,
+} from '@/lib/assets';
 import { cn } from '@/lib/utils';
 
 type Props = { slideId: string };
@@ -42,6 +50,7 @@ export function AssetView({ slideId }: Props) {
   const [preview, setPreview] = useState<AssetEntry | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<AssetEntry | null>(null);
   const [renaming, setRenaming] = useState<string | null>(null);
+  const [logoSearchOpen, setLogoSearchOpen] = useState(false);
   const dragDepth = useRef(0);
   const inputId = useId();
 
@@ -128,6 +137,17 @@ export function AssetView({ slideId }: Props) {
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setLogoSearchOpen(true)}
+            className={cn(
+              'inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-lg border bg-background px-3 text-sm font-medium transition-colors',
+              'hover:bg-muted active:translate-y-px',
+            )}
+          >
+            <Search className="size-4" />
+            <span>Search logos</span>
+          </button>
           <label
             htmlFor={inputId}
             className={cn(
@@ -239,6 +259,13 @@ export function AssetView({ slideId }: Props) {
       )}
 
       {preview && <PreviewDialog asset={preview} onClose={() => setPreview(null)} />}
+
+      {logoSearchOpen && (
+        <LogoSearchDialog
+          onClose={() => setLogoSearchOpen(false)}
+          onPick={(file) => handleFile(file)}
+        />
+      )}
     </section>
   );
 }
@@ -520,6 +547,243 @@ function PreviewDialog({ asset, onClose }: { asset: AssetEntry; onClose: () => v
       </DialogContent>
     </Dialog>
   );
+}
+
+const SKELETON_SLOTS = ['s0', 's1', 's2', 's3', 's4', 's5'] as const;
+
+function LogoSearchDialog({
+  onClose,
+  onPick,
+}: {
+  onClose: () => void;
+  onPick: (file: File) => Promise<void> | void;
+}) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SvglItem[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState<Set<number>>(() => new Set());
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    queueMicrotask(() => inputRef.current?.focus());
+  }, []);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => {
+      setLoading(true);
+      setError(null);
+      searchSvgl(query, ctrl.signal)
+        .then((next) => {
+          setResults(next);
+          setLoading(false);
+        })
+        .catch((err: unknown) => {
+          if (ctrl.signal.aborted) return;
+          setError(err instanceof Error ? err.message : 'Search failed');
+          setLoading(false);
+        });
+    }, 200);
+    return () => {
+      clearTimeout(timer);
+      ctrl.abort();
+    };
+  }, [query]);
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Search logos</DialogTitle>
+          <DialogDescription>
+            Powered by{' '}
+            <a
+              href="https://svgl.app"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2"
+            >
+              svgl.app
+            </a>
+            .
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by brand…"
+            className="w-full rounded-md border bg-background py-2 pl-8 pr-3 text-sm outline-none ring-ring/40 focus:ring-2"
+          />
+        </div>
+
+        <div className="max-h-[60vh] min-h-[16rem] overflow-y-auto">
+          {error ? (
+            <div className="flex h-32 items-center justify-center text-sm text-destructive">
+              {error}
+            </div>
+          ) : loading && !results ? (
+            <div className="grid grid-cols-3 gap-3">
+              {SKELETON_SLOTS.map((slot) => (
+                <div
+                  key={slot}
+                  className="aspect-square animate-pulse rounded-lg border bg-muted/40"
+                />
+              ))}
+            </div>
+          ) : results && results.length === 0 ? (
+            <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+              No logos found.
+            </div>
+          ) : (
+            <div className="grid grid-cols-3 gap-3">
+              {results?.map((item) => (
+                <LogoResultCard
+                  key={item.id}
+                  item={item}
+                  pending={pending.has(item.id)}
+                  onAdd={async (file) => {
+                    setPending((prev) => {
+                      const next = new Set(prev);
+                      next.add(item.id);
+                      return next;
+                    });
+                    try {
+                      await onPick(file);
+                    } catch (err) {
+                      toast.error(err instanceof Error ? err.message : 'Failed to download logo');
+                    } finally {
+                      setPending((prev) => {
+                        const next = new Set(prev);
+                        next.delete(item.id);
+                        return next;
+                      });
+                    }
+                  }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function LogoResultCard({
+  item,
+  pending,
+  onAdd,
+}: {
+  item: SvglItem;
+  pending: boolean;
+  onAdd: (file: File) => Promise<void> | void;
+}) {
+  const hasVariants = typeof item.route === 'object' && item.route !== null;
+  const [variant, setVariant] = useState<'light' | 'dark'>('light');
+
+  const previewUrl = useMemo(() => {
+    if (typeof item.route === 'string') return item.route;
+    return item.route[variant];
+  }, [item.route, variant]);
+
+  const filename = useMemo(() => {
+    const url = previewUrl;
+    const fromUrl = basenameFromUrl(url);
+    if (fromUrl) return fromUrl;
+    const slug = slugify(item.title);
+    return hasVariants ? `${slug}-${variant}.svg` : `${slug}.svg`;
+  }, [previewUrl, item.title, hasVariants, variant]);
+
+  const category = Array.isArray(item.category) ? item.category.join(', ') : item.category;
+
+  return (
+    <div className="group flex flex-col overflow-hidden rounded-lg border bg-card">
+      <div
+        className={cn(
+          'relative flex aspect-square w-full items-center justify-center overflow-hidden bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:16px_16px]',
+          variant === 'dark' && hasVariants && 'bg-neutral-900',
+        )}
+      >
+        <img src={previewUrl} alt={item.title} className="size-3/4 object-contain" />
+      </div>
+      <div className="flex flex-col gap-1.5 border-t bg-card px-2.5 py-2">
+        <div className="min-w-0">
+          <div className="truncate text-xs font-medium" title={item.title}>
+            {item.title}
+          </div>
+          <div className="truncate text-[10px] text-muted-foreground">{category}</div>
+        </div>
+        <div className="flex items-center gap-1.5">
+          {hasVariants ? (
+            <div className="flex overflow-hidden rounded-md border text-[10px]">
+              <button
+                type="button"
+                onClick={() => setVariant('light')}
+                className={cn(
+                  'px-1.5 py-0.5 transition-colors',
+                  variant === 'light' ? 'bg-foreground text-background' : 'hover:bg-muted',
+                )}
+              >
+                Light
+              </button>
+              <button
+                type="button"
+                onClick={() => setVariant('dark')}
+                className={cn(
+                  'border-l px-1.5 py-0.5 transition-colors',
+                  variant === 'dark' ? 'bg-foreground text-background' : 'hover:bg-muted',
+                )}
+              >
+                Dark
+              </button>
+            </div>
+          ) : null}
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={pending}
+            onClick={async () => {
+              try {
+                const file = await fetchSvgAsFile(previewUrl, filename);
+                await onAdd(file);
+              } catch (err) {
+                toast.error(err instanceof Error ? err.message : 'Failed to download logo');
+              }
+            }}
+            className="ml-auto h-6 px-2 text-[11px]"
+          >
+            {pending ? <Loader2 className="size-3 animate-spin" /> : 'Add'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function basenameFromUrl(u: string): string {
+  try {
+    return new URL(u).pathname.split('/').pop() || '';
+  } catch {
+    return '';
+  }
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
 }
 
 function formatSize(bytes: number): string {

--- a/packages/core/src/app/components/AssetView.tsx
+++ b/packages/core/src/app/components/AssetView.tsx
@@ -1,0 +1,521 @@
+import {
+  File as FileIcon,
+  FileImage,
+  ImageIcon,
+  MoreVertical,
+  Pencil,
+  Trash2,
+  Upload,
+} from 'lucide-react';
+import { useEffect, useId, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { Button, buttonVariants } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { type AssetEntry, useAssets } from '@/lib/assets';
+import { cn } from '@/lib/utils';
+
+type Props = { slideId: string };
+
+type ConflictState = {
+  file: File;
+  resolve: (decision: 'replace' | 'rename' | 'cancel') => void;
+};
+
+export function AssetView({ slideId }: Props) {
+  const { assets, loading, available, upload, rename, remove } = useAssets(slideId);
+  const [dragActive, setDragActive] = useState(false);
+  const [conflict, setConflict] = useState<ConflictState | null>(null);
+  const [preview, setPreview] = useState<AssetEntry | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<AssetEntry | null>(null);
+  const [renaming, setRenaming] = useState<string | null>(null);
+  const dragDepth = useRef(0);
+  const inputId = useId();
+
+  const existingNames = new Set(assets.map((a) => a.name));
+
+  async function handleFile(file: File) {
+    if (!available) return;
+    if (existingNames.has(file.name)) {
+      const decision = await new Promise<'replace' | 'rename' | 'cancel'>((resolve) => {
+        setConflict({ file, resolve });
+      });
+      if (decision === 'cancel') return;
+      if (decision === 'replace') {
+        const res = await upload(file, { overwrite: true });
+        if (!res.ok) toast.error(`Upload failed (${res.status})`);
+        return;
+      }
+      const next = renamedCopy(file, existingNames);
+      const res = await upload(next, { overwrite: false });
+      if (!res.ok) toast.error(`Upload failed (${res.status})`);
+      return;
+    }
+    const res = await upload(file);
+    if (!res.ok) toast.error(`Upload failed (${res.status})`);
+  }
+
+  async function handleFiles(files: FileList | File[]) {
+    const list = Array.from(files);
+    for (const f of list) {
+      // Sequential — keeps the conflict dialog UX coherent and avoids
+      // hammering the dev server's filesystem mutations in parallel.
+      await handleFile(f);
+    }
+  }
+
+  if (!available) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground">
+        Asset management is only available in dev mode.
+      </div>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Slide assets"
+      className={cn('relative flex h-full flex-col bg-background')}
+      onDragEnter={(e) => {
+        if (!hasFiles(e)) return;
+        e.preventDefault();
+        dragDepth.current += 1;
+        setDragActive(true);
+      }}
+      onDragOver={(e) => {
+        if (!hasFiles(e)) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'copy';
+      }}
+      onDragLeave={() => {
+        dragDepth.current = Math.max(0, dragDepth.current - 1);
+        if (dragDepth.current === 0) setDragActive(false);
+      }}
+      onDrop={(e) => {
+        if (!hasFiles(e)) return;
+        e.preventDefault();
+        dragDepth.current = 0;
+        setDragActive(false);
+        if (e.dataTransfer.files.length > 0) {
+          handleFiles(e.dataTransfer.files).catch(() => {});
+        }
+      }}
+    >
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b bg-card px-6 py-3">
+        <div className="min-w-0">
+          <h2 className="truncate text-base font-semibold tracking-tight">Assets</h2>
+          <p className="truncate text-xs text-muted-foreground">
+            <span className="font-mono">slides/{slideId}/assets/</span>
+            {!loading && (
+              <>
+                <span className="mx-1.5">·</span>
+                <span>{assets.length === 1 ? '1 file' : `${assets.length} files`}</span>
+              </>
+            )}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <label
+            htmlFor={inputId}
+            className={cn(
+              'inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground transition-opacity',
+              'hover:opacity-90 active:translate-y-px',
+            )}
+          >
+            <Upload className="size-4" />
+            <span>Upload</span>
+          </label>
+          <input
+            id={inputId}
+            type="file"
+            multiple
+            className="sr-only"
+            onChange={(e) => {
+              if (e.target.files && e.target.files.length > 0) {
+                handleFiles(e.target.files).catch(() => {});
+                e.target.value = '';
+              }
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Loading…
+          </div>
+        ) : assets.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-4 p-6">
+            {assets.map((asset) =>
+              renaming === asset.name ? (
+                <RenameCard
+                  key={asset.name}
+                  asset={asset}
+                  onCancel={() => setRenaming(null)}
+                  onSubmit={async (next) => {
+                    if (next === asset.name) {
+                      setRenaming(null);
+                      return;
+                    }
+                    if (existingNames.has(next)) {
+                      toast.error('A file with that name already exists.');
+                      return;
+                    }
+                    const res = await rename(asset.name, next);
+                    if (!res.ok) {
+                      toast.error(`Rename failed (${res.status})`);
+                      return;
+                    }
+                    setRenaming(null);
+                  }}
+                />
+              ) : (
+                <AssetCard
+                  key={asset.name}
+                  asset={asset}
+                  onPreview={() => setPreview(asset)}
+                  onRename={() => setRenaming(asset.name)}
+                  onDelete={() => setConfirmDelete(asset)}
+                />
+              ),
+            )}
+          </div>
+        )}
+      </div>
+
+      {dragActive && (
+        <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center bg-primary/10 backdrop-blur-[2px]">
+          <div className="flex flex-col items-center gap-2 rounded-2xl border-2 border-dashed border-primary/60 bg-background px-10 py-8 text-primary shadow-lg">
+            <Upload className="size-8" />
+            <p className="text-sm font-medium">Drop files to upload</p>
+          </div>
+        </div>
+      )}
+
+      {conflict && (
+        <ConflictDialog
+          file={conflict.file}
+          onChoose={(decision) => {
+            conflict.resolve(decision);
+            setConflict(null);
+          }}
+        />
+      )}
+
+      {confirmDelete && (
+        <DeleteDialog
+          asset={confirmDelete}
+          onCancel={() => setConfirmDelete(null)}
+          onConfirm={async () => {
+            const target = confirmDelete;
+            setConfirmDelete(null);
+            const res = await remove(target.name);
+            if (!res.ok) toast.error(`Delete failed (${res.status})`);
+          }}
+        />
+      )}
+
+      {preview && <PreviewDialog asset={preview} onClose={() => setPreview(null)} />}
+    </section>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+      <div className="flex size-14 items-center justify-center rounded-full bg-muted">
+        <ImageIcon className="size-6 text-muted-foreground" />
+      </div>
+      <div>
+        <p className="text-sm font-medium">No assets yet</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Drop files anywhere here or click Upload to add them.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function hasFiles(e: React.DragEvent): boolean {
+  const types = e.dataTransfer?.types;
+  if (!types) return false;
+  for (let i = 0; i < types.length; i++) {
+    if (types[i] === 'Files') return true;
+  }
+  return false;
+}
+
+function renamedCopy(file: File, taken: Set<string>): File {
+  const dot = file.name.lastIndexOf('.');
+  const stem = dot > 0 ? file.name.slice(0, dot) : file.name;
+  const ext = dot > 0 ? file.name.slice(dot) : '';
+  let i = 1;
+  let next = `${stem}-${i}${ext}`;
+  while (taken.has(next)) {
+    i += 1;
+    next = `${stem}-${i}${ext}`;
+  }
+  return new File([file], next, { type: file.type, lastModified: file.lastModified });
+}
+
+function AssetCard({
+  asset,
+  onPreview,
+  onRename,
+  onDelete,
+}: {
+  asset: AssetEntry;
+  onPreview: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+}) {
+  const isImage = asset.mime.startsWith('image/');
+  return (
+    <div className="group relative flex flex-col overflow-hidden rounded-xl border bg-card shadow-sm transition-shadow hover:shadow-md focus-within:ring-2 focus-within:ring-ring/50">
+      <button
+        type="button"
+        onClick={onPreview}
+        aria-label={`Preview ${asset.name}`}
+        className="relative flex aspect-square w-full items-center justify-center overflow-hidden bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:16px_16px]"
+      >
+        {isImage ? (
+          <img
+            src={asset.url}
+            alt=""
+            className="size-full object-contain"
+            draggable={false}
+            onError={(e) => {
+              e.currentTarget.style.display = 'none';
+            }}
+          />
+        ) : (
+          <FileIcon className="size-10 text-muted-foreground" />
+        )}
+      </button>
+
+      <div className="flex items-center gap-1 border-t bg-card px-3 py-2">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium" title={asset.name}>
+            {asset.name}
+          </div>
+          <div className="truncate text-[11px] text-muted-foreground">{formatSize(asset.size)}</div>
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            type="button"
+            aria-label={`Actions for ${asset.name}`}
+            className={cn(
+              buttonVariants({ variant: 'ghost', size: 'icon-xs' }),
+              'opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 aria-expanded:opacity-100',
+            )}
+          >
+            <MoreVertical />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-[160px]">
+            <DropdownMenuItem onSelect={onPreview}>
+              <ImageIcon />
+              Preview
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onRename}>
+              <Pencil />
+              Rename
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onDelete}>
+              <Trash2 />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}
+
+function RenameCard({
+  asset,
+  onCancel,
+  onSubmit,
+}: {
+  asset: AssetEntry;
+  onCancel: () => void;
+  onSubmit: (next: string) => Promise<void> | void;
+}) {
+  const [value, setValue] = useState(asset.name);
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    queueMicrotask(() => {
+      inputRef.current?.focus();
+      const dot = asset.name.lastIndexOf('.');
+      if (dot > 0) inputRef.current?.setSelectionRange(0, dot);
+      else inputRef.current?.select();
+    });
+  }, [asset.name]);
+
+  const commit = async () => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      onCancel();
+      return;
+    }
+    setSaving(true);
+    try {
+      await onSubmit(trimmed);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isImage = asset.mime.startsWith('image/');
+  return (
+    <div className="relative flex flex-col overflow-hidden rounded-xl border-2 border-primary bg-card shadow-sm">
+      <div className="relative flex aspect-square w-full items-center justify-center overflow-hidden bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:16px_16px]">
+        {isImage ? (
+          <img src={asset.url} alt="" className="size-full object-contain" draggable={false} />
+        ) : (
+          <FileIcon className="size-10 text-muted-foreground" />
+        )}
+      </div>
+      <div className="border-t bg-card px-2 py-2">
+        <input
+          ref={inputRef}
+          value={value}
+          disabled={saving}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={() => {
+            if (!saving) commit();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              commit();
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              onCancel();
+            }
+          }}
+          maxLength={120}
+          className="w-full rounded-md border bg-background px-2 py-1 text-sm outline-none ring-ring/40 focus:ring-2"
+        />
+      </div>
+    </div>
+  );
+}
+
+function ConflictDialog({
+  file,
+  onChoose,
+}: {
+  file: File;
+  onChoose: (decision: 'replace' | 'rename' | 'cancel') => void;
+}) {
+  return (
+    <Dialog open onOpenChange={(open) => !open && onChoose('cancel')}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>File already exists</DialogTitle>
+          <DialogDescription>
+            <span className="font-mono">{file.name}</span> is already in this slide's assets folder.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onChoose('cancel')}>
+            Cancel
+          </Button>
+          <Button variant="outline" onClick={() => onChoose('rename')}>
+            Rename copy
+          </Button>
+          <Button onClick={() => onChoose('replace')}>Replace</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DeleteDialog({
+  asset,
+  onCancel,
+  onConfirm,
+}: {
+  asset: AssetEntry;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog open onOpenChange={(open) => !open && onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete asset</DialogTitle>
+          <DialogDescription>
+            Delete <span className="font-mono">{asset.name}</span>? Imports referencing this file in
+            the slide will break.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={onConfirm}>
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PreviewDialog({ asset, onClose }: { asset: AssetEntry; onClose: () => void }) {
+  const isImage = asset.mime.startsWith('image/');
+  const importPath = `./assets/${asset.name}`;
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="font-mono text-base">{asset.name}</DialogTitle>
+          <DialogDescription>
+            {formatSize(asset.size)} · {asset.mime}
+          </DialogDescription>
+        </DialogHeader>
+        {isImage ? (
+          <div className="flex max-h-[60vh] items-center justify-center overflow-hidden rounded-md border bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:16px_16px]">
+            <img
+              src={asset.url}
+              alt={asset.name}
+              className="max-h-[60vh] max-w-full object-contain"
+            />
+          </div>
+        ) : (
+          <div className="flex items-center justify-center rounded-md border bg-muted/40 py-12 text-muted-foreground">
+            <FileImage className="mr-2 size-5" />
+            <span className="text-sm">No preview available</span>
+          </div>
+        )}
+        <div className="rounded-md border bg-muted/40 p-2 font-mono text-xs">
+          import asset from '<span className="font-semibold">{importPath}</span>';
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/packages/core/src/app/components/AssetView.tsx
+++ b/packages/core/src/app/components/AssetView.tsx
@@ -66,15 +66,18 @@ export function AssetView({ slideId }: Props) {
       if (decision === 'replace') {
         const res = await upload(file, { overwrite: true });
         if (!res.ok) toast.error(`Upload failed (${res.status})`);
+        else toast.success(`Replaced ${file.name}`);
         return;
       }
       const next = renamedCopy(file, existingNames);
       const res = await upload(next, { overwrite: false });
       if (!res.ok) toast.error(`Upload failed (${res.status})`);
+      else toast.success(`Uploaded as ${next.name}`);
       return;
     }
     const res = await upload(file);
     if (!res.ok) toast.error(`Upload failed (${res.status})`);
+    else toast.success(`Uploaded ${file.name}`);
   }
 
   async function handleFiles(files: FileList | File[]) {
@@ -202,6 +205,7 @@ export function AssetView({ slideId }: Props) {
                       toast.error(`Rename failed (${res.status})`);
                       return;
                     }
+                    toast.success(`Renamed to ${next}`);
                     setRenaming(null);
                   }}
                 />
@@ -254,6 +258,7 @@ export function AssetView({ slideId }: Props) {
             setConfirmDelete(null);
             const res = await remove(target.name);
             if (!res.ok) toast.error(`Delete failed (${res.status})`);
+            else toast.success(`Deleted ${target.name}`);
           }}
         />
       )}

--- a/packages/core/src/app/components/AssetView.tsx
+++ b/packages/core/src/app/components/AssetView.tsx
@@ -200,41 +200,37 @@ export function AssetView({ slideId }: Props) {
 
       {dragActive && (
         <div
-          className="pointer-events-none absolute inset-0 z-30 flex animate-in items-center justify-center bg-primary/10 backdrop-blur-[2px] fade-in-0 duration-150"
+          className="pointer-events-none absolute inset-0 z-30 animate-in fade-in-0 duration-150"
           aria-hidden="true"
         >
-          <div className="relative flex animate-in flex-col items-center gap-4 rounded-2xl bg-background px-14 py-10 text-primary shadow-2xl fade-in-0 zoom-in-95 slide-in-from-bottom-2 duration-200">
-            <span
-              className="pointer-events-none absolute inset-0 rounded-2xl"
-              style={{
-                padding: '2px',
-                background:
-                  'linear-gradient(110deg, transparent 25%, color-mix(in oklab, var(--color-primary) 70%, transparent) 50%, transparent 75%) 0 0 / 200% 100% no-repeat, color-mix(in oklab, var(--color-primary) 35%, transparent)',
-                WebkitMask: 'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
-                WebkitMaskComposite: 'xor',
-                maskComposite: 'exclude',
-                animation: 'asset-border-flow 2.4s linear infinite',
-              }}
-            />
-            <div className="relative flex size-16 items-center justify-center">
-              <span
-                className="absolute inset-0 rounded-full bg-primary/25"
-                style={{ animation: 'asset-ring 1.8s ease-out infinite' }}
-              />
-              <span
-                className="absolute inset-0 rounded-full bg-primary/15"
-                style={{ animation: 'asset-ring 1.8s ease-out infinite', animationDelay: '0.6s' }}
-              />
-              <div className="relative flex size-16 items-center justify-center rounded-full bg-primary/10 ring-1 ring-primary/30 ring-inset">
-                <Upload
-                  className="size-7"
-                  style={{ animation: 'asset-float 2.2s ease-in-out infinite' }}
-                />
-              </div>
-            </div>
-            <div className="flex flex-col items-center gap-1">
-              <p className="text-sm font-semibold">Drop files to upload</p>
-              <p className="text-xs text-muted-foreground">Release to add to this slide's assets</p>
+          {/* Marching-ants outline framing the whole view */}
+          <div
+            className="absolute inset-2 rounded-xl"
+            style={{
+              background:
+                'linear-gradient(90deg, var(--color-primary) 50%, transparent 0) 0 0 / 18px 2px repeat-x, linear-gradient(0deg, var(--color-primary) 50%, transparent 0) 100% 0 / 2px 18px repeat-y, linear-gradient(90deg, var(--color-primary) 50%, transparent 0) 0 100% / 18px 2px repeat-x, linear-gradient(0deg, var(--color-primary) 50%, transparent 0) 0 0 / 2px 18px repeat-y',
+              opacity: 0.7,
+              animation: 'asset-marching-ants 0.6s linear infinite',
+            }}
+          />
+          {/* Soft breathing inner glow on the whole view */}
+          <div
+            className="absolute inset-0"
+            style={{ animation: 'asset-breathe 1.8s ease-in-out infinite' }}
+          />
+          {/* Floating pill at the top */}
+          <div className="absolute inset-x-0 top-6 flex justify-center">
+            <div
+              className="flex animate-in items-center gap-2 rounded-full border border-primary/20 bg-card/95 px-4 py-2 shadow-lg backdrop-blur fade-in-0 slide-in-from-top-3 duration-300"
+              style={{ animation: 'asset-pill-bob 2s ease-in-out infinite 300ms' }}
+            >
+              <span className="flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                <Upload className="size-3" />
+              </span>
+              <span className="text-sm font-medium">Drop to upload</span>
+              <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                {existingNames.size === 0 ? 'first asset' : `${existingNames.size} files`}
+              </kbd>
             </div>
           </div>
         </div>

--- a/packages/core/src/app/components/AssetView.tsx
+++ b/packages/core/src/app/components/AssetView.tsx
@@ -199,10 +199,43 @@ export function AssetView({ slideId }: Props) {
       </div>
 
       {dragActive && (
-        <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center bg-primary/10 backdrop-blur-[2px]">
-          <div className="flex flex-col items-center gap-2 rounded-2xl border-2 border-dashed border-primary/60 bg-background px-10 py-8 text-primary shadow-lg">
-            <Upload className="size-8" />
-            <p className="text-sm font-medium">Drop files to upload</p>
+        <div
+          className="pointer-events-none absolute inset-0 z-30 flex animate-in items-center justify-center bg-primary/10 backdrop-blur-[2px] fade-in-0 duration-150"
+          aria-hidden="true"
+        >
+          <div className="relative flex animate-in flex-col items-center gap-4 rounded-2xl bg-background px-14 py-10 text-primary shadow-2xl fade-in-0 zoom-in-95 slide-in-from-bottom-2 duration-200">
+            <span
+              className="pointer-events-none absolute inset-0 rounded-2xl"
+              style={{
+                padding: '2px',
+                background:
+                  'linear-gradient(110deg, transparent 25%, color-mix(in oklab, var(--color-primary) 70%, transparent) 50%, transparent 75%) 0 0 / 200% 100% no-repeat, color-mix(in oklab, var(--color-primary) 35%, transparent)',
+                WebkitMask: 'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
+                WebkitMaskComposite: 'xor',
+                maskComposite: 'exclude',
+                animation: 'asset-border-flow 2.4s linear infinite',
+              }}
+            />
+            <div className="relative flex size-16 items-center justify-center">
+              <span
+                className="absolute inset-0 rounded-full bg-primary/25"
+                style={{ animation: 'asset-ring 1.8s ease-out infinite' }}
+              />
+              <span
+                className="absolute inset-0 rounded-full bg-primary/15"
+                style={{ animation: 'asset-ring 1.8s ease-out infinite', animationDelay: '0.6s' }}
+              />
+              <div className="relative flex size-16 items-center justify-center rounded-full bg-primary/10 ring-1 ring-primary/30 ring-inset">
+                <Upload
+                  className="size-7"
+                  style={{ animation: 'asset-float 2.2s ease-in-out infinite' }}
+                />
+              </div>
+            </div>
+            <div className="flex flex-col items-center gap-1">
+              <p className="text-sm font-semibold">Drop files to upload</p>
+              <p className="text-xs text-muted-foreground">Release to add to this slide's assets</p>
+            </div>
           </div>
         </div>
       )}

--- a/packages/core/src/app/components/AssetView.tsx
+++ b/packages/core/src/app/components/AssetView.tsx
@@ -1,12 +1,15 @@
 import {
   ArrowDownToLine,
+  CloudOff,
   File as FileIcon,
   FileImage,
   ImageIcon,
   Loader2,
   MoreVertical,
   Pencil,
+  RotateCw,
   Search,
+  SearchX,
   Trash2,
   Upload,
 } from 'lucide-react';
@@ -568,12 +571,14 @@ function LogoSearchDialog({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<Set<number>>(() => new Set());
+  const [retryToken, setRetryToken] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     queueMicrotask(() => inputRef.current?.focus());
   }, []);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: retryToken is a bump-to-refetch trigger
   useEffect(() => {
     const ctrl = new AbortController();
     const timer = setTimeout(() => {
@@ -594,7 +599,7 @@ function LogoSearchDialog({
       clearTimeout(timer);
       ctrl.abort();
     };
-  }, [query]);
+  }, [query, retryToken]);
 
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
@@ -628,8 +633,25 @@ function LogoSearchDialog({
 
         <div className="max-h-[60vh] min-h-[16rem] overflow-y-auto">
           {error ? (
-            <div className="flex h-32 items-center justify-center text-sm text-destructive">
-              {error}
+            <div className="flex h-64 flex-col items-center justify-center gap-3 px-6 text-center">
+              <div className="flex size-12 items-center justify-center rounded-full bg-muted">
+                <CloudOff className="size-5 text-muted-foreground" />
+              </div>
+              <div>
+                <p className="text-sm font-medium">Couldn't reach svgl</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Check your connection and try again.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setRetryToken((n) => n + 1)}
+                className="gap-1.5"
+              >
+                <RotateCw className="size-3.5" />
+                Try again
+              </Button>
             </div>
           ) : loading && !results ? (
             <div className="grid grid-cols-3 gap-3">
@@ -641,8 +663,34 @@ function LogoSearchDialog({
               ))}
             </div>
           ) : results && results.length === 0 ? (
-            <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
-              No logos found.
+            <div className="flex h-64 flex-col items-center justify-center gap-3 px-6 text-center">
+              <div className="flex size-12 items-center justify-center rounded-full bg-muted">
+                <SearchX className="size-5 text-muted-foreground" />
+              </div>
+              <div>
+                <p className="text-sm font-medium">
+                  {query.trim() ? (
+                    <>
+                      No logos for{' '}
+                      <span className="font-mono text-foreground">"{query.trim()}"</span>
+                    </>
+                  ) : (
+                    'No logos available'
+                  )}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Try a different brand name, or browse the full catalog at{' '}
+                  <a
+                    href="https://svgl.app"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline underline-offset-2 hover:text-foreground"
+                  >
+                    svgl.app
+                  </a>
+                  .
+                </p>
+              </div>
             </div>
           ) : (
             <div className="grid grid-cols-3 gap-3">

--- a/packages/core/src/app/components/ThumbnailRail.tsx
+++ b/packages/core/src/app/components/ThumbnailRail.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef } from 'react';
-import { cn } from '@/lib/utils';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { cn } from '@/lib/utils';
 import type { Page } from '../lib/sdk';
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
 import { SlideCanvas } from './SlideCanvas';
-import { CANVAS_WIDTH, CANVAS_HEIGHT } from '../lib/sdk';
 
 type Props = {
   pages: Page[];

--- a/packages/core/src/app/components/inspector/InspectorPanel.tsx
+++ b/packages/core/src/app/components/inspector/InspectorPanel.tsx
@@ -4,12 +4,20 @@ import {
   AlignLeft,
   AlignRight,
   Bold,
+  ImageIcon,
   Italic,
   Trash2,
   X,
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -25,9 +33,11 @@ import { Slider } from '@/components/ui/slider';
 import { Textarea } from '@/components/ui/textarea';
 import { Toggle } from '@/components/ui/toggle';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { type AssetEntry, useAssets } from '@/lib/assets';
 import { findSlideSource } from '@/lib/inspector/fiber';
 import type { SlideComment } from '@/lib/inspector/useComments';
 import type { EditOp } from '@/lib/inspector/useEditor';
+import { cn } from '@/lib/utils';
 import { type SelectedTarget, useInspector } from './InspectorProvider';
 
 const PANEL_W = 340;
@@ -43,6 +53,7 @@ type ElementSnapshot = {
   lineHeight: number | null;
   letterSpacing: number;
   text: string | null;
+  imageSrc: string | null;
 };
 
 export function InspectorPanel() {
@@ -198,6 +209,15 @@ export function InspectorPanel() {
                 clearable
               />
             </Section>
+
+            {pinSnapshot.imageSrc !== null && (
+              <>
+                <Separator />
+                <Section title="Image">
+                  <ImageField slideId={slideId} src={pinSnapshot.imageSrc} apply={apply} />
+                </Section>
+              </>
+            )}
 
             <Separator />
 
@@ -618,6 +638,124 @@ function NumberField({
   );
 }
 
+function ImageField({
+  slideId,
+  src,
+  apply,
+}: {
+  slideId: string;
+  src: string;
+  apply: (ops: EditOp[]) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-3">
+        <div className="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:8px_8px]">
+          <img
+            src={src}
+            alt=""
+            className="size-full object-contain"
+            draggable={false}
+            onError={(e) => {
+              e.currentTarget.style.display = 'none';
+            }}
+          />
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="flex-1"
+          onClick={() => setOpen(true)}
+        >
+          <ImageIcon className="size-3.5" />
+          Replace…
+        </Button>
+      </div>
+      {open && (
+        <AssetPickerDialog
+          slideId={slideId}
+          onClose={() => setOpen(false)}
+          onPick={(asset) => {
+            setOpen(false);
+            apply([
+              {
+                kind: 'set-attr-asset',
+                attr: 'src',
+                assetPath: `./assets/${asset.name}`,
+                previewUrl: asset.url,
+              },
+            ]);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function AssetPickerDialog({
+  slideId,
+  onClose,
+  onPick,
+}: {
+  slideId: string;
+  onClose: () => void;
+  onPick: (asset: AssetEntry) => void;
+}) {
+  const { assets, loading } = useAssets(slideId);
+  const images = assets.filter((a) => a.mime.startsWith('image/'));
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Replace image</DialogTitle>
+          <DialogDescription>
+            Pick an asset from <span className="font-mono">slides/{slideId}/assets/</span>.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-y-auto">
+          {loading ? (
+            <p className="px-1 py-6 text-center text-xs text-muted-foreground">Loading…</p>
+          ) : images.length === 0 ? (
+            <p className="px-1 py-6 text-center text-xs text-muted-foreground">
+              No images in this slide's assets folder yet. Add some from the Assets tab.
+            </p>
+          ) : (
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3">
+              {images.map((asset) => (
+                <button
+                  key={asset.name}
+                  type="button"
+                  onClick={() => onPick(asset)}
+                  className={cn(
+                    'group flex flex-col overflow-hidden rounded-lg border bg-card text-left shadow-sm transition-all',
+                    'hover:-translate-y-0.5 hover:shadow-md focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none',
+                  )}
+                >
+                  <div className="flex aspect-square w-full items-center justify-center overflow-hidden bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:12px_12px]">
+                    <img
+                      src={asset.url}
+                      alt=""
+                      className="size-full object-contain"
+                      draggable={false}
+                    />
+                  </div>
+                  <div className="border-t px-2 py-1.5">
+                    <div className="truncate text-[11px] font-medium" title={asset.name}>
+                      {asset.name}
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function CommentsSection({
   comments,
   selected,
@@ -714,6 +852,10 @@ function CommentsSection({
 function readSnapshot(el: HTMLElement): ElementSnapshot {
   const cs = getComputedStyle(el);
   const text = isSimpleTextElement(el) ? (el.textContent ?? '') : null;
+  const imageSrc =
+    el.tagName === 'IMG'
+      ? (el as HTMLImageElement).currentSrc || (el as HTMLImageElement).src || null
+      : null;
 
   return {
     fontSize: parseFloat(cs.fontSize) || 16,
@@ -725,6 +867,7 @@ function readSnapshot(el: HTMLElement): ElementSnapshot {
     lineHeight: parseLineHeight(cs.lineHeight, parseFloat(cs.fontSize) || 16),
     letterSpacing: parseLetterSpacing(cs.letterSpacing),
     text,
+    imageSrc,
   };
 }
 

--- a/packages/core/src/app/components/inspector/InspectorProvider.tsx
+++ b/packages/core/src/app/components/inspector/InspectorProvider.tsx
@@ -19,15 +19,19 @@ export type SelectedTarget = {
   anchor: HTMLElement;
 };
 
+type AssetAttrOp = { assetPath: string; previewUrl: string };
+
 type Bucket = {
   line: number;
   column: number;
   styleOps: Map<string, string | null>;
   textOp: { value: string } | null;
+  attrOps: Map<string, AssetAttrOp>;
   // Pre-edit snapshot of the DOM, captured the first time we touch
-  // each style key / text. Used by `cancelEdits` to revert.
+  // each style key / text / attribute. Used by `cancelEdits` to revert.
   origStyle: Map<string, string>;
   origText: { value: string } | null;
+  origAttrs: Map<string, string | null>;
 };
 
 type InspectorCtx = {
@@ -75,7 +79,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
   const refreshCount = useCallback(() => {
     let n = 0;
     for (const b of pendingRef.current.values()) {
-      if (b.styleOps.size > 0 || b.textOp !== null) n++;
+      if (b.styleOps.size > 0 || b.textOp !== null || b.attrOps.size > 0) n++;
     }
     setPendingCount(n);
   }, []);
@@ -90,8 +94,10 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
           column,
           styleOps: new Map(),
           textOp: null,
+          attrOps: new Map(),
           origStyle: new Map(),
           origText: null,
+          origAttrs: new Map(),
         };
         pendingRef.current.set(key, bucket);
       }
@@ -109,6 +115,15 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
           }
           bucket.textOp = { value: op.value };
           if (anchor.isConnected) anchor.textContent = op.value;
+        } else if (op.kind === 'set-attr-asset') {
+          if (!bucket.origAttrs.has(op.attr)) {
+            bucket.origAttrs.set(
+              op.attr,
+              anchor.hasAttribute(op.attr) ? anchor.getAttribute(op.attr) : null,
+            );
+          }
+          bucket.attrOps.set(op.attr, { assetPath: op.assetPath, previewUrl: op.previewUrl });
+          if (anchor.isConnected) anchor.setAttribute(op.attr, op.previewUrl);
         }
       }
       refreshCount();
@@ -120,10 +135,18 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
     const buckets = pendingRef.current;
     if (buckets.size === 0) return;
     const edits: Edit[] = [];
-    for (const { line, column, styleOps, textOp } of buckets.values()) {
+    for (const { line, column, styleOps, textOp, attrOps } of buckets.values()) {
       const list: EditOp[] = [];
       for (const [k, v] of styleOps) list.push({ kind: 'set-style', key: k, value: v });
       if (textOp !== null) list.push({ kind: 'set-text', value: textOp.value });
+      for (const [attr, op] of attrOps) {
+        list.push({
+          kind: 'set-attr-asset',
+          attr,
+          assetPath: op.assetPath,
+          previewUrl: op.previewUrl,
+        });
+      }
       if (list.length > 0) edits.push({ line, column, ops: list });
     }
     pendingRef.current = new Map();
@@ -146,6 +169,10 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       const style = el.style as unknown as Record<string, string>;
       for (const [k, v] of b.origStyle) style[k] = v;
       if (b.origText !== null) el.textContent = b.origText.value;
+      for (const [attr, value] of b.origAttrs) {
+        if (value === null) el.removeAttribute(attr);
+        else el.setAttribute(attr, value);
+      }
     }
     pendingRef.current = new Map();
     setPendingCount(0);
@@ -185,6 +212,9 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       }
       if (bucket.textOp !== null && el.textContent !== bucket.textOp.value) {
         el.textContent = bucket.textOp.value;
+      }
+      for (const [attr, op] of bucket.attrOps) {
+        if (el.getAttribute(attr) !== op.previewUrl) el.setAttribute(attr, op.previewUrl);
       }
     };
 

--- a/packages/core/src/app/lib/assets.ts
+++ b/packages/core/src/app/lib/assets.ts
@@ -45,6 +45,35 @@ async function deleteAsset(slideId: string, name: string): Promise<Response> {
   return fetch(`/__assets/${slideId}/${encodeURIComponent(name)}`, { method: 'DELETE' });
 }
 
+export type SvglItem = {
+  id: number;
+  title: string;
+  category: string | string[];
+  route: string | { light: string; dark: string };
+  url: string;
+};
+
+export async function searchSvgl(query: string, signal?: AbortSignal): Promise<SvglItem[]> {
+  const q = query.trim();
+  const params = new URLSearchParams();
+  if (q) params.set('q', q);
+  else params.set('limit', '24');
+  const res = await fetch(`/__svgl/search?${params.toString()}`, { signal });
+  if (!res.ok) throw new Error(`svgl ${res.status}`);
+  return (await res.json()) as SvglItem[];
+}
+
+export function svgProxyUrl(routeUrl: string): string {
+  return `/__svgl/svg?u=${encodeURIComponent(routeUrl)}`;
+}
+
+export async function fetchSvgAsFile(routeUrl: string, filename: string): Promise<File> {
+  const res = await fetch(svgProxyUrl(routeUrl));
+  if (!res.ok) throw new Error(`svgl route ${res.status}`);
+  const blob = await res.blob();
+  return new File([blob], filename, { type: 'image/svg+xml' });
+}
+
 export type UseAssetsResult = {
   assets: AssetEntry[];
   loading: boolean;

--- a/packages/core/src/app/lib/assets.ts
+++ b/packages/core/src/app/lib/assets.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type AssetEntry = {
+  name: string;
+  size: number;
+  mtime: number;
+  mime: string;
+  url: string;
+};
+
+export type UploadOptions = { overwrite?: boolean };
+
+async function listAssets(slideId: string): Promise<AssetEntry[]> {
+  const res = await fetch(`/__assets/${slideId}`);
+  if (!res.ok) throw new Error(`GET /__assets/${slideId} ${res.status}`);
+  const data = (await res.json()) as { assets?: AssetEntry[] };
+  return data.assets ?? [];
+}
+
+async function uploadAsset(
+  slideId: string,
+  file: File,
+  opts: UploadOptions = {},
+): Promise<Response> {
+  const qs = opts.overwrite ? '?overwrite=1' : '';
+  return fetch(`/__assets/${slideId}/${encodeURIComponent(file.name)}${qs}`, {
+    method: 'POST',
+    headers: {
+      'content-type': file.type || 'application/octet-stream',
+      'content-length': String(file.size),
+    },
+    body: file,
+  });
+}
+
+async function renameAsset(slideId: string, from: string, to: string): Promise<Response> {
+  return fetch(`/__assets/${slideId}/${encodeURIComponent(from)}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name: to }),
+  });
+}
+
+async function deleteAsset(slideId: string, name: string): Promise<Response> {
+  return fetch(`/__assets/${slideId}/${encodeURIComponent(name)}`, { method: 'DELETE' });
+}
+
+export type UseAssetsResult = {
+  assets: AssetEntry[];
+  loading: boolean;
+  available: boolean;
+  upload: (file: File, opts?: UploadOptions) => Promise<{ ok: boolean; status: number }>;
+  rename: (from: string, to: string) => Promise<{ ok: boolean; status: number }>;
+  remove: (name: string) => Promise<{ ok: boolean; status: number }>;
+  refresh: () => Promise<void>;
+};
+
+const NOOP_RESULT = { ok: false, status: 0 } as const;
+
+export function useAssets(slideId: string): UseAssetsResult {
+  const available = import.meta.env.DEV;
+  const [assets, setAssets] = useState<AssetEntry[]>([]);
+  const [loading, setLoading] = useState(available);
+
+  const refresh = useCallback(async () => {
+    if (!available) return;
+    const next = await listAssets(slideId);
+    setAssets(next);
+  }, [slideId]);
+
+  useEffect(() => {
+    if (!available) return;
+    let cancelled = false;
+    setLoading(true);
+    listAssets(slideId)
+      .then((next) => {
+        if (!cancelled) {
+          setAssets(next);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slideId]);
+
+  useEffect(() => {
+    if (!available || !import.meta.hot) return;
+    const handler = (data: { slideId?: string } | undefined) => {
+      if (!data || data.slideId === slideId) {
+        refresh().catch(() => {});
+      }
+    };
+    import.meta.hot.on('open-slide:assets-changed', handler);
+    return () => {
+      import.meta.hot?.off('open-slide:assets-changed', handler);
+    };
+  }, [slideId, refresh]);
+
+  const upload = useCallback(
+    async (file: File, opts?: UploadOptions) => {
+      if (!available) return NOOP_RESULT;
+      const res = await uploadAsset(slideId, file, opts);
+      if (res.ok) await refresh();
+      return { ok: res.ok, status: res.status };
+    },
+    [slideId, refresh],
+  );
+
+  const rename = useCallback(
+    async (from: string, to: string) => {
+      if (!available) return NOOP_RESULT;
+      const res = await renameAsset(slideId, from, to);
+      if (res.ok) await refresh();
+      return { ok: res.ok, status: res.status };
+    },
+    [slideId, refresh],
+  );
+
+  const remove = useCallback(
+    async (name: string) => {
+      if (!available) return NOOP_RESULT;
+      const res = await deleteAsset(slideId, name);
+      if (res.ok) await refresh();
+      return { ok: res.ok, status: res.status };
+    },
+    [slideId, refresh],
+  );
+
+  return { assets, loading, available, upload, rename, remove, refresh };
+}

--- a/packages/core/src/app/lib/assets.ts
+++ b/packages/core/src/app/lib/assets.ts
@@ -59,6 +59,9 @@ export async function searchSvgl(query: string, signal?: AbortSignal): Promise<S
   if (q) params.set('q', q);
   else params.set('limit', '24');
   const res = await fetch(`/__svgl/search?${params.toString()}`, { signal });
+  // svgl returns 404 when a search has no matches — treat it as an empty list,
+  // not an error.
+  if (res.status === 404) return [];
   if (!res.ok) throw new Error(`svgl ${res.status}`);
   return (await res.json()) as SvglItem[];
 }

--- a/packages/core/src/app/lib/inspector/useEditor.ts
+++ b/packages/core/src/app/lib/inspector/useEditor.ts
@@ -2,7 +2,8 @@ import { useCallback } from 'react';
 
 export type EditOp =
   | { kind: 'set-style'; key: string; value: string | null }
-  | { kind: 'set-text'; value: string };
+  | { kind: 'set-text'; value: string }
+  | { kind: 'set-attr-asset'; attr: string; assetPath: string; previewUrl: string };
 
 export type Edit = { line: number; column: number; ops: EditOp[] };
 

--- a/packages/core/src/app/routes/Slide.tsx
+++ b/packages/core/src/app/routes/Slide.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, Download, FileCode2, FileText, Loader2, Pencil, Play } fro
 import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
+import { AssetView } from '@/components/AssetView';
 import { CommentWidget } from '@/components/inspector/CommentWidget';
 import { InspectOverlay } from '@/components/inspector/InspectOverlay';
 import { InspectorPanel } from '@/components/inspector/InspectorPanel';
@@ -20,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useFolders } from '@/lib/folders';
 import { useWheelPageNavigation } from '@/lib/useWheelPageNavigation';
 import { cn } from '@/lib/utils';
@@ -65,6 +67,7 @@ export function Slide() {
   const pageCount = pages.length;
   const rawIndex = Number(searchParams.get('p') ?? '1') - 1;
   const index = Number.isFinite(rawIndex) ? Math.max(0, Math.min(pageCount - 1, rawIndex)) : 0;
+  const view = searchParams.get('view') === 'assets' ? 'assets' : 'slides';
 
   const goTo = useCallback(
     (i: number) => {
@@ -181,6 +184,31 @@ export function Slide() {
                 <Separator orientation="vertical" className="hidden h-5 md:block" />
               </>
             )}
+            {import.meta.env.DEV && (
+              <Tabs
+                value={view}
+                onValueChange={(next) => {
+                  setSearchParams(
+                    (prev) => {
+                      const params = new URLSearchParams(prev);
+                      if (next === 'assets') params.set('view', 'assets');
+                      else params.delete('view');
+                      return params;
+                    },
+                    { replace: true },
+                  );
+                }}
+              >
+                <TabsList className="h-8">
+                  <TabsTrigger value="slides" className="px-3 text-xs">
+                    Slides
+                  </TabsTrigger>
+                  <TabsTrigger value="assets" className="px-3 text-xs">
+                    Assets
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+            )}
           </div>
 
           <div className="pointer-events-none absolute inset-x-0 top-1/2 flex -translate-y-1/2 justify-center px-2">
@@ -190,7 +218,7 @@ export function Slide() {
           </div>
 
           <div className="flex items-center gap-1.5">
-            {allowHtmlDownload && (
+            {view === 'slides' && allowHtmlDownload && (
               <DropdownMenu>
                 <DropdownMenuTrigger
                   type="button"
@@ -264,51 +292,59 @@ export function Slide() {
                 </DropdownMenuContent>
               </DropdownMenu>
             )}
-            <InspectToggleButton />
-            <Button size="sm" onClick={() => setPlaying(true)} className="px-2 md:px-3">
-              <Play className="size-4" />
-              <span className="hidden md:inline">Play</span>
-              <kbd className="ml-1 hidden rounded bg-primary-foreground/20 px-1 text-[10px] md:inline">
-                F
-              </kbd>
-            </Button>
+            {view === 'slides' && <InspectToggleButton />}
+            {view === 'slides' && (
+              <Button size="sm" onClick={() => setPlaying(true)} className="px-2 md:px-3">
+                <Play className="size-4" />
+                <span className="hidden md:inline">Play</span>
+                <kbd className="ml-1 hidden rounded bg-primary-foreground/20 px-1 text-[10px] md:inline">
+                  F
+                </kbd>
+              </Button>
+            )}
           </div>
         </header>
 
-        <div className="flex min-h-0 flex-1">
-          <div className="hidden w-[17rem] shrink-0 md:block">
-            <ThumbnailRail pages={pages} current={index} onSelect={goTo} />
+        {view === 'assets' ? (
+          <div className="min-h-0 flex-1">
+            <AssetView slideId={slideId} />
           </div>
-          <main
-            ref={slideViewportRef}
-            data-inspector-root
-            className="relative min-h-0 min-w-0 flex-1 bg-background p-2 md:p-8"
-          >
-            <SlideWheelNavigation
-              targetRef={slideViewportRef}
-              onPrev={() => goTo(index - 1)}
-              onNext={() => goTo(index + 1)}
-              canPrev={index > 0}
-              canNext={index < pageCount - 1}
-            />
-            <SlideCanvas>
-              <CurrentPage />
-            </SlideCanvas>
-            <ClickNavZones
-              onPrev={() => goTo(index - 1)}
-              onNext={() => goTo(index + 1)}
-              canPrev={index > 0}
-              canNext={index < pageCount - 1}
-            />
-            <InspectOverlay />
-            <SaveBar />
-            <CommentWidget />
-            <div className="pointer-events-none absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-full bg-black/50 px-2.5 py-0.5 text-[11px] font-medium tabular-nums text-white backdrop-blur md:hidden">
-              {index + 1} / {pageCount}
+        ) : (
+          <div className="flex min-h-0 flex-1">
+            <div className="hidden w-[17rem] shrink-0 md:block">
+              <ThumbnailRail pages={pages} current={index} onSelect={goTo} />
             </div>
-          </main>
-          <InspectorPanel />
-        </div>
+            <main
+              ref={slideViewportRef}
+              data-inspector-root
+              className="relative min-h-0 min-w-0 flex-1 bg-background p-2 md:p-8"
+            >
+              <SlideWheelNavigation
+                targetRef={slideViewportRef}
+                onPrev={() => goTo(index - 1)}
+                onNext={() => goTo(index + 1)}
+                canPrev={index > 0}
+                canNext={index < pageCount - 1}
+              />
+              <SlideCanvas>
+                <CurrentPage />
+              </SlideCanvas>
+              <ClickNavZones
+                onPrev={() => goTo(index - 1)}
+                onNext={() => goTo(index + 1)}
+                canPrev={index > 0}
+                canNext={index < pageCount - 1}
+              />
+              <InspectOverlay />
+              <SaveBar />
+              <CommentWidget />
+              <div className="pointer-events-none absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-full bg-black/50 px-2.5 py-0.5 text-[11px] font-medium tabular-nums text-white backdrop-blur md:hidden">
+                {index + 1} / {pageCount}
+              </div>
+            </main>
+            <InspectorPanel />
+          </div>
+        )}
       </div>
     </InspectorProvider>
   );

--- a/packages/core/src/app/routes/Slide.tsx
+++ b/packages/core/src/app/routes/Slide.tsx
@@ -20,7 +20,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Separator } from '@/components/ui/separator';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useFolders } from '@/lib/folders';
 import { useWheelPageNavigation } from '@/lib/useWheelPageNavigation';
@@ -174,15 +173,12 @@ export function Slide() {
         <header className="relative flex shrink-0 items-center justify-between border-b bg-card px-3 py-2 md:px-5 md:py-3">
           <div className="flex items-center gap-2 md:gap-3">
             {showSlideBrowser && (
-              <>
-                <Button asChild variant="ghost" size="sm" className="px-2 md:px-3">
-                  <Link to="/">
-                    <ChevronLeft className="size-4" />
-                    <span className="hidden md:inline">Home</span>
-                  </Link>
-                </Button>
-                <Separator orientation="vertical" className="hidden h-5 md:block" />
-              </>
+              <Button asChild variant="ghost" size="sm" className="px-2 md:px-3">
+                <Link to="/">
+                  <ChevronLeft className="size-4" />
+                  <span className="hidden md:inline">Home</span>
+                </Link>
+              </Button>
             )}
             {import.meta.env.DEV && (
               <Tabs
@@ -199,11 +195,24 @@ export function Slide() {
                   );
                 }}
               >
-                <TabsList className="h-8">
-                  <TabsTrigger value="slides" className="px-3 text-xs">
+                <TabsList className="relative h-7 rounded-md p-0.5 group-data-[orientation=horizontal]/tabs:h-7">
+                  <div
+                    aria-hidden
+                    className="pointer-events-none absolute top-0.5 bottom-0.5 left-0.5 w-[calc(50%-2px)] rounded-[5px] bg-background shadow-sm transition-transform duration-200 ease-out"
+                    style={{
+                      transform: view === 'assets' ? 'translateX(100%)' : 'translateX(0)',
+                    }}
+                  />
+                  <TabsTrigger
+                    value="slides"
+                    className="relative z-10 h-6 px-3 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none dark:data-[state=active]:bg-transparent"
+                  >
                     Slides
                   </TabsTrigger>
-                  <TabsTrigger value="assets" className="px-3 text-xs">
+                  <TabsTrigger
+                    value="assets"
+                    className="relative z-10 h-6 px-3 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none dark:data-[state=active]:bg-transparent"
+                  >
                     Assets
                   </TabsTrigger>
                 </TabsList>

--- a/packages/core/src/app/styles.css
+++ b/packages/core/src/app/styles.css
@@ -128,3 +128,30 @@
     @apply font-sans;
   }
 }
+
+@keyframes asset-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes asset-ring {
+  0% {
+    transform: scale(0.85);
+    opacity: 0.55;
+  }
+  100% {
+    transform: scale(1.7);
+    opacity: 0;
+  }
+}
+
+@keyframes asset-border-flow {
+  to {
+    background-position: 200% 0;
+  }
+}

--- a/packages/core/src/app/styles.css
+++ b/packages/core/src/app/styles.css
@@ -128,37 +128,3 @@
     @apply font-sans;
   }
 }
-
-@keyframes asset-breathe {
-  0%,
-  100% {
-    box-shadow:
-      inset 0 0 0 2px color-mix(in oklab, var(--color-primary) 35%, transparent),
-      inset 0 0 32px 0 color-mix(in oklab, var(--color-primary) 10%, transparent);
-  }
-  50% {
-    box-shadow:
-      inset 0 0 0 2px color-mix(in oklab, var(--color-primary) 65%, transparent),
-      inset 0 0 64px 0 color-mix(in oklab, var(--color-primary) 22%, transparent);
-  }
-}
-
-@keyframes asset-marching-ants {
-  to {
-    background-position:
-      18px 0,
-      0 -18px,
-      -18px 0,
-      0 18px;
-  }
-}
-
-@keyframes asset-pill-bob {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-3px);
-  }
-}

--- a/packages/core/src/app/styles.css
+++ b/packages/core/src/app/styles.css
@@ -129,29 +129,36 @@
   }
 }
 
-@keyframes asset-float {
+@keyframes asset-breathe {
+  0%,
+  100% {
+    box-shadow:
+      inset 0 0 0 2px color-mix(in oklab, var(--color-primary) 35%, transparent),
+      inset 0 0 32px 0 color-mix(in oklab, var(--color-primary) 10%, transparent);
+  }
+  50% {
+    box-shadow:
+      inset 0 0 0 2px color-mix(in oklab, var(--color-primary) 65%, transparent),
+      inset 0 0 64px 0 color-mix(in oklab, var(--color-primary) 22%, transparent);
+  }
+}
+
+@keyframes asset-marching-ants {
+  to {
+    background-position:
+      18px 0,
+      0 -18px,
+      -18px 0,
+      0 18px;
+  }
+}
+
+@keyframes asset-pill-bob {
   0%,
   100% {
     transform: translateY(0);
   }
   50% {
-    transform: translateY(-6px);
-  }
-}
-
-@keyframes asset-ring {
-  0% {
-    transform: scale(0.85);
-    opacity: 0.55;
-  }
-  100% {
-    transform: scale(1.7);
-    opacity: 0;
-  }
-}
-
-@keyframes asset-border-flow {
-  to {
-    background-position: 200% 0;
+    transform: translateY(-3px);
   }
 }

--- a/packages/core/src/vite/comments-plugin.test.ts
+++ b/packages/core/src/vite/comments-plugin.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { applyEdit, b64urlDecode, b64urlEncode, parseMarkers } from './comments-plugin.ts';
+import {
+  applyEdit,
+  b64urlDecode,
+  b64urlEncode,
+  parseMarkers,
+  safeAssetIdentifier,
+} from './comments-plugin.ts';
 
 describe('b64url encoding', () => {
   it('round-trips arbitrary unicode strings', () => {
@@ -223,5 +229,89 @@ describe('applyEdit / combined ops', () => {
     const r = applyEdit(src, 1, 0, []);
     if (!r.ok) throw new Error('expected ok');
     expect(r.source).toBe(src);
+  });
+});
+
+describe('safeAssetIdentifier', () => {
+  it('camel-cases dashes and spaces', () => {
+    expect(safeAssetIdentifier('my-logo.svg', new Set())).toBe('myLogo');
+    expect(safeAssetIdentifier('hello world.png', new Set())).toBe('helloWorld');
+  });
+
+  it('prefixes identifiers that would start with a digit', () => {
+    expect(safeAssetIdentifier('2026-photo.jpg', new Set())).toBe('asset2026Photo');
+  });
+
+  it('falls back to "asset" for names with no usable characters', () => {
+    expect(safeAssetIdentifier('---.png', new Set())).toBe('asset');
+  });
+
+  it('appends a counter when the candidate collides with an existing name', () => {
+    const taken = new Set(['logo', 'logo2']);
+    expect(safeAssetIdentifier('logo.svg', taken)).toBe('logo3');
+  });
+});
+
+describe('applyEdit / set-attr-asset', () => {
+  it('inserts an import and rewrites the src attribute on a fresh <img>', () => {
+    const src = [
+      "import logo from './assets/logo.svg';",
+      'export default [() => (',
+      '<img src={logo} />',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 3, 0, [
+      { kind: 'set-attr-asset', attr: 'src', assetPath: './assets/photo.png' },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("import photo from './assets/photo.png';");
+    expect(r.source).toContain('<img src={photo} />');
+    // Original import is preserved.
+    expect(r.source).toContain("import logo from './assets/logo.svg';");
+  });
+
+  it('reuses an existing import when the path is already imported', () => {
+    const src = [
+      "import logo from './assets/logo.svg';",
+      "import photo from './assets/photo.png';",
+      'export default [() => (',
+      '<img src={logo} />',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 4, 0, [
+      { kind: 'set-attr-asset', attr: 'src', assetPath: './assets/photo.png' },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain('<img src={photo} />');
+    // No duplicate import added.
+    const occurrences = r.source.match(/from '\.\/assets\/photo\.png'/g) ?? [];
+    expect(occurrences.length).toBe(1);
+  });
+
+  it('inserts a fresh src attribute on an <img> that has none', () => {
+    const src = [
+      "import alt from './assets/alt.svg';",
+      'export default [() => (',
+      '<img alt="" />',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 3, 0, [
+      { kind: 'set-attr-asset', attr: 'src', assetPath: './assets/alt.svg' },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain('<img src={alt} alt="" />');
+  });
+
+  it('rejects asset paths outside ./assets/', () => {
+    const src = ['export default [() => (', '<img src="x" />', ')];', ''].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      { kind: 'set-attr-asset', attr: 'src', assetPath: '../foo.png' },
+    ]);
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.error).toMatch(/\.\/assets\//);
   });
 });

--- a/packages/core/src/vite/comments-plugin.ts
+++ b/packages/core/src/vite/comments-plugin.ts
@@ -198,7 +198,8 @@ function offsetToLine(source: string, offset: number): number {
 
 export type EditOp =
   | { kind: 'set-style'; key: string; value: string | null }
-  | { kind: 'set-text'; value: string };
+  | { kind: 'set-text'; value: string }
+  | { kind: 'set-attr-asset'; attr: string; assetPath: string };
 
 export type ApplyEditResult =
   | { ok: true; source: string }
@@ -389,6 +390,133 @@ function buildTextSplice(element: AstNode, value: string): Splice | { error: str
   return { error: 'element has complex children' };
 }
 
+type ImportInfo = { node: AstNode; source: string; defaultIdent: string | null };
+
+function findImports(ast: AstNode): ImportInfo[] {
+  const body = (ast as unknown as { program?: { body?: AstNode[] } }).program?.body ?? [];
+  const out: ImportInfo[] = [];
+  for (const node of body) {
+    if (node.type !== 'ImportDeclaration') continue;
+    const src = (node as unknown as { source?: { value?: unknown } }).source?.value;
+    if (typeof src !== 'string') continue;
+    const specs = (node as unknown as { specifiers?: AstNode[] }).specifiers ?? [];
+    let def: string | null = null;
+    for (const spec of specs) {
+      if (spec.type === 'ImportDefaultSpecifier') {
+        const local = (spec as unknown as { local?: { name?: string } }).local?.name;
+        if (typeof local === 'string') {
+          def = local;
+          break;
+        }
+      }
+    }
+    out.push({ node, source: src, defaultIdent: def });
+  }
+  return out;
+}
+
+function collectTopLevelIdentifiers(ast: AstNode): Set<string> {
+  // Only need to avoid colliding with anything resolvable by JSX —
+  // import bindings cover the common case. Local consts/lets are
+  // handled by source-level identifier scanning below.
+  const names = new Set<string>();
+  for (const imp of findImports(ast)) {
+    if (imp.defaultIdent) names.add(imp.defaultIdent);
+    const specs = (imp.node as unknown as { specifiers?: AstNode[] }).specifiers ?? [];
+    for (const spec of specs) {
+      if (spec.type !== 'ImportDefaultSpecifier') {
+        const local = (spec as unknown as { local?: { name?: string } }).local?.name;
+        if (typeof local === 'string') names.add(local);
+      }
+    }
+  }
+  return names;
+}
+
+export function safeAssetIdentifier(filename: string, taken: Set<string>): string {
+  const stem = filename.replace(/\.[^.]+$/, '');
+  let camel = '';
+  let upper = false;
+  for (const ch of stem) {
+    if (/[A-Za-z0-9]/.test(ch)) {
+      camel += upper ? ch.toUpperCase() : ch;
+      upper = false;
+    } else {
+      upper = camel.length > 0;
+    }
+  }
+  let base = camel;
+  if (!base || !/^[A-Za-z_$]/.test(base)) {
+    base = `asset${base.charAt(0).toUpperCase()}${base.slice(1)}` || 'asset';
+  }
+  base = base.charAt(0).toLowerCase() + base.slice(1);
+  let candidate = base;
+  let i = 2;
+  while (taken.has(candidate)) {
+    candidate = `${base}${i}`;
+    i += 1;
+  }
+  return candidate;
+}
+
+function findJsxAttr(opening: AstNode, name: string): AstNode | null {
+  const attrs = (opening as unknown as { attributes?: AstNode[] }).attributes ?? [];
+  for (const attr of attrs) {
+    if (attr.type !== 'JSXAttribute') continue;
+    const n = (attr as unknown as { name?: { type?: string; name?: string } }).name;
+    if (n?.type === 'JSXIdentifier' && n.name === name) return attr;
+  }
+  return null;
+}
+
+type AssetEditPlan = {
+  importSplice: Splice | null;
+  attrSplice: Splice;
+};
+
+function planAssetAttr(
+  ast: AstNode,
+  element: AstNode,
+  attr: string,
+  assetPath: string,
+): AssetEditPlan | { error: string } {
+  const opening = (element as unknown as { openingElement?: AstNode }).openingElement;
+  if (!opening) return { error: 'no opening element' };
+  if (!attr || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(attr)) return { error: 'invalid attribute name' };
+  if (!assetPath.startsWith('./assets/')) return { error: 'asset path must start with ./assets/' };
+
+  const imports = findImports(ast);
+  let identifier: string | null = null;
+  for (const imp of imports) {
+    if (imp.source === assetPath && imp.defaultIdent) {
+      identifier = imp.defaultIdent;
+      break;
+    }
+  }
+
+  let importSplice: Splice | null = null;
+  if (!identifier) {
+    const filename = assetPath.slice(assetPath.lastIndexOf('/') + 1);
+    const taken = collectTopLevelIdentifiers(ast);
+    identifier = safeAssetIdentifier(filename, taken);
+    const importStmt = `import ${identifier} from '${assetPath.replace(/'/g, "\\'")}';\n`;
+    const insertAt = imports.length > 0 ? imports[imports.length - 1].node.end : 0;
+    const prefix = imports.length > 0 ? '\n' : '';
+    importSplice = { from: insertAt, to: insertAt, text: prefix + importStmt };
+  }
+
+  const newAttr = `${attr}={${identifier}}`;
+  const existing = findJsxAttr(opening, attr);
+  let attrSplice: Splice;
+  if (existing) {
+    attrSplice = { from: existing.start, to: existing.end, text: newAttr };
+  } else {
+    const name = (opening as unknown as { name: AstNode }).name;
+    attrSplice = { from: name.end, to: name.end, text: ` ${newAttr}` };
+  }
+  return { importSplice, attrSplice };
+}
+
 export function applyEdit(
   source: string,
   line: number,
@@ -418,6 +546,29 @@ export function applyEdit(
     const result = buildTextSplice(element, op.value);
     if ('error' in result) return { ok: false, status: 422, error: result.error };
     splices.push(result);
+  }
+
+  const assetOps = ops.flatMap((op) => (op.kind === 'set-attr-asset' ? [op] : []));
+  if (assetOps.length > 0) {
+    const ast = parseSource(source);
+    if (!ast) return { ok: false, status: 422, error: 'could not parse source' };
+    const importSplices: Splice[] = [];
+    for (const op of assetOps) {
+      const plan = planAssetAttr(ast, element, op.attr, op.assetPath);
+      if ('error' in plan) return { ok: false, status: 422, error: plan.error };
+      splices.push(plan.attrSplice);
+      if (plan.importSplice) importSplices.push(plan.importSplice);
+    }
+    // Multiple new imports for the same edit must not overlap, but they
+    // all anchor to the same offset (end of last existing import). When
+    // applied in reverse-`from` order they would land at the same point,
+    // so concat their text into a single splice to keep ordering stable.
+    if (importSplices.length > 0) {
+      const from = importSplices[0].from;
+      const to = importSplices[0].to;
+      const text = importSplices.map((s) => s.text).join('');
+      splices.push({ from, to, text });
+    }
   }
 
   if (splices.length === 0) return { ok: true, source };

--- a/packages/core/src/vite/files-plugin.test.ts
+++ b/packages/core/src/vite/files-plugin.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  mimeForFilename,
   updateMetaTitleInSource,
+  validateAssetName,
   validateIcon,
   validateName,
   validateSlideName,
@@ -114,5 +116,60 @@ describe('updateMetaTitleInSource', () => {
 
   it('returns null if there is no meta and no default export', () => {
     expect(updateMetaTitleInSource('// nothing here', 'x')).toBeNull();
+  });
+});
+
+describe('validateAssetName', () => {
+  it('accepts simple filenames with extensions', () => {
+    expect(validateAssetName('logo.svg')).toBe('logo.svg');
+    expect(validateAssetName('a-b_c.1.png')).toBe('a-b_c.1.png');
+  });
+
+  it('accepts spaces, parens, and unicode in names', () => {
+    expect(validateAssetName('hello world.png')).toBe('hello world.png');
+    expect(validateAssetName('IMG (1).jpg')).toBe('IMG (1).jpg');
+    expect(validateAssetName('café.png')).toBe('café.png');
+    expect(validateAssetName('截圖.png')).toBe('截圖.png');
+  });
+
+  it('rejects names without an extension', () => {
+    expect(validateAssetName('README')).toBeNull();
+    expect(validateAssetName('foo.')).toBeNull();
+  });
+
+  it('rejects path-traversal and separators', () => {
+    expect(validateAssetName('../foo.png')).toBeNull();
+    expect(validateAssetName('foo/bar.png')).toBeNull();
+    expect(validateAssetName('foo\\bar.png')).toBeNull();
+  });
+
+  it('rejects leading dots, tildes, and shell-unsafe characters', () => {
+    expect(validateAssetName('.hidden.png')).toBeNull();
+    expect(validateAssetName('~foo.png')).toBeNull();
+    expect(validateAssetName('foo\x00bar.png')).toBeNull();
+    expect(validateAssetName('foo*.png')).toBeNull();
+    expect(validateAssetName('foo?.png')).toBeNull();
+  });
+
+  it('rejects empty / non-string / overlong names', () => {
+    expect(validateAssetName('')).toBeNull();
+    expect(validateAssetName(null)).toBeNull();
+    expect(validateAssetName(42)).toBeNull();
+    expect(validateAssetName(`${'x'.repeat(120)}.png`)).toBeNull();
+  });
+});
+
+describe('mimeForFilename', () => {
+  it('maps known extensions', () => {
+    expect(mimeForFilename('a.png')).toBe('image/png');
+    expect(mimeForFilename('a.JPG')).toBe('image/jpeg');
+    expect(mimeForFilename('a.svg')).toBe('image/svg+xml');
+    expect(mimeForFilename('a.woff2')).toBe('font/woff2');
+    expect(mimeForFilename('a.mp4')).toBe('video/mp4');
+  });
+
+  it('falls back to octet-stream for unknown / missing extensions', () => {
+    expect(mimeForFilename('a.xyz')).toBe('application/octet-stream');
+    expect(mimeForFilename('noext')).toBe('application/octet-stream');
   });
 });

--- a/packages/core/src/vite/files-plugin.ts
+++ b/packages/core/src/vite/files-plugin.ts
@@ -7,6 +7,52 @@ import type { Connect, Plugin, ViteDevServer } from 'vite';
 const FOLDER_ID_RE = /^f-[a-f0-9]{8}$/;
 const SLIDE_ID_RE = /^[a-z0-9_-]+$/i;
 const COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: explicit control-char block list for filename safety
+const ASSET_FORBIDDEN_RE = /[\x00-\x1F\x7F/\\:*?"<>|]/;
+const ASSET_MAX_BYTES = 25 * 1024 * 1024;
+
+const MIME_BY_EXT: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+  avif: 'image/avif',
+  ico: 'image/x-icon',
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+  ttf: 'font/ttf',
+  otf: 'font/otf',
+  json: 'application/json',
+  txt: 'text/plain; charset=utf-8',
+  md: 'text/markdown; charset=utf-8',
+};
+
+export function mimeForFilename(name: string): string {
+  const dot = name.lastIndexOf('.');
+  if (dot < 0) return 'application/octet-stream';
+  const ext = name.slice(dot + 1).toLowerCase();
+  return MIME_BY_EXT[ext] ?? 'application/octet-stream';
+}
+
+export function validateAssetName(v: unknown): string | null {
+  if (typeof v !== 'string') return null;
+  const trimmed = v.trim();
+  if (trimmed.length < 1 || trimmed.length > 120) return null;
+  // No path separators, control chars, or characters Windows/macOS can't store.
+  if (ASSET_FORBIDDEN_RE.test(trimmed)) return null;
+  // Block leading dots / tildes (hidden files, home expansion) and any `..` segment.
+  if (trimmed.startsWith('.') || trimmed.startsWith('~')) return null;
+  if (trimmed === '..' || trimmed.split(/[/\\]/).includes('..')) return null;
+  // Require an extension so authors get sensible MIME / dev-server behavior.
+  const dot = trimmed.lastIndexOf('.');
+  if (dot <= 0 || dot === trimmed.length - 1) return null;
+  return trimmed;
+}
 
 export type FolderIcon = { type: 'emoji'; value: string } | { type: 'color'; value: string };
 
@@ -103,6 +149,24 @@ async function rmSlideDir(slidesRoot: string, slideId: string): Promise<boolean>
   } catch {
     return false;
   }
+}
+
+function resolveAssetsDir(slidesRoot: string, slideId: string): string | null {
+  if (!SLIDE_ID_RE.test(slideId)) return null;
+  const slideDir = path.resolve(slidesRoot, slideId);
+  if (!slideDir.startsWith(slidesRoot + path.sep)) return null;
+  const assetsDir = path.resolve(slideDir, 'assets');
+  if (assetsDir !== path.join(slideDir, 'assets')) return null;
+  return assetsDir;
+}
+
+function resolveAssetFile(slidesRoot: string, slideId: string, filename: string): string | null {
+  const assetsDir = resolveAssetsDir(slidesRoot, slideId);
+  if (!assetsDir) return null;
+  if (!validateAssetName(filename)) return null;
+  const file = path.resolve(assetsDir, filename);
+  if (!file.startsWith(assetsDir + path.sep)) return null;
+  return file;
 }
 
 function resolveSlideEntry(slidesRoot: string, slideId: string): string | null {
@@ -218,6 +282,25 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
         }
       });
 
+      // Surface asset directory mutations as an HMR ping so the editor's
+      // <AssetPanel> can re-list without a full reload.
+      const onAssetChange = (p: string) => {
+        if (!p.startsWith(slidesRoot + path.sep)) return;
+        const rel = p.slice(slidesRoot.length + 1);
+        const parts = rel.split(path.sep);
+        if (parts.length < 3 || parts[1] !== 'assets') return;
+        const slideId = parts[0];
+        if (!SLIDE_ID_RE.test(slideId)) return;
+        server.ws.send({
+          type: 'custom',
+          event: 'open-slide:assets-changed',
+          data: { slideId },
+        });
+      };
+      server.watcher.on('add', onAssetChange);
+      server.watcher.on('change', onAssetChange);
+      server.watcher.on('unlink', onAssetChange);
+
       server.middlewares.use('/__slides', async (req, res, next) => {
         const url = new URL(req.url ?? '/', 'http://local');
         const method = req.method ?? 'GET';
@@ -267,6 +350,163 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
             delete manifest.assignments[slideId];
             await writeManifest(manifestPath, manifest);
             return json(res, 200, { ok: true });
+          }
+
+          return next();
+        } catch (err) {
+          json(res, 500, { error: String((err as Error).message ?? err) });
+        }
+      });
+
+      server.middlewares.use('/__assets', async (req, res, next) => {
+        const url = new URL(req.url ?? '/', 'http://local');
+        const method = req.method ?? 'GET';
+
+        try {
+          const listMatch = url.pathname.match(/^\/([^/]+)\/?$/);
+          const fileMatch = url.pathname.match(/^\/([^/]+)\/([^/]+)$/);
+
+          if (listMatch && method === 'GET') {
+            const slideId = listMatch[1];
+            const assetsDir = resolveAssetsDir(slidesRoot, slideId);
+            if (!assetsDir) return json(res, 400, { error: 'invalid slideId' });
+
+            let entries: string[];
+            try {
+              entries = await fs.readdir(assetsDir);
+            } catch (err) {
+              if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+                return json(res, 200, { assets: [] });
+              }
+              throw err;
+            }
+
+            const assets = [];
+            for (const name of entries) {
+              if (!validateAssetName(name)) continue;
+              const stat = await fs.stat(path.join(assetsDir, name));
+              if (!stat.isFile()) continue;
+              assets.push({
+                name,
+                size: stat.size,
+                mtime: stat.mtimeMs,
+                mime: mimeForFilename(name),
+                url: `/__assets/${slideId}/${encodeURIComponent(name)}`,
+              });
+            }
+            assets.sort((a, b) => a.name.localeCompare(b.name));
+            return json(res, 200, { assets });
+          }
+
+          if (fileMatch) {
+            const slideId = fileMatch[1];
+            const filename = decodeURIComponent(fileMatch[2]);
+            const file = resolveAssetFile(slidesRoot, slideId, filename);
+            if (!file) return json(res, 400, { error: 'invalid path' });
+
+            if (method === 'GET') {
+              try {
+                const buf = await fs.readFile(file);
+                res.statusCode = 200;
+                res.setHeader('content-type', mimeForFilename(filename));
+                res.setHeader('cache-control', 'no-store');
+                res.end(buf);
+                return;
+              } catch (err) {
+                if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+                  return json(res, 404, { error: 'asset not found' });
+                }
+                throw err;
+              }
+            }
+
+            if (method === 'POST') {
+              const overwrite = url.searchParams.get('overwrite') === '1';
+              const lenHeader = req.headers['content-length'];
+              const len = typeof lenHeader === 'string' ? Number(lenHeader) : NaN;
+              if (Number.isFinite(len) && len > ASSET_MAX_BYTES) {
+                return json(res, 413, { error: 'file too large' });
+              }
+
+              if (!overwrite) {
+                try {
+                  await fs.access(file);
+                  return json(res, 409, { error: 'asset exists' });
+                } catch {
+                  // fall through — file does not exist, OK to write
+                }
+              }
+
+              const assetsDir = resolveAssetsDir(slidesRoot, slideId);
+              if (!assetsDir) return json(res, 400, { error: 'invalid slideId' });
+              await fs.mkdir(assetsDir, { recursive: true });
+
+              const chunks: Buffer[] = [];
+              let total = 0;
+              let oversized = false;
+              await new Promise<void>((resolve, reject) => {
+                req.on('data', (c: Buffer) => {
+                  total += c.length;
+                  if (total > ASSET_MAX_BYTES) {
+                    oversized = true;
+                    req.destroy();
+                    return;
+                  }
+                  chunks.push(c);
+                });
+                req.on('end', () => resolve());
+                req.on('error', reject);
+              });
+              if (oversized) return json(res, 413, { error: 'file too large' });
+
+              await fs.writeFile(file, Buffer.concat(chunks));
+              return json(res, 200, {
+                ok: true,
+                name: filename,
+                size: total,
+                mime: mimeForFilename(filename),
+                url: `/__assets/${slideId}/${encodeURIComponent(filename)}`,
+              });
+            }
+
+            if (method === 'PATCH') {
+              const body = (await readBody(req)) as { name?: unknown };
+              const target = validateAssetName(body.name);
+              if (!target) return json(res, 400, { error: 'invalid name' });
+              if (target === filename) return json(res, 200, { ok: true, name: filename });
+
+              const dest = resolveAssetFile(slidesRoot, slideId, target);
+              if (!dest) return json(res, 400, { error: 'invalid name' });
+
+              try {
+                await fs.access(dest);
+                return json(res, 409, { error: 'target exists' });
+              } catch {
+                // OK
+              }
+
+              try {
+                await fs.rename(file, dest);
+              } catch (err) {
+                if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+                  return json(res, 404, { error: 'asset not found' });
+                }
+                throw err;
+              }
+              return json(res, 200, { ok: true, name: target });
+            }
+
+            if (method === 'DELETE') {
+              try {
+                await fs.unlink(file);
+              } catch (err) {
+                if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+                  return json(res, 404, { error: 'asset not found' });
+                }
+                throw err;
+              }
+              return json(res, 200, { ok: true });
+            }
           }
 
           return next();

--- a/packages/core/src/vite/files-plugin.ts
+++ b/packages/core/src/vite/files-plugin.ts
@@ -515,6 +515,52 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
         }
       });
 
+      server.middlewares.use('/__svgl', async (req, res, next) => {
+        const reqUrl = new URL(req.url ?? '/', 'http://local');
+        const method = req.method ?? 'GET';
+        if (method !== 'GET') return next();
+
+        try {
+          let target: string | null = null;
+          if (reqUrl.pathname === '/search') {
+            const params = new URLSearchParams();
+            const q = reqUrl.searchParams.get('q');
+            const limit = reqUrl.searchParams.get('limit');
+            if (q) params.set('search', q);
+            if (limit) params.set('limit', limit);
+            const qs = params.toString();
+            target = `https://api.svgl.app/${qs ? `?${qs}` : ''}`;
+          } else if (reqUrl.pathname === '/svg') {
+            const u = reqUrl.searchParams.get('u');
+            if (!u) return json(res, 400, { error: 'missing u' });
+            let parsed: URL;
+            try {
+              parsed = new URL(u);
+            } catch {
+              return json(res, 400, { error: 'invalid u' });
+            }
+            if (parsed.protocol !== 'https:') return json(res, 400, { error: 'https only' });
+            const host = parsed.hostname.toLowerCase();
+            if (host !== 'svgl.app' && !host.endsWith('.svgl.app')) {
+              return json(res, 400, { error: 'host not allowed' });
+            }
+            target = parsed.toString();
+          } else {
+            return next();
+          }
+
+          const upstream = await fetch(target);
+          const ct = upstream.headers.get('content-type') ?? 'application/octet-stream';
+          res.statusCode = upstream.status;
+          res.setHeader('content-type', ct);
+          res.setHeader('cache-control', 'no-store');
+          const buf = Buffer.from(await upstream.arrayBuffer());
+          res.end(buf);
+        } catch (err) {
+          json(res, 502, { error: String((err as Error).message ?? err) });
+        }
+      });
+
       server.middlewares.use('/__folders', async (req, res, next) => {
         const url = new URL(req.url ?? '/', 'http://local');
         const method = req.method ?? 'GET';


### PR DESCRIPTION
Add a Slides/Assets switcher in the editor header. The Assets view is a full-page Drive-like file browser scoped to the current slide's slides/<id>/assets/ folder, supporting drag-and-drop upload, rename, delete, and image preview.

Backed by new dev-server endpoints (/__assets/:slideId[/:filename]) in the files plugin, with a watcher that pings clients via an HMR custom event so the panel stays in sync. Switcher and endpoints are gated to dev mode; static exports keep the original layout.