### PR TITLE
feat: add editable PPTX export

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,8 +28,9 @@ You won't see any Vite, React, or tsconfig files in the workspace. They live ins
 | `open-slide init [dir]` | Scaffold a new workspace in `dir` (defaults to current dir). |
 | `open-slide init --force` | Scaffold into a non-empty directory. |
 | `open-slide init --name <name>` | Override the generated `package.json` name. |
+| `open-slide export:pptx <slide-id>` | In a workspace, write a schema-based editable PPTX. Use `-o, --output <file>`. |
 
-(Once installed in the workspace, `@open-slide/core` provides `open-slide dev`, `open-slide build`, and `open-slide preview` via its own bin.)
+(Once installed in the workspace, `@open-slide/core` provides `open-slide dev`, `open-slide build`, `open-slide preview`, and `open-slide export:pptx` via its own bin.)
 
 ## Authoring
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -25,6 +25,7 @@ Once installed, the `open-slide` bin is available in the workspace:
 | `open-slide dev` | Start the dev server. Flags: `-p, --port <port>`, `--host [host]`, `--open`. |
 | `open-slide build` | Build a static site. Flags: `--out-dir <dir>` (defaults to `dist`). |
 | `open-slide preview` | Preview the production build. Flags: `-p, --port <port>`, `--host [host]`, `--open`. |
+| `open-slide export:pptx <slide-id>` | Export a schema-based editable PPTX file. Flags: `-o, --output <file>`. |
 
 ## Config
 
@@ -56,9 +57,40 @@ const Cover: Page = () => (
 
 const pages: Page[] = [Cover];
 export default pages;
-
 export const meta = { title: 'Hello' };
 ```
+
+## Editable PPTX export
+
+`open-slide export:pptx <slide-id>` creates a real `.pptx` with editable PowerPoint shapes and text. It does **not** screenshot the React DOM. Because arbitrary React/CSS cannot be safely translated into OOXML, export is schema-based: add a sibling `pptx` export to the slide module.
+
+```tsx
+import type { Page, PptxDeck } from '@open-slide/core';
+
+const Cover: Page = () => <div>Hello</div>;
+export default [Cover];
+
+export const pptx: PptxDeck = {
+  title: 'Hello',
+  slides: [
+    {
+      background: '#0F172A',
+      elements: [
+        { type: 'rect', x: 96, y: 96, w: 480, h: 180, fill: '#22C55E', radius: 24 },
+        { type: 'text', x: 128, y: 124, w: 900, h: 100, text: 'Hello editable PPTX', fontSize: 44, bold: true, color: '#FFFFFF' },
+      ],
+    },
+  ],
+};
+```
+
+Then run:
+
+```bash
+open-slide export:pptx hello -o hello.pptx
+```
+
+Coordinates use the same fixed 1920×1080 canvas as Open Slide and map to PowerPoint widescreen EMUs.
 
 ## Exports
 

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -44,7 +44,7 @@ export function Player({
   controls = false,
   slideId,
 }: Props) {
-  const rootRef = useRef<HTMLDivElement>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
   // Mirrored as state so descendants portaling *into* the player subtree
   // (tooltips, popovers — the body is outside the fullscreen tree) re-render
   // once the node mounts.

--- a/packages/core/src/cli/export-pptx.test.ts
+++ b/packages/core/src/cli/export-pptx.test.ts
@@ -1,0 +1,32 @@
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { strFromU8, unzipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { exportPptx } from './export-pptx.ts';
+
+describe('exportPptx CLI action', () => {
+  it('loads a slide module pptx export and writes an editable pptx file', async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), 'open-slide-pptx-'));
+    await mkdir(path.join(cwd, 'slides', 'demo'), { recursive: true });
+    await writeFile(
+      path.join(cwd, 'slides', 'demo', 'index.tsx'),
+      `export default [];
+export const pptx = {
+  title: 'CLI PPTX',
+  slides: [{ elements: [{ type: 'text', x: 64, y: 64, w: 800, h: 90, text: 'Demo from CLI', fontSize: 40 }] }],
+};
+`,
+    );
+
+    const output = path.join(cwd, 'demo.pptx');
+    await exportPptx({ cwd, slideId: 'demo', output });
+
+    const pptx = await readFile(output);
+    const files = unzipSync(pptx);
+    const slideXml = strFromU8(files['ppt/slides/slide1.xml']);
+    expect(slideXml).toContain('Demo from CLI');
+    expect(slideXml).toContain('<p:sp>');
+    expect(slideXml).not.toContain('<p:pic>');
+  });
+});

--- a/packages/core/src/cli/export-pptx.ts
+++ b/packages/core/src/cli/export-pptx.ts
@@ -1,0 +1,50 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { createServer, mergeConfig } from 'vite';
+import { createPptxBuffer, type PptxDeck } from '../pptx/exporter.ts';
+import { createViteConfig } from '../vite/config.ts';
+
+export type ExportPptxOptions = {
+  cwd?: string;
+  slideId: string;
+  output?: string;
+};
+
+export async function exportPptx(opts: ExportPptxOptions): Promise<string> {
+  const cwd = path.resolve(opts.cwd ?? process.cwd());
+  const output = path.resolve(cwd, opts.output ?? `${opts.slideId}.pptx`);
+  const viteConfig = await createViteConfig({ userCwd: cwd, mode: 'serve' });
+  const server = await createServer(
+    mergeConfig(viteConfig, {
+      appType: 'custom',
+      logLevel: 'silent',
+      server: { middlewareMode: true },
+    }),
+  );
+
+  try {
+    const slidesModule = (await server.ssrLoadModule('virtual:open-slide/slides')) as {
+      loadSlide(id: string): Promise<Record<string, unknown>>;
+    };
+    const slideModule = await slidesModule.loadSlide(opts.slideId);
+    const pptxDeck = slideModule.pptx;
+    if (!isPptxDeck(pptxDeck)) {
+      throw new Error(
+        `Slide ${opts.slideId} does not export a valid \`pptx\` deck. Editable PPTX export is schema-based; arbitrary React/CSS cannot be converted safely.`,
+      );
+    }
+
+    const buffer = createPptxBuffer(pptxDeck);
+    await mkdir(path.dirname(output), { recursive: true });
+    await writeFile(output, buffer);
+    return output;
+  } finally {
+    await server.close();
+  }
+}
+
+function isPptxDeck(value: unknown): value is PptxDeck {
+  if (!value || typeof value !== 'object') return false;
+  const slides = (value as { slides?: unknown }).slides;
+  return Array.isArray(slides) && slides.length > 0;
+}

--- a/packages/core/src/cli/run.ts
+++ b/packages/core/src/cli/run.ts
@@ -77,6 +77,10 @@ interface BuildFlags {
   outDir?: string;
 }
 
+interface ExportPptxFlags {
+  output?: string;
+}
+
 interface SyncFlags {
   dryRun?: boolean;
 }
@@ -131,6 +135,17 @@ export async function run(argv: string[]): Promise<void> {
     .action(async (flags: ServerFlags) => {
       const { preview } = await import('./preview.ts');
       await preview(flags);
+    });
+
+  program
+    .command('export:pptx')
+    .description('Export a schema-based editable PPTX deck')
+    .argument('<slide-id>', 'slide id under slides/<id>')
+    .option('-o, --output <file>', 'output .pptx file (defaults to <slide-id>.pptx)')
+    .action(async (slideId: string, flags: ExportPptxFlags) => {
+      const { exportPptx } = await import('./export-pptx.ts');
+      const output = await exportPptx({ slideId, output: flags.output });
+      process.stdout.write(`${chalk.green('✓')} Wrote ${output}\n`);
     });
 
   program

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,3 +11,12 @@ export type { Page, SlideMeta, SlideModule } from './app/lib/sdk.ts';
 export { CANVAS_HEIGHT, CANVAS_WIDTH } from './app/lib/sdk.ts';
 export type { OpenSlideConfig } from './config.ts';
 export type { Locale, Plural } from './locale/types.ts';
+export type {
+  PptxDeck,
+  PptxElement,
+  PptxLineElement,
+  PptxRectElement,
+  PptxSlide,
+  PptxTextElement,
+} from './pptx/exporter.ts';
+export { createPptxBuffer, pxToEmu } from './pptx/exporter.ts';

--- a/packages/core/src/pptx/exporter.test.ts
+++ b/packages/core/src/pptx/exporter.test.ts
@@ -1,0 +1,55 @@
+import { strFromU8, unzipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { createPptxBuffer, type PptxDeck, pxToEmu } from './exporter.ts';
+
+function unzipXml(buffer: Uint8Array, name: string): string {
+  const files = unzipSync(buffer);
+  const file = files[name];
+  if (!file) throw new Error(`Missing ${name}`);
+  return strFromU8(file);
+}
+
+describe('editable PPTX exporter', () => {
+  it('writes editable text and shapes instead of slide screenshots', () => {
+    const deck: PptxDeck = {
+      title: 'Editable deck',
+      slides: [
+        {
+          background: '#0F172A',
+          elements: [
+            { type: 'rect', x: 96, y: 96, w: 480, h: 180, fill: '#22C55E', radius: 24 },
+            {
+              type: 'text',
+              x: 128,
+              y: 124,
+              w: 900,
+              h: 100,
+              text: 'Hello editable PPTX',
+              fontSize: 44,
+              bold: true,
+              color: '#FFFFFF',
+            },
+            { type: 'line', x: 128, y: 260, w: 640, h: 0, color: '#F97316', width: 4 },
+          ],
+        },
+      ],
+    };
+
+    const pptx = createPptxBuffer(deck);
+    const slideXml = unzipXml(pptx, 'ppt/slides/slide1.xml');
+
+    expect(slideXml).toContain('Hello editable PPTX');
+    expect(slideXml).toContain('<a:t>');
+    expect(slideXml).toContain('<p:sp>');
+    expect(slideXml).toContain('<a:solidFill>');
+    expect(slideXml).not.toContain('<p:pic>');
+    expect(slideXml).not.toContain('image/png');
+  });
+
+  it('maps Open Slide 1920x1080 pixels to PowerPoint EMUs', () => {
+    expect(pxToEmu(0)).toBe(0);
+    expect(pxToEmu(144)).toBe(914400);
+    expect(pxToEmu(1920)).toBe(12192000);
+    expect(pxToEmu(1080)).toBe(6858000);
+  });
+});

--- a/packages/core/src/pptx/exporter.ts
+++ b/packages/core/src/pptx/exporter.ts
@@ -1,0 +1,359 @@
+import { strToU8, zipSync } from 'fflate';
+
+export type HexColor = `#${string}` | string;
+
+export type PptxTextElement = {
+  type: 'text';
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  text: string;
+  fontSize?: number;
+  fontFace?: string;
+  color?: HexColor;
+  bold?: boolean;
+  italic?: boolean;
+  align?: 'left' | 'center' | 'right';
+  valign?: 'top' | 'mid' | 'bottom';
+  fill?: HexColor;
+};
+
+export type PptxRectElement = {
+  type: 'rect';
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  fill?: HexColor;
+  color?: HexColor;
+  radius?: number;
+  line?: HexColor;
+  lineWidth?: number;
+};
+
+export type PptxLineElement = {
+  type: 'line';
+  x: number;
+  y: number;
+  w: number;
+  h?: number;
+  color?: HexColor;
+  width?: number;
+};
+
+export type PptxElement = PptxTextElement | PptxRectElement | PptxLineElement;
+
+export type PptxSlide = {
+  background?: HexColor;
+  elements: PptxElement[];
+};
+
+export type PptxDeck = {
+  title?: string;
+  author?: string;
+  subject?: string;
+  company?: string;
+  slides: PptxSlide[];
+};
+
+const SLIDE_WIDTH_EMU = 12_192_000;
+const SLIDE_HEIGHT_EMU = 6_858_000;
+const PX_TO_EMU = 6_350;
+
+export function pxToEmu(px: number): number {
+  return Math.round(px * PX_TO_EMU);
+}
+
+export function createPptxBuffer(deck: PptxDeck): Uint8Array {
+  if (!Array.isArray(deck.slides) || deck.slides.length === 0) {
+    throw new Error('PPTX export requires at least one slide');
+  }
+
+  const files: Record<string, Uint8Array> = {};
+  const add = (name: string, xml: string) => {
+    files[name] = strToU8(xml);
+  };
+
+  add('[Content_Types].xml', contentTypesXml(deck.slides.length));
+  add('_rels/.rels', packageRelsXml());
+  add('docProps/core.xml', corePropsXml(deck));
+  add('docProps/app.xml', appPropsXml(deck));
+  add('ppt/presentation.xml', presentationXml(deck.slides.length));
+  add('ppt/_rels/presentation.xml.rels', presentationRelsXml(deck.slides.length));
+  add('ppt/slideMasters/slideMaster1.xml', slideMasterXml());
+  add('ppt/slideMasters/_rels/slideMaster1.xml.rels', slideMasterRelsXml());
+  add('ppt/slideLayouts/slideLayout1.xml', slideLayoutXml());
+  add('ppt/slideLayouts/_rels/slideLayout1.xml.rels', slideLayoutRelsXml());
+  add('ppt/theme/theme1.xml', themeXml());
+
+  deck.slides.forEach((slide, i) => {
+    const index = i + 1;
+    add(`ppt/slides/slide${index}.xml`, slideXml(slide));
+    add(`ppt/slides/_rels/slide${index}.xml.rels`, slideRelsXml());
+  });
+
+  return zipSync(files, { level: 6 });
+}
+
+function slideXml(slide: PptxSlide): string {
+  const shapes = slide.elements.map((element, i) => elementXml(element, i + 2)).join('\n');
+  return xml(`
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld>
+    ${backgroundXml(slide.background)}
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>
+      ${shapes}
+    </p:spTree>
+  </p:cSld>
+  <p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr>
+</p:sld>`);
+}
+
+function elementXml(element: PptxElement, id: number): string {
+  if (element.type === 'text') return textShapeXml(element, id);
+  if (element.type === 'rect') return rectShapeXml(element, id);
+  return lineShapeXml(element, id);
+}
+
+function textShapeXml(element: PptxTextElement, id: number): string {
+  const fontSize = Math.round((element.fontSize ?? 28) * 100);
+  const color = normalizeColor(element.color ?? '#111827');
+  const fontFace = element.fontFace ?? 'Aptos';
+  const align = element.align ?? 'left';
+  const anchor = element.valign ?? 'top';
+  const fill = element.fill ? solidFillXml(element.fill) : '<a:noFill/>';
+
+  return `
+<p:sp>
+  ${shapeNvXml(id, 'Text')}
+  <p:spPr>${xfrmXml(element)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>${fill}<a:ln><a:noFill/></a:ln></p:spPr>
+  <p:txBody>
+    <a:bodyPr wrap="square" anchor="${anchor}"/><a:lstStyle/>
+    ${paragraphsXml(element.text, { fontSize, color, fontFace, bold: element.bold, italic: element.italic, align })}
+  </p:txBody>
+</p:sp>`;
+}
+
+function rectShapeXml(element: PptxRectElement, id: number): string {
+  const geom = element.radius && element.radius > 0 ? 'roundRect' : 'rect';
+  const fill = element.fill ? solidFillXml(element.fill) : '<a:noFill/>';
+  const line = element.line
+    ? `<a:ln w="${lineWidthToEmu(element.lineWidth ?? 1)}">${solidFillXml(element.line)}<a:prstDash val="solid"/></a:ln>`
+    : '<a:ln><a:noFill/></a:ln>';
+
+  return `
+<p:sp>
+  ${shapeNvXml(id, 'Rectangle')}
+  <p:spPr>${xfrmXml(element)}<a:prstGeom prst="${geom}"><a:avLst/></a:prstGeom>${fill}${line}</p:spPr>
+  <p:txBody><a:bodyPr/><a:lstStyle/><a:p/></p:txBody>
+</p:sp>`;
+}
+
+function lineShapeXml(element: PptxLineElement, id: number): string {
+  const line = `<a:ln w="${lineWidthToEmu(element.width ?? 2)}">${solidFillXml(element.color ?? '#111827')}<a:prstDash val="solid"/></a:ln>`;
+  return `
+<p:sp>
+  ${shapeNvXml(id, 'Line')}
+  <p:spPr>${xfrmXml({ ...element, h: element.h ?? 0 })}<a:prstGeom prst="line"><a:avLst/></a:prstGeom>${line}</p:spPr>
+  <p:txBody><a:bodyPr/><a:lstStyle/><a:p/></p:txBody>
+</p:sp>`;
+}
+
+function paragraphsXml(
+  text: string,
+  opts: {
+    fontSize: number;
+    color: string;
+    fontFace: string;
+    bold?: boolean;
+    italic?: boolean;
+    align: string;
+  },
+): string {
+  const lines = text.split(/\r?\n/);
+  return lines
+    .map(
+      (line) => `
+    <a:p>
+      <a:pPr algn="${opts.align}"/>
+      <a:r>
+        <a:rPr lang="en-US" sz="${opts.fontSize}"${opts.bold ? ' b="1"' : ''}${opts.italic ? ' i="1"' : ''}>
+          <a:solidFill><a:srgbClr val="${opts.color}"/></a:solidFill>
+          <a:latin typeface="${escapeXml(opts.fontFace)}"/><a:ea typeface="${escapeXml(opts.fontFace)}"/><a:cs typeface="${escapeXml(opts.fontFace)}"/>
+        </a:rPr>
+        <a:t>${escapeXml(line)}</a:t>
+      </a:r>
+    </a:p>`,
+    )
+    .join('');
+}
+
+function xfrmXml(box: { x: number; y: number; w: number; h?: number }): string {
+  return `<a:xfrm><a:off x="${pxToEmu(box.x)}" y="${pxToEmu(box.y)}"/><a:ext cx="${pxToEmu(box.w)}" cy="${pxToEmu(box.h ?? 0)}"/></a:xfrm>`;
+}
+
+function shapeNvXml(id: number, name: string): string {
+  return `<p:nvSpPr><p:cNvPr id="${id}" name="${name} ${id}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>`;
+}
+
+function backgroundXml(color?: HexColor): string {
+  if (!color) return '';
+  return `<p:bg><p:bgPr>${solidFillXml(color)}<a:effectLst/></p:bgPr></p:bg>`;
+}
+
+function solidFillXml(color: HexColor): string {
+  return `<a:solidFill><a:srgbClr val="${normalizeColor(color)}"/></a:solidFill>`;
+}
+
+function normalizeColor(color: HexColor): string {
+  return String(color).replace(/^#/, '').toUpperCase();
+}
+
+function lineWidthToEmu(points: number): number {
+  return Math.round(points * 12_700);
+}
+
+function contentTypesXml(slideCount: number): string {
+  const slides = Array.from(
+    { length: slideCount },
+    (_, i) =>
+      `<Override PartName="/ppt/slides/slide${i + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>`,
+  ).join('');
+  return xml(`
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
+  <Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>
+  <Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+  <Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>
+  <Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>
+  <Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
+  ${slides}
+</Types>`);
+}
+
+function packageRelsXml(): string {
+  return xml(`
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" Target="docProps/app.xml"/>
+</Relationships>`);
+}
+
+function presentationXml(slideCount: number): string {
+  const slideIds = Array.from(
+    { length: slideCount },
+    (_, i) => `<p:sldId id="${256 + i}" r:id="rId${i + 2}"/>`,
+  ).join('');
+  return xml(`
+<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst>
+  <p:sldIdLst>${slideIds}</p:sldIdLst>
+  <p:sldSz cx="${SLIDE_WIDTH_EMU}" cy="${SLIDE_HEIGHT_EMU}" type="wide"/>
+  <p:notesSz cx="6858000" cy="9144000"/>
+  <p:defaultTextStyle/>
+</p:presentation>`);
+}
+
+function presentationRelsXml(slideCount: number): string {
+  const slides = Array.from(
+    { length: slideCount },
+    (_, i) =>
+      `<Relationship Id="rId${i + 2}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide${i + 1}.xml"/>`,
+  ).join('');
+  return xml(`
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>
+  ${slides}
+</Relationships>`);
+}
+
+function slideRelsXml(): string {
+  return xml(
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>',
+  );
+}
+
+function slideMasterXml(): string {
+  return xml(`
+<p:sldMaster xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr></p:spTree></p:cSld>
+  <p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>
+  <p:sldLayoutIdLst><p:sldLayoutId id="2147483649" r:id="rId1"/></p:sldLayoutIdLst>
+  <p:txStyles><p:titleStyle/><p:bodyStyle/><p:otherStyle/></p:txStyles>
+</p:sldMaster>`);
+}
+
+function slideMasterRelsXml(): string {
+  return xml(`
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="../theme/theme1.xml"/>
+</Relationships>`);
+}
+
+function slideLayoutXml(): string {
+  return xml(`
+<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="blank" preserve="1">
+  <p:cSld name="Blank"><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr></p:spTree></p:cSld>
+  <p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr>
+</p:sldLayout>`);
+}
+
+function slideLayoutRelsXml(): string {
+  return xml(`
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>
+</Relationships>`);
+}
+
+function themeXml(): string {
+  return xml(`
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Open Slide">
+  <a:themeElements>
+    <a:clrScheme name="Open Slide"><a:dk1><a:srgbClr val="111827"/></a:dk1><a:lt1><a:srgbClr val="FFFFFF"/></a:lt1><a:dk2><a:srgbClr val="1F2937"/></a:dk2><a:lt2><a:srgbClr val="F9FAFB"/></a:lt2><a:accent1><a:srgbClr val="2563EB"/></a:accent1><a:accent2><a:srgbClr val="22C55E"/></a:accent2><a:accent3><a:srgbClr val="F97316"/></a:accent3><a:accent4><a:srgbClr val="A855F7"/></a:accent4><a:accent5><a:srgbClr val="14B8A6"/></a:accent5><a:accent6><a:srgbClr val="EF4444"/></a:accent6><a:hlink><a:srgbClr val="2563EB"/></a:hlink><a:folHlink><a:srgbClr val="7C3AED"/></a:folHlink></a:clrScheme>
+    <a:fontScheme name="Open Slide"><a:majorFont><a:latin typeface="Aptos"/><a:ea typeface="Aptos"/><a:cs typeface="Aptos"/></a:majorFont><a:minorFont><a:latin typeface="Aptos"/><a:ea typeface="Aptos"/><a:cs typeface="Aptos"/></a:minorFont></a:fontScheme>
+    <a:fmtScheme name="Open Slide"><a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:fillStyleLst><a:lnStyleLst><a:ln w="6350"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln></a:lnStyleLst><a:effectStyleLst><a:effectStyle><a:effectLst/></a:effectStyle></a:effectStyleLst><a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:bgFillStyleLst></a:fmtScheme>
+  </a:themeElements>
+</a:theme>`);
+}
+
+function corePropsXml(deck: PptxDeck): string {
+  const now = new Date().toISOString();
+  return xml(`
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <dc:title>${escapeXml(deck.title ?? 'Open Slide export')}</dc:title>
+  <dc:creator>${escapeXml(deck.author ?? 'Open Slide')}</dc:creator>
+  <dc:subject>${escapeXml(deck.subject ?? '')}</dc:subject>
+  <dcterms:created xsi:type="dcterms:W3CDTF">${now}</dcterms:created>
+  <dcterms:modified xsi:type="dcterms:W3CDTF">${now}</dcterms:modified>
+</cp:coreProperties>`);
+}
+
+function appPropsXml(deck: PptxDeck): string {
+  return xml(`
+<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
+  <Application>Open Slide</Application>
+  <PresentationFormat>On-screen Show (16:9)</PresentationFormat>
+  <Slides>${deck.slides.length}</Slides>
+  <Company>${escapeXml(deck.company ?? '')}</Company>
+</Properties>`);
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function xml(body: string): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${body.trim()}`;
+}


### PR DESCRIPTION
## Summary
- Add `open-slide export:pptx <slide-id>` CLI command.
- Add a schema-based editable PPTX exporter that writes native PowerPoint OOXML shapes/text.
- Export `PptxDeck`/element types and `createPptxBuffer` from `@open-slide/core`.
- Document the `pptx` deck contract.

## Notes
This intentionally does not rasterize slides. Arbitrary React/CSS is not converted blindly; slides opt in by exporting a `pptx` schema.

## Test plan
- `pnpm exec biome check packages/core/src/pptx/exporter.ts packages/core/src/pptx/exporter.test.ts packages/core/src/cli/export-pptx.ts packages/core/src/cli/export-pptx.test.ts packages/core/src/cli/run.ts packages/core/src/index.ts packages/core/src/app/components/player.tsx`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Smoke generated `/tmp/open-slide-editable-smoke.pptx`; unzipped PPTX has no `ppt/media/`, no `<p:pic>`, and contains editable `<a:t>` text runs.
