### PR TITLE
refactor(design): flatten radius token from { md } to a single number

### DIFF
--- a/.changeset/flatten-radius-token.md
+++ b/.changeset/flatten-radius-token.md
@@ -1,0 +1,6 @@
+---
+"@open-slide/core": patch
+"@open-slide/cli": patch
+---
+
+Flatten `DesignSystem.radius` from `{ md: number }` to a plain `number`. The Design panel only exposes one global Radius slider and there is no planned `sm` / `lg` scale, so the wrapping object was dead structure. The CSS variable is renamed `--osd-radius-md` → `--osd-radius`, the `DesignRadius` type is removed, and the `slide-authoring` skill plus all bundled slides are updated to match.

--- a/.changeset/flatten-radius-token.md
+++ b/.changeset/flatten-radius-token.md
@@ -3,4 +3,4 @@
 "@open-slide/cli": patch
 ---
 
-Flatten `DesignSystem.radius` from `{ md: number }` to a plain `number`. The Design panel only exposes one global Radius slider and there is no planned `sm` / `lg` scale, so the wrapping object was dead structure. The CSS variable is renamed `--osd-radius-md` → `--osd-radius`, the `DesignRadius` type is removed, and the `slide-authoring` skill plus all bundled slides are updated to match.
+Flatten `DesignSystem.radius` from `{ md: number }` to `number`. CSS var renamed `--osd-radius-md` → `--osd-radius`; `DesignRadius` type removed.

--- a/apps/demo/slides/claude-code-intro/index.tsx
+++ b/apps/demo/slides/claude-code-intro/index.tsx
@@ -14,9 +14,7 @@ export const design: DesignSystem = {
     hero: 220,
     body: 28,
   },
-  radius: {
-    md: 14,
-  },
+  radius: 14,
 };
 
 /* ─────────────── Design tokens ─────────────── */
@@ -443,7 +441,7 @@ const TheLoop: Page = () => (
               style={{
                 background: palette.surface,
                 border: `1px solid ${palette.line}`,
-                borderRadius: 'var(--osd-radius-md)',
+                borderRadius: 'var(--osd-radius)',
                 padding: '40px 32px',
                 width: '100%',
                 position: 'relative',
@@ -718,7 +716,7 @@ const WhereItRuns: Page = () => (
             style={{
               background: palette.surface,
               border: `1px solid ${palette.line}`,
-              borderRadius: 'var(--osd-radius-md)',
+              borderRadius: 'var(--osd-radius)',
               padding: '36px 40px',
               display: 'flex',
               alignItems: 'center',
@@ -896,7 +894,7 @@ const Transcript: Page = () => (
           flex: 1,
           background: palette.surface,
           border: `1px solid ${palette.line}`,
-          borderRadius: 'var(--osd-radius-md)',
+          borderRadius: 'var(--osd-radius)',
           padding: '40px 48px',
           display: 'flex',
           flexDirection: 'column',
@@ -985,7 +983,7 @@ const GetStarted: Page = () => (
         style={{
           background: 'var(--osd-text)',
           color: 'var(--osd-bg)',
-          borderRadius: 'var(--osd-radius-md)',
+          borderRadius: 'var(--osd-radius)',
           padding: '40px 56px',
           fontFamily: fonts.mono,
           fontSize: 36,

--- a/apps/demo/slides/harness-engineering/index.tsx
+++ b/apps/demo/slides/harness-engineering/index.tsx
@@ -7,7 +7,7 @@ export const design: DesignSystem = {
     body: "'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace",
   },
   typeScale: { hero: 156, body: 24 },
-  radius: { md: 0 },
+  radius: 0,
 };
 
 /* ─────────────── Design tokens (neon-terminal) ─────────────── */

--- a/apps/demo/slides/llm-fundamentals/index.tsx
+++ b/apps/demo/slides/llm-fundamentals/index.tsx
@@ -7,7 +7,7 @@ export const design: DesignSystem = {
     body: '-apple-system, BlinkMacSystemFont, "Inter", "SF Pro Display", system-ui, sans-serif',
   },
   typeScale: { hero: 196, body: 28 },
-  radius: { md: 16 },
+  radius: 16,
 };
 
 /* ─────────────── Tokens & primitives ─────────────── */
@@ -364,7 +364,7 @@ const WhatIsToken: Page = () => (
         animationDelay: '600ms',
         background: palette.surface,
         border: `1px solid ${palette.line}`,
-        borderRadius: 'var(--osd-radius-md)',
+        borderRadius: 'var(--osd-radius)',
         padding: '50px 60px',
       }}
     >
@@ -486,7 +486,7 @@ const Tokenization: Page = () => (
             flex: 1,
             background: palette.surface,
             border: `1px solid ${palette.line}`,
-            borderRadius: 'var(--osd-radius-md)',
+            borderRadius: 'var(--osd-radius)',
             padding: 40,
             display: 'flex',
             flexDirection: 'column',
@@ -582,7 +582,7 @@ const VocabSize: Page = () => (
             flex: 1,
             background: palette.surface,
             border: `1px solid ${palette.line}`,
-            borderRadius: 'var(--osd-radius-md)',
+            borderRadius: 'var(--osd-radius)',
             padding: 48,
             display: 'flex',
             flexDirection: 'column',
@@ -686,7 +686,7 @@ const ContextWindow: Page = () => {
           animationDelay: '600ms',
           background: palette.surface,
           border: `1px solid ${palette.line}`,
-          borderRadius: 'var(--osd-radius-md)',
+          borderRadius: 'var(--osd-radius)',
           padding: '50px 60px',
           marginBottom: 40,
           position: 'relative',
@@ -875,7 +875,7 @@ const Attention: Page = () => {
           animationDelay: '600ms',
           background: palette.surface,
           border: `1px solid ${palette.line}`,
-          borderRadius: 'var(--osd-radius-md)',
+          borderRadius: 'var(--osd-radius)',
           padding: '40px 30px',
         }}
       >
@@ -1104,7 +1104,7 @@ const Sampling: Page = () => (
           flex: 1.4,
           background: palette.surface,
           border: `1px solid ${palette.line}`,
-          borderRadius: 'var(--osd-radius-md)',
+          borderRadius: 'var(--osd-radius)',
           padding: 40,
         }}
       >
@@ -1318,7 +1318,7 @@ const Hallucinate: Page = () => (
             flex: 1,
             background: palette.surface,
             border: `1px solid ${palette.line}`,
-            borderRadius: 'var(--osd-radius-md)',
+            borderRadius: 'var(--osd-radius)',
             padding: 50,
             display: 'flex',
             flexDirection: 'column',
@@ -1408,7 +1408,7 @@ const Practical: Page = () => (
             padding: '36px 44px',
             background: palette.surface,
             border: `1px solid ${palette.line}`,
-            borderRadius: 'var(--osd-radius-md)',
+            borderRadius: 'var(--osd-radius)',
           }}
         >
           <div

--- a/apps/demo/slides/nextjs-ppr-cache/index.tsx
+++ b/apps/demo/slides/nextjs-ppr-cache/index.tsx
@@ -10,7 +10,7 @@ export const design: DesignSystem = {
     body: "'Geist', 'Inter', -apple-system, BlinkMacSystemFont, system-ui, sans-serif",
   },
   typeScale: { hero: 176, body: 28 },
-  radius: { md: 12 },
+  radius: 12,
 };
 
 const palette = {
@@ -160,7 +160,7 @@ const Code = ({ children, fontSize = 20 }: { children: ReactNode; fontSize?: num
       padding: 24,
       background: palette.surface,
       border: `1px solid ${palette.border}`,
-      borderRadius: 'var(--osd-radius-md)',
+      borderRadius: 'var(--osd-radius)',
       fontFamily: fontMono,
       fontSize,
       lineHeight: 1.45,
@@ -459,7 +459,7 @@ const PPRConcept: Page = () => {
         left,
         width,
         height,
-        borderRadius: 'var(--osd-radius-md)',
+        borderRadius: 'var(--osd-radius)',
         background: `linear-gradient(110deg, ${palette.surface} 8%, #f0f0f0 18%, ${palette.surface} 33%)`,
         backgroundSize: '200% 100%',
         border: `1.5px dashed ${palette.pink}`,
@@ -651,7 +651,7 @@ const PPRConcept: Page = () => {
               padding: 20,
               background: palette.surface,
               border: `1px solid ${palette.border}`,
-              borderRadius: 'var(--osd-radius-md)',
+              borderRadius: 'var(--osd-radius)',
               fontSize: 24,
               fontFamily: fontMono,
               color: palette.muted,

--- a/apps/demo/slides/raycast-api/index.tsx
+++ b/apps/demo/slides/raycast-api/index.tsx
@@ -8,7 +8,7 @@ export const design: DesignSystem = {
     body: '-apple-system, BlinkMacSystemFont, "Inter", "SF Pro Display", system-ui, sans-serif',
   },
   typeScale: { hero: 112, body: 24 },
-  radius: { md: 14 },
+  radius: 14,
 };
 
 const palette = {
@@ -391,7 +391,7 @@ const Pitch: Page = () => (
             style={{
               flex: 1,
               padding: 32,
-              borderRadius: 'var(--osd-radius-md)',
+              borderRadius: 'var(--osd-radius)',
               background: palette.surface,
               border: `1px solid ${palette.border}`,
               animationDelay: `${280 + i * 100}ms`,
@@ -459,7 +459,7 @@ const Stack: Page = () => (
             style={{
               flex: 1,
               padding: 36,
-              borderRadius: 'var(--osd-radius-md)',
+              borderRadius: 'var(--osd-radius)',
               background: palette.surface,
               border: `1px solid ${palette.border}`,
               animationDelay: `${260 + i * 110}ms`,
@@ -605,7 +605,7 @@ const ActionPanel: Page = () => (
         <div
           style={{
             width: 540,
-            borderRadius: 'var(--osd-radius-md)',
+            borderRadius: 'var(--osd-radius)',
             background: palette.surface,
             border: `1px solid ${palette.border}`,
             boxShadow: '0 24px 60px rgba(0,0,0,0.5)',
@@ -709,7 +709,7 @@ const AIApi: Page = () => (
           style={{
             background: palette.surface,
             border: `1px solid ${palette.border}`,
-            borderRadius: 'var(--osd-radius-md)',
+            borderRadius: 'var(--osd-radius)',
             padding: '24px 28px',
             fontFamily: fonts.mono,
             fontSize: 22,
@@ -801,7 +801,7 @@ const Platform: Page = () => {
               className="rc-fadeup"
               style={{
                 padding: 28,
-                borderRadius: 'var(--osd-radius-md)',
+                borderRadius: 'var(--osd-radius)',
                 background: palette.surface,
                 border: `1px solid ${palette.border}`,
                 animationDelay: `${260 + i * 70}ms`,
@@ -878,7 +878,7 @@ const DX: Page = () => (
             style={{
               flex: 1,
               padding: 32,
-              borderRadius: 'var(--osd-radius-md)',
+              borderRadius: 'var(--osd-radius)',
               background: palette.surface,
               border: `1px solid ${palette.border}`,
               animationDelay: `${280 + i * 100}ms`,

--- a/apps/demo/slides/ssh-explained/index.tsx
+++ b/apps/demo/slides/ssh-explained/index.tsx
@@ -7,7 +7,7 @@ export const design: DesignSystem = {
     body: '-apple-system, BlinkMacSystemFont, "Inter", "SF Pro Display", system-ui, sans-serif',
   },
   typeScale: { hero: 196, body: 28 },
-  radius: { md: 16 },
+  radius: 16,
 };
 
 const palette = {
@@ -501,7 +501,7 @@ const Overview: Page = () => (
             flex: 1,
             background: palette.surface,
             border: `1px solid ${palette.line}`,
-            borderRadius: 'var(--osd-radius-md)',
+            borderRadius: 'var(--osd-radius)',
             padding: '48px 40px',
             display: 'flex',
             flexDirection: 'column',
@@ -850,7 +850,7 @@ const KeyExchange: Page = () => (
           flex: 1,
           background: palette.surface,
           border: `1px solid ${palette.line}`,
-          borderRadius: 'var(--osd-radius-md)',
+          borderRadius: 'var(--osd-radius)',
           padding: '40px 44px',
         }}
       >
@@ -953,7 +953,7 @@ const KeyExchange: Page = () => (
           flex: 1,
           background: palette.surface,
           border: `1px solid ${palette.line}`,
-          borderRadius: 'var(--osd-radius-md)',
+          borderRadius: 'var(--osd-radius)',
           padding: '40px 44px',
         }}
       >
@@ -1053,7 +1053,7 @@ const ServerAuth: Page = () => (
           flex: 1,
           background: palette.surface,
           border: `1px solid ${palette.line}`,
-          borderRadius: 'var(--osd-radius-md)',
+          borderRadius: 'var(--osd-radius)',
           padding: 40,
           display: 'flex',
           flexDirection: 'column',
@@ -1117,7 +1117,7 @@ const ServerAuth: Page = () => (
           flex: 1,
           background: palette.surface,
           border: `1px solid ${palette.line}`,
-          borderRadius: 'var(--osd-radius-md)',
+          borderRadius: 'var(--osd-radius)',
           padding: 40,
           display: 'flex',
           flexDirection: 'column',
@@ -1332,7 +1332,7 @@ const EncryptedSession: Page = () => (
         flex: 1,
         background: palette.surface,
         border: `1px solid ${palette.line}`,
-        borderRadius: 'var(--osd-radius-md)',
+        borderRadius: 'var(--osd-radius)',
         padding: '50px 60px',
         display: 'flex',
         alignItems: 'center',

--- a/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
@@ -125,7 +125,7 @@ export const design: DesignSystem = {
     body: '-apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif',
   },
   typeScale: { hero: 168, body: 36 },
-  radius:    { md: 12 },
+  radius:    12,
 };
 ```
 
@@ -137,9 +137,9 @@ There are **two consumption surfaces**, and you should mix them inside the same 
 
 - **`var(--osd-X)` for visual properties (color, font, font-size, radius)** — these get instant updates while the user drags a slider in the Design panel, before any file write.
   ```tsx
-  <div style={{ background: 'var(--osd-bg)', color: 'var(--osd-text)', borderRadius: 'var(--osd-radius-md)', fontFamily: 'var(--osd-font-body)', fontSize: 'var(--osd-size-body)' }}>
+  <div style={{ background: 'var(--osd-bg)', color: 'var(--osd-text)', borderRadius: 'var(--osd-radius)', fontFamily: 'var(--osd-font-body)', fontSize: 'var(--osd-size-body)' }}>
   ```
-  Available vars: `--osd-bg`, `--osd-text`, `--osd-accent`, `--osd-font-display`, `--osd-font-body`, `--osd-size-hero`, `--osd-size-body`, `--osd-radius-md`.
+  Available vars: `--osd-bg`, `--osd-text`, `--osd-accent`, `--osd-font-display`, `--osd-font-body`, `--osd-size-hero`, `--osd-size-body`, `--osd-radius`.
 
 - **Direct `design.X` reads** — when you need a JS number for arithmetic or to label something in the UI. These update via HMR after the panel commits the file, not while dragging.
   ```tsx

--- a/packages/cli/template/slides/getting-started/index.tsx
+++ b/packages/cli/template/slides/getting-started/index.tsx
@@ -24,9 +24,7 @@ export const design: DesignSystem = {
     hero: 168,
     body: 36,
   },
-  radius: {
-    md: 16,
-  },
+  radius: 16,
 };
 
 // ─── Local (non-tweakable) constants ──────────────────────────────────────────
@@ -234,7 +232,7 @@ const WindowShell = ({
     style={{
       background: palette.surface,
       border: `1px solid ${palette.border}`,
-      borderRadius: 'var(--osd-radius-md)',
+      borderRadius: 'var(--osd-radius)',
       boxShadow: '0 40px 80px -30px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.02)',
       overflow: 'hidden',
       display: 'flex',
@@ -362,7 +360,7 @@ const LogoCard = ({
       flex: 1,
       background: palette.surface,
       border: `1px solid ${palette.border}`,
-      borderRadius: 'var(--osd-radius-md)',
+      borderRadius: 'var(--osd-radius)',
       padding: '40px 28px 32px',
       display: 'flex',
       flexDirection: 'column',

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -125,7 +125,7 @@ export const design: DesignSystem = {
     body: '-apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif',
   },
   typeScale: { hero: 168, body: 36 },
-  radius:    { md: 12 },
+  radius:    12,
 };
 ```
 
@@ -137,9 +137,9 @@ There are **two consumption surfaces**, and you should mix them inside the same 
 
 - **`var(--osd-X)` for visual properties (color, font, font-size, radius)** — these get instant updates while the user drags a slider in the Design panel, before any file write.
   ```tsx
-  <div style={{ background: 'var(--osd-bg)', color: 'var(--osd-text)', borderRadius: 'var(--osd-radius-md)', fontFamily: 'var(--osd-font-body)', fontSize: 'var(--osd-size-body)' }}>
+  <div style={{ background: 'var(--osd-bg)', color: 'var(--osd-text)', borderRadius: 'var(--osd-radius)', fontFamily: 'var(--osd-font-body)', fontSize: 'var(--osd-size-body)' }}>
   ```
-  Available vars: `--osd-bg`, `--osd-text`, `--osd-accent`, `--osd-font-display`, `--osd-font-body`, `--osd-size-hero`, `--osd-size-body`, `--osd-radius-md`.
+  Available vars: `--osd-bg`, `--osd-text`, `--osd-accent`, `--osd-font-display`, `--osd-font-body`, `--osd-size-hero`, `--osd-size-body`, `--osd-radius`.
 
 - **Direct `design.X` reads** — when you need a JS number for arithmetic or to label something in the UI. These update via HMR after the panel commits the file, not while dragging.
   ```tsx

--- a/packages/core/src/app/components/style-panel/style-panel.tsx
+++ b/packages/core/src/app/components/style-panel/style-panel.tsx
@@ -158,15 +158,15 @@ export function DesignPanel({ open, onClose }: DesignPanelProps) {
       <Section title="Shape">
         <SliderField
           label="Radius"
-          value={draft.radius.md}
+          value={draft.radius}
           min={0}
           max={80}
           step={1}
           suffix="px"
           onChange={(n) =>
             update((d) => {
-              d.radius.md = n;
-            }, 'design:radius.md')
+              d.radius = n;
+            }, 'design:radius')
           }
         />
       </Section>

--- a/packages/core/src/app/lib/design.ts
+++ b/packages/core/src/app/lib/design.ts
@@ -14,15 +14,11 @@ export type DesignTypeScale = {
   body: number;
 };
 
-export type DesignRadius = {
-  md: number;
-};
-
 export type DesignSystem = {
   palette: DesignPalette;
   fonts: DesignFonts;
   typeScale: DesignTypeScale;
-  radius: DesignRadius;
+  radius: number;
 };
 
 export function designToCssVars(d: DesignSystem): Record<string, string> {
@@ -34,7 +30,7 @@ export function designToCssVars(d: DesignSystem): Record<string, string> {
     '--osd-font-body': d.fonts.body,
     '--osd-size-hero': `${d.typeScale.hero}px`,
     '--osd-size-body': `${d.typeScale.body}px`,
-    '--osd-radius-md': `${d.radius.md}px`,
+    '--osd-radius': `${d.radius}px`,
   };
 }
 
@@ -58,7 +54,5 @@ export const defaultDesign: DesignSystem = {
     hero: 168,
     body: 36,
   },
-  radius: {
-    md: 12,
-  },
+  radius: 12,
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,6 @@ export type { OpenSlideConfig } from './config.ts';
 export type {
   DesignFonts,
   DesignPalette,
-  DesignRadius,
   DesignSystem,
   DesignTypeScale,
 } from './app/lib/design.ts';

--- a/packages/core/src/vite/design-plugin.test.ts
+++ b/packages/core/src/vite/design-plugin.test.ts
@@ -20,7 +20,7 @@ const design: DesignSystem = {
     body: 'system-ui, sans-serif',
   },
   typeScale: { hero: 168, body: 36 },
-  radius: { md: 12 },
+  radius: 12,
 };
 
 const Cover: Page = () => (
@@ -47,7 +47,7 @@ describe('parseSlideDesign', () => {
     if (!r.ok) throw new Error('expected ok');
     expect(r.design.palette.accent).toBe('#6d4cff');
     expect(r.design.typeScale.hero).toBe(168);
-    expect(r.design.radius.md).toBe(12);
+    expect(r.design.radius).toBe(12);
   });
 
   it('reports exists:false for a slide with no design const', () => {
@@ -69,7 +69,7 @@ describe('parseSlideDesign', () => {
     const src = `const design = ${serializeDesign(defaultDesign)} satisfies DesignSystem;`;
     const r = parseSlideDesign(src);
     if (!r.ok) throw new Error('expected ok');
-    expect(r.design.radius.md).toBe(defaultDesign.radius.md);
+    expect(r.design.radius).toBe(defaultDesign.radius);
   });
 });
 


### PR DESCRIPTION
The Design panel only exposes one global Radius slider and there is no plan for a sm/md/lg scale, so the wrapping object was dead structure.

BREAKING CHANGE:
- DesignSystem.radius is now `number` (was `{ md: number }`)
- CSS var renamed: `--osd-radius-md` → `--osd-radius`
- DesignRadius type removed from public exports