### PR TITLE
fix(core): make dev server work on Windows

### DIFF
--- a/.changeset/fix-windows-dev-server.md
+++ b/.changeset/fix-windows-dev-server.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Fix dev server on Windows: normalize `/@fs/` URL for drive-letter paths and pre-bundle `react`, `react-dom`, `react-dom/client`, and `next-themes`.

--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -55,6 +55,10 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
     optimizeDeps: {
       entries: [path.join(APP_ROOT, 'main.tsx')],
       include: [
+        'react',
+        'react-dom',
+        'react-dom/client',
+        'next-themes',
         'react-router-dom',
         'radix-ui',
         'lucide-react',

--- a/packages/core/src/vite/open-slide-plugin.ts
+++ b/packages/core/src/vite/open-slide-plugin.ts
@@ -65,7 +65,7 @@ function toId(absFile: string, slidesRoot: string): string {
 function generateSlidesModule(files: string[], slidesRoot: string, isDev: boolean): string {
   const entries = files.map((abs) => {
     const id = toId(abs, slidesRoot);
-    const importPath = isDev ? `/@fs${abs}` : abs;
+    const importPath = isDev ? `/@fs/${abs.replace(/^\/+/, '')}` : abs;
     return { id, importPath };
   });
 


### PR DESCRIPTION
- Normalize `/@fs/` URL so Windows drive-letter paths get the required separator (was producing `/@fsE:/...` and breaking slide loading).
- Explicitly include `react`, `react-dom`, `react-dom/client`, and `next-themes` in `optimizeDeps.include` so they get pre-bundled into ESM. Without this, the in-`node_modules` `root` prevents `@vitejs/plugin-react`'s auto-include from firing and Vite serves the raw CJS files, which lack the named exports the app imports.