### PR TITLE
feat(loader): sliding hairline for slide & presenter loading

### DIFF
--- a/.changeset/loading-line.md
+++ b/.changeset/loading-line.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Replace spinner with a hairline + sliding bar for slide and presenter loading states.

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, Loader2, RotateCcw, Square, Sun } from 'lucide-react';
+import { ChevronLeft, ChevronRight, RotateCcw, Square, Sun } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
@@ -115,9 +115,14 @@ export function Presenter() {
   if (!slide) {
     return (
       <div className="grid h-dvh place-items-center bg-zinc-950 text-zinc-400">
-        <div className="flex items-center gap-2 text-[12.5px]">
-          <Loader2 className="size-4 animate-spin" />{' '}
-          {format(t.presenter.loadingSlide, { slideId })}
+        <div className="flex flex-col items-center gap-4">
+          <div className="relative h-px w-56 overflow-hidden bg-white/10">
+            <span
+              aria-hidden
+              className="line-loader-bar absolute inset-y-[-0.5px] left-0 w-1/4 bg-zinc-100"
+            />
+          </div>
+          <div className="text-[12.5px]">{format(t.presenter.loadingSlide, { slideId })}</div>
         </div>
       </div>
     );

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -128,9 +128,19 @@ export function Slide() {
 
   if (!slide) {
     return (
-      <div className="mx-auto max-w-3xl px-8 py-16 text-[12.5px] text-muted-foreground">
-        <span className="eyebrow">{t.slide.loadingEyebrow}</span>
-        <p className="mt-2 font-mono">{slideId}</p>
+      <div className="grid min-h-dvh place-items-center px-8 text-muted-foreground">
+        <div className="flex flex-col items-center gap-4">
+          <div className="relative h-px w-56 overflow-hidden bg-hairline">
+            <span
+              aria-hidden
+              className="line-loader-bar absolute inset-y-[-0.5px] left-0 w-1/4 bg-foreground"
+            />
+          </div>
+          <div className="flex flex-wrap items-baseline justify-center gap-x-2 text-[11.5px]">
+            <span className="eyebrow">{t.slide.loadingEyebrow}</span>
+            <span className="font-mono">{slideId}</span>
+          </div>
+        </div>
       </div>
     );
   }

--- a/packages/core/src/app/styles.css
+++ b/packages/core/src/app/styles.css
@@ -348,6 +348,34 @@
   }
 }
 
+/*
+ * Indeterminate "line loader" — a hairline track with a short bar that
+ * glides back and forth. Used for full-screen loading states in place of
+ * a spinner; quieter, more typographic, easier on the eye.
+ */
+@keyframes osd-line-loader {
+  0% {
+    transform: translateX(0%);
+  }
+  50% {
+    transform: translateX(300%);
+  }
+  100% {
+    transform: translateX(0%);
+  }
+}
+
+.line-loader-bar {
+  animation: osd-line-loader 1.4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .line-loader-bar {
+    animation: none;
+    transform: translateX(150%);
+  }
+}
+
 [data-osd-freeze-motion],
 [data-osd-freeze-motion] *,
 [data-osd-freeze-motion] *::before,


### PR DESCRIPTION
## Summary
- Replace the corner-stuck Loading text on slide load and the `Loader2` spinner on presenter load with a centered hairline + short bar that glides back and forth.
- Animation lives in `styles.css` as `osd-line-loader` keyframes + `.line-loader-bar` utility; respects `prefers-reduced-motion`.
- Light variant (slide) uses `bg-hairline` / `bg-foreground`; dark variant (presenter) uses `bg-white/10` / `bg-zinc-100`.

## Test plan
- [ ] `pnpm dev`, navigate to a slow-loading slide → hairline animates in viewport center.
- [ ] Open `/s/<id>/presenter` against the dark backdrop → bar reads correctly.
- [ ] System "reduce motion" enabled → bar parks mid-track without animating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)