### PR TITLE
Add design shuffle feature with curated presets

### DIFF
--- a/.changeset/design-shuffle.md
+++ b/.changeset/design-shuffle.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': minor
+---
+
+Add a shuffle button to the Design panel that swaps in a curated random preset for inspiration.

--- a/packages/core/src/app/components/style-panel/design-provider.tsx
+++ b/packages/core/src/app/components/style-panel/design-provider.tsx
@@ -11,6 +11,7 @@ import {
 import { toast } from 'sonner';
 import { useHistory } from '@/components/history-provider';
 import { type DesignSystem, defaultDesign, designToCssVars } from '../../lib/design';
+import { shuffleDesign } from '../../lib/design-presets';
 import { useDesign as useDesignFetch } from './use-design';
 
 type DesignCtx = {
@@ -26,6 +27,7 @@ type DesignCtx = {
   commit: () => Promise<void>;
   discard: () => void;
   resetToDefaults: () => void;
+  shuffle: () => void;
 };
 
 const Ctx = createContext<DesignCtx | null>(null);
@@ -98,6 +100,16 @@ export function DesignProvider({ slideId, children }: { slideId: string; childre
     });
   }, [history]);
 
+  const shuffle = useCallback(() => {
+    const prev = draftRef.current;
+    const next = clone(shuffleDesign(prev));
+    setDraft(next);
+    history.record({
+      undo: () => setDraft(prev),
+      redo: () => setDraft(next),
+    });
+  }, [history]);
+
   // SlideCanvas emits its design vars inline on the canvas root, so a draft
   // overlay must use `!important` to outrank those inline styles.
   const previewCss = useMemo(() => {
@@ -121,6 +133,7 @@ export function DesignProvider({ slideId, children }: { slideId: string; childre
     commit,
     discard,
     resetToDefaults,
+    shuffle,
   };
 
   return (

--- a/packages/core/src/app/components/style-panel/style-panel.tsx
+++ b/packages/core/src/app/components/style-panel/style-panel.tsx
@@ -1,4 +1,4 @@
-import { Palette, X } from 'lucide-react';
+import { Palette, Shuffle, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Field, NumberField, Section } from '@/components/panel/panel-fields';
 import { PanelShell, usePanelMount } from '@/components/panel/panel-shell';
@@ -28,7 +28,7 @@ type DesignPanelProps = {
 };
 
 export function DesignPanel({ open, onClose }: DesignPanelProps) {
-  const { draft, exists, warning, loaded, dirty, update } = useDesignPanelState();
+  const { draft, exists, warning, loaded, dirty, update, shuffle } = useDesignPanelState();
   const { mounted, animVisible } = usePanelMount(open);
   const t = useLocale();
 
@@ -60,15 +60,27 @@ export function DesignPanel({ open, onClose }: DesignPanelProps) {
               />
             )}
           </div>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            className="text-muted-foreground hover:text-foreground"
-            onClick={onClose}
-            aria-label={t.stylePanel.closePanelAria}
-          >
-            <X className="size-3.5" />
-          </Button>
+          <div className="flex items-center gap-0.5">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="text-muted-foreground hover:text-foreground"
+              onClick={shuffle}
+              aria-label={t.stylePanel.shuffleAria}
+              title={t.stylePanel.shuffleTitle}
+            >
+              <Shuffle className="size-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="text-muted-foreground hover:text-foreground"
+              onClick={onClose}
+              aria-label={t.stylePanel.closePanelAria}
+            >
+              <X className="size-3.5" />
+            </Button>
+          </div>
         </>
       }
       banner={

--- a/packages/core/src/app/lib/design-presets.ts
+++ b/packages/core/src/app/lib/design-presets.ts
@@ -1,0 +1,94 @@
+import { type DesignSystem, defaultDesign } from './design';
+
+const SANS_SYSTEM = '-apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif';
+const SANS_INTER = '"Inter", system-ui, sans-serif';
+const SANS_HELV = '"Helvetica Neue", Helvetica, Arial, sans-serif';
+const SERIF_GEORGIA = 'Georgia, "Times New Roman", serif';
+const SERIF_TIMES = '"Times New Roman", Times, serif';
+const MONO_SF = '"SF Mono", "JetBrains Mono", Menlo, monospace';
+
+export const designPresets: DesignSystem[] = [
+  defaultDesign,
+  {
+    palette: { bg: '#0f1115', text: '#f5f3ee', accent: '#7cc4ff' },
+    fonts: { display: SERIF_GEORGIA, body: SANS_SYSTEM },
+    typeScale: { hero: 192, body: 32 },
+    radius: 6,
+  },
+  {
+    palette: { bg: '#eef1f4', text: '#1c2733', accent: '#ff6a5b' },
+    fonts: { display: SANS_HELV, body: SANS_SYSTEM },
+    typeScale: { hero: 156, body: 30 },
+    radius: 8,
+  },
+  {
+    palette: { bg: '#fdf6e3', text: '#073642', accent: '#b58900' },
+    fonts: { display: SERIF_GEORGIA, body: SANS_INTER },
+    typeScale: { hero: 144, body: 28 },
+    radius: 14,
+  },
+  {
+    palette: { bg: '#ede2cc', text: '#3a2a1a', accent: '#2f6e3a' },
+    fonts: { display: SERIF_TIMES, body: SERIF_GEORGIA },
+    typeScale: { hero: 168, body: 32 },
+    radius: 4,
+  },
+  {
+    palette: { bg: '#ffffff', text: '#0a0a0a', accent: '#e11d48' },
+    fonts: { display: SANS_HELV, body: SANS_HELV },
+    typeScale: { hero: 200, body: 28 },
+    radius: 0,
+  },
+  {
+    palette: { bg: '#fde9d9', text: '#3a1f3d', accent: '#f97316' },
+    fonts: { display: SERIF_GEORGIA, body: SANS_SYSTEM },
+    typeScale: { hero: 184, body: 36 },
+    radius: 24,
+  },
+  {
+    palette: { bg: '#e9f5ee', text: '#0f3324', accent: '#ec4899' },
+    fonts: { display: SANS_INTER, body: SANS_INTER },
+    typeScale: { hero: 160, body: 32 },
+    radius: 16,
+  },
+  {
+    palette: { bg: '#0a0a0a', text: '#f3edd9', accent: '#eab308' },
+    fonts: { display: SERIF_GEORGIA, body: SANS_HELV },
+    typeScale: { hero: 200, body: 32 },
+    radius: 2,
+  },
+  {
+    palette: { bg: '#ece2f5', text: '#2a1c4a', accent: '#facc15' },
+    fonts: { display: SERIF_GEORGIA, body: SANS_SYSTEM },
+    typeScale: { hero: 168, body: 34 },
+    radius: 20,
+  },
+  {
+    palette: { bg: '#101418', text: '#a7f3d0', accent: '#fbbf24' },
+    fonts: { display: MONO_SF, body: MONO_SF },
+    typeScale: { hero: 144, body: 24 },
+    radius: 4,
+  },
+  {
+    palette: { bg: '#fafafa', text: '#0a0a0a', accent: '#facc15' },
+    fonts: { display: SANS_HELV, body: SANS_HELV },
+    typeScale: { hero: 220, body: 32 },
+    radius: 0,
+  },
+];
+
+function pickRandom(): DesignSystem {
+  const idx = Math.floor(Math.random() * designPresets.length);
+  return designPresets[idx] ?? defaultDesign;
+}
+
+export function shuffleDesign(current?: DesignSystem | null): DesignSystem {
+  if (designPresets.length === 0) return defaultDesign;
+  if (designPresets.length === 1) return designPresets[0] ?? defaultDesign;
+  const currentJson = current ? JSON.stringify(current) : null;
+  for (let i = 0; i < 8; i++) {
+    const pick = pickRandom();
+    if (JSON.stringify(pick) !== currentJson) return pick;
+  }
+  return pickRandom();
+}

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -224,6 +224,8 @@ export const en: Locale = {
     designToggle: 'Design',
     designToggleTitle: 'Design tokens',
     fontPresetCustom: 'Custom…',
+    shuffleAria: 'Shuffle design',
+    shuffleTitle: 'Shuffle for inspiration',
   },
 
   asset: {

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -226,6 +226,8 @@ export const ja: Locale = {
     designToggle: 'デザイン',
     designToggleTitle: 'デザイントークン',
     fontPresetCustom: 'カスタム…',
+    shuffleAria: 'デザインをシャッフル',
+    shuffleTitle: 'シャッフルしてインスピレーションを得る',
   },
 
   asset: {

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -228,6 +228,8 @@ export type Locale = {
     designToggle: string;
     designToggleTitle: string;
     fontPresetCustom: string;
+    shuffleAria: string;
+    shuffleTitle: string;
   };
 
   asset: {

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -224,6 +224,8 @@ export const zhCN: Locale = {
     designToggle: '设计',
     designToggleTitle: '设计样式',
     fontPresetCustom: '自定义…',
+    shuffleAria: '随机设计',
+    shuffleTitle: '随机配色获取灵感',
   },
 
   asset: {

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -224,6 +224,8 @@ export const zhTW: Locale = {
     designToggle: '設計',
     designToggleTitle: '設計樣式',
     fontPresetCustom: '自訂…',
+    shuffleAria: '隨機設計',
+    shuffleTitle: '隨機配色獲取靈感',
   },
 
   asset: {


### PR DESCRIPTION
## Summary
This PR adds a shuffle button to the Design panel that allows users to randomly swap in curated design presets for inspiration. The feature includes 12 pre-designed color and typography combinations that users can cycle through.

## Key Changes
- **New design presets module** (`design-presets.ts`): Created a collection of 12 curated design system presets covering various color palettes, typography combinations, and border radius values
- **Shuffle functionality**: Implemented `shuffleDesign()` function that randomly selects a different preset from the collection, with logic to avoid repeating the current design
- **UI integration**: Added a shuffle button (with Shuffle icon) to the Design panel header, positioned next to the close button
- **State management**: Extended `DesignProvider` context with a `shuffle()` method that updates the draft design and integrates with the undo/redo history system
- **Internationalization**: Added shuffle button labels and tooltips in English, Japanese, Chinese Simplified, and Chinese Traditional

## Implementation Details
- The shuffle function attempts up to 8 random picks to ensure a different preset is selected, falling back to a random pick if needed
- Shuffle actions are fully integrated with the history system, allowing users to undo/redo shuffle operations
- Presets use a mix of serif (Georgia, Times New Roman) and sans-serif (Inter, Helvetica, system fonts) typography with varied type scales and border radius values
- The feature is non-destructive—users can shuffle multiple times or discard changes without affecting their original design

https://claude.ai/code/session_01C4wY8WPg8T6Yd5hSDQeDHx