### PR TITLE
feat(sidebar): polish folder UX

### DIFF
--- a/.changeset/sidebar-folder-ux.md
+++ b/.changeset/sidebar-folder-ux.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Polish sidebar folder UX: pick color/emoji while creating, success/error toasts on create/delete and slide drag-drop, right-aligned counts.

--- a/packages/core/src/app/components/sidebar/folder-item.tsx
+++ b/packages/core/src/app/components/sidebar/folder-item.tsx
@@ -187,7 +187,14 @@ export function FolderItem({
         </button>
       )}
 
-      <span className={cn('folio shrink-0', count === 0 && 'opacity-0 group-hover:opacity-100')}>
+      <span
+        className={cn(
+          'folio ml-auto shrink-0 transition-opacity',
+          row.kind === 'folder' &&
+            import.meta.env.DEV &&
+            'group-hover:opacity-0 group-has-[[aria-expanded=true]]:opacity-0',
+        )}
+      >
         {count.toString().padStart(2, '0')}
       </span>
 
@@ -197,7 +204,7 @@ export function FolderItem({
             <button
               type="button"
               onClick={(e) => e.stopPropagation()}
-              className="size-5 shrink-0 rounded opacity-0 transition-opacity hover:bg-foreground/10 group-hover:opacity-100 aria-expanded:opacity-100"
+              className="absolute right-2 top-1/2 size-5 -translate-y-1/2 rounded opacity-0 transition-opacity hover:bg-foreground/10 group-hover:opacity-100 aria-expanded:opacity-100"
               aria-label={t.home.folderActions}
             >
               <MoreHorizontal className="mx-auto size-3.5" />

--- a/packages/core/src/app/components/sidebar/icon-picker.tsx
+++ b/packages/core/src/app/components/sidebar/icon-picker.tsx
@@ -1,7 +1,7 @@
 import EmojiPicker, { EmojiStyle, Theme } from 'emoji-picker-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useLocale } from '@/lib/use-locale';
 import type { FolderIcon } from '@/lib/sdk';
+import { useLocale } from '@/lib/use-locale';
 
 // Editorial palette — restrained warm/earth tones, no shadcn defaults
 // (no #8b5cf6 violet, no #3b82f6 blue, etc.). Picked to coexist with the

--- a/packages/core/src/app/components/sidebar/sidebar.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar.tsx
@@ -1,10 +1,12 @@
 import { Plus } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
 import { ThemeToggle } from '@/components/theme-toggle';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import type { Folder, FolderIcon } from '@/lib/sdk';
-import { useLocale } from '@/lib/use-locale';
-import { FolderItem } from './folder-item';
-import { PRESET_COLORS } from './icon-picker';
+import { format, useLocale } from '@/lib/use-locale';
+import { FolderIconChip, FolderItem } from './folder-item';
+import { IconPicker, PRESET_COLORS } from './icon-picker';
 
 export const DRAFT_ID = 'draft';
 
@@ -33,20 +35,64 @@ export function Sidebar({
 }) {
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState('');
+  const [newIcon, setNewIcon] = useState<FolderIcon>(() => ({
+    type: 'color',
+    value: PRESET_COLORS[0],
+  }));
+  const [iconOpen, setIconOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
   const t = useLocale();
 
-  const commitCreate = () => {
-    const trimmed = newName.trim();
+  const startCreating = () => {
+    const color = PRESET_COLORS[folders.length % PRESET_COLORS.length];
+    setNewIcon({ type: 'color', value: color });
+    setNewName('');
+    setCreating(true);
+  };
+
+  useEffect(() => {
+    if (creating) inputRef.current?.focus();
+  }, [creating]);
+
+  const stateRef = useRef({ name: newName, icon: newIcon, iconOpen });
+  stateRef.current = { name: newName, icon: newIcon, iconOpen };
+
+  const exitCreate = () => {
+    setCreating(false);
+    setNewName('');
+    setIconOpen(false);
+  };
+
+  const commitCreate = async () => {
+    const trimmed = stateRef.current.name.trim();
+    const icon = stateRef.current.icon;
     if (!trimmed) {
-      setCreating(false);
-      setNewName('');
+      exitCreate();
       return;
     }
-    const color = PRESET_COLORS[folders.length % PRESET_COLORS.length];
-    onCreate(trimmed, { type: 'color', value: color });
-    setNewName('');
-    setCreating(false);
+    exitCreate();
+    try {
+      const folder = await onCreate(trimmed, icon);
+      toast.success(format(t.home.toastFolderCreated, { name: folder?.name ?? trimmed }));
+    } catch {
+      toast.error(t.home.toastFolderCreateFailed);
+    }
   };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: commitCreate reads latest state via stateRef
+  useEffect(() => {
+    if (!creating) return;
+    const onDown = (e: MouseEvent) => {
+      if (stateRef.current.iconOpen) return;
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest('[data-folder-create]')) return;
+      if (target.closest('[data-radix-popper-content-wrapper]')) return;
+      commitCreate();
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [creating]);
 
   return (
     <aside className="paper relative flex h-full w-[16.5rem] shrink-0 flex-col border-r border-hairline bg-sidebar text-sidebar-foreground">
@@ -91,18 +137,31 @@ export function Sidebar({
 
         {import.meta.env.DEV &&
           (creating ? (
-            <div className="mt-1 flex items-center gap-2 rounded-[5px] border border-dashed border-foreground/30 bg-card px-2 py-1.5">
-              <span className="size-2 shrink-0 rounded-[2px] bg-brand" aria-hidden />
+            <div
+              data-folder-create
+              className="mt-1 flex items-center gap-2.5 rounded-[5px] border border-dashed border-foreground/30 bg-card px-2 py-[5px]"
+            >
+              <Popover open={iconOpen} onOpenChange={setIconOpen}>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    className="flex size-5 shrink-0 items-center justify-center rounded transition-transform hover:scale-110"
+                    aria-label={t.home.pickIcon}
+                  >
+                    <FolderIconChip icon={newIcon} />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent side="right" align="start" className="w-auto p-2">
+                  <IconPicker value={newIcon} onChange={setNewIcon} />
+                </PopoverContent>
+              </Popover>
               <input
+                ref={inputRef}
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
-                onBlur={commitCreate}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') commitCreate();
-                  if (e.key === 'Escape') {
-                    setCreating(false);
-                    setNewName('');
-                  }
+                  if (e.key === 'Escape') exitCreate();
                 }}
                 placeholder={t.home.folderName}
                 maxLength={40}
@@ -112,7 +171,7 @@ export function Sidebar({
           ) : (
             <button
               type="button"
-              onClick={() => setCreating(true)}
+              onClick={startCreating}
               className="mt-1 flex w-full items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12px] text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
             >
               <Plus className="size-3.5" />

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -1,6 +1,7 @@
 import { FolderInput, FolderPlus, MoreHorizontal, Pencil, Search, Trash2, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -17,7 +18,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useFolders } from '@/lib/folders';
-import { useLocale } from '@/lib/use-locale';
+import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import { FolderIconChip, SLIDE_DND_MIME } from '../components/sidebar/folder-item';
 import { DRAFT_ID, Sidebar } from '../components/sidebar/sidebar';
@@ -78,6 +79,24 @@ export function Home() {
     );
   }, []);
 
+  const moveSlideWithToast = useCallback(
+    async (slideId: string, folderId: string | null) => {
+      if (manifest.assignments[slideId] === (folderId ?? undefined)) return;
+      const slideName = titleMap[slideId] ?? slideId;
+      const folderName =
+        folderId === null
+          ? t.home.draft
+          : (manifest.folders.find((f) => f.id === folderId)?.name ?? folderId);
+      try {
+        await assign(slideId, folderId);
+        toast.success(format(t.home.toastSlideMoved, { slide: slideName, folder: folderName }));
+      } catch {
+        toast.error(t.home.toastSlideMoveFailed);
+      }
+    },
+    [assign, manifest, titleMap, t],
+  );
+
   const trimmedQuery = query.trim().toLowerCase();
   const filteredSlides = useMemo(() => {
     if (!trimmedQuery) return visibleSlides;
@@ -100,12 +119,18 @@ export function Home() {
           onCreate={(name, icon) => create(name, icon)}
           onRename={(id, name) => update(id, { name })}
           onChangeIcon={(id, icon) => update(id, { icon })}
-          onDelete={(id) => {
+          onDelete={async (id) => {
+            const name = manifest.folders.find((f) => f.id === id)?.name ?? id;
             if (selectedId === id) selectFolder(DRAFT_ID);
-            remove(id);
+            try {
+              await remove(id);
+              toast.success(format(t.home.toastFolderDeleted, { name }));
+            } catch {
+              toast.error(t.home.toastFolderDeleteFailed);
+            }
           }}
-          onDropToFolder={(folderId, slideId) => assign(slideId, folderId)}
-          onDropToDraft={(slideId) => assign(slideId, null)}
+          onDropToFolder={(folderId, slideId) => moveSlideWithToast(slideId, folderId)}
+          onDropToDraft={(slideId) => moveSlideWithToast(slideId, null)}
         />
       </div>
 

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -71,6 +71,13 @@ export const en: Locale = {
     deleteDialogDescriptionPrefix: 'This permanently removes ',
     deleteDialogDescriptionMid: ' and its files from disk. ',
     deleteDialogDescriptionSuffix: 'This action cannot be undone.',
+    toastFolderCreated: 'Created folder “{name}”',
+    toastFolderCreateFailed: 'Failed to create folder',
+    toastSlideMoved: 'Moved “{slide}” to {folder}',
+    toastSlideMoveFailed: 'Failed to move slide',
+    toastFolderDeleted: 'Deleted folder “{name}”',
+    toastFolderDeleteFailed: 'Failed to delete folder',
+    pickIcon: 'Pick icon',
   },
 
   slide: {

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -71,6 +71,13 @@ export const ja: Locale = {
     deleteDialogDescriptionPrefix: '',
     deleteDialogDescriptionMid: ' とそのファイルをディスクから完全に削除します。',
     deleteDialogDescriptionSuffix: 'この操作は元に戻せません。',
+    toastFolderCreated: 'フォルダ「{name}」を作成しました',
+    toastFolderCreateFailed: 'フォルダの作成に失敗しました',
+    toastSlideMoved: '「{slide}」を {folder} に移動しました',
+    toastSlideMoveFailed: 'スライドの移動に失敗しました',
+    toastFolderDeleted: 'フォルダ「{name}」を削除しました',
+    toastFolderDeleteFailed: 'フォルダの削除に失敗しました',
+    pickIcon: 'アイコンを選択',
   },
 
   slide: {

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -71,6 +71,16 @@ export type Locale = {
     deleteDialogDescriptionPrefix: string;
     deleteDialogDescriptionMid: string;
     deleteDialogDescriptionSuffix: string;
+    /** template: "Created folder “{name}”" */
+    toastFolderCreated: string;
+    toastFolderCreateFailed: string;
+    /** template: "Moved “{slide}” to {folder}" */
+    toastSlideMoved: string;
+    toastSlideMoveFailed: string;
+    /** template: "Deleted folder “{name}”" */
+    toastFolderDeleted: string;
+    toastFolderDeleteFailed: string;
+    pickIcon: string;
   };
 
   slide: {

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -71,6 +71,13 @@ export const zhCN: Locale = {
     deleteDialogDescriptionPrefix: '这将永久从磁盘移除 ',
     deleteDialogDescriptionMid: ' 及其文件。',
     deleteDialogDescriptionSuffix: '此操作无法撤销。',
+    toastFolderCreated: '已创建文件夹"{name}"',
+    toastFolderCreateFailed: '创建文件夹失败',
+    toastSlideMoved: '已将"{slide}"移至 {folder}',
+    toastSlideMoveFailed: '移动幻灯片失败',
+    toastFolderDeleted: '已删除文件夹"{name}"',
+    toastFolderDeleteFailed: '删除文件夹失败',
+    pickIcon: '选择图标',
   },
 
   slide: {

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -71,6 +71,13 @@ export const zhTW: Locale = {
     deleteDialogDescriptionPrefix: '這將永久從磁碟移除 ',
     deleteDialogDescriptionMid: ' 與其檔案。',
     deleteDialogDescriptionSuffix: '此操作無法復原。',
+    toastFolderCreated: '已建立資料夾「{name}」',
+    toastFolderCreateFailed: '建立資料夾失敗',
+    toastSlideMoved: '已將「{slide}」移至 {folder}',
+    toastSlideMoveFailed: '移動投影片失敗',
+    toastFolderDeleted: '已刪除資料夾「{name}」',
+    toastFolderDeleteFailed: '刪除資料夾失敗',
+    pickIcon: '選擇圖示',
   },
 
   slide: {


### PR DESCRIPTION
## Summary

Tightens up the sidebar folder creation/management flow and the folder list layout.

- **Create flow** — Clicking *New folder* now auto-focuses the name input. A popover next to the input lets you pick a color or emoji *before* committing, instead of having to rename + change icon as two steps. Default color still rotates through `PRESET_COLORS` based on folder count.
- **Toasts** — Success/error toasts on folder create, folder delete, and slide drag-and-drop between folders/draft. Drops with no actual change are silent.
- **Layout** — Folder counts (`02`, `01`, …) are now right-aligned. The hover more-menu absolutely overlays the count instead of pushing it off-axis, and `00` is always rendered (no longer hidden when empty).

Localized in en / zh-TW / zh-CN / ja.

## Test plan

- [ ] Click *New folder* → input is focused; type → press Enter → success toast appears.
- [ ] Click *New folder* → click the swatch → pick an emoji or different color → press Enter → folder is created with that icon.
- [ ] Click *New folder* → click outside (not into the picker popover) → form closes; empty input does not create a folder.
- [ ] Drag a slide from Draft into a folder → success toast “Moved … to …”; drag back to Draft → toast “Moved … to Draft”.
- [ ] Delete a folder via the more-menu → success toast “Deleted folder …”.
- [ ] Folder rows show counts right-aligned. Hovering a folder row reveals the more-menu in place of the count. `00`-count folders still render `00` by default.