### PR TITLE
fix(vite-plugin): emit /@fs/ with leading slash for Windows paths

### DIFF
--- a/.changeset/fix-windows-fs-import-path.md
+++ b/.changeset/fix-windows-fs-import-path.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Fix dev-time slide imports on Windows by emitting `/@fs/` with a leading slash before the absolute path.

--- a/packages/core/src/vite/open-slide-plugin.ts
+++ b/packages/core/src/vite/open-slide-plugin.ts
@@ -62,10 +62,17 @@ function toId(absFile: string, slidesRoot: string): string {
   return rel.split(path.sep)[0];
 }
 
+function toFsImportPath(abs: string): string {
+  // Vite's `/@fs/` prefix expects exactly one slash before the absolute path.
+  // POSIX abs paths already start with `/`; Windows ones start with a drive
+  // letter (`C:\…`). Normalise both to a single leading slash form.
+  return `/@fs/${abs.replace(/\\/g, '/').replace(/^\/+/, '')}`;
+}
+
 function generateSlidesModule(files: string[], slidesRoot: string, isDev: boolean): string {
   const entries = files.map((abs) => {
     const id = toId(abs, slidesRoot);
-    const importPath = isDev ? `/@fs${abs}` : abs;
+    const importPath = isDev ? toFsImportPath(abs) : abs;
     return { id, importPath };
   });
 


### PR DESCRIPTION
## Problem

On Windows, the dev-time slide-loader virtual module emits unresolvable import URLs:

```
[plugin:vite:import-analysis] Failed to resolve import "/@fsC:/Users/dev/my-deck/slides/example/index.tsx" from "virtual:open-slide/slides". Does the file exist?
```

Note the missing slash between `/@fs` and `C:`. The current code:

```ts
const importPath = isDev ? `/@fs${abs}` : abs;
```

assumes `abs` is POSIX (starts with `/`), which is true on Linux/macOS but not on Windows where it starts with a drive letter.

## Repro

1. On Windows, `npx @open-slide/cli init my-deck`
2. `cd my-deck && npm run dev`
3. Open the generated slide route — Vite overlay shows the error above.

## Fix

Extract a `toFsImportPath` helper that normalises both forms (forward-slash backslashes, strip any leading slash, then prepend exactly one `/@fs/`). Behaviour on Linux/macOS is unchanged.

## Notes

- One-line behaviour change in `packages/core/src/vite/open-slide-plugin.ts`.
- Changeset added (`patch` for `@open-slide/core`).
- `pnpm check` is clean for the modified file. The 4 pre-existing warnings/errors in `apps/web`, `apps/demo/slides/*`, and `packages/cli/src/index.ts` are unrelated to this change.
- Same goes for the pre-existing `player.tsx` typecheck error — untouched.