### PR TITLE
feat(sidebar): hide total folder count next to "Folders" header

### DIFF
--- a/.changeset/sidebar-hide-counts.md
+++ b/.changeset/sidebar-hide-counts.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Hide the total folder count next to the sidebar "Folders" header.

--- a/packages/core/src/app/components/sidebar/sidebar.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar.tsx
@@ -116,7 +116,6 @@ export function Sidebar({
       <div className="mt-5 flex items-center gap-2 px-4 pb-1.5">
         <span className="eyebrow">{t.home.folders}</span>
         <span className="h-px flex-1 bg-hairline" aria-hidden />
-        <span className="folio">{folders.length.toString().padStart(2, '0')}</span>
       </div>
 
       <div className="flex-1 overflow-y-auto px-2 pb-2">


### PR DESCRIPTION
## Summary
- Remove the aggregate folder count badge that sat beside the sidebar "Folders" section header
- Per-folder slide counts are unchanged

## Test plan
- [ ] `pnpm dev` and confirm the "Folders" header no longer shows a trailing two-digit number
- [ ] Each folder row still shows its slide count

🤖 Generated with [Claude Code](https://claude.com/claude-code)