### PR TITLE
feat(core): add <ImagePlaceholder> with inspector replace flow

### DIFF
--- a/apps/demo/.agents/skills/create-slide/SKILL.md
+++ b/apps/demo/.agents/skills/create-slide/SKILL.md
@@ -52,6 +52,8 @@ Sketch the slide as a list of page roles before writing code. Common page types:
 
 **Rule of thumb**: one idea per page. If you're tempted to put two, split them.
 
+If the deck topic naturally calls for specific real images the user must supply (product screenshots, team photos, customer dashboards), plan where those go and use `<ImagePlaceholder>` from `@open-slide/core` — see the **Image placeholders** section in `slide-authoring`. Default is **no placeholders**: only insert one when a real image is genuinely required.
+
 ## Step 5 — Commit to a visual direction
 
 Pick one coherent palette / type scale / aesthetic and hold it across every page. The full set of constraints (palette structure, type scale, padding, aesthetic options) lives in `slide-authoring` — apply it.

--- a/apps/demo/.agents/skills/slide-authoring/SKILL.md
+++ b/apps/demo/.agents/skills/slide-authoring/SKILL.md
@@ -230,6 +230,24 @@ const videoUrl = new URL('./assets/intro.mp4', import.meta.url).href;
 
 Skip the `assets/` folder entirely for pure-text slides.
 
+## Image placeholders
+
+When a page genuinely needs a real image **the user has to provide** — a product screenshot, a team photo, a chart from their data — leave a typed placeholder instead of inventing a stand-in:
+
+```tsx
+import { ImagePlaceholder } from '@open-slide/core';
+
+<ImagePlaceholder hint="Product hero screenshot" width={1280} height={720} />
+```
+
+The user uploads the real file via the Assets panel, then clicks the placeholder in the inspector and picks "Replace…" — the JSX is rewritten to a real `<img>` with the import added.
+
+**Use a placeholder only when** a specific concrete image is required by the deck's topic. Examples that warrant one: a product-intro deck (product screenshot per feature), an offsite recap (team photo), a case study (customer logo, dashboard screenshot).
+
+**Do not use a placeholder** for decoration, generic "stock photo" filler, hero imagery on a text-heavy slide, or anywhere a typographic / iconographic / illustrative solution would do. If you can carry the page with type, layout, and color — do that. Empty placeholders the user has to fill are friction; only spend that friction when the alternative is worse.
+
+Size the placeholder to the slot it occupies. Pass `width`/`height` when the layout has a fixed image box; omit them when the placeholder fills a flex/grid cell. The `hint` should describe the *content* the user needs ("Q3 revenue chart") not the *role* ("hero image").
+
 ## Runtime behavior you get for free
 
 - Home page lists every folder under `slides/`.
@@ -249,6 +267,7 @@ Skip the `assets/` folder entirely for pure-text slides.
 - [ ] If the slide should be tweakable from the Design panel, it declares a top-level `const design: DesignSystem = { … }` and references `design.X` from inline styles.
 - [ ] One idea per page.
 - [ ] All imported assets exist on disk under `slides/<id>/assets/`.
+- [ ] Every `<ImagePlaceholder>` corresponds to a real image the user must supply — not decorative filler. If it could be replaced by typography or layout, it should be.
 - [ ] Nothing outside `slides/<id>/` was edited.
 
 ## Anti-patterns
@@ -265,3 +284,5 @@ Skip the `assets/` folder entirely for pure-text slides.
 - ❌ Writing CSS to a shared file. Inline styles or scoped classnames only.
 - ❌ Creating `README.md` or other prose files inside the slide folder.
 - ❌ Editing `package.json`, `open-slide.config.ts`, or other slides.
+- ❌ Sprinkling `<ImagePlaceholder>` across pages "for visual interest". Placeholders are for content the user owns; they're not stock-photo slots.
+- ❌ Using a placeholder for an icon or decorative shape — those are typography/SVG problems, not asset problems.

--- a/packages/core/src/app/components/ImagePlaceholder.tsx
+++ b/packages/core/src/app/components/ImagePlaceholder.tsx
@@ -1,0 +1,56 @@
+import type { CSSProperties, HTMLAttributes } from 'react';
+
+export type ImagePlaceholderProps = {
+  hint: string;
+  width?: number;
+  height?: number;
+  style?: CSSProperties;
+  className?: string;
+} & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'style' | 'className'>;
+
+export function ImagePlaceholder({
+  hint,
+  width,
+  height,
+  style,
+  className,
+  ...rest
+}: ImagePlaceholderProps) {
+  const dims = width && height ? `${width} × ${height}` : null;
+  return (
+    <div
+      {...rest}
+      data-slide-placeholder={hint}
+      data-placeholder-w={width}
+      data-placeholder-h={height}
+      role="img"
+      aria-label={hint}
+      style={{
+        width: width ?? '100%',
+        height: height ?? '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        gap: 8,
+        border: '2px dashed currentColor',
+        borderRadius: 8,
+        background:
+          'repeating-conic-gradient(rgba(127,127,127,0.18) 0% 25%, transparent 0% 50%) 50% / 24px 24px',
+        color: 'rgba(127,127,127,0.85)',
+        fontFamily: 'system-ui, sans-serif',
+        fontSize: 18,
+        textAlign: 'center',
+        padding: 16,
+        boxSizing: 'border-box',
+        opacity: 0.9,
+        ...style,
+      }}
+      className={className}
+    >
+      <span style={{ fontSize: 28, opacity: 0.6 }}>🖼</span>
+      <span style={{ fontWeight: 600, maxWidth: '90%' }}>{hint}</span>
+      {dims && <span style={{ fontSize: 14, opacity: 0.7 }}>{dims}</span>}
+    </div>
+  );
+}

--- a/packages/core/src/app/components/ImagePlaceholder.tsx
+++ b/packages/core/src/app/components/ImagePlaceholder.tsx
@@ -109,8 +109,10 @@ function PlaceholderIcon() {
       strokeLinecap="round"
       strokeLinejoin="round"
       style={{ opacity: 0.55 }}
-      aria-hidden
+      role="img"
+      aria-label="image placeholder"
     >
+      <title>image placeholder</title>
       <rect x="4" y="6" width="24" height="20" rx="2.5" />
       <circle cx="11" cy="13" r="2" />
       <path d="M4 22l7-7 6 6 4-4 7 7" />

--- a/packages/core/src/app/components/ImagePlaceholder.tsx
+++ b/packages/core/src/app/components/ImagePlaceholder.tsx
@@ -39,8 +39,7 @@ export function ImagePlaceholder({
         background:
           'linear-gradient(135deg, rgba(120,120,130,0.06) 0%, rgba(120,120,130,0.02) 50%, rgba(120,120,130,0.06) 100%)',
         color: 'rgba(90, 90, 100, 0.7)',
-        fontFamily:
-          '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif',
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif',
         textAlign: 'center',
         padding: 24,
         boxSizing: 'border-box',
@@ -85,8 +84,7 @@ export function ImagePlaceholder({
             style={{
               fontSize: 11,
               fontVariantNumeric: 'tabular-nums',
-              fontFamily:
-                'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
+              fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
               opacity: 0.5,
               marginTop: 2,
             }}

--- a/packages/core/src/app/components/ImagePlaceholder.tsx
+++ b/packages/core/src/app/components/ImagePlaceholder.tsx
@@ -26,31 +26,96 @@ export function ImagePlaceholder({
       role="img"
       aria-label={hint}
       style={{
+        position: 'relative',
         width: width ?? '100%',
         height: height ?? '100%',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         flexDirection: 'column',
-        gap: 8,
-        border: '2px dashed currentColor',
-        borderRadius: 8,
+        gap: 14,
+        border: '1px dashed rgba(120, 120, 130, 0.35)',
+        borderRadius: 12,
         background:
-          'repeating-conic-gradient(rgba(127,127,127,0.18) 0% 25%, transparent 0% 50%) 50% / 24px 24px',
-        color: 'rgba(127,127,127,0.85)',
-        fontFamily: 'system-ui, sans-serif',
-        fontSize: 18,
+          'linear-gradient(135deg, rgba(120,120,130,0.06) 0%, rgba(120,120,130,0.02) 50%, rgba(120,120,130,0.06) 100%)',
+        color: 'rgba(90, 90, 100, 0.7)',
+        fontFamily:
+          '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif',
         textAlign: 'center',
-        padding: 16,
+        padding: 24,
         boxSizing: 'border-box',
-        opacity: 0.9,
+        overflow: 'hidden',
         ...style,
       }}
       className={className}
     >
-      <span style={{ fontSize: 28, opacity: 0.6 }}>🖼</span>
-      <span style={{ fontWeight: 600, maxWidth: '90%' }}>{hint}</span>
-      {dims && <span style={{ fontSize: 14, opacity: 0.7 }}>{dims}</span>}
+      <PlaceholderIcon />
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 6,
+          maxWidth: '85%',
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: '0.14em',
+            textTransform: 'uppercase',
+            opacity: 0.55,
+          }}
+        >
+          Image
+        </span>
+        <span
+          style={{
+            fontSize: 16,
+            fontWeight: 500,
+            lineHeight: 1.4,
+            color: 'rgba(60, 60, 70, 0.85)',
+          }}
+        >
+          {hint}
+        </span>
+        {dims && (
+          <span
+            style={{
+              fontSize: 11,
+              fontVariantNumeric: 'tabular-nums',
+              fontFamily:
+                'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
+              opacity: 0.5,
+              marginTop: 2,
+            }}
+          >
+            {dims}
+          </span>
+        )}
+      </div>
     </div>
+  );
+}
+
+function PlaceholderIcon() {
+  return (
+    <svg
+      width="32"
+      height="32"
+      viewBox="0 0 32 32"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ opacity: 0.55 }}
+      aria-hidden
+    >
+      <rect x="4" y="6" width="24" height="20" rx="2.5" />
+      <circle cx="11" cy="13" r="2" />
+      <path d="M4 22l7-7 6 6 4-4 7 7" />
+    </svg>
   );
 }

--- a/packages/core/src/app/components/inspector/InspectorPanel.tsx
+++ b/packages/core/src/app/components/inspector/InspectorPanel.tsx
@@ -51,11 +51,22 @@ type ElementSnapshot = {
   letterSpacing: number;
   text: string | null;
   imageSrc: string | null;
+  placeholder: { hint: string; width?: number; height?: number } | null;
 };
 
 export function InspectorPanel() {
-  const { active, slideId, selected, setSelected, bufferOps, pendingCount, comments, add, remove } =
-    useInspector();
+  const {
+    active,
+    slideId,
+    selected,
+    setSelected,
+    bufferOps,
+    pendingCount,
+    comments,
+    add,
+    remove,
+    applyEdit,
+  } = useInspector();
   const [snapshot, setSnapshot] = useState<ElementSnapshot | null>(null);
   const reloadCounter = useReloadCounter();
 
@@ -196,6 +207,21 @@ export function InspectorPanel() {
           <Separator />
           <Section title="Image">
             <ImageField slideId={slideId} src={pinSnapshot.imageSrc} apply={apply} />
+          </Section>
+        </>
+      )}
+
+      {pinSnapshot.placeholder && (
+        <>
+          <Separator />
+          <Section title="Image placeholder">
+            <PlaceholderField
+              slideId={slideId}
+              hint={pinSnapshot.placeholder.hint}
+              line={pinSelected.line}
+              column={pinSelected.column}
+              applyEdit={applyEdit}
+            />
           </Section>
         </>
       )}
@@ -613,6 +639,61 @@ function ImageField({
   );
 }
 
+function PlaceholderField({
+  slideId,
+  hint,
+  line,
+  column,
+  applyEdit,
+}: {
+  slideId: string;
+  hint: string;
+  line: number;
+  column: number;
+  applyEdit: (line: number, column: number, ops: EditOp[]) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  return (
+    <div className="space-y-2">
+      <p className="text-[11px] leading-relaxed text-muted-foreground">
+        Hint: <span className="font-medium text-foreground">{hint}</span>
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="w-full"
+        disabled={submitting}
+        onClick={() => setOpen(true)}
+      >
+        <ImageIcon className="size-3.5" />
+        Replace…
+      </Button>
+      {open && (
+        <AssetPickerDialog
+          slideId={slideId}
+          onClose={() => setOpen(false)}
+          onPick={async (asset) => {
+            setOpen(false);
+            setSubmitting(true);
+            try {
+              await applyEdit(line, column, [
+                {
+                  kind: 'replace-placeholder-with-image',
+                  assetPath: `./assets/${asset.name}`,
+                },
+              ]);
+            } finally {
+              setSubmitting(false);
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
 function AssetPickerDialog({
   slideId,
   onClose,
@@ -775,6 +856,15 @@ function readSnapshot(el: HTMLElement): ElementSnapshot {
     el.tagName === 'IMG'
       ? (el as HTMLImageElement).currentSrc || (el as HTMLImageElement).src || null
       : null;
+  const ph = el.dataset.slidePlaceholder ?? null;
+  const placeholder =
+    ph !== null
+      ? {
+          hint: ph,
+          width: el.dataset.placeholderW ? Number(el.dataset.placeholderW) : undefined,
+          height: el.dataset.placeholderH ? Number(el.dataset.placeholderH) : undefined,
+        }
+      : null;
 
   return {
     fontSize: parseFloat(cs.fontSize) || 16,
@@ -787,6 +877,7 @@ function readSnapshot(el: HTMLElement): ElementSnapshot {
     letterSpacing: parseLetterSpacing(cs.letterSpacing),
     text,
     imageSrc,
+    placeholder,
   };
 }
 

--- a/packages/core/src/app/lib/inspector/useEditor.ts
+++ b/packages/core/src/app/lib/inspector/useEditor.ts
@@ -3,7 +3,8 @@ import { useCallback } from 'react';
 export type EditOp =
   | { kind: 'set-style'; key: string; value: string | null }
   | { kind: 'set-text'; value: string }
-  | { kind: 'set-attr-asset'; attr: string; assetPath: string; previewUrl: string };
+  | { kind: 'set-attr-asset'; attr: string; assetPath: string; previewUrl: string }
+  | { kind: 'replace-placeholder-with-image'; assetPath: string };
 
 export type Edit = { line: number; column: number; ops: EditOp[] };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
+export type { ImagePlaceholderProps } from './app/components/ImagePlaceholder.tsx';
+export { ImagePlaceholder } from './app/components/ImagePlaceholder.tsx';
 export type { Page, SlideMeta, SlideModule } from './app/lib/sdk.ts';
 export { CANVAS_HEIGHT, CANVAS_WIDTH } from './app/lib/sdk.ts';
 export type { OpenSlideConfig } from './config.ts';

--- a/packages/core/src/vite/comments-plugin.test.ts
+++ b/packages/core/src/vite/comments-plugin.test.ts
@@ -315,3 +315,86 @@ describe('applyEdit / set-attr-asset', () => {
     expect(r.error).toMatch(/\.\/assets\//);
   });
 });
+
+describe('applyEdit / replace-placeholder-with-image', () => {
+  it('rewrites <ImagePlaceholder> to <img> and adds an import', () => {
+    const src = [
+      "import { ImagePlaceholder } from '@open-slide/core';",
+      'export default [() => (',
+      '<ImagePlaceholder hint="Product hero" width={1280} height={720} />',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 3, 0, [
+      { kind: 'replace-placeholder-with-image', assetPath: './assets/hero.png' },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("import hero from './assets/hero.png';");
+    expect(r.source).toContain(
+      "<img src={hero} alt='Product hero' style={{ width: 1280, height: 720, objectFit: 'cover' }} />",
+    );
+    expect(r.source).not.toContain('<ImagePlaceholder');
+  });
+
+  it('reuses an existing import for the same asset path', () => {
+    const src = [
+      "import { ImagePlaceholder } from '@open-slide/core';",
+      "import hero from './assets/hero.png';",
+      'export default [() => (',
+      '<ImagePlaceholder hint="Hero" width={800} height={600} />',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 4, 0, [
+      { kind: 'replace-placeholder-with-image', assetPath: './assets/hero.png' },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain('<img src={hero}');
+    const occurrences = r.source.match(/from '\.\/assets\/hero\.png'/g) ?? [];
+    expect(occurrences.length).toBe(1);
+  });
+
+  it('omits width/height when the placeholder did not specify them', () => {
+    const src = [
+      "import { ImagePlaceholder } from '@open-slide/core';",
+      'export default [() => (',
+      '<ImagePlaceholder hint="Logo" />',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 3, 0, [
+      { kind: 'replace-placeholder-with-image', assetPath: './assets/logo.svg' },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<img src={logo} alt='Logo' style={{ objectFit: 'cover' }} />");
+    expect(r.source).not.toMatch(/width:\s/);
+    expect(r.source).not.toMatch(/height:\s/);
+  });
+
+  it('rejects when the targeted JSX is not an ImagePlaceholder', () => {
+    const src = ['export default [() => (', '<div>hi</div>', ')];', ''].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      { kind: 'replace-placeholder-with-image', assetPath: './assets/a.png' },
+    ]);
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.status).toBe(422);
+    expect(r.error).toMatch(/placeholder/);
+  });
+
+  it('rejects asset paths outside ./assets/', () => {
+    const src = [
+      "import { ImagePlaceholder } from '@open-slide/core';",
+      'export default [() => (',
+      '<ImagePlaceholder hint="x" />',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 3, 0, [
+      { kind: 'replace-placeholder-with-image', assetPath: '../bad.png' },
+    ]);
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.error).toMatch(/\.\/assets\//);
+  });
+});

--- a/packages/core/src/vite/comments-plugin.ts
+++ b/packages/core/src/vite/comments-plugin.ts
@@ -199,7 +199,8 @@ function offsetToLine(source: string, offset: number): number {
 export type EditOp =
   | { kind: 'set-style'; key: string; value: string | null }
   | { kind: 'set-text'; value: string }
-  | { kind: 'set-attr-asset'; attr: string; assetPath: string };
+  | { kind: 'set-attr-asset'; attr: string; assetPath: string }
+  | { kind: 'replace-placeholder-with-image'; assetPath: string };
 
 export type ApplyEditResult =
   | { ok: true; source: string }
@@ -517,6 +518,90 @@ function planAssetAttr(
   return { importSplice, attrSplice };
 }
 
+type PlaceholderEditPlan = {
+  importSplice: Splice | null;
+  elementSplice: Splice;
+};
+
+function readJsxStringAttr(opening: AstNode, name: string): string | null {
+  const attr = findJsxAttr(opening, name);
+  if (!attr) return null;
+  const value = (attr as unknown as { value?: AstNode | null }).value ?? null;
+  if (!value) return null;
+  if (value.type === 'StringLiteral') {
+    return (value as unknown as { value: string }).value;
+  }
+  if (value.type === 'JSXExpressionContainer') {
+    const expr = (value as unknown as { expression: AstNode }).expression;
+    if (expr.type === 'StringLiteral') return (expr as unknown as { value: string }).value;
+  }
+  return null;
+}
+
+function readJsxNumberAttr(opening: AstNode, name: string): number | null {
+  const attr = findJsxAttr(opening, name);
+  if (!attr) return null;
+  const value = (attr as unknown as { value?: AstNode | null }).value ?? null;
+  if (!value || value.type !== 'JSXExpressionContainer') return null;
+  const expr = (value as unknown as { expression: AstNode }).expression;
+  if (expr.type === 'NumericLiteral') {
+    const n = (expr as unknown as { value: number }).value;
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function planReplacePlaceholder(
+  ast: AstNode,
+  element: AstNode,
+  assetPath: string,
+): PlaceholderEditPlan | { error: string } {
+  const opening = (element as unknown as { openingElement?: AstNode }).openingElement;
+  if (!opening) return { error: 'no opening element' };
+  const elName = (opening as unknown as { name?: { type?: string; name?: string } }).name;
+  if (elName?.type !== 'JSXIdentifier' || elName.name !== 'ImagePlaceholder') {
+    return { error: 'not a placeholder' };
+  }
+  if (!assetPath.startsWith('./assets/')) return { error: 'asset path must start with ./assets/' };
+
+  const hint = readJsxStringAttr(opening, 'hint') ?? '';
+  const width = readJsxNumberAttr(opening, 'width');
+  const height = readJsxNumberAttr(opening, 'height');
+
+  const imports = findImports(ast);
+  let identifier: string | null = null;
+  for (const imp of imports) {
+    if (imp.source === assetPath && imp.defaultIdent) {
+      identifier = imp.defaultIdent;
+      break;
+    }
+  }
+
+  let importSplice: Splice | null = null;
+  if (!identifier) {
+    const filename = assetPath.slice(assetPath.lastIndexOf('/') + 1);
+    const taken = collectTopLevelIdentifiers(ast);
+    identifier = safeAssetIdentifier(filename, taken);
+    const importStmt = `import ${identifier} from '${assetPath.replace(/'/g, "\\'")}';\n`;
+    const insertAt = imports.length > 0 ? imports[imports.length - 1].node.end : 0;
+    const prefix = imports.length > 0 ? '\n' : '';
+    importSplice = { from: insertAt, to: insertAt, text: prefix + importStmt };
+  }
+
+  const styleParts: string[] = [];
+  if (width != null) styleParts.push(`width: ${width}`);
+  if (height != null) styleParts.push(`height: ${height}`);
+  styleParts.push(`objectFit: 'cover'`);
+  const styleAttr = ` style={{ ${styleParts.join(', ')} }}`;
+  const altAttr = ` alt=${jsString(hint)}`;
+  const replacement = `<img src={${identifier}}${altAttr}${styleAttr} />`;
+
+  return {
+    importSplice,
+    elementSplice: { from: element.start, to: element.end, text: replacement },
+  };
+}
+
 export function applyEdit(
   source: string,
   line: number,
@@ -549,7 +634,10 @@ export function applyEdit(
   }
 
   const assetOps = ops.flatMap((op) => (op.kind === 'set-attr-asset' ? [op] : []));
-  if (assetOps.length > 0) {
+  const placeholderOps = ops.flatMap((op) =>
+    op.kind === 'replace-placeholder-with-image' ? [op] : [],
+  );
+  if (assetOps.length > 0 || placeholderOps.length > 0) {
     const ast = parseSource(source);
     if (!ast) return { ok: false, status: 422, error: 'could not parse source' };
     const importSplices: Splice[] = [];
@@ -557,6 +645,12 @@ export function applyEdit(
       const plan = planAssetAttr(ast, element, op.attr, op.assetPath);
       if ('error' in plan) return { ok: false, status: 422, error: plan.error };
       splices.push(plan.attrSplice);
+      if (plan.importSplice) importSplices.push(plan.importSplice);
+    }
+    for (const op of placeholderOps) {
+      const plan = planReplacePlaceholder(ast, element, op.assetPath);
+      if ('error' in plan) return { ok: false, status: 422, error: plan.error };
+      splices.push(plan.elementSplice);
       if (plan.importSplice) importSplices.push(plan.importSplice);
     }
     // Multiple new imports for the same edit must not overlap, but they

--- a/packages/core/src/vite/loc-tags-plugin.test.ts
+++ b/packages/core/src/vite/loc-tags-plugin.test.ts
@@ -79,4 +79,30 @@ describe('injectLocTags', () => {
     expect(out).not.toContain('<Layout data-slide-loc');
     expect(out).not.toContain('<SubBox data-slide-loc');
   });
+
+  it('tags <ImagePlaceholder> as a forwarding component', () => {
+    const src = ['export default [() => (', '  <ImagePlaceholder hint="hero" />', ')];', ''].join(
+      '\n',
+    );
+    const out = injectLocTags(src);
+    if (out === null) throw new Error('expected transform');
+    expect(out).toContain('<ImagePlaceholder data-slide-loc="2:2" hint="hero" />');
+  });
+
+  it('does not tag other PascalCase components alongside ImagePlaceholder', () => {
+    const src = [
+      'export default [() => (',
+      '  <Layout>',
+      '    <ImagePlaceholder hint="hero" />',
+      '    <CustomThing />',
+      '  </Layout>',
+      ')];',
+      '',
+    ].join('\n');
+    const out = injectLocTags(src);
+    if (out === null) throw new Error('expected transform');
+    expect(out).toContain('<ImagePlaceholder data-slide-loc="3:4"');
+    expect(out).not.toContain('<Layout data-slide-loc');
+    expect(out).not.toContain('<CustomThing data-slide-loc');
+  });
 });

--- a/packages/core/src/vite/loc-tags-plugin.ts
+++ b/packages/core/src/vite/loc-tags-plugin.ts
@@ -7,12 +7,15 @@ import { type AstNode, walkJsx } from './babel-walk.ts';
 // slide source files so the inspector can map a click straight to a
 // source location, sidestepping HMR-stale `_debugSource` on fibers.
 
-function isHostJsxName(name: unknown): name is { type: string; name: string; end: number } {
+// Capitalized components that explicitly forward `data-slide-loc` to a
+// host root, so the inspector can target them like a host element.
+const FORWARDING_COMPONENTS = new Set(['ImagePlaceholder']);
+
+function isTaggableJsxName(name: unknown): name is { type: string; name: string; end: number } {
   if (!name || typeof name !== 'object') return false;
   const n = name as { type?: string; name?: string };
-  // Only lowercase tags are host elements; capitalized ones are
-  // components that may not forward arbitrary props.
-  return n.type === 'JSXIdentifier' && typeof n.name === 'string' && /^[a-z]/.test(n.name);
+  if (n.type !== 'JSXIdentifier' || typeof n.name !== 'string') return false;
+  return /^[a-z]/.test(n.name) || FORWARDING_COMPONENTS.has(n.name);
 }
 
 function alreadyTagged(opening: AstNode): boolean {
@@ -43,7 +46,7 @@ export function injectLocTags(code: string): string | null {
     const opening = (node as unknown as { openingElement?: AstNode }).openingElement;
     if (!opening) return;
     const name = (opening as unknown as { name?: unknown }).name;
-    if (!isHostJsxName(name)) return;
+    if (!isTaggableJsxName(name)) return;
     if (alreadyTagged(opening)) return;
     const loc = node.loc;
     if (!loc) return;


### PR DESCRIPTION
Slides can drop a typed placeholder when a real user-supplied image is
required. The inspector recognizes placeholder elements and offers a
"Replace…" picker that swaps the JSX for an <img> with the import added.

- New <ImagePlaceholder> component re-exported from @open-slide/core,
  rendering a dashed/checkered box with hint and target dimensions; the
  host root carries data-slide-placeholder so the inspector can pick it
  up.
- loc-tags-plugin allowlists ImagePlaceholder so call sites get a
  data-slide-loc forwarded through to the rendered div.
- New replace-placeholder-with-image EditOp in comments-plugin: extracts
  hint/width/height from the call site, reuses or adds an asset import,
  and splices the JSX node with <img src={ident} alt='…' style={…} />.
- InspectorPanel reads the placeholder dataset into a snapshot field and
  renders a sibling section reusing the existing AssetPickerDialog.
- slide-authoring + create-slide skills get a new "Image placeholders"
  section, checklist item, and anti-patterns; bias is no placeholders by
  default.