### PR TITLE
chore(web): update site title tagline

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -24,7 +24,7 @@ const instrument = Instrument_Serif({
   display: 'swap',
 });
 
-const title = `${appName} — slides as React code, crafted by agents`;
+const title = `${appName} — a slide framework built for agents`;
 const description =
   'A React-first slide framework authored by AI agents. Each page is arbitrary code on a 1920×1080 canvas — versioned, reviewable, yours.';
 


### PR DESCRIPTION
## Summary
- Update the marketing site `<title>` tagline from "slides as React code, crafted by agents" to "a slide framework built for agents".

## Test plan
- [ ] `pnpm --filter web build` passes
- [ ] Verify rendered `<title>` on the landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)