### PR TITLE
feat(core): add dev-mode notes drawer for editing speaker notes

### DIFF
--- a/.changeset/dev-notes-drawer.md
+++ b/.changeset/dev-notes-drawer.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': minor
+---
+
+Add a dev-mode notes drawer at the bottom of the slide view for editing speaker notes per page; autosaves to the slide source and creates `export const notes` if missing.

--- a/.changeset/fix-notes-drawer-flicker.md
+++ b/.changeset/fix-notes-drawer-flicker.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Fix notes drawer flickering, dropping keystrokes, and losing focus mid-typing.

--- a/.changeset/fix-notes-drawer-flicker.md
+++ b/.changeset/fix-notes-drawer-flicker.md
@@ -1,5 +1,0 @@
----
-'@open-slide/core': patch
----
-
-Fix notes drawer flickering, dropping keystrokes, and losing focus mid-typing.

--- a/packages/core/src/app/components/notes-drawer.tsx
+++ b/packages/core/src/app/components/notes-drawer.tsx
@@ -1,10 +1,12 @@
 import { ChevronDown, ChevronUp, NotebookPen } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { PANEL_TRANSITION_MS, usePanelMount } from '@/components/panel/panel-shell';
 import { useNotes } from '@/lib/inspector/use-notes';
 import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 
 const STORAGE_KEY = 'open-slide:notes-drawer-open';
+const DRAWER_CONTENT_H = 166;
 
 type Props = {
   slideId: string;
@@ -21,6 +23,7 @@ export function NotesDrawer({ slideId, index, total, initial }: Props) {
   });
   const { value, setValue, status, flush } = useNotes(slideId, index, initial);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const { mounted, animVisible } = usePanelMount(open);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -76,29 +79,37 @@ export function NotesDrawer({ slideId, index, total, initial }: Props) {
           <ChevronUp className="size-3.5 text-muted-foreground" />
         )}
       </button>
-      {open && (
-        <div className="border-t border-hairline px-3 py-2">
-          <textarea
-            ref={textareaRef}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            onBlur={() => {
-              void flush();
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') {
-                e.preventDefault();
-                textareaRef.current?.blur();
-              } else if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-                e.preventDefault();
+      {mounted && (
+        <div
+          className="overflow-hidden border-t border-hairline transition-[height] ease-out"
+          style={{
+            height: animVisible ? DRAWER_CONTENT_H : 0,
+            transitionDuration: `${PANEL_TRANSITION_MS}ms`,
+          }}
+        >
+          <div className="px-3 py-2">
+            <textarea
+              ref={textareaRef}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onBlur={() => {
                 void flush();
-              }
-            }}
-            placeholder={t.notesDrawer.placeholder}
-            rows={6}
-            spellCheck
-            className="block h-[150px] w-full resize-none rounded-[6px] border border-border bg-card px-3 py-2 text-[13px] leading-relaxed text-card-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
-          />
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  textareaRef.current?.blur();
+                } else if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                  e.preventDefault();
+                  void flush();
+                }
+              }}
+              placeholder={t.notesDrawer.placeholder}
+              rows={6}
+              spellCheck
+              className="block h-[150px] w-full resize-none rounded-[6px] border border-border bg-card px-3 py-2 text-[13px] leading-relaxed text-card-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+            />
+          </div>
         </div>
       )}
     </aside>

--- a/packages/core/src/app/components/notes-drawer.tsx
+++ b/packages/core/src/app/components/notes-drawer.tsx
@@ -1,0 +1,106 @@
+import { ChevronDown, ChevronUp, NotebookPen } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { useNotes } from '@/lib/inspector/use-notes';
+import { format, useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
+
+const STORAGE_KEY = 'open-slide:notes-drawer-open';
+
+type Props = {
+  slideId: string;
+  index: number;
+  total: number;
+  initial: string | undefined;
+};
+
+export function NotesDrawer({ slideId, index, total, initial }: Props) {
+  const t = useLocale();
+  const [open, setOpen] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(STORAGE_KEY) === '1';
+  });
+  const { value, setValue, status, flush } = useNotes(slideId, index, initial);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(STORAGE_KEY, open ? '1' : '0');
+  }, [open]);
+
+  const statusLabel = (() => {
+    switch (status.kind) {
+      case 'saving':
+        return t.notesDrawer.statusSaving;
+      case 'saved':
+        return t.notesDrawer.statusSaved;
+      case 'error':
+        return format(t.notesDrawer.statusError, { msg: status.message });
+      default:
+        return '';
+    }
+  })();
+
+  return (
+    <aside
+      data-notes-drawer
+      className="hidden shrink-0 border-t border-hairline bg-sidebar/85 backdrop-blur md:block"
+    >
+      <button
+        type="button"
+        onClick={() => {
+          setOpen((o) => {
+            if (o) void flush();
+            return !o;
+          });
+        }}
+        className="flex h-9 w-full items-center gap-2 px-3 text-[12px] text-foreground/80 hover:bg-muted/40"
+        aria-expanded={open}
+      >
+        <NotebookPen className="size-3.5 text-muted-foreground" />
+        <span className="font-medium">{t.notesDrawer.toggle}</span>
+        <span className="font-mono text-[11px] text-muted-foreground">
+          {format(t.notesDrawer.pageLabel, { n: index + 1, total })}
+        </span>
+        <span
+          className={cn(
+            'ml-auto truncate text-[11px]',
+            status.kind === 'error' ? 'text-destructive' : 'text-muted-foreground',
+          )}
+          aria-live="polite"
+        >
+          {statusLabel}
+        </span>
+        {open ? (
+          <ChevronDown className="size-3.5 text-muted-foreground" />
+        ) : (
+          <ChevronUp className="size-3.5 text-muted-foreground" />
+        )}
+      </button>
+      {open && (
+        <div className="border-t border-hairline px-3 py-2">
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onBlur={() => {
+              void flush();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                textareaRef.current?.blur();
+              } else if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                e.preventDefault();
+                void flush();
+              }
+            }}
+            placeholder={t.notesDrawer.placeholder}
+            rows={6}
+            spellCheck
+            className="block h-[150px] w-full resize-none rounded-[6px] border border-border bg-card px-3 py-2 text-[13px] leading-relaxed text-card-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+          />
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/packages/core/src/app/lib/inspector/use-notes.ts
+++ b/packages/core/src/app/lib/inspector/use-notes.ts
@@ -10,8 +10,14 @@ const DEBOUNCE_MS = 600;
 
 type Target = { slideId: string; index: number };
 
+// HMR is suppressed for our writes, so the cached slide module's `notes`
+// stays stale across navigation. Cache last-saved text per target so
+// switching slides and back doesn't surface the old value.
+const sessionCache = new Map<string, string>();
+const cacheKey = (slideId: string, index: number) => `${slideId}:${index}`;
+
 export function useNotes(slideId: string, index: number, initial: string | undefined) {
-  const initialText = initial ?? '';
+  const initialText = sessionCache.get(cacheKey(slideId, index)) ?? initial ?? '';
   const [value, setValueState] = useState(initialText);
   const [status, setStatus] = useState<NoteSaveStatus>({ kind: 'idle' });
 
@@ -20,6 +26,8 @@ export function useNotes(slideId: string, index: number, initial: string | undef
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inflightRef = useRef<AbortController | null>(null);
   const targetRef = useRef<Target>({ slideId, index });
+  const valueRef = useRef(value);
+  valueRef.current = value;
 
   const cancelTimer = useCallback(() => {
     if (timerRef.current != null) {
@@ -42,6 +50,7 @@ export function useNotes(slideId: string, index: number, initial: string | undef
       });
       const body = (await res.json().catch(() => ({}))) as { error?: string };
       if (!res.ok) throw new Error(body.error ?? `PUT /__notes → ${res.status}`);
+      sessionCache.set(cacheKey(target.slideId, target.index), text);
       if (inflightRef.current !== ctl) return;
       lastSavedRef.current = text;
       dirtyRef.current = false;
@@ -58,8 +67,8 @@ export function useNotes(slideId: string, index: number, initial: string | undef
     cancelTimer();
     if (!dirtyRef.current) return;
     const target = targetRef.current;
-    await persist(target, value);
-  }, [cancelTimer, persist, value]);
+    await persist(target, valueRef.current);
+  }, [cancelTimer, persist]);
 
   // When the (slideId, index) target changes, flush pending edits for the
   // previous target before adopting the new initial text.
@@ -68,8 +77,8 @@ export function useNotes(slideId: string, index: number, initial: string | undef
     const targetChanged = prev.slideId !== slideId || prev.index !== index;
     if (targetChanged && dirtyRef.current) {
       cancelTimer();
-      const pending = lastSavedRef.current === value ? null : value;
-      if (pending !== null) void persist(prev, pending);
+      const pending = valueRef.current;
+      if (lastSavedRef.current !== pending) void persist(prev, pending);
     }
     targetRef.current = { slideId, index };
     cancelTimer();
@@ -77,7 +86,7 @@ export function useNotes(slideId: string, index: number, initial: string | undef
     lastSavedRef.current = initialText;
     dirtyRef.current = false;
     setStatus({ kind: 'idle' });
-  }, [slideId, index, initialText, persist, value, cancelTimer]);
+  }, [slideId, index, initialText, persist, cancelTimer]);
 
   useEffect(() => {
     return () => {

--- a/packages/core/src/app/lib/inspector/use-notes.ts
+++ b/packages/core/src/app/lib/inspector/use-notes.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type NoteSaveStatus =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'saved' }
+  | { kind: 'error'; message: string };
+
+const DEBOUNCE_MS = 600;
+
+type Target = { slideId: string; index: number };
+
+export function useNotes(slideId: string, index: number, initial: string | undefined) {
+  const initialText = initial ?? '';
+  const [value, setValueState] = useState(initialText);
+  const [status, setStatus] = useState<NoteSaveStatus>({ kind: 'idle' });
+
+  const lastSavedRef = useRef(initialText);
+  const dirtyRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inflightRef = useRef<AbortController | null>(null);
+  const targetRef = useRef<Target>({ slideId, index });
+
+  const cancelTimer = useCallback(() => {
+    if (timerRef.current != null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const persist = useCallback(async (target: Target, text: string) => {
+    inflightRef.current?.abort();
+    const ctl = new AbortController();
+    inflightRef.current = ctl;
+    setStatus({ kind: 'saving' });
+    try {
+      const res = await fetch('/__notes', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ slideId: target.slideId, index: target.index, text }),
+        signal: ctl.signal,
+      });
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) throw new Error(body.error ?? `PUT /__notes → ${res.status}`);
+      if (inflightRef.current !== ctl) return;
+      lastSavedRef.current = text;
+      dirtyRef.current = false;
+      setStatus({ kind: 'saved' });
+    } catch (err) {
+      if ((err as { name?: string }).name === 'AbortError') return;
+      setStatus({ kind: 'error', message: String((err as Error).message ?? err) });
+    } finally {
+      if (inflightRef.current === ctl) inflightRef.current = null;
+    }
+  }, []);
+
+  const flush = useCallback(async () => {
+    cancelTimer();
+    if (!dirtyRef.current) return;
+    const target = targetRef.current;
+    await persist(target, value);
+  }, [cancelTimer, persist, value]);
+
+  // When the (slideId, index) target changes, flush pending edits for the
+  // previous target before adopting the new initial text.
+  useEffect(() => {
+    const prev = targetRef.current;
+    const targetChanged = prev.slideId !== slideId || prev.index !== index;
+    if (targetChanged && dirtyRef.current) {
+      cancelTimer();
+      const pending = lastSavedRef.current === value ? null : value;
+      if (pending !== null) void persist(prev, pending);
+    }
+    targetRef.current = { slideId, index };
+    cancelTimer();
+    setValueState(initialText);
+    lastSavedRef.current = initialText;
+    dirtyRef.current = false;
+    setStatus({ kind: 'idle' });
+  }, [slideId, index, initialText, persist, value, cancelTimer]);
+
+  useEffect(() => {
+    return () => {
+      cancelTimer();
+      inflightRef.current?.abort();
+    };
+  }, [cancelTimer]);
+
+  const setValue = useCallback(
+    (next: string) => {
+      setValueState(next);
+      dirtyRef.current = next !== lastSavedRef.current;
+      cancelTimer();
+      if (!dirtyRef.current) {
+        setStatus({ kind: 'idle' });
+        return;
+      }
+      const target = targetRef.current;
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        void persist(target, next);
+      }, DEBOUNCE_MS);
+    },
+    [persist, cancelTimer],
+  );
+
+  return { value, setValue, status, flush };
+}

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -29,6 +29,7 @@ import { useLocale } from '@/lib/use-locale';
 import { useWheelPageNavigation } from '@/lib/use-wheel-page-navigation';
 import { cn } from '@/lib/utils';
 import { ClickNavZones } from '../components/click-nav-zones';
+import { NotesDrawer } from '../components/notes-drawer';
 import { PdfProgressToast } from '../components/pdf-progress-toast';
 import { Player } from '../components/player';
 import { SlideCanvas } from '../components/slide-canvas';
@@ -400,57 +401,67 @@ export function Slide() {
             </div>
           ) : (
             <DesignProvider slideId={slideId}>
-              <div className="flex min-h-0 flex-1 flex-col md:flex-row">
-                <div className="hidden w-[16.5rem] shrink-0 md:block">
-                  <ThumbnailRail
-                    pages={pages}
-                    design={slide.design}
-                    current={index}
-                    onSelect={goTo}
-                    onReorder={import.meta.env.DEV ? reorderPage : undefined}
-                  />
-                </div>
-                <main
-                  ref={slideViewportRef}
-                  data-inspector-root
-                  className="paper relative min-h-0 min-w-0 flex-1 bg-canvas p-2 md:p-10"
-                >
-                  <SlideWheelNavigation
-                    targetRef={slideViewportRef}
-                    onPrev={() => goTo(index - 1)}
-                    onNext={() => goTo(index + 1)}
-                    canPrev={index > 0}
-                    canNext={index < pageCount - 1}
-                  />
-                  <SlideCanvas design={slide.design}>
-                    <CurrentPage />
-                  </SlideCanvas>
-                  <ClickNavZones
-                    onPrev={() => goTo(index - 1)}
-                    onNext={() => goTo(index + 1)}
-                    canPrev={index > 0}
-                    canNext={index < pageCount - 1}
-                  />
-                  <InspectOverlay />
-                  <SaveBar />
-                  {import.meta.env.DEV && <CommentWidget />}
-                </main>
-                {/* Mobile-only horizontal rail. Sits below the canvas and
+              <div className="flex min-h-0 flex-1 flex-col">
+                <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+                  <div className="hidden w-[16.5rem] shrink-0 md:block">
+                    <ThumbnailRail
+                      pages={pages}
+                      design={slide.design}
+                      current={index}
+                      onSelect={goTo}
+                      onReorder={import.meta.env.DEV ? reorderPage : undefined}
+                    />
+                  </div>
+                  <main
+                    ref={slideViewportRef}
+                    data-inspector-root
+                    className="paper relative min-h-0 min-w-0 flex-1 bg-canvas p-2 md:p-10"
+                  >
+                    <SlideWheelNavigation
+                      targetRef={slideViewportRef}
+                      onPrev={() => goTo(index - 1)}
+                      onNext={() => goTo(index + 1)}
+                      canPrev={index > 0}
+                      canNext={index < pageCount - 1}
+                    />
+                    <SlideCanvas design={slide.design}>
+                      <CurrentPage />
+                    </SlideCanvas>
+                    <ClickNavZones
+                      onPrev={() => goTo(index - 1)}
+                      onNext={() => goTo(index + 1)}
+                      canPrev={index > 0}
+                      canNext={index < pageCount - 1}
+                    />
+                    <InspectOverlay />
+                    <SaveBar />
+                    {import.meta.env.DEV && <CommentWidget />}
+                  </main>
+                  {/* Mobile-only horizontal rail. Sits below the canvas and
                     pads its bottom for the iOS home indicator / Safari URL bar. */}
-                <div
-                  className="shrink-0 border-t border-hairline md:hidden"
-                  style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
-                >
-                  <ThumbnailRail
-                    pages={pages}
-                    design={slide.design}
-                    current={index}
-                    onSelect={goTo}
-                    orientation="horizontal"
-                  />
+                  <div
+                    className="shrink-0 border-t border-hairline md:hidden"
+                    style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+                  >
+                    <ThumbnailRail
+                      pages={pages}
+                      design={slide.design}
+                      current={index}
+                      onSelect={goTo}
+                      orientation="horizontal"
+                    />
+                  </div>
+                  <InspectorPanel />
+                  <DesignPanel open={designOpen} onClose={() => setDesignOpen(false)} />
                 </div>
-                <InspectorPanel />
-                <DesignPanel open={designOpen} onClose={() => setDesignOpen(false)} />
+                {import.meta.env.DEV && (
+                  <NotesDrawer
+                    slideId={slideId}
+                    index={index}
+                    total={pageCount}
+                    initial={slide.notes?.[index]}
+                  />
+                )}
               </div>
             </DesignProvider>
           )}

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -309,4 +309,13 @@ export const en: Locale = {
     prevAria: 'Previous page',
     nextAria: 'Next page',
   },
+
+  notesDrawer: {
+    toggle: 'Notes',
+    pageLabel: 'page {n}/{total}',
+    placeholder: 'Write speaker notes for this slide…',
+    statusSaving: 'Saving…',
+    statusSaved: 'Saved',
+    statusError: 'Save failed: {msg}',
+  },
 };

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -313,4 +313,13 @@ export const ja: Locale = {
     prevAria: '前のページ',
     nextAria: '次のページ',
   },
+
+  notesDrawer: {
+    toggle: '発表者ノート',
+    pageLabel: '{n} / {total} ページ',
+    placeholder: 'このスライドの発表者ノートを記入…',
+    statusSaving: '保存中…',
+    statusSaved: '保存済み',
+    statusError: '保存に失敗しました: {msg}',
+  },
 };

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -329,4 +329,15 @@ export type Locale = {
     prevAria: string;
     nextAria: string;
   };
+
+  notesDrawer: {
+    toggle: string;
+    /** template: "page {n}/{total}" */
+    pageLabel: string;
+    placeholder: string;
+    statusSaving: string;
+    statusSaved: string;
+    /** template: "Save failed: {msg}" */
+    statusError: string;
+  };
 };

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -309,4 +309,13 @@ export const zhCN: Locale = {
     prevAria: '上一页',
     nextAria: '下一页',
   },
+
+  notesDrawer: {
+    toggle: '演讲备注',
+    pageLabel: '第 {n} / {total} 页',
+    placeholder: '为这一页撰写演讲备注…',
+    statusSaving: '保存中…',
+    statusSaved: '已保存',
+    statusError: '保存失败：{msg}',
+  },
 };

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -309,4 +309,13 @@ export const zhTW: Locale = {
     prevAria: '上一頁',
     nextAria: '下一頁',
   },
+
+  notesDrawer: {
+    toggle: '講稿',
+    pageLabel: '第 {n} / {total} 頁',
+    placeholder: '為這一頁撰寫演講備忘…',
+    statusSaving: '儲存中…',
+    statusSaved: '已儲存',
+    statusError: '儲存失敗：{msg}',
+  },
 };

--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -8,6 +8,7 @@ import { commentsPlugin } from './comments-plugin.ts';
 import { designPlugin } from './design-plugin.ts';
 import { filesPlugin } from './files-plugin.ts';
 import { locTagsPlugin } from './loc-tags-plugin.ts';
+import { notesPlugin } from './notes-plugin.ts';
 import { loadUserConfig, type OpenSlideConfig, openSlidePlugin } from './open-slide-plugin.ts';
 
 function findPackageRoot(fromFile: string): string {
@@ -45,6 +46,7 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
       openSlidePlugin({ userCwd, config }),
       designPlugin({ userCwd }),
       commentsPlugin({ userCwd, slidesDir }),
+      notesPlugin({ userCwd, slidesDir }),
       filesPlugin({ userCwd, slidesDir }),
     ],
     resolve: {

--- a/packages/core/src/vite/notes-plugin.test.ts
+++ b/packages/core/src/vite/notes-plugin.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { applyNotesEdit, renderNoteLiteral } from './notes-plugin.ts';
+
+describe('renderNoteLiteral', () => {
+  it('returns undefined for empty strings', () => {
+    expect(renderNoteLiteral('')).toBe('undefined');
+  });
+
+  it('uses JSON-quoted strings for single-line text', () => {
+    expect(renderNoteLiteral('hello')).toBe('"hello"');
+    expect(renderNoteLiteral('with "quotes"')).toBe('"with \\"quotes\\""');
+  });
+
+  it('uses template literals for multi-line text and escapes specials', () => {
+    expect(renderNoteLiteral('a\nb')).toBe('`a\nb`');
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal `${}` is the test input
+    expect(renderNoteLiteral('back`tick\nand ${interp}')).toBe('`back\\`tick\nand \\${interp}`');
+    expect(renderNoteLiteral('back\\slash\nhere')).toBe('`back\\\\slash\nhere`');
+  });
+});
+
+describe('applyNotesEdit / no existing export', () => {
+  it('inserts a new notes export padded to the target index', () => {
+    const source = `import type { Page } from '@open-slide/core';\n\nexport default [];\n`;
+    const result = applyNotesEdit(source, 2, 'hello');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.source).toContain(
+      'export const notes: (string | undefined)[] = [\n' +
+        '  undefined,\n' +
+        '  undefined,\n' +
+        '  "hello",\n' +
+        '];',
+    );
+  });
+
+  it('places the export after the last import', () => {
+    const source = `import a from 'a';\nimport b from 'b';\n\nexport default [];\n`;
+    const result = applyNotesEdit(source, 0, 'first');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const importEnd = result.source.indexOf("import b from 'b';") + "import b from 'b';".length;
+    const exportStart = result.source.indexOf('export const notes');
+    expect(exportStart).toBeGreaterThan(importEnd);
+    expect(result.source.indexOf('export default [];')).toBeGreaterThan(exportStart);
+  });
+
+  it('is a no-op when text is empty and there is no export', () => {
+    const source = `export default [];\n`;
+    const result = applyNotesEdit(source, 3, '');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.source).toBe(source);
+  });
+});
+
+describe('applyNotesEdit / existing export', () => {
+  it('updates an existing slot in place', () => {
+    const source = [
+      "import type { Page } from '@open-slide/core';",
+      '',
+      'export default [];',
+      '',
+      'export const notes = [',
+      '  "old",',
+      '  undefined,',
+      '];',
+      '',
+    ].join('\n');
+    const result = applyNotesEdit(source, 0, 'new');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.source).toContain('"new"');
+    expect(result.source).not.toContain('"old"');
+  });
+
+  it('pads with undefined when extending past current length', () => {
+    const source = `export const notes = ["a"];\nexport default [];\n`;
+    const result = applyNotesEdit(source, 3, 'd');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.source).toContain('[\n  "a",\n  undefined,\n  undefined,\n  "d",\n]');
+  });
+
+  it('clears a slot back to undefined and trims trailing undefined entries', () => {
+    const source = `export const notes = ["a", "b", "c"];\nexport default [];\n`;
+    const result = applyNotesEdit(source, 2, '');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.source).toContain('[\n  "a",\n  "b",\n]');
+    expect(result.source).not.toContain('"c"');
+  });
+
+  it('preserves existing element source formatting (template literals, comments)', () => {
+    const original = '`multi\nline old`';
+    const source = `export const notes = [\n  ${original},\n  "kept",\n];\n`;
+    const result = applyNotesEdit(source, 0, 'replaced');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.source).toContain('"replaced"');
+    expect(result.source).toContain('"kept"');
+    expect(result.source).not.toContain('multi\nline old');
+  });
+
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: literal `${}` is the test input
+  it('round-trips strings with backticks and ${} via template literals', () => {
+    const source = `export const notes = [];\n`;
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal `${}` is the test input
+    const text = 'has `backticks` and ${vars}\nover lines';
+    const result = applyNotesEdit(source, 0, text);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal `${}` is the test input
+    expect(result.source).toContain('`has \\`backticks\\` and \\${vars}\nover lines`');
+  });
+
+  it('rejects non-array notes export', () => {
+    const source = `export const notes = "oops";\n`;
+    const result = applyNotesEdit(source, 0, 'x');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(422);
+  });
+});

--- a/packages/core/src/vite/notes-plugin.ts
+++ b/packages/core/src/vite/notes-plugin.ts
@@ -191,9 +191,22 @@ export type NotesPluginOptions = {
 export function notesPlugin(opts: NotesPluginOptions): Plugin {
   const userCwd = opts.userCwd;
   const slidesDir = opts.slidesDir ?? 'slides';
+  // Suppress HMR for our own writes — RFR bails on the slide's mixed exports
+  // and remounts the tree, stealing textarea focus mid-typing.
+  const recentWrites = new Map<string, number>();
+  const RECENT_WRITE_WINDOW_MS = 1500;
+
   return {
     name: 'open-slide:notes',
     apply: 'serve',
+    handleHotUpdate(ctx) {
+      const ts = recentWrites.get(ctx.file);
+      if (ts != null && Date.now() - ts < RECENT_WRITE_WINDOW_MS) {
+        recentWrites.delete(ctx.file);
+        return [];
+      }
+      return undefined;
+    },
     configureServer(server: ViteDevServer) {
       server.middlewares.use('/__notes', async (req, res, next) => {
         const url = new URL(req.url ?? '/', 'http://local');
@@ -218,7 +231,10 @@ export function notesPlugin(opts: NotesPluginOptions): Plugin {
           const result = applyNotesEdit(source, body.index, body.text);
           if (!result.ok) return json(res, result.status, { error: result.error });
           const changed = result.source !== source;
-          if (changed) await fs.writeFile(file, result.source, 'utf8');
+          if (changed) {
+            recentWrites.set(file, Date.now());
+            await fs.writeFile(file, result.source, 'utf8');
+          }
           return json(res, 200, { ok: true, changed });
         } catch (err) {
           json(res, 500, { error: String((err as Error).message ?? err) });

--- a/packages/core/src/vite/notes-plugin.ts
+++ b/packages/core/src/vite/notes-plugin.ts
@@ -1,0 +1,229 @@
+import fs from 'node:fs/promises';
+import type { ServerResponse } from 'node:http';
+import path from 'node:path';
+import { parse as babelParse } from '@babel/parser';
+import * as t from '@babel/types';
+import type { Connect, Plugin, ViteDevServer } from 'vite';
+
+const SLIDE_ID_RE = /^[a-z0-9_-]+$/i;
+
+type NotesBody = {
+  slideId?: string;
+  index?: number;
+  text?: string;
+};
+
+export type ApplyNotesEditResult =
+  | { ok: true; source: string }
+  | { ok: false; status: number; error: string };
+
+async function readBody(req: Connect.IncomingMessage): Promise<unknown> {
+  return await new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (!raw) return resolve({});
+      try {
+        resolve(JSON.parse(raw));
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function json(res: ServerResponse, status: number, body: unknown) {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+function resolveSlidePath(userCwd: string, slidesDir: string, slideId: string): string | null {
+  if (!SLIDE_ID_RE.test(slideId)) return null;
+  const slidesRoot = path.resolve(userCwd, slidesDir);
+  const full = path.resolve(slidesRoot, slideId, 'index.tsx');
+  if (!full.startsWith(slidesRoot + path.sep)) return null;
+  return full;
+}
+
+function parseSource(source: string): t.File | null {
+  try {
+    return babelParse(source, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+      errorRecovery: true,
+    });
+  } catch {
+    return null;
+  }
+}
+
+type NotesExport = {
+  declStart: number;
+  declEnd: number;
+  arrayStart: number;
+  arrayEnd: number;
+  elements: Array<t.Expression | t.SpreadElement | null>;
+};
+
+function findNotesExport(ast: t.File): NotesExport | { error: string } | null {
+  for (const stmt of ast.program.body) {
+    if (!t.isExportNamedDeclaration(stmt)) continue;
+    const decl = stmt.declaration;
+    if (!decl || !t.isVariableDeclaration(decl)) continue;
+    for (const d of decl.declarations) {
+      if (!t.isVariableDeclarator(d)) continue;
+      if (!t.isIdentifier(d.id) || d.id.name !== 'notes') continue;
+      if (!d.init) return { error: '`notes` export has no initializer' };
+      if (!t.isArrayExpression(d.init)) {
+        return { error: '`notes` export is not an array literal' };
+      }
+      const arr = d.init;
+      if (typeof stmt.start !== 'number' || typeof stmt.end !== 'number') {
+        return { error: '`notes` export missing source range' };
+      }
+      if (typeof arr.start !== 'number' || typeof arr.end !== 'number') {
+        return { error: '`notes` array missing source range' };
+      }
+      return {
+        declStart: stmt.start,
+        declEnd: stmt.end,
+        arrayStart: arr.start,
+        arrayEnd: arr.end,
+        elements: arr.elements,
+      };
+    }
+  }
+  return null;
+}
+
+// Render a string as a TS literal. Prefer template literals for multi-line
+// strings so the source stays readable; otherwise a JSON-quoted single-line
+// string keeps escapes minimal.
+export function renderNoteLiteral(text: string): string {
+  if (text === '') return 'undefined';
+  const hasNewline = /\n/.test(text);
+  if (hasNewline) {
+    const escaped = text.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+    return `\`${escaped}\``;
+  }
+  return JSON.stringify(text);
+}
+
+function findInsertionOffset(ast: t.File, source: string): number {
+  let lastImportEnd = -1;
+  for (const stmt of ast.program.body) {
+    if (t.isImportDeclaration(stmt) && typeof stmt.end === 'number') {
+      lastImportEnd = Math.max(lastImportEnd, stmt.end);
+    }
+  }
+  if (lastImportEnd >= 0) return lastImportEnd;
+  return source.length;
+}
+
+export function applyNotesEdit(source: string, index: number, text: string): ApplyNotesEditResult {
+  if (!Number.isInteger(index) || index < 0) {
+    return { ok: false, status: 400, error: 'invalid index' };
+  }
+
+  const ast = parseSource(source);
+  if (!ast) return { ok: false, status: 422, error: 'could not parse source' };
+
+  const found = findNotesExport(ast);
+  if (found && 'error' in found) {
+    return { ok: false, status: 422, error: found.error };
+  }
+
+  const literal = renderNoteLiteral(text);
+
+  if (!found) {
+    if (text === '') return { ok: true, source };
+
+    const padding = Array.from({ length: index }, () => 'undefined');
+    const items = [...padding, literal];
+    const block = [
+      '',
+      '',
+      'export const notes: (string | undefined)[] = [',
+      ...items.map((s) => `  ${s},`),
+      '];',
+      '',
+    ].join('\n');
+
+    const offset = findInsertionOffset(ast, source);
+    const next = source.slice(0, offset) + block + source.slice(offset);
+    return { ok: true, source: next };
+  }
+
+  const elementTexts: string[] = [];
+  for (const el of found.elements) {
+    if (el === null) {
+      elementTexts.push('undefined');
+      continue;
+    }
+    if (typeof el.start !== 'number' || typeof el.end !== 'number') {
+      return { ok: false, status: 422, error: '`notes` element missing source range' };
+    }
+    elementTexts.push(source.slice(el.start, el.end));
+  }
+
+  while (elementTexts.length <= index) elementTexts.push('undefined');
+  elementTexts[index] = literal;
+
+  while (elementTexts.length > 0 && elementTexts[elementTexts.length - 1] === 'undefined') {
+    elementTexts.pop();
+  }
+
+  const replacement =
+    elementTexts.length === 0 ? '[]' : `[\n${elementTexts.map((s) => `  ${s},`).join('\n')}\n]`;
+
+  const next = source.slice(0, found.arrayStart) + replacement + source.slice(found.arrayEnd);
+  return { ok: true, source: next };
+}
+
+export type NotesPluginOptions = {
+  userCwd: string;
+  slidesDir?: string;
+};
+
+export function notesPlugin(opts: NotesPluginOptions): Plugin {
+  const userCwd = opts.userCwd;
+  const slidesDir = opts.slidesDir ?? 'slides';
+  return {
+    name: 'open-slide:notes',
+    apply: 'serve',
+    configureServer(server: ViteDevServer) {
+      server.middlewares.use('/__notes', async (req, res, next) => {
+        const url = new URL(req.url ?? '/', 'http://local');
+        const method = req.method ?? 'GET';
+        if (method !== 'PUT' || url.pathname !== '/') return next();
+
+        try {
+          const body = (await readBody(req)) as NotesBody;
+          const slideId = body.slideId ?? '';
+          const file = resolveSlidePath(userCwd, slidesDir, slideId);
+          if (!file) return json(res, 400, { error: 'invalid slideId' });
+          if (typeof body.index !== 'number') return json(res, 400, { error: 'missing index' });
+          if (typeof body.text !== 'string') return json(res, 400, { error: 'missing text' });
+
+          let source: string;
+          try {
+            source = await fs.readFile(file, 'utf8');
+          } catch {
+            return json(res, 404, { error: 'slide not found' });
+          }
+
+          const result = applyNotesEdit(source, body.index, body.text);
+          if (!result.ok) return json(res, result.status, { error: result.error });
+          const changed = result.source !== source;
+          if (changed) await fs.writeFile(file, result.source, 'utf8');
+          return json(res, 200, { ok: true, changed });
+        } catch (err) {
+          json(res, 500, { error: String((err as Error).message ?? err) });
+        }
+      });
+    },
+  };
+}


### PR DESCRIPTION
Add a collapsible drawer at the bottom of the slide view (dev mode only)
that lets authors write per-page speaker notes inline. Edits debounce-save
to the slide source via a new `PUT /__notes` middleware which patches the
`notes` array literal — creating `export const notes` if absent and padding
the array up to the target index.