### PR TITLE
fix(core): reorder speaker notes alongside pages on drag-and-drop

### DIFF
--- a/.changeset/reorder-notes-with-pages.md
+++ b/.changeset/reorder-notes-with-pages.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Reorder the `notes` export alongside the page array when slides are dragged in the thumbnail rail, so speaker notes stay attached to their slides.

--- a/packages/core/src/app/lib/inspector/use-notes.ts
+++ b/packages/core/src/app/lib/inspector/use-notes.ts
@@ -16,6 +16,23 @@ type Target = { slideId: string; index: number };
 const sessionCache = new Map<string, string>();
 const cacheKey = (slideId: string, index: number) => `${slideId}:${index}`;
 
+// Remap the per-target cache after a reorder. `order[i]` is the original
+// page index that lands at new position `i`, matching the contract used by
+// the `/__slides/:id/reorder` endpoint.
+export function remapNotesSessionCacheAfterReorder(slideId: string, order: number[]): void {
+  const prev = new Map<number, string>();
+  for (let i = 0; i < order.length; i++) {
+    const cached = sessionCache.get(cacheKey(slideId, i));
+    if (cached !== undefined) prev.set(i, cached);
+    sessionCache.delete(cacheKey(slideId, i));
+  }
+  for (let newIdx = 0; newIdx < order.length; newIdx++) {
+    const oldIdx = order[newIdx];
+    const text = prev.get(oldIdx);
+    if (text !== undefined) sessionCache.set(cacheKey(slideId, newIdx), text);
+  }
+}
+
 export function useNotes(slideId: string, index: number, initial: string | undefined) {
   const initialText = sessionCache.get(cacheKey(slideId, index)) ?? initial ?? '';
   const [value, setValueState] = useState(initialText);

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -36,6 +36,7 @@ import { SlideCanvas } from '../components/slide-canvas';
 import { type ThumbnailActions, ThumbnailRail } from '../components/thumbnail-rail';
 import { exportSlideAsHtml } from '../lib/export-html';
 import { exportSlideAsPdf } from '../lib/export-pdf';
+import { remapNotesSessionCacheAfterReorder } from '../lib/inspector/use-notes';
 import type { SlideModule } from '../lib/sdk';
 import { loadSlide } from '../lib/slides';
 
@@ -107,6 +108,8 @@ export function Slide() {
       const [movedIdx] = order.splice(from, 1);
       order.splice(to, 0, movedIdx);
 
+      remapNotesSessionCacheAfterReorder(slideId, order);
+
       // Keep the user looking at the same page they were on before the drag.
       let nextIndex = index;
       if (index === from) nextIndex = to;
@@ -126,6 +129,8 @@ export function Slide() {
         }
       } catch (err) {
         setPages(before);
+        const inverse = order.map((_, i) => order.indexOf(i));
+        remapNotesSessionCacheAfterReorder(slideId, inverse);
         toast.error(`Reorder failed: ${String((err as Error).message ?? err)}`);
       }
     },

--- a/packages/core/src/vite/files-plugin.test.ts
+++ b/packages/core/src/vite/files-plugin.test.ts
@@ -4,6 +4,7 @@ import {
   mimeForFilename,
   removePageFromDefaultExportInSource,
   reorderDefaultExportPagesInSource,
+  reorderNotesArrayInSource,
   updateMetaTitleInSource,
   validateAssetName,
   validateIcon,
@@ -193,6 +194,91 @@ export default [A, B, C];
     expect(out).toContain('const A = () => null;');
     expect(out).toContain('const B = () => null;');
     expect(out).toContain('const C = () => null;');
+  });
+});
+
+describe('reorderNotesArrayInSource', () => {
+  it('returns the source unchanged when there is no notes export', () => {
+    const source = `export default [];\n`;
+    expect(reorderNotesArrayInSource(source, [])).toBe(source);
+  });
+
+  it('reorders notes alongside pages', () => {
+    const source = [
+      'export const notes: (string | undefined)[] = [',
+      '  "first",',
+      '  "second",',
+      '  "third",',
+      '];',
+      'export default [A, B, C];',
+      '',
+    ].join('\n');
+    const out = reorderNotesArrayInSource(source, [2, 0, 1]);
+    expect(out).not.toBeNull();
+    expect(out).toContain(
+      'export const notes: (string | undefined)[] = [\n  "third",\n  "first",\n  "second",\n];',
+    );
+  });
+
+  it('preserves template-literal notes verbatim', () => {
+    const source = [
+      'export const notes = [',
+      '  `multi',
+      'line`,',
+      '  "second",',
+      '];',
+      'export default [A, B];',
+      '',
+    ].join('\n');
+    const out = reorderNotesArrayInSource(source, [1, 0]);
+    expect(out).not.toBeNull();
+    expect(out).toContain('export const notes = [\n  "second",\n  `multi\nline`,\n];');
+  });
+
+  it('pads with undefined when notes is shorter than pages', () => {
+    const source = ['export const notes = ["only"];', 'export default [A, B, C];', ''].join('\n');
+    const out = reorderNotesArrayInSource(source, [2, 0, 1]);
+    expect(out).not.toBeNull();
+    expect(out).toContain('export const notes = [\n  undefined,\n  "only",\n];');
+  });
+
+  it('trims trailing undefined entries', () => {
+    const source = [
+      'export const notes = [',
+      '  undefined,',
+      '  "kept",',
+      '  undefined,',
+      '];',
+      'export default [A, B, C];',
+      '',
+    ].join('\n');
+    const out = reorderNotesArrayInSource(source, [2, 0, 1]);
+    expect(out).not.toBeNull();
+    expect(out).toContain('export const notes = [\n  undefined,\n  undefined,\n  "kept",\n];');
+  });
+
+  it('collapses to [] when reorder leaves only undefineds', () => {
+    const source = ['export const notes = [', '  "x",', '];', 'export default [A, B];', ''].join(
+      '\n',
+    );
+    const out = reorderNotesArrayInSource(source, [1, 1]);
+    expect(out).not.toBeNull();
+    expect(out).toContain('export const notes = [];');
+  });
+
+  it('returns the source unchanged for an identity-like reorder of an empty notes array', () => {
+    const source = `export const notes = [];\nexport default [A, B];\n`;
+    expect(reorderNotesArrayInSource(source, [0, 1])).toBe(source);
+  });
+
+  it('returns null on out-of-range indices', () => {
+    const source = `export const notes = ["a", "b"];\nexport default [A, B];\n`;
+    expect(reorderNotesArrayInSource(source, [-1, 0])).toBeNull();
+  });
+
+  it('returns null when notes is not an array literal', () => {
+    const source = `export const notes = "oops";\nexport default [A];\n`;
+    expect(reorderNotesArrayInSource(source, [0])).toBeNull();
   });
 });
 

--- a/packages/core/src/vite/files-plugin.ts
+++ b/packages/core/src/vite/files-plugin.ts
@@ -335,6 +335,92 @@ export function reorderDefaultExportPagesInSource(source: string, order: number[
   return source.slice(0, arrayStart) + rebuilt + source.slice(arrayEnd);
 }
 
+type NotesArrayInfo = {
+  arrayStart: number;
+  arrayEnd: number;
+  elementTexts: string[];
+};
+
+function findNotesArray(source: string): NotesArrayInfo | null | 'invalid' {
+  let ast: unknown;
+  try {
+    ast = babelParse(source, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+      errorRecovery: true,
+    });
+  } catch {
+    return 'invalid';
+  }
+  const body = (ast as { program?: { body?: Array<Record<string, unknown>> } }).program?.body ?? [];
+  for (const stmt of body) {
+    if (stmt.type !== 'ExportNamedDeclaration') continue;
+    const decl = stmt.declaration as Record<string, unknown> | undefined;
+    if (!decl || decl.type !== 'VariableDeclaration') continue;
+    const declarations = (decl.declarations as Array<Record<string, unknown>> | undefined) ?? [];
+    for (const d of declarations) {
+      const id = d.id as Record<string, unknown> | undefined;
+      if (!id || id.type !== 'Identifier' || id.name !== 'notes') continue;
+      const init = d.init as Record<string, unknown> | undefined;
+      if (!init || init.type !== 'ArrayExpression') return 'invalid';
+      const arrayStart = init.start as number | undefined;
+      const arrayEnd = init.end as number | undefined;
+      if (typeof arrayStart !== 'number' || typeof arrayEnd !== 'number') return 'invalid';
+      const rawElements = (init.elements as Array<Record<string, unknown> | null>) ?? [];
+      const elementTexts: string[] = [];
+      for (const el of rawElements) {
+        if (el === null) {
+          elementTexts.push('undefined');
+          continue;
+        }
+        if (el.type === 'SpreadElement') return 'invalid';
+        const start = el.start as number | undefined;
+        const end = el.end as number | undefined;
+        if (typeof start !== 'number' || typeof end !== 'number') return 'invalid';
+        elementTexts.push(source.slice(start, end));
+      }
+      return { arrayStart, arrayEnd, elementTexts };
+    }
+  }
+  return null;
+}
+
+/**
+ * Reorder `export const notes = [...]` to follow the page-array reorder.
+ *
+ * `order[i]` is the original page index that should land at new position `i`.
+ * The notes array is index-aligned with the pages array but may be shorter
+ * (trailing `undefined` slots are routinely trimmed). Missing elements are
+ * treated as `undefined`, and trailing `undefined` is trimmed again after
+ * reordering to keep the file tidy.
+ *
+ * Returns the rewritten source, the original source if no `notes` export
+ * exists or the reorder is a no-op, or `null` if the `notes` export's shape
+ * is too surprising to touch safely.
+ */
+export function reorderNotesArrayInSource(source: string, order: number[]): string | null {
+  for (const idx of order) {
+    if (!Number.isInteger(idx) || idx < 0) return null;
+  }
+  const found = findNotesArray(source);
+  if (found === 'invalid') return null;
+  if (found === null) return source;
+
+  const { arrayStart, arrayEnd, elementTexts } = found;
+  const pick = (i: number): string =>
+    i >= 0 && i < elementTexts.length ? elementTexts[i] : 'undefined';
+  const reordered = order.map(pick);
+  while (reordered.length > 0 && reordered[reordered.length - 1] === 'undefined') {
+    reordered.pop();
+  }
+
+  const replacement =
+    reordered.length === 0 ? '[]' : `[\n${reordered.map((s) => `  ${s},`).join('\n')}\n]`;
+  if (replacement === source.slice(arrayStart, arrayEnd)) return source;
+
+  return source.slice(0, arrayStart) + replacement + source.slice(arrayEnd);
+}
+
 /**
  * Remove the element at `index` from `export default [...]`.
  *
@@ -524,15 +610,21 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
               return json(res, 404, { error: 'slide not found' });
             }
 
-            const updated = reorderDefaultExportPagesInSource(source, order);
-            if (updated === null) {
+            const reordered = reorderDefaultExportPagesInSource(source, order);
+            if (reordered === null) {
               return json(res, 422, {
                 error:
                   'could not reorder pages — order must be a permutation of the existing array',
               });
             }
-            if (updated !== source) {
-              await fs.writeFile(entry, updated, 'utf8');
+            const withNotes = reorderNotesArrayInSource(reordered, order);
+            if (withNotes === null) {
+              return json(res, 422, {
+                error: 'could not reorder pages — `notes` export has an unexpected shape',
+              });
+            }
+            if (withNotes !== source) {
+              await fs.writeFile(entry, withNotes, 'utf8');
             }
             return json(res, 200, { ok: true, slideId, order });
           }


### PR DESCRIPTION
## Summary
- Drag-and-drop reorder in the thumbnail rail now also reorders the `export const notes` array, so speaker notes stay attached to their slides.
- `useNotes` session cache is remapped on reorder (and reverted on rollback) so HMR doesn't surface stale notes at the old index.
- Adds `reorderNotesArrayInSource` (alongside the existing `reorderDefaultExportPagesInSource`) with 9 unit tests covering padding, trimming, template literals, and unexpected shapes.

## Test plan
- [x] `pnpm test` — 164 passed
- [x] `pnpm check` — clean
- [ ] Manually drag a slide that has notes on neighbours; verify each slide keeps its own note both in the drawer and in the on-disk `notes` array
- [ ] Edit a note, then drag the slide to a new position — verify the edited text follows it (covers the session-cache remap)
- [ ] Reorder a slide whose notes array is shorter than the page array — verify holes get padded with `undefined` and trailing `undefined`s are trimmed