### PR TITLE
Add drag-to-reorder for thumbnail rail in dev mode

### DIFF
--- a/.changeset/thumbnail-rail-reorder.md
+++ b/.changeset/thumbnail-rail-reorder.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': minor
+---
+
+Drag thumbnails in the dev-mode rail to reorder pages — the new order is written back to the slide's `index.tsx`.

--- a/.changeset/thumbnail-rail-reorder.md
+++ b/.changeset/thumbnail-rail-reorder.md
@@ -2,4 +2,4 @@
 '@open-slide/core': minor
 ---
 
-Drag thumbnails in the dev-mode rail to reorder pages — the new order is written back to the slide's `index.tsx`.
+Drag thumbnails vertically in the dev-mode rail to reorder pages — the new order is written back to the slide's `index.tsx`.

--- a/.changeset/thumbnail-rail-vertical-drag.md
+++ b/.changeset/thumbnail-rail-vertical-drag.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Lock thumbnail-rail drag to vertical movement so the dragged page can't drift sideways.

--- a/.changeset/thumbnail-rail-vertical-drag.md
+++ b/.changeset/thumbnail-rail-vertical-drag.md
@@ -1,5 +1,0 @@
----
-'@open-slide/core': patch
----
-
-Lock thumbnail-rail drag to vertical movement so the dragged page can't drift sideways.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,9 @@
   "dependencies": {
     "@babel/parser": "^7.29.2",
     "@babel/types": "^7.29.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",
     "@tailwindcss/vite": "^4.2.2",
     "@vitejs/plugin-react": "^4.3.3",

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -1,3 +1,19 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { useEffect, useRef } from 'react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { format, useLocale } from '@/lib/use-locale';
@@ -14,6 +30,7 @@ type Props = {
   design?: DesignSystem;
   current: number;
   onSelect: (index: number) => void;
+  onReorder?: (from: number, to: number) => void;
   orientation?: Orientation;
 };
 
@@ -25,6 +42,7 @@ export function ThumbnailRail({
   design,
   current,
   onSelect,
+  onReorder,
   orientation = 'vertical',
 }: Props) {
   const activeRef = useRef<HTMLButtonElement | null>(null);
@@ -93,61 +111,208 @@ export function ThumbnailRail({
 
   const scale = VERTICAL_THUMB_WIDTH / CANVAS_WIDTH;
   const height = CANVAS_HEIGHT * scale;
+
+  const renderThumb = (PageComp: Page, i: number) => {
+    const active = i === current;
+    const inner = (
+      <ThumbContents
+        index={i}
+        active={active}
+        page={PageComp}
+        design={design}
+        scale={scale}
+        height={height}
+      />
+    );
+
+    if (onReorder) {
+      return (
+        <SortableThumb
+          key={i}
+          index={i}
+          active={active}
+          activeRef={active ? activeRef : undefined}
+          onSelect={() => onSelect(i)}
+          ariaLabel={format(t.thumbnailRail.goToPageAria, { n: i + 1 })}
+        >
+          {inner}
+        </SortableThumb>
+      );
+    }
+
+    return (
+      <button
+        key={i}
+        type="button"
+        ref={active ? activeRef : undefined}
+        onClick={() => onSelect(i)}
+        aria-label={format(t.thumbnailRail.goToPageAria, { n: i + 1 })}
+        aria-current={active ? 'true' : undefined}
+        className={thumbButtonClass(active)}
+      >
+        {inner}
+      </button>
+    );
+  };
+
+  const list = (
+    <aside className="flex flex-col gap-2 px-3 py-3">
+      <div className="flex items-baseline justify-between px-1 pb-1">
+        <span className="eyebrow">{t.thumbnailRail.pages}</span>
+        <span className="folio">{pages.length.toString().padStart(2, '0')}</span>
+      </div>
+      {pages.map(renderThumb)}
+    </aside>
+  );
+
+  if (!onReorder) {
+    return <ScrollArea className="h-full border-r border-hairline bg-sidebar">{list}</ScrollArea>;
+  }
+
   return (
     <ScrollArea className="h-full border-r border-hairline bg-sidebar">
-      <aside className="flex flex-col gap-2 px-3 py-3">
-        <div className="flex items-baseline justify-between px-1 pb-1">
-          <span className="eyebrow">{t.thumbnailRail.pages}</span>
-          <span className="folio">{pages.length.toString().padStart(2, '0')}</span>
-        </div>
-        {pages.map((PageComp, i) => {
-          const active = i === current;
-          return (
-            <button
-              // biome-ignore lint/suspicious/noArrayIndexKey: pages list is render-stable
-              key={i}
-              type="button"
-              ref={active ? activeRef : undefined}
-              onClick={() => onSelect(i)}
-              aria-label={`Go to page ${i + 1}`}
-              aria-current={active ? 'true' : undefined}
-              className={cn(
-                'group/thumb flex items-start gap-2.5 rounded-[6px] p-1.5 text-left motion-safe:transition-colors',
-                'hover:bg-muted/60',
-                active && 'bg-muted',
-              )}
-            >
-              <span
-                className={cn(
-                  'mt-1.5 w-7 shrink-0 text-right font-mono text-[10px] font-medium tracking-[0.06em] tabular-nums uppercase',
-                  active ? 'text-brand' : 'text-muted-foreground/70',
-                )}
-              >
-                {(i + 1).toString().padStart(2, '0')}
-              </span>
-              <div
-                className={cn(
-                  'relative shrink-0 overflow-hidden rounded-[4px] border bg-card motion-safe:transition-all',
-                  active
-                    ? 'border-brand shadow-[0_0_0_1px_var(--brand)]'
-                    : 'border-hairline group-hover/thumb:border-foreground/25',
-                )}
-                style={{ width: VERTICAL_THUMB_WIDTH, height }}
-              >
-                <SlideCanvas scale={scale} center={false} flat freezeMotion design={design}>
-                  <PageComp />
-                </SlideCanvas>
-                {active && (
-                  <span
-                    aria-hidden
-                    className="pointer-events-none absolute inset-y-0 left-0 w-[2px] bg-brand"
-                  />
-                )}
-              </div>
-            </button>
-          );
-        })}
-      </aside>
+      <SortableRail pages={pages} onReorder={onReorder}>
+        {list}
+      </SortableRail>
     </ScrollArea>
+  );
+}
+
+function thumbButtonClass(active: boolean): string {
+  return cn(
+    'group/thumb flex w-full items-start gap-2.5 rounded-[6px] p-1.5 text-left motion-safe:transition-colors',
+    'hover:bg-muted/60',
+    active && 'bg-muted',
+  );
+}
+
+function ThumbContents({
+  index,
+  active,
+  page: PageComp,
+  design,
+  scale,
+  height,
+}: {
+  index: number;
+  active: boolean;
+  page: Page;
+  design?: DesignSystem;
+  scale: number;
+  height: number;
+}) {
+  return (
+    <>
+      <span
+        className={cn(
+          'mt-1.5 w-7 shrink-0 text-right font-mono text-[10px] font-medium tracking-[0.06em] tabular-nums uppercase',
+          active ? 'text-brand' : 'text-muted-foreground/70',
+        )}
+      >
+        {(index + 1).toString().padStart(2, '0')}
+      </span>
+      <div
+        className={cn(
+          'relative shrink-0 overflow-hidden rounded-[4px] border bg-card motion-safe:transition-all',
+          active
+            ? 'border-brand shadow-[0_0_0_1px_var(--brand)]'
+            : 'border-hairline group-hover/thumb:border-foreground/25',
+        )}
+        style={{ width: VERTICAL_THUMB_WIDTH, height }}
+      >
+        <SlideCanvas scale={scale} center={false} flat freezeMotion design={design}>
+          <PageComp />
+        </SlideCanvas>
+        {active && (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-y-0 left-0 w-[2px] bg-brand"
+          />
+        )}
+      </div>
+    </>
+  );
+}
+
+function SortableRail({
+  pages,
+  onReorder,
+  children,
+}: {
+  pages: Page[];
+  onReorder: (from: number, to: number) => void;
+  children: React.ReactNode;
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const items = pages.map((_, i) => i + 1);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const from = (active.id as number) - 1;
+    const to = (over.id as number) - 1;
+    if (from < 0 || to < 0 || from === to) return;
+    onReorder(from, to);
+  };
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={items} strategy={verticalListSortingStrategy}>
+        {children}
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+function SortableThumb({
+  index,
+  active,
+  activeRef,
+  onSelect,
+  ariaLabel,
+  children,
+}: {
+  index: number;
+  active: boolean;
+  activeRef: React.MutableRefObject<HTMLButtonElement | null> | undefined;
+  onSelect: () => void;
+  ariaLabel: string;
+  children: React.ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: index + 1,
+  });
+
+  const setRef = (node: HTMLButtonElement | null) => {
+    setNodeRef(node);
+    if (activeRef) activeRef.current = node;
+  };
+
+  return (
+    <button
+      ref={setRef}
+      type="button"
+      onClick={onSelect}
+      aria-label={ariaLabel}
+      aria-current={active ? 'true' : undefined}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        touchAction: 'none',
+      }}
+      className={cn(
+        thumbButtonClass(active),
+        'cursor-grab active:cursor-grabbing',
+        isDragging && 'z-10 opacity-60 shadow-edge ring-1 ring-brand',
+      )}
+      {...attributes}
+      {...listeners}
+    >
+      {children}
+    </button>
   );
 }

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -292,6 +292,8 @@ function SortableThumb({
     if (activeRef) activeRef.current = node;
   };
 
+  const yOnlyTransform = transform ? { ...transform, x: 0 } : transform;
+
   return (
     <button
       ref={setRef}
@@ -300,7 +302,7 @@ function SortableThumb({
       aria-label={ariaLabel}
       aria-current={active ? 'true' : undefined}
       style={{
-        transform: CSS.Transform.toString(transform),
+        transform: CSS.Transform.toString(yOnlyTransform),
         transition,
         touchAction: 'none',
       }}

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -68,11 +68,62 @@ export function Slide() {
     };
   }, [slideId]);
 
-  const pages = useMemo(() => slide?.default ?? [], [slide]);
+  const modulePages = useMemo(() => slide?.default ?? [], [slide]);
+  const [pages, setPages] = useState<typeof modulePages>(modulePages);
+  useEffect(() => {
+    setPages(modulePages);
+  }, [modulePages]);
   const pageCount = pages.length;
   const rawIndex = Number(searchParams.get('p') ?? '1') - 1;
   const index = Number.isFinite(rawIndex) ? Math.max(0, Math.min(pageCount - 1, rawIndex)) : 0;
   const view = searchParams.get('view') === 'assets' ? 'assets' : 'slides';
+
+  const reorderPage = useCallback(
+    async (from: number, to: number) => {
+      if (from === to) return;
+      const before = pages;
+      const nextPages = [...before];
+      const [moved] = nextPages.splice(from, 1);
+      nextPages.splice(to, 0, moved);
+      setPages(nextPages);
+
+      const order = before.map((_, i) => i);
+      const [movedIdx] = order.splice(from, 1);
+      order.splice(to, 0, movedIdx);
+
+      // Keep the user looking at the same page they were on before the drag.
+      let nextIndex = index;
+      if (index === from) nextIndex = to;
+      else if (from < index && to >= index) nextIndex = index - 1;
+      else if (from > index && to <= index) nextIndex = index + 1;
+      if (nextIndex !== index) {
+        setSearchParams(
+          (prev) => {
+            const params = new URLSearchParams(prev);
+            params.set('p', String(nextIndex + 1));
+            return params;
+          },
+          { replace: true },
+        );
+      }
+
+      try {
+        const res = await fetch(`/__slides/${encodeURIComponent(slideId)}/reorder`, {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ order }),
+        });
+        if (!res.ok) {
+          const detail = await res.json().catch(() => ({ error: res.statusText }));
+          throw new Error(detail.error ?? `HTTP ${res.status}`);
+        }
+      } catch (err) {
+        setPages(before);
+        toast.error(`Reorder failed: ${String((err as Error).message ?? err)}`);
+      }
+    },
+    [pages, index, slideId, setSearchParams],
+  );
 
   const goTo = useCallback(
     (i: number) => {
@@ -356,6 +407,7 @@ export function Slide() {
                     design={slide.design}
                     current={index}
                     onSelect={goTo}
+                    onReorder={import.meta.env.DEV ? reorderPage : undefined}
                   />
                 </div>
                 <main

--- a/packages/core/src/vite/files-plugin.test.ts
+++ b/packages/core/src/vite/files-plugin.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   mimeForFilename,
+  reorderDefaultExportPagesInSource,
   updateMetaTitleInSource,
   validateAssetName,
   validateIcon,
@@ -116,6 +117,80 @@ describe('updateMetaTitleInSource', () => {
 
   it('returns null if there is no meta and no default export', () => {
     expect(updateMetaTitleInSource('// nothing here', 'x')).toBeNull();
+  });
+});
+
+describe('reorderDefaultExportPagesInSource', () => {
+  const withSatisfies = `import type { Page } from '@open-slide/core';
+const A = () => null;
+const B = () => null;
+const C = () => null;
+export const meta = { title: 't' };
+export default [
+  A,
+  B,
+  C,
+] satisfies Page[];
+`;
+
+  const withoutSatisfies = `const A = () => null;
+const B = () => null;
+const C = () => null;
+export default [A, B, C];
+`;
+
+  it('reorders a 3-element multi-line array', () => {
+    const out = reorderDefaultExportPagesInSource(withSatisfies, [2, 0, 1]);
+    expect(out).not.toBeNull();
+    expect(out).toContain('export default [\n  C,\n  A,\n  B,\n] satisfies Page[];');
+    // surrounding source untouched
+    expect(out).toContain("import type { Page } from '@open-slide/core';");
+    expect(out).toContain("export const meta = { title: 't' };");
+  });
+
+  it('reorders an inline array without satisfies', () => {
+    const out = reorderDefaultExportPagesInSource(withoutSatisfies, [1, 2, 0]);
+    expect(out).toContain('export default [B, C, A];');
+  });
+
+  it('is a no-op for the identity permutation (returns input unchanged)', () => {
+    expect(reorderDefaultExportPagesInSource(withSatisfies, [0, 1, 2])).toBe(withSatisfies);
+  });
+
+  it('returns null on length mismatch', () => {
+    expect(reorderDefaultExportPagesInSource(withSatisfies, [0, 1])).toBeNull();
+    expect(reorderDefaultExportPagesInSource(withSatisfies, [0, 1, 2, 3])).toBeNull();
+  });
+
+  it('returns null on duplicate indices', () => {
+    expect(reorderDefaultExportPagesInSource(withSatisfies, [0, 0, 2])).toBeNull();
+  });
+
+  it('returns null on out-of-range indices', () => {
+    expect(reorderDefaultExportPagesInSource(withSatisfies, [0, 1, 5])).toBeNull();
+    expect(reorderDefaultExportPagesInSource(withSatisfies, [-1, 1, 2])).toBeNull();
+  });
+
+  it('returns null when the default export is not an array', () => {
+    const source = `const A = () => null;\nexport default A;\n`;
+    expect(reorderDefaultExportPagesInSource(source, [0])).toBeNull();
+  });
+
+  it('returns null when there is no default export', () => {
+    expect(reorderDefaultExportPagesInSource('// nothing\n', [])).toBeNull();
+  });
+
+  it('returns the input unchanged for an empty array (zero-length identity)', () => {
+    const empty = `export default [];\n`;
+    expect(reorderDefaultExportPagesInSource(empty, [])).toBe(empty);
+  });
+
+  it('preserves the rest of the file (component bodies, imports, meta)', () => {
+    const out = reorderDefaultExportPagesInSource(withSatisfies, [2, 1, 0]);
+    expect(out).not.toBeNull();
+    expect(out).toContain('const A = () => null;');
+    expect(out).toContain('const B = () => null;');
+    expect(out).toContain('const C = () => null;');
   });
 });
 

--- a/packages/core/src/vite/files-plugin.ts
+++ b/packages/core/src/vite/files-plugin.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import type { ServerResponse } from 'node:http';
 import path from 'node:path';
+import { parse as babelParse } from '@babel/parser';
 import type { Connect, Plugin, ViteDevServer } from 'vite';
 
 const FOLDER_ID_RE = /^f-[a-f0-9]{8}$/;
@@ -245,6 +246,95 @@ export function updateMetaTitleInSource(source: string, title: string): string |
   return source.slice(0, exportDefaultIdx) + insertion + source.slice(exportDefaultIdx);
 }
 
+type ArrayElementRange = { start: number; end: number };
+
+function findDefaultExportArray(
+  source: string,
+): { elements: ArrayElementRange[]; arrayStart: number; arrayEnd: number } | null {
+  let ast: unknown;
+  try {
+    ast = babelParse(source, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+      errorRecovery: true,
+    });
+  } catch {
+    return null;
+  }
+  const body = (ast as { program?: { body?: Array<Record<string, unknown>> } }).program?.body ?? [];
+  for (const node of body) {
+    if (node.type !== 'ExportDefaultDeclaration') continue;
+    let inner = node.declaration as Record<string, unknown> | undefined;
+    while (inner && (inner.type === 'TSAsExpression' || inner.type === 'TSSatisfiesExpression')) {
+      inner = inner.expression as Record<string, unknown> | undefined;
+    }
+    if (!inner || inner.type !== 'ArrayExpression') return null;
+    const arrayStart = inner.start as number;
+    const arrayEnd = inner.end as number;
+    const rawElements = (inner.elements as Array<Record<string, unknown> | null>) ?? [];
+    const elements: ArrayElementRange[] = [];
+    for (const el of rawElements) {
+      if (!el || typeof el.start !== 'number' || typeof el.end !== 'number') return null;
+      elements.push({ start: el.start as number, end: el.end as number });
+    }
+    return { elements, arrayStart, arrayEnd };
+  }
+  return null;
+}
+
+/**
+ * Rewrite `export default [...]` so its elements appear in the requested order.
+ *
+ * `order[i]` is the original index that should land at new position `i`. The
+ * function preserves each element's exact source slice (including any inline
+ * comments that hug an identifier) and keeps the inter-element separator slots
+ * in their original positions, so a 3-page array `[A, B, C]` reordered to
+ * `[2, 0, 1]` becomes `[C, A, B]` with the same indentation and trailing
+ * commas the author wrote.
+ *
+ * Returns `null` when the file's default export isn't an array literal, or the
+ * order is not a valid permutation of `[0, n-1]`.
+ */
+export function reorderDefaultExportPagesInSource(source: string, order: number[]): string | null {
+  const found = findDefaultExportArray(source);
+  if (!found) return null;
+  const { elements, arrayStart, arrayEnd } = found;
+  const n = elements.length;
+  if (order.length !== n) return null;
+  const seen = new Set<number>();
+  for (const idx of order) {
+    if (!Number.isInteger(idx) || idx < 0 || idx >= n) return null;
+    if (seen.has(idx)) return null;
+    seen.add(idx);
+  }
+  if (n === 0) return source;
+
+  let identity = true;
+  for (let i = 0; i < n; i++) {
+    if (order[i] !== i) {
+      identity = false;
+      break;
+    }
+  }
+  if (identity) return source;
+
+  const prefix = source.slice(arrayStart, elements[0].start);
+  const suffix = source.slice(elements[n - 1].end, arrayEnd);
+  const separators: string[] = [];
+  for (let i = 0; i < n - 1; i++) {
+    separators.push(source.slice(elements[i].end, elements[i + 1].start));
+  }
+  const elementText = elements.map((el) => source.slice(el.start, el.end));
+
+  let rebuilt = prefix + elementText[order[0]];
+  for (let i = 1; i < n; i++) {
+    rebuilt += separators[i - 1] + elementText[order[i]];
+  }
+  rebuilt += suffix;
+
+  return source.slice(0, arrayStart) + rebuilt + source.slice(arrayEnd);
+}
+
 export function validateIcon(v: unknown): FolderIcon | null {
   if (!v || typeof v !== 'object') return null;
   const icon = v as { type?: unknown; value?: unknown };
@@ -306,6 +396,42 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
         const method = req.method ?? 'GET';
 
         try {
+          const reorderMatch = url.pathname.match(/^\/([^/]+)\/reorder$/);
+          if (reorderMatch && method === 'PUT') {
+            const slideId = reorderMatch[1];
+            if (!SLIDE_ID_RE.test(slideId)) return json(res, 400, { error: 'invalid slideId' });
+
+            const body = (await readBody(req)) as { order?: unknown };
+            if (!Array.isArray(body.order)) return json(res, 400, { error: 'invalid order' });
+            const order: number[] = [];
+            for (const v of body.order) {
+              if (!Number.isInteger(v)) return json(res, 400, { error: 'invalid order' });
+              order.push(v as number);
+            }
+
+            const entry = resolveSlideEntry(slidesRoot, slideId);
+            if (!entry) return json(res, 400, { error: 'invalid slideId' });
+
+            let source: string;
+            try {
+              source = await fs.readFile(entry, 'utf8');
+            } catch {
+              return json(res, 404, { error: 'slide not found' });
+            }
+
+            const updated = reorderDefaultExportPagesInSource(source, order);
+            if (updated === null) {
+              return json(res, 422, {
+                error:
+                  'could not reorder pages — order must be a permutation of the existing array',
+              });
+            }
+            if (updated !== source) {
+              await fs.writeFile(entry, updated, 'utf8');
+            }
+            return json(res, 200, { ok: true, slideId, order });
+          }
+
           const idMatch = url.pathname.match(/^\/([^/]+)$/);
           if (!idMatch) return next();
           const slideId = idMatch[1];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,15 @@ importers:
       '@babel/types':
         specifier: ^7.29.0
         version: 7.29.0
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@18.3.1)
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.8
@@ -540,6 +549,28 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dotenvx/dotenvx@1.61.1':
     resolution: {integrity: sha512-2OUX4KDKvQA6oa7oESG8eNcV4K/2C5jgrbxUcT0VoH9Zelg6dT+rDYew4w2GmXRV3db0tUaM4QZG3MyJL3fU5Q==}
@@ -5656,6 +5687,31 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
+
+  '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
 
   '@dotenvx/dotenvx@1.61.1':
     dependencies:


### PR DESCRIPTION
## Summary
Adds drag-and-drop reordering functionality to the thumbnail rail in development mode, allowing users to reorder pages by dragging thumbnails. The new order is persisted back to the slide's `index.tsx` file.

## Key Changes
- **Thumbnail Rail Component** (`thumbnail-rail.tsx`):
  - Integrated `@dnd-kit` for drag-and-drop functionality
  - Added optional `onReorder` callback prop to enable reordering
  - Extracted thumbnail rendering logic into `ThumbContents` component for reusability
  - Created `SortableRail` wrapper component to manage drag context and handle reorder events
  - Created `SortableThumb` component that wraps individual thumbnails with drag handles
  - Conditionally renders sortable or static thumbnails based on `onReorder` prop

- **Files Plugin** (`files-plugin.ts`):
  - Added `findDefaultExportArray()` to parse and locate array elements in the default export using Babel
  - Implemented `reorderDefaultExportPagesInSource()` to reorder array elements while preserving formatting, comments, and separators
  - Added `/reorder` PUT endpoint to handle page reordering requests and write changes back to disk
  - Validates reorder requests and returns appropriate error responses

- **Slide Route** (`slide.tsx`):
  - Added local state to track page order separately from the imported module
  - Implemented `reorderPage()` callback that:
    - Updates local page state optimistically
    - Maintains user's current page selection during reorder
    - Sends reorder request to backend
    - Reverts changes on failure with error toast
  - Passes `reorderPage` to thumbnail rail only in dev mode

- **Tests** (`files-plugin.test.ts`):
  - Added comprehensive test suite for `reorderDefaultExportPagesInSource()`
  - Tests cover multi-line arrays, inline arrays, identity permutations, validation, edge cases, and file preservation

## Implementation Details
- The reordering preserves exact source formatting including indentation, trailing commas, and inline comments
- Drag activation requires a 5px pointer movement to avoid accidental triggers
- Keyboard support included via `sortableKeyboardCoordinates`
- The feature is dev-mode only (`import.meta.env.DEV`)
- Optimistic UI updates with automatic rollback on server errors
- Page selection follows the moved page during reorder to maintain user context

https://claude.ai/code/session_01VW9S5dJWqn6Du9PnsX27of