### PR TITLE
Hide cursor immediately when navigating slides with keyboard

### DIFF
--- a/.changeset/hide-cursor-keyboard-nav.md
+++ b/.changeset/hide-cursor-keyboard-nav.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Hide the mouse cursor immediately when navigating slides with the keyboard in fullscreen presentation mode. Cursor reappears as soon as the mouse moves.

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -58,6 +58,7 @@ export function Player({
   const [helpOpen, setHelpOpen] = useState(false);
   const [blackout, setBlackout] = useState<'black' | 'white' | null>(null);
   const [laser, setLaser] = useState(false);
+  const [keyboardDriven, setKeyboardDriven] = useState(false);
   const [startedAt] = useState(() => Date.now());
 
   const goPrev = useCallback(() => {
@@ -181,19 +182,23 @@ export function Player({
 
       if (isNext) {
         e.preventDefault();
+        setKeyboardDriven(true);
         goNext();
         return;
       }
       if (isPrev) {
         e.preventDefault();
+        setKeyboardDriven(true);
         goPrev();
         return;
       }
       if (e.key === 'Home') {
+        setKeyboardDriven(true);
         onIndexChange(0);
         return;
       }
       if (e.key === 'End') {
+        setKeyboardDriven(true);
         onIndexChange(pages.length - 1);
         return;
       }
@@ -246,7 +251,16 @@ export function Player({
   const pointerNearBottom = usePointerNearBottom(BAR_HOTZONE_PX, controls && !overlayActive);
   const chromeVisible = pointerNearBottom || overlayActive;
   const idle = useIdle(IDLE_HIDE_MS, controls && !overlayActive);
-  const hideCursor = controls && (laser || (idle && !overlayActive && !pointerNearBottom));
+
+  useEffect(() => {
+    if (!keyboardDriven) return;
+    const clear = () => setKeyboardDriven(false);
+    window.addEventListener('mousemove', clear, { passive: true });
+    return () => window.removeEventListener('mousemove', clear);
+  }, [keyboardDriven]);
+
+  const hideCursor =
+    controls && (laser || keyboardDriven || (idle && !overlayActive && !pointerNearBottom));
 
   const PageComp = pages[index];
 

--- a/packages/core/src/app/components/present/use-idle.ts
+++ b/packages/core/src/app/components/present/use-idle.ts
@@ -1,10 +1,14 @@
 import { useEffect, useState } from 'react';
 
 /**
- * Reports whether the user has been idle (no pointer / key / touch input)
- * for at least `delayMs`. Resets on any input event. The hook starts in
+ * Reports whether the user has been idle (no pointer / touch input) for at
+ * least `delayMs`. Resets on any pointer-related event. The hook starts in
  * the non-idle state so freshly-mounted UI is visible while the user
  * orients themselves.
+ *
+ * Keyboard input is intentionally excluded — during a talk the presenter
+ * drives slides with arrow keys, and we want the cursor to stay hidden
+ * while they do.
  *
  * Pass `enabled = false` to short-circuit (useful when the player is
  * paused on an overlay and we don't want to hide chrome behind it).
@@ -27,14 +31,12 @@ export function useIdle(delayMs: number, enabled = true) {
     const opts = { passive: true } as const;
     window.addEventListener('mousemove', reset, opts);
     window.addEventListener('mousedown', reset, opts);
-    window.addEventListener('keydown', reset);
     window.addEventListener('touchstart', reset, opts);
     window.addEventListener('wheel', reset, opts);
     return () => {
       if (timer) clearTimeout(timer);
       window.removeEventListener('mousemove', reset);
       window.removeEventListener('mousedown', reset);
-      window.removeEventListener('keydown', reset);
       window.removeEventListener('touchstart', reset);
       window.removeEventListener('wheel', reset);
     };


### PR DESCRIPTION
## Summary
Improves the presentation experience by hiding the mouse cursor immediately when the presenter uses keyboard navigation (arrow keys, Home, End) in fullscreen mode, rather than waiting for the idle timeout. The cursor reappears as soon as the mouse moves.

## Changes
- Added `keyboardDriven` state to track when navigation is triggered by keyboard input
- Set `keyboardDriven` to `true` when handling keyboard navigation events (next/prev/Home/End keys)
- Added effect to reset `keyboardDriven` state when mouse movement is detected
- Updated cursor hiding logic to hide cursor when `keyboardDriven` is active
- Modified `useIdle` hook to exclude keyboard events from idle detection, since presenters actively use arrow keys during talks and shouldn't trigger the idle cursor-hiding behavior through keyboard input alone

## Implementation Details
The solution uses a separate `keyboardDriven` state rather than relying on the existing idle detection because keyboard input is intentional navigation during presentations. By excluding keyboard events from idle detection and instead explicitly tracking keyboard-driven navigation, the cursor hides immediately without waiting for the idle timeout, while still respecting mouse movement as a signal to show the cursor again.

https://claude.ai/code/session_01DYBxotePbvCDxGDagVabiU