### PR TITLE
fix(web): remove init button from landing nav

### DIFF
--- a/apps/web/components/landing/nav.tsx
+++ b/apps/web/components/landing/nav.tsx
@@ -59,13 +59,6 @@ export function Nav() {
           >
             GitHub ↗
           </a>
-          <a
-            href="#install"
-            className="inline-flex items-center gap-2 px-3.5 h-8 rounded-full border border-[color:var(--color-rule)] text-[color:var(--color-text)] hover:border-[color:var(--color-accent)] hover:text-[color:var(--color-accent)] transition"
-          >
-            init
-            <span aria-hidden>→</span>
-          </a>
           <ThemeToggle />
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- Drop the `init →` pill from the landing navbar; `ThemeToggle` is now the trailing nav element.

## Test plan
- [ ] Visual check the landing nav on desktop and mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)