### PR TITLE
docs(web): document the locale config

### DIFF
--- a/apps/web/content/docs/reference/config.mdx
+++ b/apps/web/content/docs/reference/config.mdx
@@ -31,6 +31,8 @@ type OpenSlideConfig = {
   slidesDir?: string;
   /** Dev server port. Default: first free port from 5173 upward. */
   port?: number;
+  /** UI language for the runtime (home, inspector, presenter, etc.). */
+  locale?: Locale;
   /** Build-time UI toggles. */
   build?: OpenSlideBuildConfig;
 };
@@ -54,3 +56,16 @@ const config: OpenSlideConfig = {
 
 `slidesDir` is a single path today. If you want multiple roots, group them
 under one folder and use subfolder ids.
+
+### Switch the UI language
+
+```ts
+import { zhTW } from '@open-slide/core/locale';
+
+const config: OpenSlideConfig = {
+  locale: zhTW,
+};
+```
+
+See [Locale](/docs/reference/locale) for the full list of presets and how to
+ship your own dictionary.

--- a/apps/web/content/docs/reference/locale.mdx
+++ b/apps/web/content/docs/reference/locale.mdx
@@ -1,0 +1,97 @@
+---
+title: Locale
+description: Translate the runtime UI — home, inspector, presenter, toasts.
+---
+
+The runtime ships with four built-in dictionaries. Pick one in
+`open-slide.config.ts`, or pass your own object that satisfies the `Locale`
+type.
+
+The locale only affects the **runtime UI** that open-slide renders around
+your slides (the home screen, slide browser, inspector, asset panel,
+presenter mode, toasts, etc.). It does **not** translate slide content —
+that lives in your own React code.
+
+## Presets
+
+```ts title="open-slide.config.ts"
+import type { OpenSlideConfig } from '@open-slide/core';
+import { zhTW } from '@open-slide/core/locale';
+
+const config: OpenSlideConfig = {
+  locale: zhTW,
+};
+
+export default config;
+```
+
+| Import   | `id`      | Language            |
+| -------- | --------- | ------------------- |
+| `en`     | `'en'`    | English (default)   |
+| `zhTW`   | `'zh-TW'` | 繁體中文            |
+| `zhCN`   | `'zh-CN'` | 简体中文            |
+| `ja`     | `'ja'`    | 日本語              |
+
+All presets are re-exported from the `@open-slide/core/locale` subpath:
+
+```ts
+import { en, zhTW, zhCN, ja } from '@open-slide/core/locale';
+```
+
+If `locale` is omitted, the runtime falls back to `en`.
+
+## Custom dictionaries
+
+A locale is plain data — no functions, no JSX — so it serializes through
+the build cleanly. Provide your own object as long as it matches the
+`Locale` type from `@open-slide/core`.
+
+```ts title="open-slide.config.ts"
+import type { OpenSlideConfig, Locale } from '@open-slide/core';
+import { en } from '@open-slide/core/locale';
+
+const fr: Locale = {
+  ...en,
+  id: 'en', // pick the closest built-in id
+  common: {
+    ...en.common,
+    save: 'Enregistrer',
+    cancel: 'Annuler',
+    // …override the rest
+  },
+};
+
+const config: OpenSlideConfig = { locale: fr };
+export default config;
+```
+
+The `id` field today only has to be one of the built-in ids
+(`'en' | 'zh-TW' | 'zh-CN' | 'ja'`); it is reserved for future locale-aware
+formatting. The dictionary keys are what actually drive the UI.
+
+The full shape lives in `packages/core/src/locale/types.ts` — start from a
+preset and override the keys you need rather than building one from scratch.
+
+## Templates and plurals
+
+A few entries are templates with `{name}`-style placeholders, or plural
+forms (`{ one, other }`). They are flagged in the type definition with
+JSDoc, e.g.:
+
+```ts
+/** template: "Loading {slideId}…" */
+loadingSlide: string;
+
+/** templates: "{count} unsaved change" / "{count} unsaved changes" */
+unsavedChanges: Plural;
+```
+
+The runtime expands these for you — your job is just to keep the same
+`{placeholder}` tokens (and both `one` and `other` forms) when translating.
+
+## Notes
+
+- Locale is read at module init. Changing it requires a dev-server reload
+  or a fresh build.
+- There is no in-app language switcher today; pick a single locale per
+  deployment.

--- a/apps/web/content/docs/reference/meta.json
+++ b/apps/web/content/docs/reference/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Reference",
-  "pages": ["config", "slide-meta"]
+  "pages": ["config", "slide-meta", "locale"]
 }


### PR DESCRIPTION
## Summary
- Add a Reference > Locale page covering the four built-in presets (`en`, `zhTW`, `zhCN`, `ja`), the `@open-slide/core/locale` subpath, custom `Locale` dictionaries, and template/plural placeholders.
- Add `locale?: Locale` to the schema in the config reference and a short recipe linking to the new page.
- Add `locale` to the Reference sidebar.

Follow-up to #25 — the i18n feature shipped without docs.

## Test plan
- [ ] `pnpm --filter web dev` renders the new Reference > Locale page and the config page lists the `locale` field.
- [ ] Sidebar order is config → slide-meta → locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)