### PR TITLE
fix(cli): add vite to template devDependencies for Vercel auto-detection

### DIFF
--- a/.changeset/vercel-vite-detection.md
+++ b/.changeset/vercel-vite-detection.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/cli": patch
+---
+
+Add `vite` to the scaffolded template's `devDependencies` so projects created via `open-slide init` are auto-detected as Vite projects on Vercel. Vercel's framework detector regex-matches `"vite"` in `package.json` dependencies, and previously the template only declared `@open-slide/core`, leaving vite transitive and undetected. The existing `build` script (`open-slide build`) and `dist` output directory already match Vercel's Vite preset defaults.

--- a/packages/cli/template/package.json
+++ b/packages/cli/template/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1"
+    "@types/react-dom": "^18.3.1",
+    "vite": "^5.4.10"
   }
 }


### PR DESCRIPTION
Vercel's framework detector regex-matches "vite" inside the project's package.json dependencies/devDependencies. The CLI template only declared @open-slide/core, so vite stayed transitive and projects scaffolded via `open-slide init` were not auto-recognised as Vite projects on import. Declaring vite directly lets Vercel pick the correct preset; the existing `build` script (open-slide build) and `dist` output dir already match Vite's defaults.