### PR TITLE
fix(web): use light variants for vercel/zeabur logos on landing assets

### DIFF
--- a/apps/web/components/landing/assets.tsx
+++ b/apps/web/components/landing/assets.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-type AssetMock = { name: string; size: string; logo: string };
+type AssetMock = { name: string; size: string; logo: string; themed?: boolean };
 
 const assets: AssetMock[] = [
   { name: 'claude.svg', size: '3.4 KB', logo: 'claude' },
@@ -8,13 +8,13 @@ const assets: AssetMock[] = [
   { name: 'gemini.svg', size: '4.0 KB', logo: 'gemini' },
   { name: 'cursor-dark.svg', size: '5.2 KB', logo: 'cursor-dark' },
   { name: 'cloudflare.svg', size: '6.8 KB', logo: 'cloudflare' },
-  { name: 'zeabur-dark.svg', size: '4.7 KB', logo: 'zeabur-dark' },
+  { name: 'zeabur-dark.svg', size: '4.7 KB', logo: 'zeabur', themed: true },
 ];
 
-const svglResults: { name: string; logo: string }[] = [
-  { name: 'Vercel', logo: 'vercel-dark' },
+const svglResults: { name: string; logo: string; themed?: boolean }[] = [
+  { name: 'Vercel', logo: 'vercel', themed: true },
   { name: 'Cloudflare', logo: 'cloudflare' },
-  { name: 'Zeabur', logo: 'zeabur-dark' },
+  { name: 'Zeabur', logo: 'zeabur', themed: true },
 ];
 
 const callouts: { eyebrow: string; title: string; body: ReactNode }[] = [
@@ -166,11 +166,27 @@ function AssetManagerMock() {
                 } p-2 flex flex-col items-center gap-1.5`}
               >
                 <div className="h-8 flex items-center justify-center">
-                  <img
-                    src={`/assets/${r.logo}.svg`}
-                    alt={r.name}
-                    className="h-7 w-auto object-contain"
-                  />
+                  {r.themed ? (
+                    <>
+                      <img
+                        src={`/assets/${r.logo}-dark.svg`}
+                        alt={r.name}
+                        className="h-7 w-auto object-contain logo-dark"
+                      />
+                      <img
+                        src={`/assets/${r.logo}-light.svg`}
+                        alt=""
+                        aria-hidden
+                        className="h-7 w-auto object-contain logo-light"
+                      />
+                    </>
+                  ) : (
+                    <img
+                      src={`/assets/${r.logo}.svg`}
+                      alt={r.name}
+                      className="h-7 w-auto object-contain"
+                    />
+                  )}
                 </div>
                 <span className="font-[family-name:var(--font-mono)] text-[10px] text-[color:var(--color-text-soft)]">
                   {r.name}
@@ -194,18 +210,41 @@ function AssetCard({ asset }: { asset: AssetMock }) {
             'repeating-conic-gradient(color-mix(in srgb, var(--color-rule) 70%, transparent) 0 25%, transparent 0 50%) 0 0 / 16px 16px',
         }}
       >
-        <img
-          src={`/assets/${asset.logo}.svg`}
-          alt=""
-          className="h-12 w-auto object-contain agent-mono"
-        />
+        {asset.themed ? (
+          <>
+            <img
+              src={`/assets/${asset.logo}-dark.svg`}
+              alt=""
+              className="h-12 w-auto object-contain agent-mono logo-dark"
+            />
+            <img
+              src={`/assets/${asset.logo}-light.svg`}
+              alt=""
+              aria-hidden
+              className="h-12 w-auto object-contain agent-mono logo-light"
+            />
+          </>
+        ) : (
+          <img
+            src={`/assets/${asset.logo}.svg`}
+            alt=""
+            className="h-12 w-auto object-contain agent-mono"
+          />
+        )}
       </div>
       <div className="border-t border-[color:var(--color-rule)] px-3 py-2">
         <div
           className="font-[family-name:var(--font-sans)] text-[13px] text-[color:var(--color-text)] truncate"
           title={asset.name}
         >
-          {asset.name}
+          {asset.themed ? (
+            <>
+              <span className="logo-dark">{asset.name}</span>
+              <span className="logo-light">{asset.name.replace('-dark', '-light')}</span>
+            </>
+          ) : (
+            asset.name
+          )}
         </div>
         <div className="font-[family-name:var(--font-mono)] text-[10px] text-[color:var(--color-muted)] mt-0.5">
           {asset.size}

--- a/apps/web/public/assets/vercel-light.svg
+++ b/apps/web/public/assets/vercel-light.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 256 222" width="256" height="222" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid"><path fill="#000" d="m128 0 128 221.705H0z"/></svg>

--- a/apps/web/public/assets/zeabur-light.svg
+++ b/apps/web/public/assets/zeabur-light.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 294 229" xmlns="http://www.w3.org/2000/svg" width="294" height="229" preserveAspectRatio="xMidYMid">
+  <path fill="#000" d="M114 145h179v84H0v-84h82l114-61H0V0h293v84l-179 61Z" />
+  <path fill="#6300FF" d="M195 0H0v84h195V0Z" />
+  <path fill="#F40" d="M293 145H115v84h178v-84Z" />
+</svg>


### PR DESCRIPTION
## Summary
- On the landing **Drop in images. Pull in logos.** section, vercel and zeabur logos were forced to the `-dark` SVGs, which read as muddy patches in light mode.
- Adds `vercel-light.svg` / `zeabur-light.svg` and renders both variants gated by the existing `.logo-dark` / `.logo-light` classes (same pattern as `agents.tsx`).
- Filename label `zeabur-dark.svg` now flips to `zeabur-light.svg` in light mode for consistency with the rendered icon.

## Test plan
- [ ] Toggle the site theme on the landing page and confirm vercel + zeabur swap correctly in both the asset grid and the svgl search popup.
- [ ] `pnpm exec biome check apps/web/components/landing/assets.tsx` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)