### PR TITLE
fix(core): add envDir to load .env from user project root

### DIFF
--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -37,6 +37,7 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
   return {
     root: APP_ROOT,
     configFile: false,
+    envDir: userCwd,
     plugins: [
       locTagsPlugin({ userCwd, slidesDir }),
       react(),


### PR DESCRIPTION
envDir isn't set so Vite couldn't scan user project's environment variables. This change allows users to use .env / .env.local with VITE_ prefixed variables in their project.