### PR TITLE
feat(core): allow resizing the image crop rectangle

### DIFF
--- a/.changeset/image-crop-resize.md
+++ b/.changeset/image-crop-resize.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Allow resizing the crop rectangle in the image Crop dialog (Fill mode) and add a crop icon to the inspector Crop button.

--- a/packages/core/src/app/components/inspector/image-crop-dialog.tsx
+++ b/packages/core/src/app/components/inspector/image-crop-dialog.tsx
@@ -13,11 +13,9 @@ import {
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useLocale } from '@/lib/use-locale';
 
-export type ImageCropResult = {
-  fit: 'cover' | 'contain';
-  x: number;
-  y: number;
-};
+export type ImageCropRect = { x: number; y: number; width: number; height: number };
+
+export type ImageCropResult = { fit: 'contain' } | { fit: 'cover'; rect: ImageCropRect };
 
 export function ImageCropDialog({
   src,
@@ -25,6 +23,7 @@ export function ImageCropDialog({
   targetHeight,
   initialFit,
   initialPosition,
+  initialRect,
   onClose,
   onApply,
 }: {
@@ -33,6 +32,7 @@ export function ImageCropDialog({
   targetHeight: number;
   initialFit: 'cover' | 'contain';
   initialPosition: { x: number; y: number };
+  initialRect: ImageCropRect | null;
   onClose: () => void;
   onApply: (result: ImageCropResult) => void;
 }) {
@@ -44,26 +44,30 @@ export function ImageCropDialog({
 
   const onImageLoad = (e: SyntheticEvent<HTMLImageElement>) => {
     const im = e.currentTarget;
-    setCrop(makeMaxSizeCrop(im.naturalWidth, im.naturalHeight, aspect, initialPosition));
+    setCrop(initialCrop(im.naturalWidth, im.naturalHeight, aspect, initialRect, initialPosition));
   };
 
   useEffect(() => {
     const im = imgRef.current;
-    if (!im || !im.complete || !im.naturalWidth || !im.naturalHeight) return;
+    if (!im?.complete || !im.naturalWidth || !im.naturalHeight) return;
     setCrop((prev) => {
-      const pos = prev ? deriveObjectPosition(prev as PercentCrop) : initialPosition;
-      return makeMaxSizeCrop(im.naturalWidth, im.naturalHeight, aspect, pos);
+      if (prev && prev.unit === '%') {
+        return clampToAspect(prev as PercentCrop, aspect, im.naturalWidth, im.naturalHeight);
+      }
+      return initialCrop(im.naturalWidth, im.naturalHeight, aspect, initialRect, initialPosition);
     });
-  }, [aspect, initialPosition]);
+  }, [aspect, initialPosition, initialRect]);
 
   const onApplyClick = () => {
     if (fit === 'contain') {
-      onApply({ fit, x: 50, y: 50 });
+      onApply({ fit });
       return;
     }
-    const pos =
-      crop && crop.unit === '%' ? deriveObjectPosition(crop as PercentCrop) : { x: 50, y: 50 };
-    onApply({ fit, x: round2(pos.x), y: round2(pos.y) });
+    const rect =
+      crop && crop.unit === '%'
+        ? roundRect(crop as PercentCrop)
+        : { x: 0, y: 0, width: 100, height: 100 };
+    onApply({ fit, rect });
   };
 
   return (
@@ -98,7 +102,6 @@ export function ImageCropDialog({
               onChange={(_, percentCrop) => setCrop(percentCrop)}
               aspect={aspect}
               keepSelection
-              locked
               className="max-h-full"
             >
               <img
@@ -122,6 +125,19 @@ export function ImageCropDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+function initialCrop(
+  naturalW: number,
+  naturalH: number,
+  aspect: number,
+  rect: ImageCropRect | null,
+  position: { x: number; y: number },
+): PercentCrop {
+  if (rect) {
+    return clampToAspect({ unit: '%', ...rect }, aspect, naturalW, naturalH);
+  }
+  return makeMaxSizeCrop(naturalW, naturalH, aspect, position);
 }
 
 function makeMaxSizeCrop(
@@ -150,12 +166,40 @@ function makeMaxSizeCrop(
   return { unit: '%', x, y, width, height };
 }
 
-function deriveObjectPosition(crop: PercentCrop): { x: number; y: number } {
-  const slackX = 100 - crop.width;
-  const slackY = 100 - crop.height;
+function clampToAspect(
+  crop: PercentCrop,
+  aspect: number,
+  naturalW: number,
+  naturalH: number,
+): PercentCrop {
+  const cx = crop.x + crop.width / 2;
+  const cy = crop.y + crop.height / 2;
+  let width = crop.width;
+  let height = crop.height;
+  const targetPctRatio = naturalW > 0 && naturalH > 0 ? (aspect * naturalH) / naturalW : aspect;
+  const currentRatio = height > 0 ? width / height : targetPctRatio;
+  if (Math.abs(currentRatio - targetPctRatio) > 0.0001) {
+    if (currentRatio > targetPctRatio) {
+      height = width / targetPctRatio;
+    } else {
+      width = height * targetPctRatio;
+    }
+  }
+  width = clamp(width, 1, 100);
+  height = clamp(height, 1, 100);
+  let x = cx - width / 2;
+  let y = cy - height / 2;
+  x = clamp(x, 0, 100 - width);
+  y = clamp(y, 0, 100 - height);
+  return { unit: '%', x, y, width, height };
+}
+
+function roundRect(crop: PercentCrop): ImageCropRect {
   return {
-    x: slackX > 0 ? clamp((crop.x / slackX) * 100, 0, 100) : 50,
-    y: slackY > 0 ? clamp((crop.y / slackY) * 100, 0, 100) : 50,
+    x: round2(crop.x),
+    y: round2(crop.y),
+    width: round2(crop.width),
+    height: round2(crop.height),
   };
 }
 

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -4,6 +4,7 @@ import {
   AlignLeft,
   AlignRight,
   Bold,
+  Crop,
   ImageIcon,
   Italic,
   X,
@@ -637,6 +638,7 @@ function ImageField({
               className="flex-1"
               onClick={() => openCrop(anchor as HTMLImageElement)}
             >
+              <Crop className="size-3.5" />
               {t.inspector.crop}
             </Button>
           )}

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -15,7 +15,7 @@ import { Button } from '@/components/ui/button';
 import { type SlideComment, useComments } from '@/lib/inspector/use-comments';
 import { type Edit, type EditOp, type EditResult, useEditor } from '@/lib/inspector/use-editor';
 import { useLocale } from '@/lib/use-locale';
-import { ImageCropDialog } from './image-crop-dialog';
+import { ImageCropDialog, type ImageCropRect } from './image-crop-dialog';
 
 export type SelectedTarget = {
   line: number;
@@ -101,6 +101,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
     targetHeight: number;
     initialFit: 'cover' | 'contain';
     initialPosition: { x: number; y: number };
+    initialRect: ImageCropRect | null;
   } | null>(null);
   const t = useLocale();
 
@@ -558,6 +559,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       targetHeight: anchor.offsetHeight || anchor.getBoundingClientRect().height,
       initialFit: cs.objectFit === 'contain' ? 'contain' : 'cover',
       initialPosition: parseObjectPosition(cs.objectPosition),
+      initialRect: parseObjectViewBox(cs.getPropertyValue('object-view-box')),
     });
   }, []);
 
@@ -615,18 +617,30 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
           targetHeight={cropTarget.targetHeight}
           initialFit={cropTarget.initialFit}
           initialPosition={cropTarget.initialPosition}
+          initialRect={cropTarget.initialRect}
           onClose={() => setCropTarget(null)}
           onApply={(result) => {
             const { line, column, anchor } = cropTarget;
             if (anchor.isConnected) {
-              bufferOps(line, column, anchor, [
+              const ops: EditOp[] = [
                 { kind: 'set-style', key: 'objectFit', value: result.fit },
-                {
+                { kind: 'set-style', key: 'objectPosition', value: '50% 50%' },
+              ];
+              if (result.fit === 'cover') {
+                const { x, y, width, height } = result.rect;
+                const top = round2(y);
+                const left = round2(x);
+                const right = round2(100 - x - width);
+                const bottom = round2(100 - y - height);
+                ops.push({
                   kind: 'set-style',
-                  key: 'objectPosition',
-                  value: `${round2(result.x)}% ${round2(result.y)}%`,
-                },
-              ]);
+                  key: 'objectViewBox',
+                  value: `inset(${top}% ${right}% ${bottom}% ${left}%)`,
+                });
+              } else {
+                ops.push({ kind: 'set-style', key: 'objectViewBox', value: null });
+              }
+              bufferOps(line, column, anchor, ops);
             }
             setCropTarget(null);
           }}
@@ -638,6 +652,45 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
 
 function round2(n: number): number {
   return Math.round(n * 100) / 100;
+}
+
+function parseObjectViewBox(value: string): ImageCropRect | null {
+  const v = value?.trim();
+  if (!v || v === 'none') return null;
+  const m = v.match(/^inset\(([^)]+)\)$/);
+  if (!m?.[1]) return null;
+  const nums = m[1]
+    .trim()
+    .split(/\s+/)
+    .map((p) => {
+      const n = p.match(/^(-?\d+(?:\.\d+)?)%$/);
+      return n?.[1] ? Number(n[1]) : null;
+    });
+  if (nums.some((n) => n === null)) return null;
+  let top: number, right: number, bottom: number, left: number;
+  if (nums.length === 1) {
+    top = right = bottom = left = nums[0] as number;
+  } else if (nums.length === 2) {
+    top = bottom = nums[0] as number;
+    right = left = nums[1] as number;
+  } else if (nums.length === 3) {
+    top = nums[0] as number;
+    right = left = nums[1] as number;
+    bottom = nums[2] as number;
+  } else if (nums.length === 4) {
+    top = nums[0] as number;
+    right = nums[1] as number;
+    bottom = nums[2] as number;
+    left = nums[3] as number;
+  } else {
+    return null;
+  }
+  const x = left;
+  const y = top;
+  const width = 100 - left - right;
+  const height = 100 - top - bottom;
+  if (width <= 0 || height <= 0) return null;
+  return { x, y, width, height };
 }
 
 function parseObjectPosition(value: string): { x: number; y: number } {


### PR DESCRIPTION
## Summary
- Drag-resize the crop selection in the inspector Crop dialog (Fill mode), so users can zoom into a portion of the image instead of only repositioning a fixed-size frame.
- Persist the full crop rectangle as `object-view-box: inset(...)` alongside `object-fit: cover`. Reopening the dialog parses the existing view-box and seeds the selection with it.
- Add a Crop icon to the inspector Crop button.
- Fix a snap-on-first-drag glitch when re-opening: compare crop ratios in % space using `(aspect * naturalH) / naturalW` when re-seeding, otherwise non-square sources render as the wrong shape until ReactCrop corrects it.

## Test plan
- [ ] On any demo slide containing an `<img>` (e.g. `open-slide-launch`), open the inspector and click Crop. Verify the selection can be both moved and resized while staying locked to the slot's aspect.
- [ ] Apply a tighter crop, reopen the dialog. The selection should appear at its saved shape immediately (no snap on first drag).
- [ ] Verify the saved JSX writes `objectViewBox: 'inset(...)'` and a centered `objectPosition`.
- [ ] Switch to Contain in the dialog and apply — `objectViewBox` should be removed.
- [ ] Confirm the inspector Crop button now shows the Crop icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)