### PR TITLE
fix(skills): include radius in slide-authoring starter design token

### DIFF
--- a/.changeset/fix-design-token-radius.md
+++ b/.changeset/fix-design-token-radius.md
@@ -1,0 +1,6 @@
+---
+"@open-slide/core": patch
+"@open-slide/cli": patch
+---
+
+Add the required `radius` field to the `slide-authoring` skill's starter template. Without it, slides scaffolded from the template fail TypeScript because `DesignSystem` requires `radius: number`.

--- a/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
@@ -167,6 +167,7 @@ export const design: DesignSystem = {
     body: 'system-ui, -apple-system, sans-serif',
   },
   typeScale: { hero: 180, body: 40 },
+  radius: 12,
 };
 
 // Extra colors / sizes outside the DesignSystem shape stay as plain consts.

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -167,6 +167,7 @@ export const design: DesignSystem = {
     body: 'system-ui, -apple-system, sans-serif',
   },
   typeScale: { hero: 180, body: 40 },
+  radius: 12,
 };
 
 // Extra colors / sizes outside the DesignSystem shape stay as plain consts.


### PR DESCRIPTION
The starter template typed `design` as `DesignSystem` but omitted the
required `radius` field, so any slide an agent generated verbatim from
this template failed TypeScript.