### PR TITLE
fix(sidebar): align theme toggle flush with folder count column

### DIFF
--- a/.changeset/sidebar-theme-toggle-align.md
+++ b/.changeset/sidebar-theme-toggle-align.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Align sidebar theme toggle flush with the right column of folder counts.

--- a/packages/core/src/app/components/sidebar/sidebar.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar.tsx
@@ -98,7 +98,9 @@ export function Sidebar({
     <aside className="paper relative flex h-full w-[16.5rem] shrink-0 flex-col border-r border-hairline bg-sidebar text-sidebar-foreground">
       <div className="flex items-center justify-between px-4 pt-5 pb-4">
         <h1 className="font-heading text-lg font-bold tracking-tight">{t.home.appTitle}</h1>
-        <ThemeToggle />
+        <div className="-mr-1.5">
+          <ThemeToggle />
+        </div>
       </div>
 
       <div className="px-2">


### PR DESCRIPTION
## Summary
- Wrap the sidebar `ThemeToggle` in a `-mr-1.5` spacer so the sun/moon glyph's visual edge lines up with the `07`/`00` numerals below it. The icon button's internal padding (28px button, 14px icon) made the toggle look inset against `justify-between`'s mathematical right edge.

## Test plan
- [ ] Open the home view in light + dark mode and confirm the toggle visually aligns with the Draft count and FOLDERS `00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)