### PR TITLE
refactor(core): refresh editor UI with editorial design language

### DIFF
--- a/packages/core/src/app/app.tsx
+++ b/packages/core/src/app/app.tsx
@@ -1,5 +1,5 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import config from 'virtual:open-slide/config';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { Toaster } from './components/ui/sonner';
 import { Home } from './routes/home';
 import { Slide } from './routes/slide';
@@ -19,10 +19,10 @@ export function App() {
 
 function NotFound() {
   return (
-    <div className="grid h-screen place-items-center bg-background px-6 text-center">
+    <div className="grid h-screen place-items-center bg-background px-6 text-center text-foreground">
       <div>
-        <p className="font-mono text-sm tracking-widest text-muted-foreground uppercase">404</p>
-        <h1 className="mt-2 text-2xl font-semibold tracking-tight">Page not found</h1>
+        <p className="folio">404 · not found</p>
+        <h1 className="mt-2 font-heading text-2xl font-semibold tracking-tight">Page not found</h1>
       </div>
     </div>
   );

--- a/packages/core/src/app/components/asset-view.tsx
+++ b/packages/core/src/app/components/asset-view.tsx
@@ -129,39 +129,44 @@ export function AssetView({ slideId }: Props) {
         }
       }}
     >
-      <div className="flex shrink-0 items-center justify-between gap-3 border-b bg-card px-6 py-3">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-hairline bg-sidebar px-6 py-3">
         <div className="min-w-0">
-          <h2 className="truncate text-base font-semibold tracking-tight">Assets</h2>
-          <p className="truncate text-xs text-muted-foreground">
-            <span className="font-mono">slides/{slideId}/assets/</span>
+          <span className="eyebrow">Assets</span>
+          <p className="mt-0.5 truncate text-[12px] text-muted-foreground">
+            <span className="font-mono text-[11.5px]">slides/{slideId}/assets/</span>
             {!loading && (
               <>
-                <span className="mx-1.5">·</span>
-                <span>{assets.length === 1 ? '1 file' : `${assets.length} files`}</span>
+                <span className="mx-2 opacity-50">·</span>
+                <span className="folio">
+                  {assets.length.toString().padStart(2, '0')}
+                  <span className="opacity-40"> </span>
+                  {assets.length === 1 ? 'file' : 'files'}
+                </span>
               </>
             )}
           </p>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
+        <div className="flex shrink-0 items-center gap-1.5">
           <button
             type="button"
             onClick={() => setLogoSearchOpen(true)}
             className={cn(
-              'inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-lg border bg-background px-3 text-sm font-medium transition-colors',
-              'hover:bg-muted active:translate-y-px',
+              'inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-[5px] border border-border bg-card px-2.5 text-[12.5px] font-medium transition-colors',
+              'hover:bg-muted/60 hover:border-foreground/20 active:translate-y-px',
             )}
           >
-            <Search className="size-4" />
+            <Search className="size-3.5" />
             <span>Search logos</span>
           </button>
           <label
             htmlFor={inputId}
             className={cn(
-              'inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground transition-opacity',
-              'hover:opacity-90 active:translate-y-px',
+              'inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-[5px] bg-foreground px-3 text-[12.5px] font-medium text-background transition-colors',
+              'shadow-[inset_0_1px_0_oklch(1_0_0/0.12),0_1px_0_oklch(0_0_0/0.12)]',
+              'hover:bg-foreground/90 active:translate-y-px',
             )}
           >
-            <Upload className="size-4" />
+            <Upload className="size-3.5" />
             <span>Upload</span>
           </label>
           <input
@@ -231,11 +236,11 @@ export function AssetView({ slideId }: Props) {
           className="pointer-events-none absolute inset-0 z-30 animate-in fade-in-0 duration-200"
           aria-hidden="true"
         >
-          <div className="absolute inset-0 bg-foreground/[0.03]" />
-          <div className="absolute inset-2 rounded-xl border border-dashed border-foreground/25" />
+          <div className="absolute inset-0 bg-brand/5" />
+          <div className="absolute inset-2 rounded-[10px] border border-dashed border-brand/40" />
           <div className="absolute inset-x-0 bottom-8 flex justify-center">
-            <div className="flex animate-in items-center gap-2 rounded-full border bg-background px-3.5 py-1.5 text-xs font-medium shadow-sm fade-in-0 slide-in-from-bottom-1 duration-300">
-              <ArrowDownToLine className="size-3.5 text-muted-foreground" />
+            <div className="flex animate-in items-center gap-2 rounded-[6px] border border-border bg-card px-3 py-1.5 text-[12px] font-medium shadow-floating fade-in-0 slide-in-from-bottom-1 duration-300">
+              <ArrowDownToLine className="size-3.5 text-brand" />
               <span>Drop to upload</span>
             </div>
           </div>
@@ -280,14 +285,15 @@ export function AssetView({ slideId }: Props) {
 
 function EmptyState() {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
-      <div className="flex size-14 items-center justify-center rounded-full bg-muted">
-        <ImageIcon className="size-6 text-muted-foreground" />
+    <div className="flex h-full flex-col items-center justify-center gap-4 px-6 py-16 text-center">
+      <div className="flex size-12 items-center justify-center rounded-full border border-hairline bg-card text-muted-foreground">
+        <ImageIcon className="size-5" />
       </div>
       <div>
-        <p className="text-sm font-medium">No assets yet</p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Drop files anywhere here or click Upload to add them.
+        <p className="font-heading text-[14px] font-semibold tracking-tight">No assets yet</p>
+        <p className="mt-1 max-w-xs text-[12.5px] leading-relaxed text-muted-foreground">
+          Drop files anywhere here, or use <span className="font-mono text-foreground">Upload</span>
+          .
         </p>
       </div>
     </div>
@@ -329,12 +335,12 @@ function AssetCard({
 }) {
   const isImage = asset.mime.startsWith('image/');
   return (
-    <div className="group relative flex flex-col overflow-hidden rounded-xl border bg-card shadow-sm transition-shadow hover:shadow-md focus-within:ring-2 focus-within:ring-ring/50">
+    <div className="group relative flex flex-col overflow-hidden rounded-[6px] border border-border bg-card shadow-edge transition-shadow hover:shadow-floating focus-within:ring-2 focus-within:ring-ring/30">
       <button
         type="button"
         onClick={onPreview}
         aria-label={`Preview ${asset.name}`}
-        className="relative flex aspect-square w-full items-center justify-center overflow-hidden bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:16px_16px]"
+        className="relative flex aspect-square w-full items-center justify-center overflow-hidden border-b border-hairline bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:14px_14px]"
       >
         {isImage ? (
           <img
@@ -347,16 +353,16 @@ function AssetCard({
             }}
           />
         ) : (
-          <FileIcon className="size-10 text-muted-foreground" />
+          <FileIcon className="size-9 text-muted-foreground" />
         )}
       </button>
 
-      <div className="flex items-center gap-1 border-t bg-card px-3 py-2">
+      <div className="flex items-center gap-1 px-2.5 py-2">
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium" title={asset.name}>
+          <div className="truncate text-[12.5px] font-medium" title={asset.name}>
             {asset.name}
           </div>
-          <div className="truncate text-[11px] text-muted-foreground">{formatSize(asset.size)}</div>
+          <div className="folio truncate">{formatSize(asset.size)}</div>
         </div>
         <DropdownMenu>
           <DropdownMenuTrigger
@@ -549,8 +555,10 @@ function PreviewDialog({ asset, onClose }: { asset: AssetEntry; onClose: () => v
             <span className="text-sm">No preview available</span>
           </div>
         )}
-        <div className="rounded-md border bg-muted/40 p-2 font-mono text-xs">
-          import asset from '<span className="font-semibold">{importPath}</span>';
+        <div className="rounded-[5px] border border-hairline bg-muted/50 px-3 py-2 font-mono text-[11.5px] leading-relaxed">
+          <span className="text-muted-foreground">import asset from </span>
+          <span className="text-brand">'{importPath}'</span>
+          <span className="text-muted-foreground">;</span>
         </div>
       </DialogContent>
     </Dialog>
@@ -621,13 +629,13 @@ function LogoSearchDialog({
         </DialogHeader>
 
         <div className="relative">
-          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
           <input
             ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search by brand…"
-            className="w-full rounded-md border bg-background py-2 pl-8 pr-3 text-sm outline-none ring-ring/40 focus:ring-2"
+            className="h-9 w-full rounded-[6px] border border-border bg-background py-2 pl-8 pr-3 text-[13px] outline-none focus-visible:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring/30"
           />
         </div>
 

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -138,14 +138,16 @@ export function InspectorPanel() {
       header={
         <>
           <div className="flex min-w-0 items-center gap-2">
-            <span className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground">
+            <span className="font-heading text-[12px] font-semibold tracking-tight">Inspect</span>
+            <span aria-hidden className="h-3 w-px bg-hairline" />
+            <span className="rounded-[3px] border border-hairline bg-card px-1.5 py-px font-mono text-[10.5px] text-foreground/85">
               &lt;{pinSelected.anchor.tagName.toLowerCase()}&gt;
             </span>
           </div>
           <Button
             variant="ghost"
-            size="icon"
-            className="size-7 text-muted-foreground hover:text-foreground"
+            size="icon-sm"
+            className="text-muted-foreground hover:text-foreground"
             onClick={() => setSelected(null)}
             aria-label="Deselect"
           >
@@ -762,9 +764,9 @@ function CommentsSection({
   };
 
   return (
-    <Section title="Comments">
+    <Section title="Note for the agent">
       <div className="flex flex-col gap-2">
-        <div className="comment-cue rounded-md">
+        <div className="comment-cue rounded-[6px]">
           <Textarea
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
@@ -775,17 +777,13 @@ function CommentsSection({
               }
             }}
             placeholder="Describe a change for the agent…"
-            className="min-h-16 resize-none text-xs"
+            className="min-h-16 resize-none text-[12px]"
           />
         </div>
-        <div className="flex items-center justify-end">
-          <Button
-            size="sm"
-            disabled={submitting || !draft.trim()}
-            onClick={submit}
-            className="h-7 px-2.5 text-[11px]"
-          >
-            Add comment
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-mono text-[10.5px] text-muted-foreground/70">⌘↵ to send</span>
+          <Button size="sm" variant="brand" disabled={submitting || !draft.trim()} onClick={submit}>
+            Add note
           </Button>
         </div>
       </div>

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -452,9 +452,15 @@ export function InspectToggleButton() {
   const { active, toggle } = useInspector();
   if (import.meta.env.PROD) return null;
   return (
-    <Button size="sm" variant={active ? 'default' : 'outline'} onClick={toggle} data-inspector-ui>
-      <Crosshair className="size-4" />
-      Inspect
+    <Button
+      size="sm"
+      variant={active ? 'default' : 'ghost'}
+      onClick={toggle}
+      data-inspector-ui
+      title="Inspect"
+    >
+      <Crosshair className="size-3.5" />
+      <span className="hidden md:inline">Inspect</span>
     </Button>
   );
 }

--- a/packages/core/src/app/components/panel/panel-fields.tsx
+++ b/packages/core/src/app/components/panel/panel-fields.tsx
@@ -2,20 +2,21 @@ import { Label } from '@/components/ui/label';
 
 export function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section className="px-4 py-4">
-      <div className="mb-3 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-        {title}
+    <section className="px-3.5 py-3.5">
+      <div className="mb-2.5 flex items-center gap-2">
+        <span className="eyebrow">{title}</span>
+        <span aria-hidden className="h-px flex-1 bg-hairline" />
       </div>
-      <div className="flex flex-col gap-3">{children}</div>
+      <div className="flex flex-col gap-2.5">{children}</div>
     </section>
   );
 }
 
 export function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div className="grid grid-cols-[80px_1fr] items-center gap-3">
+    <div className="grid grid-cols-[68px_1fr] items-center gap-3">
       <Label className="text-[11px] font-normal text-muted-foreground">{label}</Label>
-      <div className="flex min-w-0 items-center gap-2">{children}</div>
+      <div className="flex min-w-0 items-center gap-1.5">{children}</div>
     </div>
   );
 }
@@ -36,7 +37,7 @@ export function NumberField({
   suffix?: string;
 }) {
   return (
-    <div className="flex h-8 shrink-0 items-center rounded-md border bg-background pr-2 shadow-xs focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50">
+    <div className="flex h-7 shrink-0 items-center rounded-[5px] border border-border bg-background pr-1.5 transition-colors focus-within:border-foreground/40 focus-within:ring-2 focus-within:ring-ring/30">
       <input
         type="number"
         value={value}
@@ -47,9 +48,13 @@ export function NumberField({
         min={min}
         max={max}
         step={step}
-        className="h-full w-12 bg-transparent px-2 text-right text-[11px] tabular-nums outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+        className="nums h-full w-12 bg-transparent px-2 text-right font-mono text-[11px] outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
       />
-      {suffix && <span className="text-[10px] text-muted-foreground">{suffix}</span>}
+      {suffix && (
+        <span className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground/80">
+          {suffix}
+        </span>
+      )}
     </div>
   );
 }

--- a/packages/core/src/app/components/panel/panel-shell.tsx
+++ b/packages/core/src/app/components/panel/panel-shell.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
-export const PANEL_W = 340;
-export const PANEL_TRANSITION_MS = 280;
+export const PANEL_W = 320;
+export const PANEL_TRANSITION_MS = 240;
 
 // Defer the width expansion to the next frame so the browser paints once
 // at width=0 first; otherwise the transition has no starting frame.
@@ -55,22 +55,23 @@ export function PanelShell({
   return (
     <aside
       {...dataAttrs}
-      className="flex h-full shrink-0 justify-end overflow-hidden bg-card transition-[width,border-left-width] ease-out"
+      className="flex h-full shrink-0 justify-end overflow-hidden bg-sidebar transition-[width,border-left-width] ease-out"
       style={{
         width: animVisible ? PANEL_W : 0,
         borderLeftWidth: animVisible ? 1 : 0,
+        borderLeftColor: 'var(--hairline)',
         transitionDuration: `${PANEL_TRANSITION_MS}ms`,
       }}
     >
       <div style={{ width: PANEL_W }} className="flex h-full shrink-0 flex-col">
-        <header className="flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2.5">
+        <header className="flex h-9 shrink-0 items-center justify-between gap-2 border-b border-hairline px-3">
           {header}
         </header>
         {banner}
         <ScrollArea className="flex flex-1 flex-col">
           <div className="flex min-h-full flex-col">{children}</div>
         </ScrollArea>
-        {footer && <div className="shrink-0 border-t">{footer}</div>}
+        {footer && <div className="shrink-0 border-t border-hairline">{footer}</div>}
       </div>
     </aside>
   );

--- a/packages/core/src/app/components/panel/save-card.tsx
+++ b/packages/core/src/app/components/panel/save-card.tsx
@@ -16,9 +16,9 @@ type SaveCardProps = {
   canRedo?: boolean;
 };
 
-// Optimistic DOM updates make the canvas *look* saved, so without
-// this affordance a user could close the tab thinking their tweaks
-// hit disk when they're still buffered in memory.
+// Optimistic DOM updates make the canvas *look* saved, so without this
+// affordance a user could close the tab thinking their tweaks hit disk
+// when they're still buffered in memory.
 export function SaveCard({
   dirty,
   committing,
@@ -34,15 +34,12 @@ export function SaveCard({
 }: SaveCardProps) {
   const [justSaved, setJustSaved] = useState(false);
 
-  // Brief "Saved" hold so the bar's disappearance feels intentional.
   useEffect(() => {
     if (!justSaved) return;
     const t = setTimeout(() => setJustSaved(false), 1200);
     return () => clearTimeout(t);
   }, [justSaved]);
 
-  // Keep the pill mounted while history has a redo to offer, even if
-  // the user has undone all the way back to a clean state.
   const visible = dirty || committing || justSaved || canUndo || canRedo;
   if (!visible) return null;
 
@@ -58,15 +55,15 @@ export function SaveCard({
   return (
     <div
       {...dataAttrs}
-      className="pointer-events-none absolute bottom-6 left-1/2 z-30 -translate-x-1/2 animate-in fade-in slide-in-from-bottom-3 duration-300 ease-out"
+      className="pointer-events-none absolute bottom-6 left-1/2 z-30 -translate-x-1/2 animate-in fade-in slide-in-from-bottom-2 duration-200 ease-out"
     >
-      <div className="pointer-events-auto flex items-center gap-1 rounded-full border bg-card py-1 pr-1 pl-1.5 shadow-lg">
+      <div className="pointer-events-auto flex h-9 items-center gap-1 rounded-[8px] border border-border bg-popover/95 py-0.5 pr-0.5 pl-1 shadow-overlay backdrop-blur-md">
         {showHistory && (
           <div className="flex items-center">
             <Button
-              size="icon"
+              size="icon-sm"
               variant="ghost"
-              className="size-7 rounded-full text-muted-foreground hover:text-foreground"
+              className="text-muted-foreground hover:text-foreground"
               onClick={onUndo}
               disabled={committing || !canUndo}
               aria-label="Undo"
@@ -75,9 +72,9 @@ export function SaveCard({
               <Undo2 className="size-3.5" />
             </Button>
             <Button
-              size="icon"
+              size="icon-sm"
               variant="ghost"
-              className="size-7 rounded-full text-muted-foreground hover:text-foreground"
+              className="text-muted-foreground hover:text-foreground"
               onClick={onRedo}
               disabled={committing || !canRedo}
               aria-label="Redo"
@@ -85,21 +82,30 @@ export function SaveCard({
             >
               <Redo2 className="size-3.5" />
             </Button>
+            {(justSaved || dirty || committing) && (
+              <span aria-hidden className="ml-1 mr-0.5 h-4 w-px bg-hairline" />
+            )}
           </div>
         )}
         {justSaved ? (
-          <span className="flex items-center gap-1.5 px-2 text-xs font-medium text-foreground">
-            <Check className="size-3.5 text-emerald-600" />
+          <span className="flex items-center gap-1.5 px-2.5 text-[12px] font-medium text-foreground">
+            <Check className="size-3.5 text-[oklch(0.55_0.13_165)]" strokeWidth={2.5} />
             {savedLabel}
           </span>
         ) : dirty || committing ? (
-          <span className="px-2 text-xs font-medium text-foreground">{unsavedLabel}</span>
+          <span className="inline-flex items-center gap-1.5 px-2.5 text-[12px] font-medium text-foreground">
+            <span
+              aria-hidden
+              className="size-1.5 rounded-full bg-brand shadow-[0_0_0_3px_var(--brand-soft)]"
+            />
+            <span className="nums">{unsavedLabel}</span>
+          </span>
         ) : null}
         {!justSaved && dirty && (
           <Button
             size="sm"
             variant="ghost"
-            className="h-7 rounded-full px-2.5 text-[11px] text-muted-foreground hover:text-foreground"
+            className="text-muted-foreground hover:text-foreground"
             onClick={onDiscard}
             disabled={committing || !dirty}
           >
@@ -109,7 +115,8 @@ export function SaveCard({
         {(dirty || committing) && (
           <Button
             size="sm"
-            className="h-7 rounded-full px-3 text-[11px]"
+            variant="brand"
+            className="h-7 px-3"
             onClick={handleSave}
             disabled={committing || !dirty}
           >

--- a/packages/core/src/app/components/pdf-progress-toast.tsx
+++ b/packages/core/src/app/components/pdf-progress-toast.tsx
@@ -5,18 +5,20 @@ import { Progress } from './ui/progress';
 export function PdfProgressToast({ progress }: { progress: PdfExportProgress }) {
   const text =
     progress.phase === 'processing'
-      ? `Processing slide ${progress.current} / ${progress.total}`
+      ? `Processing page ${progress.current.toString().padStart(2, '0')} of ${progress.total.toString().padStart(2, '0')}`
       : progress.phase === 'printing'
         ? 'Opening print dialog…'
         : 'Done';
 
   return (
-    <div className="flex w-80 items-start gap-3 rounded-md border bg-popover px-4 py-3 text-popover-foreground shadow-lg">
-      <Loader2 className="mt-0.5 size-4 shrink-0 animate-spin text-primary" />
+    <div className="flex w-80 items-start gap-3 rounded-[8px] border border-border bg-popover px-3.5 py-3 text-popover-foreground shadow-floating">
+      <Loader2 className="mt-0.5 size-3.5 shrink-0 animate-spin text-brand" />
       <div className="min-w-0 flex-1">
-        <p className="text-sm font-medium">Exporting PDF</p>
-        <p className="truncate text-xs text-muted-foreground">{text}</p>
-        <Progress value={Math.round(progress.percent)} className="mt-2 h-1.5" />
+        <p className="font-heading text-[12.5px] font-semibold tracking-tight">Exporting PDF</p>
+        <p className="truncate font-mono text-[10.5px] tracking-[0.04em] text-muted-foreground">
+          {text}
+        </p>
+        <Progress value={Math.round(progress.percent)} className="mt-2 h-[3px]" />
       </div>
     </div>
   );

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -80,7 +80,7 @@ export function Player({ pages, design, index, onIndexChange, onExit, allowExit 
   return (
     <div
       ref={rootRef}
-      className="relative flex h-screen w-screen items-center justify-center bg-black"
+      className="relative flex h-dvh w-screen items-center justify-center bg-black"
     >
       <SlideCanvas flat design={design}>
         {PageComp ? <PageComp /> : null}

--- a/packages/core/src/app/components/sidebar/folder-item.tsx
+++ b/packages/core/src/app/components/sidebar/folder-item.tsx
@@ -1,14 +1,14 @@
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import type { Folder, FolderIcon } from '@/lib/sdk';
-import { cn } from '@/lib/utils';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import type { Folder, FolderIcon } from '@/lib/sdk';
+import { cn } from '@/lib/utils';
 import { IconPicker } from './icon-picker';
 
 export const SLIDE_DND_MIME = 'application/x-slide-id';
@@ -18,7 +18,7 @@ export function FolderIconChip({ icon, className }: { icon: FolderIcon; classNam
     return (
       <span
         className={cn(
-          'inline-flex size-5 items-center justify-center text-base leading-none',
+          'inline-flex size-5 items-center justify-center text-[15px] leading-none',
           className,
         )}
       >
@@ -28,7 +28,10 @@ export function FolderIconChip({ icon, className }: { icon: FolderIcon; classNam
   }
   return (
     <span
-      className={cn('inline-block size-4 rounded-[4px] ring-1 ring-black/10', className)}
+      className={cn(
+        'inline-block size-3 rounded-[3px] ring-1 ring-foreground/15 shadow-[inset_0_1px_0_oklch(1_0_0/0.18)]',
+        className,
+      )}
       style={{ background: icon.value }}
     />
   );
@@ -94,9 +97,13 @@ export function FolderItem({
     // biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop target wraps interactive children
     <div
       className={cn(
-        'group relative flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
-        selected ? 'bg-muted text-foreground' : 'text-foreground/80 hover:bg-muted/60',
-        dragOver && 'ring-2 ring-primary ring-offset-1 ring-offset-background',
+        'group relative flex items-center gap-2.5 rounded-[5px] px-2 py-[5px] text-[12.5px] transition-colors',
+        // Editorial selected state: subtle warm tint + a thin vermillion
+        // ink-mark on the leading edge. Avoids the heavy "filled pill" look.
+        selected
+          ? 'bg-muted text-foreground before:absolute before:inset-y-1.5 before:-left-0.5 before:w-[2px] before:rounded-full before:bg-brand'
+          : 'text-foreground/70 hover:bg-muted/60 hover:text-foreground',
+        dragOver && 'ring-1 ring-brand ring-offset-1 ring-offset-sidebar',
       )}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
@@ -137,7 +144,7 @@ export function FolderItem({
             }
           }}
           maxLength={40}
-          className="min-w-0 flex-1 rounded-sm bg-background px-1 text-sm outline-none ring-1 ring-ring/40"
+          className="min-w-0 flex-1 rounded-[3px] bg-card px-1 text-[12.5px] outline-none ring-1 ring-foreground/20"
         />
       ) : (
         <button type="button" onClick={onSelect} className="min-w-0 flex-1 truncate text-left">
@@ -145,13 +152,8 @@ export function FolderItem({
         </button>
       )}
 
-      <span
-        className={cn(
-          'shrink-0 text-xs tabular-nums text-muted-foreground',
-          count === 0 && 'opacity-0 group-hover:opacity-100',
-        )}
-      >
-        {count}
+      <span className={cn('folio shrink-0', count === 0 && 'opacity-0 group-hover:opacity-100')}>
+        {count.toString().padStart(2, '0')}
       </span>
 
       {row.kind === 'folder' && import.meta.env.DEV && (
@@ -160,7 +162,7 @@ export function FolderItem({
             <button
               type="button"
               onClick={(e) => e.stopPropagation()}
-              className="size-5 shrink-0 rounded opacity-0 transition-opacity hover:bg-muted-foreground/10 group-hover:opacity-100 aria-expanded:opacity-100"
+              className="size-5 shrink-0 rounded opacity-0 transition-opacity hover:bg-foreground/10 group-hover:opacity-100 aria-expanded:opacity-100"
               aria-label="Folder actions"
             >
               <MoreHorizontal className="mx-auto size-3.5" />

--- a/packages/core/src/app/components/sidebar/icon-picker.tsx
+++ b/packages/core/src/app/components/sidebar/icon-picker.tsx
@@ -1,16 +1,19 @@
 import EmojiPicker, { EmojiStyle, Theme } from 'emoji-picker-react';
-import type { FolderIcon } from '@/lib/sdk';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import type { FolderIcon } from '@/lib/sdk';
 
+// Editorial palette — restrained warm/earth tones, no shadcn defaults
+// (no #8b5cf6 violet, no #3b82f6 blue, etc.). Picked to coexist with the
+// vermillion brand accent without shouting over it.
 export const PRESET_COLORS = [
-  '#8b5cf6',
-  '#6366f1',
-  '#3b82f6',
-  '#10b981',
-  '#f59e0b',
-  '#ef4444',
-  '#ec4899',
-  '#64748b',
+  '#c0392b', // vermillion
+  '#b8743e', // ochre
+  '#6f7a3a', // olive
+  '#2f6a4f', // forest
+  '#3a5a7c', // ink blue
+  '#6b4675', // plum
+  '#a3543b', // terracotta
+  '#3a3a3a', // graphite
 ];
 
 export function IconPicker({
@@ -47,7 +50,7 @@ export function IconPicker({
               key={c}
               type="button"
               onClick={() => onChange({ type: 'color', value: c })}
-              className="size-6 rounded-md ring-1 ring-black/10 transition-transform hover:scale-110"
+              className="size-6 rounded-[4px] ring-1 ring-foreground/10 shadow-[inset_0_1px_0_oklch(1_0_0/0.18)] transition-transform hover:scale-110"
               style={{ background: c }}
               aria-label={c}
             />

--- a/packages/core/src/app/components/sidebar/sidebar.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar.tsx
@@ -47,8 +47,8 @@ export function Sidebar({
   };
 
   return (
-    <aside className="flex h-full w-[17rem] shrink-0 flex-col border-r bg-card/40">
-      <div className="flex items-center justify-between px-5 pt-6 pb-3">
+    <aside className="paper relative flex h-full w-[16.5rem] shrink-0 flex-col border-r border-hairline bg-sidebar text-sidebar-foreground">
+      <div className="flex items-center justify-between px-4 pt-5 pb-4">
         <h1 className="font-heading text-lg font-bold tracking-tight">open-slide</h1>
         <ThemeToggle />
       </div>
@@ -63,8 +63,10 @@ export function Sidebar({
         />
       </div>
 
-      <div className="mt-4 px-4 pb-1 text-xs font-medium tracking-wide text-muted-foreground/70">
-        FOLDERS
+      <div className="mt-5 flex items-center gap-2 px-4 pb-1.5">
+        <span className="eyebrow">Folders</span>
+        <span className="h-px flex-1 bg-hairline" aria-hidden />
+        <span className="folio">{folders.length.toString().padStart(2, '0')}</span>
       </div>
 
       <div className="flex-1 overflow-y-auto px-2 pb-2">
@@ -87,7 +89,8 @@ export function Sidebar({
 
         {import.meta.env.DEV &&
           (creating ? (
-            <div className="mt-1 flex items-center gap-2 rounded-md border border-dashed bg-background px-2 py-1.5">
+            <div className="mt-1 flex items-center gap-2 rounded-[5px] border border-dashed border-foreground/30 bg-card px-2 py-1.5">
+              <span className="size-2 shrink-0 rounded-[2px] bg-brand" aria-hidden />
               <input
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
@@ -101,17 +104,17 @@ export function Sidebar({
                 }}
                 placeholder="Folder name"
                 maxLength={40}
-                className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+                className="min-w-0 flex-1 bg-transparent text-[12.5px] outline-none placeholder:text-muted-foreground/60"
               />
             </div>
           ) : (
             <button
               type="button"
               onClick={() => setCreating(true)}
-              className="mt-1 flex w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-border/70 px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/40 hover:text-foreground"
+              className="mt-1 flex w-full items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12px] text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
             >
               <Plus className="size-3.5" />
-              Add folder
+              <span>New folder</span>
             </button>
           ))}
       </div>

--- a/packages/core/src/app/components/slide-canvas.tsx
+++ b/packages/core/src/app/components/slide-canvas.tsx
@@ -54,7 +54,9 @@ export function SlideCanvas({
       <div
         className={cn(
           'overflow-hidden bg-white text-black',
-          !flat && 'rounded-md shadow-xl ring-1 ring-black/5',
+          // Inset shadow keeps the 1px edge inside the canvas box so it
+          // can't be clipped by the parent's overflow-hidden.
+          !flat && 'rounded-[6px] shadow-[inset_0_0_0_1px_oklch(0_0_0/0.08)]',
         )}
         style={{
           width: scaledW,

--- a/packages/core/src/app/components/style-panel/style-panel.tsx
+++ b/packages/core/src/app/components/style-panel/style-panel.tsx
@@ -42,18 +42,22 @@ export function DesignPanel({ open, onClose }: DesignPanelProps) {
         <>
           <div className="flex min-w-0 items-center gap-2">
             <Palette className="size-3.5 text-muted-foreground" />
-            <span className="text-xs font-semibold tracking-tight">Design</span>
+            <span className="font-heading text-[12px] font-semibold tracking-tight">
+              Design tokens
+            </span>
             {!exists && (
-              <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                not added
+              <span className="rounded-[3px] border border-hairline bg-muted/60 px-1.5 py-px font-mono text-[9.5px] uppercase tracking-[0.08em] text-muted-foreground">
+                draft
               </span>
             )}
-            {dirty && <span className="size-1.5 rounded-full bg-amber-500" aria-hidden />}
+            {dirty && (
+              <span className="size-1.5 rounded-full bg-brand" title="Unsaved" aria-hidden />
+            )}
           </div>
           <Button
             variant="ghost"
-            size="icon"
-            className="size-7 text-muted-foreground hover:text-foreground"
+            size="icon-sm"
+            className="text-muted-foreground hover:text-foreground"
             onClick={onClose}
             aria-label="Close design panel"
           >
@@ -63,8 +67,9 @@ export function DesignPanel({ open, onClose }: DesignPanelProps) {
       }
       banner={
         warning && (
-          <div className="border-b bg-amber-50 px-3 py-2 text-[11px] text-amber-900 dark:bg-amber-950 dark:text-amber-200">
-            {warning}
+          <div className="flex gap-2 border-b border-hairline bg-[oklch(0.97_0.04_85)] px-3 py-2 text-[11px] leading-relaxed text-[oklch(0.35_0.08_45)] dark:bg-[oklch(0.25_0.04_60)] dark:text-[oklch(0.85_0.08_85)]">
+            <span aria-hidden className="mt-0.5 size-1.5 shrink-0 rounded-full bg-brand" />
+            <span>{warning}</span>
           </div>
         )
       }
@@ -178,9 +183,15 @@ export function DesignToggleButton({
 }) {
   if (import.meta.env.PROD) return null;
   return (
-    <Button size="sm" variant={active ? 'default' : 'outline'} onClick={onToggle} data-design-ui>
-      <Palette className="size-4" />
-      Design
+    <Button
+      size="sm"
+      variant={active ? 'default' : 'ghost'}
+      onClick={onToggle}
+      data-design-ui
+      title="Design tokens"
+    >
+      <Palette className="size-3.5" />
+      <span className="hidden md:inline">Design</span>
     </Button>
   );
 }

--- a/packages/core/src/app/components/theme-toggle.tsx
+++ b/packages/core/src/app/components/theme-toggle.tsx
@@ -24,10 +24,10 @@ export function ThemeToggle() {
         type="button"
         aria-label="Toggle theme"
         title="Theme"
-        className={cn(buttonVariants({ variant: 'outline', size: 'icon-sm' }), 'relative')}
+        className={cn(buttonVariants({ variant: 'ghost', size: 'icon-sm' }), 'relative')}
       >
-        <Sun className="size-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-        <Moon className="absolute size-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+        <Sun className="size-3.5 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+        <Moon className="absolute size-3.5 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-[140px]">
         <DropdownMenuItem

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -13,7 +13,7 @@ type Props = {
   onSelect: (index: number) => void;
 };
 
-const THUMB_WIDTH = 200;
+const THUMB_WIDTH = 184;
 const THUMB_SCALE = THUMB_WIDTH / CANVAS_WIDTH;
 const THUMB_HEIGHT = CANVAS_HEIGHT * THUMB_SCALE;
 
@@ -26,8 +26,12 @@ export function ThumbnailRail({ pages, design, current, onSelect }: Props) {
   }, [current]);
 
   return (
-    <ScrollArea className="h-full border-r bg-card">
-      <aside className="flex flex-col gap-2.5 p-3">
+    <ScrollArea className="h-full border-r border-hairline bg-sidebar">
+      <aside className="flex flex-col gap-2 px-3 py-3">
+        <div className="flex items-baseline justify-between px-1 pb-1">
+          <span className="eyebrow">Pages</span>
+          <span className="folio">{pages.length.toString().padStart(2, '0')}</span>
+        </div>
         {pages.map((PageComp, i) => {
           const active = i === current;
           return (
@@ -40,26 +44,37 @@ export function ThumbnailRail({ pages, design, current, onSelect }: Props) {
               aria-label={`Go to page ${i + 1}`}
               aria-current={active ? 'true' : undefined}
               className={cn(
-                'flex items-center gap-2.5 rounded-lg border-2 border-transparent p-1.5 text-left transition-colors',
-                'hover:bg-muted',
-                active && 'border-primary bg-primary/5',
+                'group/thumb flex items-start gap-2.5 rounded-[6px] p-1.5 text-left transition-colors',
+                'hover:bg-muted/60',
+                active && 'bg-muted',
               )}
             >
               <span
                 className={cn(
-                  'w-5 shrink-0 text-right text-xs tabular-nums text-muted-foreground',
-                  active && 'font-semibold text-primary',
+                  'mt-1.5 w-7 shrink-0 text-right font-mono text-[10px] font-medium tracking-[0.06em] tabular-nums uppercase',
+                  active ? 'text-brand' : 'text-muted-foreground/70',
                 )}
               >
-                {i + 1}
+                {(i + 1).toString().padStart(2, '0')}
               </span>
               <div
-                className="relative shrink-0 overflow-hidden rounded border shadow-sm"
+                className={cn(
+                  'relative shrink-0 overflow-hidden rounded-[4px] border bg-card transition-all',
+                  active
+                    ? 'border-brand shadow-[0_0_0_1px_var(--brand)]'
+                    : 'border-hairline group-hover/thumb:border-foreground/25',
+                )}
                 style={{ width: THUMB_WIDTH, height: THUMB_HEIGHT }}
               >
                 <SlideCanvas scale={THUMB_SCALE} center={false} flat design={design}>
                   <PageComp />
                 </SlideCanvas>
+                {active && (
+                  <span
+                    aria-hidden
+                    className="pointer-events-none absolute inset-y-0 left-0 w-[2px] bg-brand"
+                  />
+                )}
               </div>
             </button>
           );

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -6,25 +6,89 @@ import type { Page } from '../lib/sdk';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
 import { SlideCanvas } from './slide-canvas';
 
+type Orientation = 'vertical' | 'horizontal';
+
 type Props = {
   pages: Page[];
   design?: DesignSystem;
   current: number;
   onSelect: (index: number) => void;
+  orientation?: Orientation;
 };
 
-const THUMB_WIDTH = 184;
-const THUMB_SCALE = THUMB_WIDTH / CANVAS_WIDTH;
-const THUMB_HEIGHT = CANVAS_HEIGHT * THUMB_SCALE;
+const VERTICAL_THUMB_WIDTH = 184;
+const HORIZONTAL_THUMB_HEIGHT = 64;
 
-export function ThumbnailRail({ pages, design, current, onSelect }: Props) {
+export function ThumbnailRail({
+  pages,
+  design,
+  current,
+  onSelect,
+  orientation = 'vertical',
+}: Props) {
   const activeRef = useRef<HTMLButtonElement | null>(null);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: `current` triggers re-scroll on selection change
   useEffect(() => {
-    activeRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    activeRef.current?.scrollIntoView({
+      block: 'nearest',
+      inline: 'nearest',
+      behavior: 'smooth',
+    });
   }, [current]);
 
+  if (orientation === 'horizontal') {
+    const scale = HORIZONTAL_THUMB_HEIGHT / CANVAS_HEIGHT;
+    const width = CANVAS_WIDTH * scale;
+    return (
+      <div className="bg-sidebar">
+        <div className="overflow-x-auto overflow-y-hidden">
+          <div className="flex items-center gap-2 px-3 py-2.5">
+            {pages.map((PageComp, i) => {
+              const active = i === current;
+              return (
+                <button
+                  // biome-ignore lint/suspicious/noArrayIndexKey: pages list is render-stable
+                  key={i}
+                  type="button"
+                  ref={active ? activeRef : undefined}
+                  onClick={() => onSelect(i)}
+                  aria-label={`Go to page ${i + 1}`}
+                  aria-current={active ? 'true' : undefined}
+                  className={cn('group/thumb relative flex shrink-0 flex-col items-center gap-1.5')}
+                >
+                  <span
+                    className={cn(
+                      'font-mono text-[9.5px] font-medium tracking-[0.06em] tabular-nums uppercase',
+                      active ? 'text-brand' : 'text-muted-foreground/70',
+                    )}
+                  >
+                    {(i + 1).toString().padStart(2, '0')}
+                  </span>
+                  <div
+                    className={cn(
+                      'relative shrink-0 overflow-hidden rounded-[4px] border bg-card transition-all',
+                      active
+                        ? 'border-brand shadow-[0_0_0_1px_var(--brand)]'
+                        : 'border-hairline group-hover/thumb:border-foreground/25',
+                    )}
+                    style={{ width, height: HORIZONTAL_THUMB_HEIGHT }}
+                  >
+                    <SlideCanvas scale={scale} center={false} flat design={design}>
+                      <PageComp />
+                    </SlideCanvas>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const scale = VERTICAL_THUMB_WIDTH / CANVAS_WIDTH;
+  const height = CANVAS_HEIGHT * scale;
   return (
     <ScrollArea className="h-full border-r border-hairline bg-sidebar">
       <aside className="flex flex-col gap-2 px-3 py-3">
@@ -64,9 +128,9 @@ export function ThumbnailRail({ pages, design, current, onSelect }: Props) {
                     ? 'border-brand shadow-[0_0_0_1px_var(--brand)]'
                     : 'border-hairline group-hover/thumb:border-foreground/25',
                 )}
-                style={{ width: THUMB_WIDTH, height: THUMB_HEIGHT }}
+                style={{ width: VERTICAL_THUMB_WIDTH, height }}
               >
-                <SlideCanvas scale={THUMB_SCALE} center={false} flat design={design}>
+                <SlideCanvas scale={scale} center={false} flat design={design}>
                   <PageComp />
                 </SlideCanvas>
                 {active && (

--- a/packages/core/src/app/components/ui/button.tsx
+++ b/packages/core/src/app/components/ui/button.tsx
@@ -4,33 +4,65 @@ import { Slot } from 'radix-ui';
 
 import { cn } from '@/lib/utils';
 
+/*
+ * Editorial button. Tight square-ish radius, hairline borders instead of
+ * shadcn's default ring/shadow stack. The default variant is the strongest
+ * affordance — solid ink with subtle inner highlight on hover so the press
+ * feels physical without glow.
+ */
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  [
+    "group/button relative inline-flex shrink-0 items-center justify-center",
+    "rounded-[6px] text-[13px] font-medium whitespace-nowrap select-none",
+    "outline-none transition-[background-color,color,border-color,box-shadow,transform] duration-100",
+    "focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+    "active:not-aria-[haspopup]:translate-y-px",
+    "disabled:pointer-events-none disabled:opacity-45",
+    "aria-invalid:border-destructive aria-invalid:ring-destructive/30",
+    "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+  ].join(' '),
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground [a]:hover:bg-primary/80',
-        outline:
-          'border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+        default: [
+          'bg-foreground text-background',
+          'shadow-[inset_0_1px_0_oklch(1_0_0/0.12),0_1px_0_oklch(0_0_0/0.12)]',
+          'hover:bg-foreground/90',
+          'aria-expanded:bg-foreground/85',
+        ].join(' '),
+        brand: [
+          'bg-brand text-brand-foreground',
+          'shadow-[inset_0_1px_0_oklch(1_0_0/0.18),0_1px_0_oklch(0_0_0/0.16)]',
+          'hover:brightness-105 active:brightness-95',
+        ].join(' '),
+        outline: [
+          'border border-border bg-card text-foreground',
+          'hover:bg-muted/60 hover:border-foreground/20',
+          'aria-expanded:bg-muted aria-expanded:border-foreground/25',
+          'data-[state=on]:bg-foreground data-[state=on]:text-background data-[state=on]:border-foreground',
+        ].join(' '),
         secondary:
-          'bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
-        ghost:
-          'hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50',
-        destructive:
-          'bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40',
-        link: 'text-primary underline-offset-4 hover:underline',
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary/90',
+        ghost: [
+          'text-foreground/75 hover:text-foreground hover:bg-muted',
+          'aria-expanded:bg-muted aria-expanded:text-foreground',
+        ].join(' '),
+        destructive: [
+          'bg-destructive text-white',
+          'shadow-[inset_0_1px_0_oklch(1_0_0/0.16),0_1px_0_oklch(0_0_0/0.12)]',
+          'hover:brightness-105 active:brightness-95',
+          'focus-visible:ring-destructive/35',
+        ].join(' '),
+        link: 'text-foreground underline decoration-foreground/30 decoration-1 underline-offset-[3px] hover:decoration-foreground/70 [&_svg]:hidden',
       },
       size: {
-        default:
-          'h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: 'h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        default: 'h-8 gap-1.5 px-3',
+        xs: 'h-6 gap-1 rounded-[5px] px-2 text-[11.5px]',
+        sm: 'h-7 gap-1.5 rounded-[5px] px-2.5 text-[12px]',
+        lg: 'h-9 gap-1.5 px-3.5 text-[13.5px]',
         icon: 'size-8',
-        'icon-xs':
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        'icon-sm':
-          'size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg',
+        'icon-xs': 'size-6 rounded-[5px]',
+        'icon-sm': 'size-7 rounded-[5px]',
         'icon-lg': 'size-9',
       },
     },

--- a/packages/core/src/app/components/ui/card.tsx
+++ b/packages/core/src/app/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        'group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl',
+        'group/card flex flex-col gap-4 overflow-hidden rounded-[10px] bg-card py-4 text-sm text-card-foreground border border-border has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-[10px] *:[img:last-child]:rounded-b-[10px]',
         className,
       )}
       {...props}

--- a/packages/core/src/app/components/ui/dialog.tsx
+++ b/packages/core/src/app/components/ui/dialog.tsx
@@ -28,7 +28,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        'fixed inset-0 z-50 bg-foreground/35 backdrop-blur-[2px] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
         className,
       )}
       {...props}
@@ -50,7 +50,14 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          // Crisp paper card with hairline edge + soft drop. No oversized
+          // shadcn-glow ring; sits cleanly on the dimmed canvas.
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-5',
+          'rounded-[10px] border border-border bg-card p-6 text-card-foreground',
+          'shadow-overlay outline-none',
+          'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+          'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'duration-200 sm:max-w-md',
           className,
         )}
         {...props}
@@ -59,9 +66,10 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            aria-label="Close"
+            className="absolute top-3.5 right-3.5 inline-flex size-7 items-center justify-center rounded-[5px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
           >
-            <XIcon />
+            <XIcon className="size-3.5" />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}
@@ -74,7 +82,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      className={cn('flex flex-col gap-1.5 text-left', className)}
       {...props}
     />
   );
@@ -91,7 +99,10 @@ function DialogFooter({
   return (
     <div
       data-slot="dialog-footer"
-      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      className={cn(
+        'flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end sm:gap-1.5',
+        className,
+      )}
       {...props}
     >
       {children}
@@ -108,7 +119,10 @@ function DialogTitle({ className, ...props }: React.ComponentProps<typeof Dialog
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('text-lg leading-none font-semibold', className)}
+      className={cn(
+        'font-heading text-[15px] font-semibold leading-tight tracking-tight text-foreground',
+        className,
+      )}
       {...props}
     />
   );
@@ -121,7 +135,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn('text-sm text-muted-foreground', className)}
+      className={cn('text-[13px] leading-relaxed text-muted-foreground', className)}
       {...props}
     />
   );

--- a/packages/core/src/app/components/ui/dropdown-menu.tsx
+++ b/packages/core/src/app/components/ui/dropdown-menu.tsx
@@ -24,7 +24,7 @@ function DropdownMenuTrigger({
 
 function DropdownMenuContent({
   className,
-  sideOffset = 4,
+  sideOffset = 6,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
   return (
@@ -33,7 +33,11 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          'z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[9rem] origin-(--radix-dropdown-menu-content-transform-origin)',
+          'overflow-x-hidden overflow-y-auto rounded-[8px] border border-border bg-popover p-1 text-popover-foreground shadow-floating',
+          'data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1',
+          'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+          'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           className,
         )}
         {...props}
@@ -61,7 +65,12 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        'relative flex cursor-default items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12.5px] outline-hidden select-none transition-colors',
+        'focus:bg-foreground focus:text-background',
+        'data-[active=true]:bg-muted data-[active=true]:text-foreground',
+        'data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[inset]:pl-8',
+        'data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive data-[variant=destructive]:focus:text-white',
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 [&_svg:not([class*='text-'])]:text-current [&_svg]:opacity-80",
         className,
       )}
       {...props}
@@ -79,7 +88,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        'relative flex cursor-default items-center gap-2 rounded-[5px] py-1.5 pr-2 pl-8 text-[12.5px] outline-hidden select-none focus:bg-foreground focus:text-background data-[disabled]:pointer-events-none data-[disabled]:opacity-45',
         className,
       )}
       checked={checked}
@@ -87,7 +96,7 @@ function DropdownMenuCheckboxItem({
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <CheckIcon className="size-3.5" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -110,7 +119,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        'relative flex cursor-default items-center gap-2 rounded-[5px] py-1.5 pr-2 pl-8 text-[12.5px] outline-hidden select-none focus:bg-foreground focus:text-background data-[disabled]:pointer-events-none data-[disabled]:opacity-45',
         className,
       )}
       {...props}
@@ -136,7 +145,10 @@ function DropdownMenuLabel({
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
       data-inset={inset}
-      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      className={cn(
+        'eyebrow px-2 py-1.5 data-[inset]:pl-8',
+        className,
+      )}
       {...props}
     />
   );
@@ -149,7 +161,7 @@ function DropdownMenuSeparator({
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn('-mx-1 my-1 h-px bg-border', className)}
+      className={cn('-mx-1 my-1 h-px bg-hairline', className)}
       {...props}
     />
   );
@@ -159,7 +171,10 @@ function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'spa
   return (
     <span
       data-slot="dropdown-menu-shortcut"
-      className={cn('ml-auto text-xs tracking-widest text-muted-foreground', className)}
+      className={cn(
+        'ml-auto font-mono text-[10.5px] tracking-[0.06em] text-muted-foreground/80',
+        className,
+      )}
       {...props}
     />
   );
@@ -182,13 +197,13 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        'flex cursor-default items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12.5px] outline-hidden select-none focus:bg-foreground focus:text-background data-[inset]:pl-8 data-[state=open]:bg-muted',
         className,
       )}
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto size-4" />
+      <ChevronRightIcon className="ml-auto size-3.5 opacity-60" />
     </DropdownMenuPrimitive.SubTrigger>
   );
 }
@@ -201,7 +216,9 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        'z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+        'z-50 min-w-[9rem] overflow-hidden rounded-[8px] border border-border bg-popover p-1 text-popover-foreground shadow-floating',
+        'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+        'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
         className,
       )}
       {...props}

--- a/packages/core/src/app/components/ui/input.tsx
+++ b/packages/core/src/app/components/ui/input.tsx
@@ -1,21 +1,25 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
-        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
-        className
+        'h-8 w-full min-w-0 rounded-[5px] border border-border bg-background px-2.5 text-[13px] outline-none',
+        'transition-colors selection:bg-brand-soft selection:text-foreground',
+        'placeholder:text-muted-foreground/70',
+        'focus-visible:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring/30',
+        'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+        'aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/25',
+        'file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/packages/core/src/app/components/ui/popover.tsx
+++ b/packages/core/src/app/components/ui/popover.tsx
@@ -14,7 +14,7 @@ function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimiti
 function PopoverContent({
   className,
   align = 'center',
-  sideOffset = 4,
+  sideOffset = 6,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
   return (
@@ -24,7 +24,10 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-[8px] border border-border bg-popover p-3 text-popover-foreground shadow-floating outline-hidden',
+          'data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1',
+          'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+          'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           className,
         )}
         {...props}

--- a/packages/core/src/app/components/ui/progress.tsx
+++ b/packages/core/src/app/components/ui/progress.tsx
@@ -14,14 +14,14 @@ function Progress({
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn(
-        "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+        "relative h-[3px] w-full overflow-hidden rounded-full bg-muted",
         className
       )}
       {...props}
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="h-full w-full flex-1 bg-primary transition-all"
+        className="h-full w-full flex-1 bg-brand transition-all"
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/packages/core/src/app/components/ui/select.tsx
+++ b/packages/core/src/app/components/ui/select.tsx
@@ -37,14 +37,20 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "flex w-fit items-center justify-between gap-2 rounded-[5px] border border-border bg-background px-2.5 text-[13px] whitespace-nowrap outline-none transition-colors",
+        "hover:border-foreground/25 focus-visible:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring/30",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/25",
+        "data-[placeholder]:text-muted-foreground/70 data-[size=default]:h-8 data-[size=sm]:h-7",
+        "*:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       {...props}
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="size-4 opacity-50" />
+        <ChevronDownIcon className="size-3.5 opacity-50" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   )
@@ -62,7 +68,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[9rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[8px] border border-border bg-popover text-popover-foreground shadow-floating data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className
@@ -109,7 +115,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "relative flex w-full cursor-default items-center gap-2 rounded-[5px] py-1.5 pr-8 pl-2 text-[12.5px] outline-hidden select-none focus:bg-foreground focus:text-background data-[disabled]:pointer-events-none data-[disabled]:opacity-45 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 [&_svg:not([class*='text-'])]:text-current *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}
@@ -119,7 +125,7 @@ function SelectItem({
         className="absolute right-2 flex size-3.5 items-center justify-center"
       >
         <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <CheckIcon className="size-3.5" />
         </SelectPrimitive.ItemIndicator>
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>

--- a/packages/core/src/app/components/ui/separator.tsx
+++ b/packages/core/src/app/components/ui/separator.tsx
@@ -17,7 +17,7 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        'shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch',
+        'shrink-0 bg-hairline data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch',
         className,
       )}
       {...props}

--- a/packages/core/src/app/components/ui/slider.tsx
+++ b/packages/core/src/app/components/ui/slider.tsx
@@ -29,7 +29,7 @@ function Slider({
       min={min}
       max={max}
       className={cn(
-        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        "group/slider relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
         className
       )}
       {...props}
@@ -37,13 +37,13 @@ function Slider({
       <SliderPrimitive.Track
         data-slot="slider-track"
         className={cn(
-          "relative grow overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+          "relative grow overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-[3px] data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-[3px]"
         )}
       >
         <SliderPrimitive.Range
           data-slot="slider-range"
           className={cn(
-            "absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+            "absolute bg-foreground data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
           )}
         />
       </SliderPrimitive.Track>
@@ -51,7 +51,7 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm ring-ring/50 transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className="block size-3.5 shrink-0 rounded-full border border-foreground bg-card shadow-edge transition-transform hover:scale-110 focus-visible:scale-110 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring/50 disabled:pointer-events-none disabled:opacity-50"
         />
       ))}
     </SliderPrimitive.Root>

--- a/packages/core/src/app/components/ui/sonner.tsx
+++ b/packages/core/src/app/components/ui/sonner.tsx
@@ -27,9 +27,19 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--normal-bg": "var(--popover)",
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",
-          "--border-radius": "var(--radius)",
+          "--border-radius": "8px",
+          "--font-family":
+            "Geist Variable, -apple-system, BlinkMacSystemFont, sans-serif",
         } as React.CSSProperties
       }
+      toastOptions={{
+        classNames: {
+          toast:
+            "!font-sans !text-[12.5px] !shadow-floating !border-border !rounded-[8px]",
+          title: "!font-medium !text-[12.5px] !tracking-tight",
+          description: "!text-[12px] !text-muted-foreground",
+        },
+      }}
       {...props}
     />
   )

--- a/packages/core/src/app/components/ui/tabs.tsx
+++ b/packages/core/src/app/components/ui/tabs.tsx
@@ -21,11 +21,11 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  'group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none',
+  'group/tabs-list inline-flex w-fit items-center justify-center rounded-[6px] p-[2px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-7 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none',
   {
     variants: {
       variant: {
-        default: 'bg-muted',
+        default: 'bg-muted/70 ring-1 ring-inset ring-border/60',
         line: 'gap-1 bg-transparent',
       },
     },
@@ -55,10 +55,10 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent',
-        'data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground',
-        'after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100',
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-[5px] border border-transparent px-2.5 text-[12px] font-medium whitespace-nowrap text-foreground/55 transition-colors group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring/50 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+        'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent',
+        'data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:shadow-edge dark:data-[state=active]:bg-foreground/10',
+        'after:absolute after:bg-brand after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:-bottom-[6px] group-data-[orientation=horizontal]/tabs:after:h-[2px] group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100',
         className,
       )}
       {...props}

--- a/packages/core/src/app/components/ui/textarea.tsx
+++ b/packages/core/src/app/components/ui/textarea.tsx
@@ -1,18 +1,22 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
   return (
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
-        className
+        'flex field-sizing-content min-h-16 w-full rounded-[6px] border border-border bg-background px-2.5 py-2 text-[13px] leading-relaxed outline-none',
+        'transition-colors placeholder:text-muted-foreground/70',
+        'focus-visible:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring/30',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        'aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/25',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Textarea }
+export { Textarea };

--- a/packages/core/src/app/components/ui/toggle-group.tsx
+++ b/packages/core/src/app/components/ui/toggle-group.tsx
@@ -36,7 +36,7 @@ function ToggleGroup({
       data-spacing={spacing}
       style={{ "--gap": spacing } as React.CSSProperties}
       className={cn(
-        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
+        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-[5px]",
         className
       )}
       {...props}
@@ -70,7 +70,7 @@ function ToggleGroupItem({
           size: context.size || size,
         }),
         "w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10",
-        "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",
+        "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-[5px] data-[spacing=0]:last:rounded-r-[5px] data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",
         className
       )}
       {...props}

--- a/packages/core/src/app/components/ui/toggle.tsx
+++ b/packages/core/src/app/components/ui/toggle.tsx
@@ -5,18 +5,18 @@ import { Toggle as TogglePrimitive } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex items-center justify-center gap-2 rounded-[5px] text-[12px] font-medium whitespace-nowrap outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-foreground data-[state=on]:text-background [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
   {
     variants: {
       variant: {
-        default: "bg-transparent",
+        default: "bg-transparent text-foreground/70",
         outline:
-          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+          "border border-border bg-card text-foreground/75 hover:border-foreground/20 data-[state=on]:border-foreground",
       },
       size: {
-        default: "h-9 min-w-9 px-2",
-        sm: "h-8 min-w-8 px-1.5",
-        lg: "h-10 min-w-10 px-2.5",
+        default: "h-8 min-w-8 px-2",
+        sm: "h-7 min-w-7 px-1.5",
+        lg: "h-9 min-w-9 px-2.5",
       },
     },
     defaultVariants: {

--- a/packages/core/src/app/lib/folders.ts
+++ b/packages/core/src/app/lib/folders.ts
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
 import buildManifest from 'virtual:open-slide/folders';
+import { useCallback, useEffect, useState } from 'react';
 import type { Folder, FolderIcon, FoldersManifest } from './sdk';
 
 const EMPTY: FoldersManifest = { folders: [], assignments: {} };

--- a/packages/core/src/app/lib/slides.ts
+++ b/packages/core/src/app/lib/slides.ts
@@ -1,5 +1,5 @@
-import type { SlideModule } from './sdk';
 import { slideIds as ids, loadSlide as load } from 'virtual:open-slide/slides';
+import type { SlideModule } from './sdk';
 
 export const slideIds: string[] = ids;
 

--- a/packages/core/src/app/lib/utils.ts
+++ b/packages/core/src/app/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from 'clsx';
+import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -2,7 +2,6 @@ import { FolderInput, FolderPlus, MoreHorizontal, Pencil, Trash2 } from 'lucide-
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 import {
   Dialog,
   DialogContent,
@@ -19,9 +18,9 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useFolders } from '@/lib/folders';
 import { cn } from '@/lib/utils';
-import { SlideCanvas } from '../components/slide-canvas';
 import { FolderIconChip, SLIDE_DND_MIME } from '../components/sidebar/folder-item';
 import { DRAFT_ID, Sidebar } from '../components/sidebar/sidebar';
+import { SlideCanvas } from '../components/slide-canvas';
 import type { Folder, FolderIcon, SlideModule } from '../lib/sdk';
 import { loadSlide, slideIds } from '../lib/slides';
 
@@ -67,9 +66,10 @@ export function Home() {
 
   const title = selectedFolder?.name ?? 'Draft';
   const headerIcon = selectedFolder?.icon ?? { type: 'emoji' as const, value: '📝' };
+  const isDraft = selectedId === DRAFT_ID;
 
   return (
-    <div className="flex h-screen overflow-hidden bg-background">
+    <div className="flex h-screen overflow-hidden bg-background text-foreground">
       <div className="hidden md:block">
         <Sidebar
           folders={manifest.folders}
@@ -88,9 +88,12 @@ export function Home() {
         />
       </div>
 
-      <div className="flex min-w-0 flex-1 flex-col overflow-y-auto">
-        <div className="border-b bg-card/40 px-4 py-3 md:hidden">
-          <div className="mb-2 font-heading text-lg font-bold tracking-tight">open-slide</div>
+      <div className="paper relative flex min-w-0 flex-1 flex-col overflow-y-auto bg-canvas">
+        {/* Mobile chrome */}
+        <div className="flex items-center justify-between border-b border-hairline bg-sidebar px-4 py-3 md:hidden">
+          <h1 className="font-heading text-lg font-bold tracking-tight">open-slide</h1>
+        </div>
+        <div className="border-b border-hairline bg-sidebar px-4 py-2 md:hidden">
           <div className="flex gap-2 overflow-x-auto pb-1">
             <MobileFolderPill
               icon={{ type: 'emoji', value: '📝' }}
@@ -112,19 +115,23 @@ export function Home() {
           </div>
         </div>
 
-        <div className="mx-auto w-full max-w-6xl px-4 py-6 md:px-8 md:py-12">
-          <header className="mb-6 flex items-center gap-3 md:mb-8">
-            <FolderIconChip icon={headerIcon} className="size-6 text-xl" />
-            <h2 className="font-heading text-xl font-bold tracking-tight md:text-2xl">{title}</h2>
-            <span className="text-sm text-muted-foreground">
-              {visibleSlides.length} slide{visibleSlides.length === 1 ? '' : 's'}
-            </span>
+        <div className="mx-auto w-full max-w-[1180px] px-5 py-8 md:px-10 md:py-12">
+          <header className="mb-8 md:mb-12">
+            <div className="flex items-center gap-3">
+              <FolderIconChip icon={headerIcon} className="size-7 text-2xl" />
+              <h1 className="font-heading text-[32px] font-semibold leading-[1.05] tracking-[-0.025em] md:text-[44px]">
+                {title}
+              </h1>
+              <span className="folio ml-1 self-end pb-2">
+                {visibleSlides.length.toString().padStart(2, '0')}
+              </span>
+            </div>
           </header>
 
           {visibleSlides.length === 0 ? (
-            <EmptyState isDraft={selectedId === DRAFT_ID} folderName={selectedFolder?.name} />
+            <EmptyState isDraft={isDraft} folderName={selectedFolder?.name} />
           ) : (
-            <ul className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-4 md:grid-cols-[repeat(auto-fill,minmax(280px,1fr))] md:gap-5">
+            <ul className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-x-6 gap-y-9 md:grid-cols-[repeat(auto-fill,minmax(300px,1fr))]">
               {visibleSlides.map((id) => (
                 <li key={id}>
                   <SlideCard
@@ -162,35 +169,39 @@ function MobileFolderPill({
     <button
       type="button"
       onClick={onClick}
-      className={
-        'flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ' +
-        (active
-          ? 'border-primary bg-primary/10 text-primary'
-          : 'border-border bg-background text-muted-foreground hover:text-foreground')
-      }
+      className={cn(
+        'flex shrink-0 items-center gap-1.5 rounded-[5px] border px-2.5 py-1 text-[11.5px] font-medium transition-colors',
+        active
+          ? 'border-foreground/40 bg-foreground text-background'
+          : 'border-border bg-card text-muted-foreground hover:text-foreground',
+      )}
     >
-      <FolderIconChip icon={icon} className="size-4 text-sm" />
+      <FolderIconChip icon={icon} className="size-3.5 text-sm" />
       <span className="truncate max-w-[8rem]">{label}</span>
-      <span className="tabular-nums opacity-70">{count}</span>
+      <span className="folio nums">{count.toString().padStart(2, '0')}</span>
     </button>
   );
 }
 
 function EmptyState({ isDraft, folderName }: { isDraft: boolean; folderName?: string }) {
   return (
-    <Card className="border-dashed">
-      <CardContent className="flex flex-col items-center gap-3 py-16 text-center text-muted-foreground">
-        <FolderPlus className="size-8 opacity-50" />
+    <div className="rounded-[10px] border border-dashed border-border bg-card/60 px-8 py-20">
+      <div className="mx-auto flex max-w-md flex-col items-center text-center">
+        <div className="flex size-12 items-center justify-center rounded-full border border-hairline bg-card text-muted-foreground">
+          <FolderPlus className="size-5" />
+        </div>
         {isDraft ? (
           <>
-            <p>No slides yet.</p>
-            <p className="text-sm">
+            <p className="mt-4 font-heading text-[15px] font-semibold tracking-tight">
+              No slides yet
+            </p>
+            <p className="mt-1.5 text-[13px] leading-relaxed text-muted-foreground">
               Create{' '}
-              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+              <code className="rounded-[4px] bg-muted px-1.5 py-0.5 font-mono text-[11.5px] text-foreground">
                 slides/my-slide/index.tsx
               </code>{' '}
-              with{' '}
-              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+              that{' '}
+              <code className="rounded-[4px] bg-muted px-1.5 py-0.5 font-mono text-[11.5px] text-foreground">
                 export default [Page1, Page2]
               </code>
               .
@@ -198,12 +209,16 @@ function EmptyState({ isDraft, folderName }: { isDraft: boolean; folderName?: st
           </>
         ) : (
           <>
-            <p>No slides in {folderName ?? 'this folder'}.</p>
-            <p className="text-sm">Drag a slide from Draft into the sidebar folder.</p>
+            <p className="mt-4 font-heading text-[15px] font-semibold tracking-tight">
+              {folderName ?? 'This folder'} is empty
+            </p>
+            <p className="mt-1.5 text-[13px] leading-relaxed text-muted-foreground">
+              Drag a slide from Draft into this folder in the sidebar.
+            </p>
           </>
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }
 
@@ -259,25 +274,35 @@ function SlideCard({
       >
         <Link
           to={`/s/${id}`}
-          className="block overflow-hidden rounded-xl bg-card text-card-foreground ring-1 ring-foreground/10 transition-all duration-200 hover:-translate-y-0.5 hover:ring-foreground/20 hover:shadow-lg"
+          className={cn(
+            'block transition-transform duration-200 hover:-translate-y-1 focus-visible:outline-none',
+          )}
         >
-          <div className="relative aspect-video overflow-hidden bg-gradient-to-br from-indigo-50 to-violet-50">
+          {/* Slide thumb — tight border, grey baseboard, no shadcn rounded-xl */}
+          <div className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] transition-shadow group-hover:shadow-floating">
             {FirstPage ? (
               <SlideCanvas flat design={slide?.design}>
                 <FirstPage />
               </SlideCanvas>
             ) : (
-              <div className="grid h-full w-full place-items-center text-xs tracking-widest uppercase text-muted-foreground/60">
+              <div className="grid h-full w-full place-items-center text-[10px] tracking-[0.16em] uppercase text-muted-foreground/60">
                 Loading
               </div>
             )}
           </div>
-          <div className="flex items-baseline justify-between gap-3 px-4 py-3">
-            <span className="truncate text-sm font-medium">{displayTitle}</span>
+
+          <div className="mt-3 flex items-baseline gap-2">
+            <h3 className="min-w-0 truncate font-heading text-[14px] font-medium tracking-tight">
+              {displayTitle}
+            </h3>
             {pageCount > 0 && (
-              <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
-                {pageCount} page{pageCount === 1 ? '' : 's'}
-              </span>
+              <>
+                <span className="h-px min-w-3 flex-1 translate-y-[-3px] bg-hairline" aria-hidden />
+                <span className="folio shrink-0">
+                  {pageCount.toString().padStart(2, '0')}
+                  <span className="opacity-40"> pp</span>
+                </span>
+              </>
             )}
           </div>
         </Link>
@@ -292,10 +317,10 @@ function SlideCard({
                     e.stopPropagation();
                     e.preventDefault();
                   }}
-                  className="flex size-7 items-center justify-center rounded-md bg-background/80 text-foreground shadow-sm ring-1 ring-foreground/10 opacity-0 backdrop-blur transition-opacity hover:bg-background group-hover:opacity-100 aria-expanded:opacity-100"
+                  className="flex size-7 items-center justify-center rounded-[5px] bg-card/90 text-foreground shadow-edge ring-1 ring-border opacity-0 backdrop-blur transition-opacity hover:bg-card group-hover:opacity-100 aria-expanded:opacity-100"
                   aria-label="Slide actions"
                 >
-                  <MoreHorizontal className="size-4" />
+                  <MoreHorizontal className="size-3.5" />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="min-w-[160px]">
@@ -305,7 +330,7 @@ function SlideCard({
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => setDialog('move')}>
                   <FolderInput />
-                  Move to folder
+                  Move to folder…
                 </DropdownMenuItem>
                 <DropdownMenuItem variant="destructive" onSelect={() => setDialog('delete')}>
                   <Trash2 />
@@ -394,6 +419,7 @@ function RenameDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
+          <span className="eyebrow">Rename</span>
           <DialogTitle>Rename slide</DialogTitle>
           <DialogDescription>Give this slide a new display name.</DialogDescription>
         </DialogHeader>
@@ -409,10 +435,10 @@ function RenameDialog({
           }}
           maxLength={80}
           placeholder="Slide name"
-          className="h-9 w-full rounded-md border bg-background px-3 text-sm outline-none ring-ring/40 focus:ring-2"
+          className="h-9 w-full rounded-[6px] border border-border bg-background px-3 text-[13px] outline-none focus-visible:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring/30"
         />
         <DialogFooter>
-          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
           <Button size="sm" disabled={submitting} onClick={submit}>
@@ -466,12 +492,13 @@ function MoveDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
+          <span className="eyebrow">Move</span>
           <DialogTitle>Move slide</DialogTitle>
           <DialogDescription>
             Choose a folder for <span className="font-medium text-foreground">{slideName}</span>.
           </DialogDescription>
         </DialogHeader>
-        <div className="max-h-[320px] overflow-y-auto rounded-md border">
+        <div className="max-h-[320px] overflow-y-auto rounded-[6px] border border-border bg-background">
           <FolderOption
             icon={{ type: 'emoji', value: '📝' }}
             label="Draft"
@@ -489,7 +516,7 @@ function MoveDialog({
           ))}
         </div>
         <DialogFooter>
-          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
           <Button size="sm" disabled={submitting || selected === currentFolderId} onClick={submit}>
@@ -517,13 +544,18 @@ function FolderOption({
       type="button"
       onClick={onClick}
       className={cn(
-        'flex w-full items-center gap-2 border-b px-3 py-2 text-left text-sm last:border-b-0 transition-colors',
-        active ? 'bg-primary/10 text-primary' : 'hover:bg-muted/60',
+        'flex w-full items-center gap-2 border-b border-hairline px-3 py-2 text-left text-[13px] transition-colors last:border-b-0',
+        active ? 'bg-muted text-foreground' : 'hover:bg-muted/60',
       )}
     >
       <FolderIconChip icon={icon} />
       <span className="truncate">{label}</span>
-      {active && <span className="ml-auto text-xs tracking-wide opacity-70">Selected</span>}
+      {active && (
+        <span className="ml-auto inline-flex items-center gap-1 text-[10.5px] text-brand">
+          <span className="inline-block size-1 rounded-full bg-brand" aria-hidden />
+          Selected
+        </span>
+      )}
     </button>
   );
 }
@@ -558,6 +590,7 @@ function DeleteDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
+          <span className="eyebrow text-destructive/80">Destructive</span>
           <DialogTitle>Delete slide?</DialogTitle>
           <DialogDescription>
             This permanently removes{' '}
@@ -566,7 +599,7 @@ function DeleteDialog({
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
           <Button variant="destructive" size="sm" disabled={submitting} onClick={confirm}>

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -69,7 +69,7 @@ export function Home() {
   const isDraft = selectedId === DRAFT_ID;
 
   return (
-    <div className="flex h-screen overflow-hidden bg-background text-foreground">
+    <div className="flex h-dvh overflow-hidden bg-background text-foreground">
       <div className="hidden md:block">
         <Sidebar
           folders={manifest.folders}

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -190,7 +190,7 @@ export function Slide() {
   return (
     <HistoryProvider>
       <InspectorProvider slideId={slideId}>
-        <div className="flex h-screen flex-col overflow-hidden bg-background text-foreground">
+        <div className="flex h-dvh flex-col overflow-hidden bg-background text-foreground">
           {/* Editorial toolbar — three zones, hairline separators, mono-folio center */}
           <header className="relative flex h-12 shrink-0 items-center justify-between border-b border-hairline bg-sidebar/85 px-2 backdrop-blur-md md:px-3">
             <div className="flex items-center gap-1.5 md:gap-2">
@@ -368,7 +368,11 @@ export function Slide() {
                   <InspectOverlay />
                   <SaveBar />
                   {import.meta.env.DEV && <CommentWidget />}
-                  <div className="pointer-events-none absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-[5px] border border-foreground/10 bg-foreground/85 px-2 py-0.5 font-mono text-[10.5px] font-medium tracking-[0.06em] text-background backdrop-blur md:hidden">
+                  {/* Safe-area aware so Safari's URL bar can't cover the folio. */}
+                  <div
+                    className="pointer-events-none absolute left-1/2 z-10 -translate-x-1/2 rounded-[5px] border border-foreground/10 bg-foreground/85 px-2 py-0.5 font-mono text-[10.5px] font-medium tracking-[0.06em] text-background backdrop-blur md:hidden"
+                    style={{ bottom: 'max(0.75rem, calc(env(safe-area-inset-bottom) + 0.5rem))' }}
+                  >
                     {(index + 1).toString().padStart(2, '0')}
                     <span className="opacity-50"> / </span>
                     {pageCount.toString().padStart(2, '0')}

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -335,7 +335,7 @@ export function Slide() {
             </div>
           ) : (
             <DesignProvider slideId={slideId}>
-              <div className="flex min-h-0 flex-1">
+              <div className="flex min-h-0 flex-1 flex-col md:flex-row">
                 <div className="hidden w-[16.5rem] shrink-0 md:block">
                   <ThumbnailRail
                     pages={pages}
@@ -368,16 +368,21 @@ export function Slide() {
                   <InspectOverlay />
                   <SaveBar />
                   {import.meta.env.DEV && <CommentWidget />}
-                  {/* Safe-area aware so Safari's URL bar can't cover the folio. */}
-                  <div
-                    className="pointer-events-none absolute left-1/2 z-10 -translate-x-1/2 rounded-[5px] border border-foreground/10 bg-foreground/85 px-2 py-0.5 font-mono text-[10.5px] font-medium tracking-[0.06em] text-background backdrop-blur md:hidden"
-                    style={{ bottom: 'max(0.75rem, calc(env(safe-area-inset-bottom) + 0.5rem))' }}
-                  >
-                    {(index + 1).toString().padStart(2, '0')}
-                    <span className="opacity-50"> / </span>
-                    {pageCount.toString().padStart(2, '0')}
-                  </div>
                 </main>
+                {/* Mobile-only horizontal rail. Sits below the canvas and
+                    pads its bottom for the iOS home indicator / Safari URL bar. */}
+                <div
+                  className="shrink-0 border-t border-hairline md:hidden"
+                  style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+                >
+                  <ThumbnailRail
+                    pages={pages}
+                    design={slide.design}
+                    current={index}
+                    onSelect={goTo}
+                    orientation="horizontal"
+                  />
+                </div>
                 <InspectorPanel />
                 <DesignPanel open={designOpen} onClose={() => setDesignOpen(false)} />
               </div>

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -109,12 +109,15 @@ export function Slide() {
     return (
       <div className="mx-auto max-w-3xl px-8 py-16 text-muted-foreground">
         {showSlideBrowser && (
-          <Link to="/" className="text-sm font-medium text-primary hover:underline">
+          <Link to="/" className="text-[12px] font-medium text-foreground/70 hover:text-foreground">
             ← Home
           </Link>
         )}
-        <h2 className="mt-4 text-xl font-semibold text-foreground">Failed to load slide</h2>
-        <pre className="mt-4 overflow-auto rounded-md border bg-card p-4 text-xs whitespace-pre-wrap shadow-sm">
+        <span className="mt-6 block eyebrow text-destructive/80">Load failed</span>
+        <h2 className="mt-2 font-heading text-xl font-semibold tracking-tight text-foreground">
+          Failed to load slide
+        </h2>
+        <pre className="mt-4 overflow-auto rounded-[6px] border border-border bg-card p-4 text-[11.5px] leading-relaxed whitespace-pre-wrap shadow-edge">
           {error}
         </pre>
       </div>
@@ -123,8 +126,9 @@ export function Slide() {
 
   if (!slide) {
     return (
-      <div className="mx-auto max-w-3xl px-8 py-16 text-sm text-muted-foreground">
-        Loading {slideId}…
+      <div className="mx-auto max-w-3xl px-8 py-16 text-[12.5px] text-muted-foreground">
+        <span className="eyebrow">Loading</span>
+        <p className="mt-2 font-mono">{slideId}</p>
       </div>
     );
   }
@@ -133,18 +137,23 @@ export function Slide() {
     return (
       <div className="mx-auto max-w-3xl px-8 py-16 text-muted-foreground">
         {showSlideBrowser && (
-          <Link to="/" className="text-sm font-medium text-primary hover:underline">
+          <Link to="/" className="text-[12px] font-medium text-foreground/70 hover:text-foreground">
             ← Home
           </Link>
         )}
-        <h2 className="mt-4 text-xl font-semibold text-foreground">Empty slide</h2>
-        <p className="mt-2 text-sm">
-          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+        <span className="mt-6 block eyebrow">Empty</span>
+        <h2 className="mt-2 font-heading text-xl font-semibold tracking-tight text-foreground">
+          Nothing to show.
+        </h2>
+        <p className="mt-3 text-[13px] leading-relaxed">
+          <code className="rounded-[4px] bg-muted px-1.5 py-0.5 font-mono text-[11.5px]">
             slides/{slideId}/index.tsx
           </code>{' '}
           must{' '}
-          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">export default</code> a
-          non-empty array of components.
+          <code className="rounded-[4px] bg-muted px-1.5 py-0.5 font-mono text-[11.5px]">
+            export default
+          </code>{' '}
+          a non-empty array of components.
         </p>
       </div>
     );
@@ -181,17 +190,18 @@ export function Slide() {
   return (
     <HistoryProvider>
       <InspectorProvider slideId={slideId}>
-        <div className="flex h-screen flex-col overflow-hidden bg-background">
-          <header className="relative flex shrink-0 items-center justify-between border-b bg-card px-3 py-2 md:px-5 md:py-3">
-            <div className="flex items-center gap-2 md:gap-3">
+        <div className="flex h-screen flex-col overflow-hidden bg-background text-foreground">
+          {/* Editorial toolbar — three zones, hairline separators, mono-folio center */}
+          <header className="relative flex h-12 shrink-0 items-center justify-between border-b border-hairline bg-sidebar/85 px-2 backdrop-blur-md md:px-3">
+            <div className="flex items-center gap-1.5 md:gap-2">
               {showSlideBrowser && (
-                <Button asChild variant="ghost" size="sm" className="px-2 md:px-3">
-                  <Link to="/">
+                <Button asChild variant="ghost" size="icon-sm" title="Home">
+                  <Link to="/" aria-label="Back to home">
                     <ChevronLeft className="size-4" />
-                    <span className="hidden md:inline">Home</span>
                   </Link>
                 </Button>
               )}
+              <span aria-hidden className="mx-0.5 hidden h-5 w-px bg-hairline md:block" />
               {import.meta.env.DEV && (
                 <Tabs
                   value={view}
@@ -207,38 +217,22 @@ export function Slide() {
                     );
                   }}
                 >
-                  <TabsList className="relative h-7 rounded-md p-0.5 group-data-[orientation=horizontal]/tabs:h-7">
-                    <div
-                      aria-hidden
-                      className="pointer-events-none absolute top-0.5 bottom-0.5 left-0.5 w-[calc(50%-2px)] rounded-[5px] bg-background shadow-sm transition-transform duration-200 ease-out"
-                      style={{
-                        transform: view === 'assets' ? 'translateX(100%)' : 'translateX(0)',
-                      }}
-                    />
-                    <TabsTrigger
-                      value="slides"
-                      className="relative z-10 h-6 px-3 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none dark:data-[state=active]:bg-transparent"
-                    >
-                      Slides
-                    </TabsTrigger>
-                    <TabsTrigger
-                      value="assets"
-                      className="relative z-10 h-6 px-3 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none dark:data-[state=active]:bg-transparent"
-                    >
-                      Assets
-                    </TabsTrigger>
+                  <TabsList>
+                    <TabsTrigger value="slides">Slides</TabsTrigger>
+                    <TabsTrigger value="assets">Assets</TabsTrigger>
                   </TabsList>
                 </Tabs>
               )}
             </div>
 
+            {/* Centered title — the rail and mobile pill carry the page count. */}
             <div className="pointer-events-none absolute inset-x-0 top-1/2 flex -translate-y-1/2 justify-center px-2">
-              <div className="pointer-events-auto min-w-0 max-w-[min(32rem,calc(100vw-20rem))]">
+              <div className="pointer-events-auto min-w-0 max-w-[min(34rem,calc(100vw-22rem))]">
                 <InlineTitleEditor title={title} onSubmit={(next) => renameSlide(slideId, next)} />
               </div>
             </div>
 
-            <div className="flex items-center gap-1.5">
+            <div className="flex items-center gap-1">
               {view === 'slides' && allowHtmlDownload && (
                 <DropdownMenu>
                   <DropdownMenuTrigger
@@ -246,7 +240,7 @@ export function Slide() {
                     disabled={exporting}
                     aria-label="Download"
                     title="Download"
-                    className={cn(buttonVariants({ variant: 'outline', size: 'icon-sm' }))}
+                    className={cn(buttonVariants({ variant: 'ghost', size: 'icon-sm' }))}
                   >
                     {exporting ? (
                       <Loader2 className="size-4 animate-spin" />
@@ -254,7 +248,7 @@ export function Slide() {
                       <Download className="size-4" />
                     )}
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="min-w-[180px]">
+                  <DropdownMenuContent align="end" className="min-w-[200px]">
                     <DropdownMenuItem
                       disabled={exporting}
                       onSelect={async () => {
@@ -270,7 +264,7 @@ export function Slide() {
                       }}
                     >
                       <FileCode2 />
-                      Download HTML
+                      Export as HTML
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       disabled={exporting}
@@ -308,7 +302,7 @@ export function Slide() {
                       }}
                     >
                       <FileText />
-                      Download PDF
+                      Export as PDF
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
@@ -317,11 +311,17 @@ export function Slide() {
                 <DesignToggleButton active={designOpen} onToggle={() => setDesignOpen((v) => !v)} />
               )}
               {view === 'slides' && <InspectToggleButton />}
+              <span aria-hidden className="mx-0.5 hidden h-5 w-px bg-hairline md:block" />
               {view === 'slides' && (
-                <Button size="sm" onClick={() => setPlaying(true)} className="px-2 md:px-3">
-                  <Play className="size-4" />
-                  <span className="hidden md:inline">Play</span>
-                  <kbd className="ml-1 hidden rounded bg-primary-foreground/20 px-1 text-[10px] md:inline">
+                <Button
+                  size="sm"
+                  variant="brand"
+                  onClick={() => setPlaying(true)}
+                  className="px-2.5 md:px-3"
+                >
+                  <Play className="size-3.5 fill-current" />
+                  <span className="hidden md:inline">Present</span>
+                  <kbd className="ml-1 hidden rounded-[3px] bg-brand-foreground/15 px-1 font-mono text-[9.5px] tracking-[0.04em] md:inline">
                     F
                   </kbd>
                 </Button>
@@ -336,7 +336,7 @@ export function Slide() {
           ) : (
             <DesignProvider slideId={slideId}>
               <div className="flex min-h-0 flex-1">
-                <div className="hidden w-[17rem] shrink-0 md:block">
+                <div className="hidden w-[16.5rem] shrink-0 md:block">
                   <ThumbnailRail
                     pages={pages}
                     design={slide.design}
@@ -347,7 +347,7 @@ export function Slide() {
                 <main
                   ref={slideViewportRef}
                   data-inspector-root
-                  className="relative min-h-0 min-w-0 flex-1 bg-background p-2 md:p-8"
+                  className="paper relative min-h-0 min-w-0 flex-1 bg-canvas p-2 md:p-10"
                 >
                   <SlideWheelNavigation
                     targetRef={slideViewportRef}
@@ -368,8 +368,10 @@ export function Slide() {
                   <InspectOverlay />
                   <SaveBar />
                   {import.meta.env.DEV && <CommentWidget />}
-                  <div className="pointer-events-none absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-full bg-black/50 px-2.5 py-0.5 text-[11px] font-medium tabular-nums text-white backdrop-blur md:hidden">
-                    {index + 1} / {pageCount}
+                  <div className="pointer-events-none absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-[5px] border border-foreground/10 bg-foreground/85 px-2 py-0.5 font-mono text-[10.5px] font-medium tracking-[0.06em] text-background backdrop-blur md:hidden">
+                    {(index + 1).toString().padStart(2, '0')}
+                    <span className="opacity-50"> / </span>
+                    {pageCount.toString().padStart(2, '0')}
                   </div>
                 </main>
                 <InspectorPanel />
@@ -477,26 +479,28 @@ function InlineTitleEditor({
             }
           }}
           maxLength={80}
-          className="min-w-0 max-w-[min(32rem,90%)] rounded-md border bg-background px-2 py-0.5 text-center text-xs font-semibold tracking-tight outline-none ring-ring/40 focus:ring-2 md:text-sm"
+          className="min-w-0 max-w-[min(34rem,90%)] rounded-[5px] border border-foreground/30 bg-card px-2 py-0.5 text-center font-heading text-[13px] font-medium tracking-tight outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
         />
       </div>
     );
   }
 
   return (
-    <div className="group/title flex flex-1 items-center justify-center gap-1.5 min-w-0">
-      <h1 className="truncate text-xs font-semibold tracking-tight md:text-sm">{title}</h1>
+    <div className="group/title flex min-w-0 items-baseline justify-center gap-1.5">
+      <h1 className="truncate font-heading text-[13.5px] font-semibold tracking-[-0.01em]">
+        {title}
+      </h1>
       {import.meta.env.DEV && (
         <button
           type="button"
           onClick={() => setEditing(true)}
           aria-label="Rename slide"
           className={cn(
-            'flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground',
+            'flex size-5 shrink-0 items-center justify-center rounded-[4px] text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground',
             'opacity-0 group-hover/title:opacity-100 focus-visible:opacity-100',
           )}
         >
-          <Pencil className="size-3.5" />
+          <Pencil className="size-3" />
         </button>
       )}
     </div>

--- a/packages/core/src/app/styles.css
+++ b/packages/core/src/app/styles.css
@@ -5,9 +5,22 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/*
+ * "Atelier" design language for open-slide core.
+ *
+ * Editorial / pro-tool aesthetic: warm paper, ink foreground, vermillion
+ * accent, hairline rules, serif display counterpointing a tight Geist UI.
+ * Aim: feels like a designer's studio, not a SaaS dashboard. Avoids the
+ * shadcn defaults (rounded-lg everywhere, cool grays, soft shadows).
+ */
 @theme inline {
-  --font-heading: var(--font-sans);
-  --font-sans: "Geist Variable", sans-serif;
+  --font-sans: "Geist Variable", -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-heading: "Geist Variable", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-serif:
+    ui-serif, "New York", "Iowan Old Style", "Apple Garamond", "Big Caslon", "Charter", Georgia,
+    serif;
+  --font-mono: ui-monospace, "JetBrains Mono", "SF Mono", "Menlo", "Cascadia Code", monospace;
+
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -24,6 +37,7 @@
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
+  --color-hairline: var(--hairline);
   --color-destructive: var(--destructive);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
@@ -37,103 +51,216 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+  --color-canvas: var(--canvas);
   --color-foreground: var(--foreground);
   --color-background: var(--background);
+  --color-brand: var(--brand);
+  --color-brand-foreground: var(--brand-foreground);
+  --color-brand-soft: var(--brand-soft);
+
   --radius-sm: calc(var(--radius) * 0.6);
-  --radius-md: calc(var(--radius) * 0.8);
+  --radius-md: calc(var(--radius) * 0.85);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) * 1.4);
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+
+  --shadow-edge: 0 0 0 0.5px oklch(0 0 0 / 0.06), 0 1px 0 oklch(0 0 0 / 0.025);
+  --shadow-floating:
+    0 0 0 0.5px oklch(0 0 0 / 0.08), 0 1px 1px oklch(0 0 0 / 0.04),
+    0 4px 16px -2px oklch(0 0 0 / 0.08);
+  --shadow-overlay:
+    0 0 0 0.5px oklch(0 0 0 / 0.1), 0 8px 28px -4px oklch(0 0 0 / 0.18),
+    0 24px 64px -12px oklch(0 0 0 / 0.2);
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  /* Warm paper, ink foreground. Not pure white / pure black — those read as
+     "default browser"; the slight warmth gives the surface a quiet voice. */
+  --background: oklch(0.985 0.004 75);
+  --foreground: oklch(0.2 0.012 60);
+  --canvas: oklch(0.974 0.005 75);
+
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --card-foreground: oklch(0.2 0.012 60);
+  --popover: oklch(0.998 0.002 75);
+  --popover-foreground: oklch(0.2 0.012 60);
+
+  --primary: oklch(0.215 0.012 60);
+  --primary-foreground: oklch(0.985 0.004 75);
+  --secondary: oklch(0.96 0.006 75);
+  --secondary-foreground: oklch(0.215 0.012 60);
+  --muted: oklch(0.955 0.008 75);
+  --muted-foreground: oklch(0.485 0.012 60);
+  --accent: oklch(0.945 0.012 75);
+  --accent-foreground: oklch(0.215 0.012 60);
+  --destructive: oklch(0.55 0.21 27);
+
+  --border: oklch(0.895 0.008 70);
+  --hairline: oklch(0.86 0.008 70);
+  --input: oklch(0.91 0.008 70);
+  --ring: oklch(0.55 0.18 28);
+
+  /* Vermillion — refined editorial red. Single accent across the app;
+     restraint is the point. */
+  --brand: oklch(0.555 0.185 28);
+  --brand-foreground: oklch(0.985 0.004 75);
+  --brand-soft: oklch(0.555 0.185 28 / 0.1);
+
+  --chart-1: oklch(0.555 0.185 28);
+  --chart-2: oklch(0.55 0.1 60);
+  --chart-3: oklch(0.45 0.06 245);
+  --chart-4: oklch(0.55 0.12 160);
+  --chart-5: oklch(0.4 0.04 60);
+
+  /* Tight, considered radius — drops the trendy 10px squish for 6px crisp. */
+  --radius: 0.375rem;
+
+  --sidebar: oklch(0.972 0.005 75);
+  --sidebar-foreground: oklch(0.215 0.012 60);
+  --sidebar-primary: oklch(0.215 0.012 60);
+  --sidebar-primary-foreground: oklch(0.985 0.004 75);
+  --sidebar-accent: oklch(0.94 0.01 75);
+  --sidebar-accent-foreground: oklch(0.215 0.012 60);
+  --sidebar-border: oklch(0.895 0.008 70);
+  --sidebar-ring: oklch(0.55 0.18 28);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: oklch(0.155 0.005 70);
+  --foreground: oklch(0.945 0.005 80);
+  --canvas: oklch(0.135 0.005 70);
+
+  --card: oklch(0.195 0.006 70);
+  --card-foreground: oklch(0.945 0.005 80);
+  --popover: oklch(0.21 0.006 70);
+  --popover-foreground: oklch(0.945 0.005 80);
+
+  --primary: oklch(0.94 0.005 80);
+  --primary-foreground: oklch(0.18 0.008 70);
+  --secondary: oklch(0.245 0.006 70);
+  --secondary-foreground: oklch(0.945 0.005 80);
+  --muted: oklch(0.235 0.006 70);
+  --muted-foreground: oklch(0.68 0.008 75);
+  --accent: oklch(0.27 0.008 70);
+  --accent-foreground: oklch(0.945 0.005 80);
+  --destructive: oklch(0.68 0.2 25);
+
+  --border: oklch(1 0 0 / 0.1);
+  --hairline: oklch(1 0 0 / 0.06);
+  --input: oklch(1 0 0 / 0.13);
+  --ring: oklch(0.62 0.18 28);
+
+  --brand: oklch(0.66 0.19 28);
+  --brand-foreground: oklch(0.155 0.005 70);
+  --brand-soft: oklch(0.66 0.19 28 / 0.18);
+
+  --chart-1: oklch(0.66 0.19 28);
+  --chart-2: oklch(0.7 0.1 60);
+  --chart-3: oklch(0.65 0.08 245);
+  --chart-4: oklch(0.65 0.12 160);
+  --chart-5: oklch(0.6 0.04 60);
+
+  --sidebar: oklch(0.18 0.006 70);
+  --sidebar-foreground: oklch(0.945 0.005 80);
+  --sidebar-primary: oklch(0.94 0.005 80);
+  --sidebar-primary-foreground: oklch(0.18 0.008 70);
+  --sidebar-accent: oklch(0.265 0.008 70);
+  --sidebar-accent-foreground: oklch(0.945 0.005 80);
+  --sidebar-border: oklch(1 0 0 / 0.1);
+  --sidebar-ring: oklch(0.62 0.18 28);
+}
+
+/* Tabular numerics — pages, counts, hex values, slider readouts.
+   Declared as a Tailwind v4 `@utility` so it can be `@apply`d (e.g. by
+   .folio below) and used as a className token. */
+@utility nums {
+  font-feature-settings:
+    "tnum" on,
+    "cv11" on;
+  font-variant-numeric: tabular-nums;
 }
 
 @layer base {
   * {
     @apply border-border outline-ring/50;
   }
-  body {
-    @apply bg-background text-foreground;
-  }
   html {
     @apply font-sans;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-feature-settings:
+      "ss01" on,
+      "cv11" on,
+      "calt" on;
+  }
+  body {
+    @apply bg-background text-foreground;
+    font-feature-settings:
+      "ss01" on,
+      "cv11" on,
+      "calt" on,
+      "tnum" off;
+    letter-spacing: -0.005em;
+  }
+  ::selection {
+    background: var(--brand-soft);
+    color: var(--foreground);
+  }
+}
+
+@layer components {
+  /*
+   * Eyebrow label — the single typographic gesture used for *every* section
+   * label across the app. Tracked-out small caps in muted ink.
+   */
+  .eyebrow {
+    @apply font-sans text-[10px] font-semibold uppercase text-muted-foreground;
+    letter-spacing: 0.14em;
+  }
+
+  /* Hairline divider — 0.5px on retina, snaps to 1px elsewhere. */
+  .hairline {
+    background: var(--hairline);
+  }
+
+  /* Subtle paper texture for "studio" surfaces (sidebar, gallery bg).
+     Pure-CSS noise via SVG; cheap, dark-mode aware via mix-blend. */
+  .paper {
+    position: relative;
+    isolation: isolate;
+  }
+  .paper::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='3'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.55 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+    opacity: 0.025;
+    pointer-events: none;
+    z-index: 0;
+    mix-blend-mode: multiply;
+  }
+  .dark .paper::before {
+    opacity: 0.05;
+    mix-blend-mode: screen;
+  }
+  .paper > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  /* Numeric folio-style page count. */
+  .folio {
+    @apply nums font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground;
   }
 }
 
 /*
- * Comment input cue.
- * One-shot perimeter sheen + soft halo so the user notices this is the
- * agent input field on first open. Plays once per selection, then settles.
- * Restrained warm/cool palette — avoids the canonical AI purple-cyan look.
+ * Comment input cue — kept from the original design but retoned to match
+ * the new palette (warm vermillion + amber instead of the AI-classic
+ * blue/violet halo). Plays once on first open, then settles.
  */
 @property --comment-cue-angle {
   syntax: "<angle>";
@@ -156,9 +283,9 @@
     from var(--comment-cue-angle),
     transparent 0deg,
     transparent 250deg,
-    hsla(38, 92%, 70%, 0.55) 295deg,
-    hsla(220, 90%, 78%, 0.75) 325deg,
-    hsla(265, 85%, 78%, 0.55) 350deg,
+    oklch(0.78 0.14 60 / 0.55) 295deg,
+    oklch(0.62 0.2 28 / 0.85) 325deg,
+    oklch(0.78 0.14 60 / 0.55) 350deg,
     transparent 360deg
   );
   -webkit-mask:
@@ -181,8 +308,8 @@
   inset: -10px;
   border-radius: calc(var(--radius-md) + 10px);
   background:
-    radial-gradient(80% 60% at 30% 50%, hsla(220, 90%, 70%, 0.18), transparent 70%),
-    radial-gradient(70% 60% at 75% 60%, hsla(38, 92%, 65%, 0.14), transparent 70%);
+    radial-gradient(80% 60% at 30% 50%, oklch(0.62 0.2 28 / 0.18), transparent 70%),
+    radial-gradient(70% 60% at 75% 60%, oklch(0.78 0.14 60 / 0.16), transparent 70%);
   filter: blur(14px);
   opacity: 0;
   z-index: -1;
@@ -226,5 +353,37 @@
   .comment-cue::before,
   .comment-cue::after {
     animation: none;
+  }
+}
+
+/*
+ * Custom scrollbar — slim, ink-on-paper. Removes the chunky default that
+ * fights the calm surfaces.
+ */
+@media (pointer: fine) {
+  *::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background: oklch(0 0 0 / 0.1);
+    border: 3px solid transparent;
+    background-clip: content-box;
+    border-radius: 999px;
+  }
+  *::-webkit-scrollbar-thumb:hover {
+    background: oklch(0 0 0 / 0.18);
+    background-clip: content-box;
+  }
+  .dark *::-webkit-scrollbar-thumb {
+    background: oklch(1 0 0 / 0.1);
+    background-clip: content-box;
+  }
+  .dark *::-webkit-scrollbar-thumb:hover {
+    background: oklch(1 0 0 / 0.18);
+    background-clip: content-box;
   }
 }

--- a/packages/core/src/app/styles.css
+++ b/packages/core/src/app/styles.css
@@ -5,14 +5,6 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/*
- * "Atelier" design language for open-slide core.
- *
- * Editorial / pro-tool aesthetic: warm paper, ink foreground, vermillion
- * accent, hairline rules, serif display counterpointing a tight Geist UI.
- * Aim: feels like a designer's studio, not a SaaS dashboard. Avoids the
- * shadcn defaults (rounded-lg everywhere, cool grays, soft shadows).
- */
 @theme inline {
   --font-sans: "Geist Variable", -apple-system, BlinkMacSystemFont, sans-serif;
   --font-heading: "Geist Variable", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;


### PR DESCRIPTION
Move away from the shadcn defaults toward a tighter, ink-on-paper look: warm paper tokens, vermillion accent, hairline rules, tabular folio numerics, and a tightened 6px radius. Touches every primitive (button, dialog, dropdown, popover, input, select, toggle, tabs, sonner, slider, progress, card, separator) plus the sidebar, home gallery, slide editor toolbar, thumbnail rail, inspector and design panels, asset view, and save bar. Drops the gradient placeholders and the shadcn-default purple/blue folder color presets.