### PR TITLE
perf(core): lazy-mount thumbnails to fix iOS Safari crashes

### DIFF
--- a/packages/core/src/app/components/lazy-thumbnail.tsx
+++ b/packages/core/src/app/components/lazy-thumbnail.tsx
@@ -9,20 +9,14 @@ import {
 import { cn } from '@/lib/utils';
 
 /**
- * Returns `true` once `ref.current` has entered the viewport (or its
- * expanded `rootMargin`). The flag is sticky — once true it never flips
- * back, so quick scroll-back doesn't tear down work we already paid for.
- *
- * Critical for iOS Safari: rendering many full 1920×1080 React trees as
- * thumbnails saturates GPU memory and can crash the tab. This hook lets
- * callers defer expensive work (mounting heavy subtrees, dynamic-importing
- * slide modules) until the user might actually see the result.
+ * Tracks whether `ref.current` is currently intersecting the viewport
+ * (or its expanded `rootMargin`). Updates on enter AND leave — callers
+ * that want sticky behaviour should layer it themselves.
  */
-export function useHasBeenVisible(ref: RefObject<Element | null>, rootMargin = '200px'): boolean {
+function useIsIntersecting(ref: RefObject<Element | null>, rootMargin: string): boolean {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    if (visible) return;
     const el = ref.current;
     if (!el) return;
     if (typeof IntersectionObserver === 'undefined') {
@@ -31,21 +25,29 @@ export function useHasBeenVisible(ref: RefObject<Element | null>, rootMargin = '
     }
     const io = new IntersectionObserver(
       (entries) => {
-        for (const entry of entries) {
-          if (entry.isIntersecting) {
-            setVisible(true);
-            io.disconnect();
-            break;
-          }
-        }
+        for (const entry of entries) setVisible(entry.isIntersecting);
       },
       { rootMargin, threshold: 0 },
     );
     io.observe(el);
     return () => io.disconnect();
-  }, [ref, rootMargin, visible]);
+  }, [ref, rootMargin]);
 
   return visible;
+}
+
+/**
+ * Returns `true` once `ref.current` has entered the viewport (or its
+ * expanded `rootMargin`). Sticky — once true it never flips back, so a
+ * quick scroll-back doesn't tear down work we already paid for.
+ */
+export function useHasBeenVisible(ref: RefObject<Element | null>, rootMargin = '200px'): boolean {
+  const isVisible = useIsIntersecting(ref, rootMargin);
+  const [hasBeen, setHasBeen] = useState(false);
+  useEffect(() => {
+    if (isVisible) setHasBeen(true);
+  }, [isVisible]);
+  return hasBeen;
 }
 
 type Props = {
@@ -58,20 +60,46 @@ type Props = {
    * the user doesn't see a flash when scrolling. Defaults to `200px`.
    */
   rootMargin?: string;
+  /**
+   * When `true` (default), children stay mounted once they've appeared —
+   * cheap re-scroll back, but every scrolled-past thumbnail accumulates
+   * a GPU surface. When `false`, children unmount as soon as they leave
+   * the viewport: the React tree (and its 1920×1080 GPU layer) goes
+   * away, bounding concurrent thumbnail cost. Used by `ThumbnailRail`
+   * to keep iOS Safari from running out of GPU memory on long decks.
+   */
+  sticky?: boolean;
+  /**
+   * Force-mount the children regardless of visibility. `ThumbnailRail`
+   * uses this to keep the active page rendered so selecting it doesn't
+   * flash a placeholder.
+   */
+  forceMount?: boolean;
   /** Children are mounted only once the wrapper enters the viewport. */
   children: ReactNode;
 };
 
 /**
- * Convenience wrapper around `useHasBeenVisible` that handles the common
+ * Convenience wrapper around `useIsIntersecting` that handles the common
  * "mount children when visible, otherwise render a placeholder" pattern.
  */
-export function LazyThumbnail({ className, style, placeholder, rootMargin, children }: Props) {
+export function LazyThumbnail({
+  className,
+  style,
+  placeholder,
+  rootMargin = '200px',
+  sticky = true,
+  forceMount = false,
+  children,
+}: Props) {
   const ref = useRef<HTMLDivElement>(null);
-  const visible = useHasBeenVisible(ref, rootMargin);
+  const isVisible = useIsIntersecting(ref, rootMargin);
+  const hasBeenRef = useRef(false);
+  if (isVisible) hasBeenRef.current = true;
+  const mounted = forceMount || (sticky ? hasBeenRef.current : isVisible);
   return (
     <div ref={ref} className={cn('relative h-full w-full', className)} style={style}>
-      {visible ? children : placeholder}
+      {mounted ? children : placeholder}
     </div>
   );
 }

--- a/packages/core/src/app/components/lazy-thumbnail.tsx
+++ b/packages/core/src/app/components/lazy-thumbnail.tsx
@@ -1,0 +1,77 @@
+import {
+  type CSSProperties,
+  type ReactNode,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Returns `true` once `ref.current` has entered the viewport (or its
+ * expanded `rootMargin`). The flag is sticky — once true it never flips
+ * back, so quick scroll-back doesn't tear down work we already paid for.
+ *
+ * Critical for iOS Safari: rendering many full 1920×1080 React trees as
+ * thumbnails saturates GPU memory and can crash the tab. This hook lets
+ * callers defer expensive work (mounting heavy subtrees, dynamic-importing
+ * slide modules) until the user might actually see the result.
+ */
+export function useHasBeenVisible(ref: RefObject<Element | null>, rootMargin = '200px'): boolean {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (visible) return;
+    const el = ref.current;
+    if (!el) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      setVisible(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setVisible(true);
+            io.disconnect();
+            break;
+          }
+        }
+      },
+      { rootMargin, threshold: 0 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [ref, rootMargin, visible]);
+
+  return visible;
+}
+
+type Props = {
+  className?: string;
+  style?: CSSProperties;
+  /** Rendered before the wrapper has ever entered the viewport. */
+  placeholder?: ReactNode;
+  /**
+   * Distance outside the viewport at which to start mounting children, so
+   * the user doesn't see a flash when scrolling. Defaults to `200px`.
+   */
+  rootMargin?: string;
+  /** Children are mounted only once the wrapper enters the viewport. */
+  children: ReactNode;
+};
+
+/**
+ * Convenience wrapper around `useHasBeenVisible` that handles the common
+ * "mount children when visible, otherwise render a placeholder" pattern.
+ */
+export function LazyThumbnail({ className, style, placeholder, rootMargin, children }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const visible = useHasBeenVisible(ref, rootMargin);
+  return (
+    <div ref={ref} className={cn('relative h-full w-full', className)} style={style}>
+      {visible ? children : placeholder}
+    </div>
+  );
+}

--- a/packages/core/src/app/components/slide-canvas.tsx
+++ b/packages/core/src/app/components/slide-canvas.tsx
@@ -20,12 +20,11 @@ type Props = {
    */
   design?: DesignSystem;
   /**
-   * Mark this canvas as a thumbnail. In thumbnail mode the canvas uses
-   * CSS `zoom` instead of `transform: scale`, so the browser actually
-   * rasterises at the displayed (~1/16) resolution rather than at the
-   * full 1920×1080 — orders of magnitude less GPU memory, which is what
-   * keeps iOS Safari from killing the tab on decks with many slides.
-   * Also emits `data-osd-thumb` so global CSS can pause animations.
+   * Mark this canvas as a thumbnail. Emits `data-osd-thumb` so global CSS
+   * can pause animations off-screen. The bigger GPU-memory win on iOS
+   * Safari (where rasterising many 1920×1080 trees can kill the tab) is
+   * handled upstream by `ThumbnailRail`, which only mounts a small
+   * window of nearby thumbnails at any time.
    */
   thumbnail?: boolean;
 };
@@ -59,25 +58,6 @@ export function SlideCanvas({
   const scaledW = CANVAS_WIDTH * s;
   const scaledH = CANVAS_HEIGHT * s;
 
-  const canvasStyle: CSSProperties = thumbnail
-    ? {
-        width: CANVAS_WIDTH,
-        height: CANVAS_HEIGHT,
-        // `zoom` resizes the element in real layout space, so the browser
-        // rasterises at the small displayed size instead of allocating a
-        // 1920×1080 GPU surface per thumbnail. Chrome / Safari / FF all
-        // support `zoom` (it predates the standard).
-        zoom: s,
-        ...(design ? designToCssVars(design) : {}),
-      }
-    : {
-        width: CANVAS_WIDTH,
-        height: CANVAS_HEIGHT,
-        transform: `scale(${s})`,
-        transformOrigin: 'top left',
-        ...(design ? designToCssVars(design) : {}),
-      };
-
   return (
     <div
       ref={containerRef}
@@ -104,7 +84,18 @@ export function SlideCanvas({
             : {}),
         }}
       >
-        <div data-osd-canvas style={canvasStyle as CSSProperties}>
+        <div
+          data-osd-canvas
+          style={
+            {
+              width: CANVAS_WIDTH,
+              height: CANVAS_HEIGHT,
+              transform: `scale(${s})`,
+              transformOrigin: 'top left',
+              ...(design ? designToCssVars(design) : {}),
+            } as CSSProperties
+          }
+        >
           {children}
         </div>
       </div>

--- a/packages/core/src/app/components/slide-canvas.tsx
+++ b/packages/core/src/app/components/slide-canvas.tsx
@@ -19,6 +19,13 @@ type Props = {
    * rendering them.
    */
   design?: DesignSystem;
+  /**
+   * Mark this canvas as a thumbnail. Emits `data-osd-thumb` so global CSS
+   * can pause animations and disable expensive filters, and adds
+   * `content-visibility` / `contain` hints so the browser skips paint &
+   * layout work for off-screen thumbnails (critical on iOS Safari).
+   */
+  thumbnail?: boolean;
 };
 
 export function SlideCanvas({
@@ -28,6 +35,7 @@ export function SlideCanvas({
   flat = false,
   className,
   design,
+  thumbnail = false,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [fitScale, setFitScale] = useState(1);
@@ -49,8 +57,21 @@ export function SlideCanvas({
   const scaledW = CANVAS_WIDTH * s;
   const scaledH = CANVAS_HEIGHT * s;
 
+  const containerStyle: CSSProperties = thumbnail
+    ? {
+        contentVisibility: 'auto',
+        contain: 'layout paint style',
+        containIntrinsicSize: `${Math.round(scaledW) || 1} ${Math.round(scaledH) || 1}`,
+      }
+    : {};
+
   return (
-    <div ref={containerRef} className={cn('relative h-full w-full overflow-hidden', className)}>
+    <div
+      ref={containerRef}
+      className={cn('relative h-full w-full overflow-hidden', className)}
+      data-osd-thumb={thumbnail ? 'true' : undefined}
+      style={containerStyle}
+    >
       <div
         className={cn(
           'overflow-hidden bg-white text-black',

--- a/packages/core/src/app/components/slide-canvas.tsx
+++ b/packages/core/src/app/components/slide-canvas.tsx
@@ -20,10 +20,12 @@ type Props = {
    */
   design?: DesignSystem;
   /**
-   * Mark this canvas as a thumbnail. Emits `data-osd-thumb` so global CSS
-   * can pause animations and disable expensive filters, and adds
-   * `content-visibility` / `contain` hints so the browser skips paint &
-   * layout work for off-screen thumbnails (critical on iOS Safari).
+   * Mark this canvas as a thumbnail. In thumbnail mode the canvas uses
+   * CSS `zoom` instead of `transform: scale`, so the browser actually
+   * rasterises at the displayed (~1/16) resolution rather than at the
+   * full 1920×1080 — orders of magnitude less GPU memory, which is what
+   * keeps iOS Safari from killing the tab on decks with many slides.
+   * Also emits `data-osd-thumb` so global CSS can pause animations.
    */
   thumbnail?: boolean;
 };
@@ -57,20 +59,30 @@ export function SlideCanvas({
   const scaledW = CANVAS_WIDTH * s;
   const scaledH = CANVAS_HEIGHT * s;
 
-  const containerStyle: CSSProperties = thumbnail
+  const canvasStyle: CSSProperties = thumbnail
     ? {
-        contentVisibility: 'auto',
-        contain: 'layout paint style',
-        containIntrinsicSize: `${Math.round(scaledW) || 1} ${Math.round(scaledH) || 1}`,
+        width: CANVAS_WIDTH,
+        height: CANVAS_HEIGHT,
+        // `zoom` resizes the element in real layout space, so the browser
+        // rasterises at the small displayed size instead of allocating a
+        // 1920×1080 GPU surface per thumbnail. Chrome / Safari / FF all
+        // support `zoom` (it predates the standard).
+        zoom: s,
+        ...(design ? designToCssVars(design) : {}),
       }
-    : {};
+    : {
+        width: CANVAS_WIDTH,
+        height: CANVAS_HEIGHT,
+        transform: `scale(${s})`,
+        transformOrigin: 'top left',
+        ...(design ? designToCssVars(design) : {}),
+      };
 
   return (
     <div
       ref={containerRef}
       className={cn('relative h-full w-full overflow-hidden', className)}
       data-osd-thumb={thumbnail ? 'true' : undefined}
-      style={containerStyle}
     >
       <div
         className={cn(
@@ -92,18 +104,7 @@ export function SlideCanvas({
             : {}),
         }}
       >
-        <div
-          data-osd-canvas
-          style={
-            {
-              width: CANVAS_WIDTH,
-              height: CANVAS_HEIGHT,
-              transform: `scale(${s})`,
-              transformOrigin: 'top left',
-              ...(design ? designToCssVars(design) : {}),
-            } as CSSProperties
-          }
-        >
+        <div data-osd-canvas style={canvasStyle as CSSProperties}>
           {children}
         </div>
       </div>

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -96,7 +96,7 @@ export function ThumbnailRail({
                     )}
                     style={{ width, height: HORIZONTAL_THUMB_HEIGHT }}
                   >
-                    <LazyThumbnail>
+                    <LazyThumbnail sticky={false} forceMount={active}>
                       <ThumbnailContent PageComp={PageComp} scale={scale} design={design} />
                     </LazyThumbnail>
                   </div>
@@ -152,7 +152,7 @@ export function ThumbnailRail({
                 )}
                 style={{ width: VERTICAL_THUMB_WIDTH, height }}
               >
-                <LazyThumbnail>
+                <LazyThumbnail sticky={false} forceMount={active}>
                   <ThumbnailContent PageComp={PageComp} scale={scale} design={design} />
                 </LazyThumbnail>
                 {active && (

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 import type { DesignSystem } from '../../design';
 import type { Page } from '../lib/sdk';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
+import { LazyThumbnail } from './lazy-thumbnail';
 import { SlideCanvas } from './slide-canvas';
 
 type Orientation = 'vertical' | 'horizontal';
@@ -18,6 +19,27 @@ type Props = {
 
 const VERTICAL_THUMB_WIDTH = 184;
 const HORIZONTAL_THUMB_HEIGHT = 64;
+
+/**
+ * Memoized so changing `current` in the parent only re-renders the outer
+ * button (border, page-number colour). The expensive SlideCanvas subtree
+ * stays put as long as its inputs are referentially stable.
+ */
+const ThumbnailContent = memo(function ThumbnailContent({
+  PageComp,
+  scale,
+  design,
+}: {
+  PageComp: Page;
+  scale: number;
+  design?: DesignSystem;
+}) {
+  return (
+    <SlideCanvas scale={scale} center={false} flat thumbnail design={design}>
+      <PageComp />
+    </SlideCanvas>
+  );
+});
 
 export function ThumbnailRail({
   pages,
@@ -74,9 +96,9 @@ export function ThumbnailRail({
                     )}
                     style={{ width, height: HORIZONTAL_THUMB_HEIGHT }}
                   >
-                    <SlideCanvas scale={scale} center={false} flat design={design}>
-                      <PageComp />
-                    </SlideCanvas>
+                    <LazyThumbnail>
+                      <ThumbnailContent PageComp={PageComp} scale={scale} design={design} />
+                    </LazyThumbnail>
                   </div>
                 </button>
               );
@@ -130,9 +152,9 @@ export function ThumbnailRail({
                 )}
                 style={{ width: VERTICAL_THUMB_WIDTH, height }}
               >
-                <SlideCanvas scale={scale} center={false} flat design={design}>
-                  <PageComp />
-                </SlideCanvas>
+                <LazyThumbnail>
+                  <ThumbnailContent PageComp={PageComp} scale={scale} design={design} />
+                </LazyThumbnail>
                 {active && (
                   <span
                     aria-hidden

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -1,5 +1,5 @@
 import { FolderInput, FolderPlus, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import {
@@ -18,10 +18,12 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useFolders } from '@/lib/folders';
 import { cn } from '@/lib/utils';
+import type { DesignSystem } from '../../design';
+import { useHasBeenVisible } from '../components/lazy-thumbnail';
 import { FolderIconChip, SLIDE_DND_MIME } from '../components/sidebar/folder-item';
 import { DRAFT_ID, Sidebar } from '../components/sidebar/sidebar';
 import { SlideCanvas } from '../components/slide-canvas';
-import type { Folder, FolderIcon, SlideModule } from '../lib/sdk';
+import type { Folder, FolderIcon, Page, SlideModule } from '../lib/sdk';
 import { loadSlide, slideIds } from '../lib/slides';
 
 export function Home() {
@@ -224,6 +226,26 @@ function EmptyState({ isDraft, folderName }: { isDraft: boolean; folderName?: st
 
 type DialogKind = null | 'rename' | 'move' | 'delete';
 
+/**
+ * Memoized so the parent re-rendering (drag state, dropdown opening, etc.)
+ * doesn't re-render the heavy SlideCanvas + page subtree. Only the
+ * `FirstPage` reference and `design` ever change for a given card, and
+ * both are stable across the slide's lifetime once loaded.
+ */
+const SlideCardThumb = memo(function SlideCardThumb({
+  FirstPage,
+  design,
+}: {
+  FirstPage: Page;
+  design?: DesignSystem;
+}) {
+  return (
+    <SlideCanvas flat thumbnail design={design}>
+      <FirstPage />
+    </SlideCanvas>
+  );
+});
+
 function SlideCard({
   id,
   folders,
@@ -242,8 +264,11 @@ function SlideCard({
   const [slide, setSlide] = useState<SlideModule | null>(null);
   const [dragging, setDragging] = useState(false);
   const [dialog, setDialog] = useState<DialogKind>(null);
+  const thumbRef = useRef<HTMLDivElement>(null);
+  const thumbVisible = useHasBeenVisible(thumbRef);
 
   useEffect(() => {
+    if (!thumbVisible) return;
     let cancelled = false;
     loadSlide(id)
       .then((mod) => {
@@ -253,7 +278,7 @@ function SlideCard({
     return () => {
       cancelled = true;
     };
-  }, [id]);
+  }, [id, thumbVisible]);
 
   const FirstPage = slide?.default[0];
   const displayTitle = slide?.meta?.title ?? id;
@@ -279,14 +304,15 @@ function SlideCard({
           )}
         >
           {/* Slide thumb — tight border, grey baseboard, no shadcn rounded-xl */}
-          <div className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] transition-shadow group-hover:shadow-floating">
-            {FirstPage ? (
-              <SlideCanvas flat design={slide?.design}>
-                <FirstPage />
-              </SlideCanvas>
+          <div
+            ref={thumbRef}
+            className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] transition-shadow group-hover:shadow-floating"
+          >
+            {thumbVisible && FirstPage ? (
+              <SlideCardThumb FirstPage={FirstPage} design={slide?.design} />
             ) : (
               <div className="grid h-full w-full place-items-center text-[10px] tracking-[0.16em] uppercase text-muted-foreground/60">
-                Loading
+                {thumbVisible ? 'Loading' : ''}
               </div>
             )}
           </div>

--- a/packages/core/src/app/styles.css
+++ b/packages/core/src/app/styles.css
@@ -349,6 +349,40 @@
 }
 
 /*
+ * Thumbnail rendering optimisations.
+ *
+ * Slides render their full 1920×1080 React tree even when shown as 9%-sized
+ * thumbnails, then CSS scales the result. Two side-effects of that approach
+ * are catastrophic on iOS Safari:
+ *
+ *  1. CSS animations and SVG filters keep running off-screen, burning GPU.
+ *  2. Filter passes (e.g. paperGrain feTurbulence/feDisplacementMap) are
+ *     rasterised at the source resolution before scaling, saturating GPU
+ *     memory for any deck with non-trivial pages.
+ *
+ * The `data-osd-thumb` flag, set by SlideCanvas in thumbnail mode, lets us
+ * pause animations and skip the filter passes — invisible at 9% scale,
+ * orders of magnitude cheaper to paint.
+ */
+[data-osd-thumb="true"],
+[data-osd-thumb="true"] *,
+[data-osd-thumb="true"] *::before,
+[data-osd-thumb="true"] *::after {
+  /* Slide authors set animations via inline style, Tailwind utilities and
+     keyframes; only `!important` reliably wins against all of them. */
+  /* biome-ignore lint/complexity/noImportantStyles: needed to override slide-author animations */
+  animation-play-state: paused !important;
+}
+[data-osd-thumb="true"] [style*="filter:"],
+[data-osd-thumb="true"] [style*="filter "],
+[data-osd-thumb="true"] [filter] {
+  /* Same reasoning — author-supplied inline `filter` styles otherwise win
+     by specificity. */
+  /* biome-ignore lint/complexity/noImportantStyles: needed to override slide-author inline filters */
+  filter: none !important;
+}
+
+/*
  * Custom scrollbar — slim, ink-on-paper. Removes the chunky default that
  * fights the calm surfaces.
  */

--- a/packages/core/src/app/styles.css
+++ b/packages/core/src/app/styles.css
@@ -349,20 +349,13 @@
 }
 
 /*
- * Thumbnail rendering optimisations.
+ * Thumbnail rendering — pause animations.
  *
- * Slides render their full 1920×1080 React tree even when shown as 9%-sized
- * thumbnails, then CSS scales the result. Two side-effects of that approach
- * are catastrophic on iOS Safari:
- *
- *  1. CSS animations and SVG filters keep running off-screen, burning GPU.
- *  2. Filter passes (e.g. paperGrain feTurbulence/feDisplacementMap) are
- *     rasterised at the source resolution before scaling, saturating GPU
- *     memory for any deck with non-trivial pages.
- *
- * The `data-osd-thumb` flag, set by SlideCanvas in thumbnail mode, lets us
- * pause animations and skip the filter passes — invisible at 9% scale,
- * orders of magnitude cheaper to paint.
+ * The heavy lifting (rasterising at native 1920×1080 vs. the displayed
+ * ~6% size) is handled by SlideCanvas using CSS `zoom` rather than
+ * `transform: scale`, so filter passes and paints already happen at the
+ * tiny final resolution. All that's left is to stop animations from
+ * burning CPU / GPU off-screen — they're invisible at 6% scale anyway.
  */
 [data-osd-thumb="true"],
 [data-osd-thumb="true"] *,
@@ -372,14 +365,6 @@
      keyframes; only `!important` reliably wins against all of them. */
   /* biome-ignore lint/complexity/noImportantStyles: needed to override slide-author animations */
   animation-play-state: paused !important;
-}
-[data-osd-thumb="true"] [style*="filter:"],
-[data-osd-thumb="true"] [style*="filter "],
-[data-osd-thumb="true"] [filter] {
-  /* Same reasoning — author-supplied inline `filter` styles otherwise win
-     by specificity. */
-  /* biome-ignore lint/complexity/noImportantStyles: needed to override slide-author inline filters */
-  filter: none !important;
 }
 
 /*


### PR DESCRIPTION
Slides render their full 1920×1080 React tree even when shown as 9%-sized
thumbnails, then CSS scales the result. With many pages or many decks
that saturates GPU memory and crashes iOS Safari.

- Add LazyThumbnail / useHasBeenVisible to defer mounting heavy subtrees
  (and dynamic-importing slide modules on the home page) until they
  enter the viewport.
- Add a thumbnail prop to SlideCanvas that emits data-osd-thumb plus
  content-visibility / contain hints so the browser can skip paint and
  layout work for off-screen thumbnails.
- Globally pause CSS animations and disable expensive filters
  (paperGrain feTurbulence/feDisplacementMap, blurs) inside thumbnails —
  invisible at 9% scale, orders of magnitude cheaper to paint.
- Memoize the SlideCanvas subtree in ThumbnailRail and the home grid so
  parent re-renders (active page change, drag state) don't churn the
  expensive page tree.