### PR TITLE
feat(core): publish current slide + page for agents

### DIFF
--- a/.changeset/current-slide-skill.md
+++ b/.changeset/current-slide-skill.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': minor
+---
+
+Publish the user's current slide and page index to `node_modules/.open-slide/current.json` whenever they navigate, and add a `current-slide` skill that teaches agents to read it when the user says "this page" or "the slide I'm on".

--- a/.changeset/current-slide-skill.md
+++ b/.changeset/current-slide-skill.md
@@ -2,4 +2,4 @@
 '@open-slide/core': minor
 ---
 
-Publish the user's current slide, page, and inspector-selected element to `node_modules/.open-slide/current.json` whenever they navigate or pick an element, and add a `current-slide` skill that teaches agents to read it when the user says "this page", "this element", or "the slide I'm on".
+Publish the user's current slide, page, and inspector-selected element to `node_modules/.open-slide/current.json` whenever they navigate or pick an element, and add a `current-slide` skill that teaches agents to resolve references like "this page" or "this element". Surface this in the dev UI with a live "Agent connected" badge in the slide header and an "Agent is watching" badge in the inspector panel; rename the inspector comments section from "note" to "comment" terminology to match the existing `@slide-comment` / `apply-comments` vocabulary.

--- a/.changeset/current-slide-skill.md
+++ b/.changeset/current-slide-skill.md
@@ -2,4 +2,4 @@
 '@open-slide/core': minor
 ---
 
-Publish the user's current slide and page index to `node_modules/.open-slide/current.json` whenever they navigate, and add a `current-slide` skill that teaches agents to read it when the user says "this page" or "the slide I'm on".
+Publish the user's current slide, page, and inspector-selected element to `node_modules/.open-slide/current.json` whenever they navigate or pick an element, and add a `current-slide` skill that teaches agents to read it when the user says "this page", "this element", or "the slide I'm on".

--- a/.changeset/inspector-agent-watching-badge.md
+++ b/.changeset/inspector-agent-watching-badge.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Add a live "Agent is watching" badge in the inspector panel header — a green dot with a tooltip explaining that the agent already sees the current selection, so users can chat directly and only leave comments to queue several before asking. Rename the comments section copy from "note" to "comment" terminology to match the existing `@slide-comment` / `apply-comments` vocabulary.

--- a/.changeset/inspector-agent-watching-badge.md
+++ b/.changeset/inspector-agent-watching-badge.md
@@ -1,5 +1,0 @@
----
-'@open-slide/core': patch
----
-
-Add a live "Agent is watching" badge in the inspector panel header — a green dot with a tooltip explaining that the agent already sees the current selection, so users can chat directly and only leave comments to queue several before asking. Rename the comments section copy from "note" to "comment" terminology to match the existing `@slide-comment` / `apply-comments` vocabulary.

--- a/.changeset/slide-agent-connected-badge.md
+++ b/.changeset/slide-agent-connected-badge.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Show a dev-only "Agent connected" badge in the slide header (next to the slides/assets tabs) with a tooltip explaining that the dev server is publishing the current slide and selection to the agent. Hidden in production builds.

--- a/.changeset/slide-agent-connected-badge.md
+++ b/.changeset/slide-agent-connected-badge.md
@@ -1,5 +1,0 @@
----
-'@open-slide/core': patch
----
-
-Show a dev-only "Agent connected" badge in the slide header (next to the slides/assets tabs) with a tooltip explaining that the dev server is publishing the current slide and selection to the agent. Hidden in production builds.

--- a/apps/demo/.agents/skills/current-slide/SKILL.md
+++ b/apps/demo/.agents/skills/current-slide/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: current-slide
+description: Resolve which slide and page the user is currently viewing in the open-slide dev server. Consult this whenever the user references "this page", "this slide", "the slide I'm on", "the current page", or any deictic reference to slide content without naming it. Reads `node_modules/.open-slide/current.json`, which the dev server writes whenever the user navigates.
+---
+
+# Where is the user right now?
+
+When the user says "fix this page", "tweak the layout here", or "the slide I'm looking at", they almost never name the slide id or page number — they mean wherever they are in the dev viewer. Before asking "which slide?", check the file the dev server writes on every navigation.
+
+## How to read it
+
+```
+node_modules/.open-slide/current.json
+```
+
+Path is relative to the project root (the user's `cwd`, the directory that contains `slides/` and `package.json`). Use the `Read` tool. The file is JSON.
+
+## What you get
+
+```json
+{
+  "slideId": "q2-roadmap",
+  "pageIndex": 2,
+  "pageNumber": 3,
+  "totalPages": 8,
+  "slideTitle": "Q2 Roadmap",
+  "view": "slides",
+  "pagePath": "slides/q2-roadmap/index.tsx",
+  "updatedAt": "2026-05-09T14:32:11.123Z"
+}
+```
+
+- `slideId` — folder name under `slides/`. Use as-is for any `/__slides/<id>/...` API or as the URL segment.
+- `pageIndex` — 0-based, for use with the page array in `index.tsx` (`export default [Cover, Body, ...]`).
+- `pageNumber` — 1-based, for use in messages to the user ("page 3 of 8") and for the URL `?p=N`.
+- `pagePath` — relative path to the slide source. Hand straight to `Read` / `Edit`.
+- `view` — `"slides"` (canvas view) or `"assets"` (asset manager). If `"assets"`, the user is browsing files for that slide rather than viewing a page.
+- `updatedAt` — ISO timestamp of the last navigation. Use it to detect staleness.
+
+## When to use this
+
+- The user references the current slide/page deictically: "this", "here", "the page I'm on", "the slide I'm looking at", "what I'm working on".
+- Before asking "which slide?" as a clarifying question — check this file first.
+- Before guessing from `git log`, recently-edited files, or the most recent slide folder.
+
+## When NOT to use this
+
+- The user names a slide explicitly ("edit `q2-roadmap`") — use that name directly.
+- The `apply-comments` workflow already finds the right file via `@slide-comment` markers; it doesn't need this skill.
+- For listing or discovering slides — read `slides/` directly.
+
+## Staleness — verify before acting
+
+`updatedAt` is the last time the user navigated. Treat it like a cache:
+
+- **Fresh (under ~5 minutes old)**: trust it. Open `pagePath`, do the work.
+- **Older than ~5 minutes, or older than your last interaction with the user**: confirm with the user before editing. The dev server may not be running; the user may have switched contexts.
+- **Hours/days old**: ignore it. Ask the user which slide they mean.
+
+## When the file is missing
+
+- The dev server hasn't been opened on a slide yet, or has never run.
+- Don't create the file or guess. Ask the user which slide they mean, or suggest they open the slide in the dev server first.
+
+## Example
+
+User: "tighten the spacing on this page"
+
+1. Read `node_modules/.open-slide/current.json`.
+2. Check `updatedAt` is recent.
+3. Read `pagePath` (e.g. `slides/q2-roadmap/index.tsx`).
+4. Identify the page at `pageIndex` in the default-exported array.
+5. Consult the `slide-authoring` skill for spacing rules, then edit that page in place.
+
+If `current.json` is missing or stale, ask: "Which slide and page should I tighten? The dev server hasn't published a current page recently."

--- a/apps/demo/.agents/skills/current-slide/SKILL.md
+++ b/apps/demo/.agents/skills/current-slide/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: current-slide
-description: Resolve which slide and page the user is currently viewing in the open-slide dev server. Consult this whenever the user references "this page", "this slide", "the slide I'm on", "the current page", or any deictic reference to slide content without naming it. Reads `node_modules/.open-slide/current.json`, which the dev server writes whenever the user navigates.
+description: Resolve which slide, page, and (optionally) selected element the user is currently viewing in the open-slide dev server. Consult this whenever the user references "this page", "this slide", "this element", "the slide I'm on", "the current page", or any deictic reference to slide content without naming it. Reads `node_modules/.open-slide/current.json`, which the dev server writes whenever the user navigates or picks an element in the inspector.
 ---
 
 # Where is the user right now?
 
-When the user says "fix this page", "tweak the layout here", or "the slide I'm looking at", they almost never name the slide id or page number — they mean wherever they are in the dev viewer. Before asking "which slide?", check the file the dev server writes on every navigation.
+When the user says "fix this page", "tweak this heading", or "the slide I'm looking at", they almost never name the slide id, page number, or element — they mean wherever they are in the dev viewer. Before asking "which slide?" or "which element?", check the file the dev server writes on every navigation and inspector pick.
 
 ## How to read it
 
@@ -26,6 +26,12 @@ Path is relative to the project root (the user's `cwd`, the directory that conta
   "slideTitle": "Q2 Roadmap",
   "view": "slides",
   "pagePath": "slides/q2-roadmap/index.tsx",
+  "selection": {
+    "line": 42,
+    "column": 6,
+    "tagName": "h1",
+    "text": "Q2 Roadmap"
+  },
   "updatedAt": "2026-05-09T14:32:11.123Z"
 }
 ```
@@ -35,12 +41,18 @@ Path is relative to the project root (the user's `cwd`, the directory that conta
 - `pageNumber` — 1-based, for use in messages to the user ("page 3 of 8") and for the URL `?p=N`.
 - `pagePath` — relative path to the slide source. Hand straight to `Read` / `Edit`.
 - `view` — `"slides"` (canvas view) or `"assets"` (asset manager). If `"assets"`, the user is browsing files for that slide rather than viewing a page.
-- `updatedAt` — ISO timestamp of the last navigation. Use it to detect staleness.
+- `selection` — `null` if nothing is selected. Otherwise, the JSX element the user picked in the inspector overlay:
+  - `line` (1-indexed) and `column` (0-indexed) point to the JSX opening tag inside `pagePath`. This is the canonical handle — match against the source line, not the rendered DOM.
+  - `tagName` is the rendered DOM tag, lowercased (`"h1"`, `"div"`, `"img"`).
+  - `text` is a trimmed text snippet (≤120 chars) from the element's `textContent`, useful as a sanity check that you're looking at the right node.
+  - Selection auto-clears whenever the user navigates to a different slide or page.
+- `updatedAt` — ISO timestamp of the last navigation or selection change. Use it to detect staleness.
 
 ## When to use this
 
 - The user references the current slide/page deictically: "this", "here", "the page I'm on", "the slide I'm looking at", "what I'm working on".
-- Before asking "which slide?" as a clarifying question — check this file first.
+- The user references a specific element: "this heading", "this image", "the button I just clicked", "tighten this", "change the color of this". If `selection` is non-null, that's the element they mean.
+- Before asking "which slide?" or "which element?" as a clarifying question — check this file first.
 - Before guessing from `git log`, recently-edited files, or the most recent slide folder.
 
 ## When NOT to use this
@@ -62,7 +74,7 @@ Path is relative to the project root (the user's `cwd`, the directory that conta
 - The dev server hasn't been opened on a slide yet, or has never run.
 - Don't create the file or guess. Ask the user which slide they mean, or suggest they open the slide in the dev server first.
 
-## Example
+## Example — page-level reference
 
 User: "tighten the spacing on this page"
 
@@ -73,3 +85,14 @@ User: "tighten the spacing on this page"
 5. Consult the `slide-authoring` skill for spacing rules, then edit that page in place.
 
 If `current.json` is missing or stale, ask: "Which slide and page should I tighten? The dev server hasn't published a current page recently."
+
+## Example — element-level reference
+
+User: "make this bigger"
+
+1. Read `node_modules/.open-slide/current.json`.
+2. If `selection` is non-null, the user means that element. Read `pagePath`, jump to `selection.line`, and find the JSX opening tag near that line/column. Confirm with the snippet in `selection.text` and the `tagName`.
+3. Consult `slide-authoring` for type-scale and layout rules before editing.
+4. Edit the JSX node in place.
+
+If `selection` is null, fall back to the page-level flow above — and consider asking "which element?" since the user used a deictic but hasn't picked one in the inspector.

--- a/apps/demo/.claude/skills/current-slide
+++ b/apps/demo/.claude/skills/current-slide
@@ -1,0 +1,1 @@
+../../.agents/skills/current-slide

--- a/apps/web/content/docs/agents/overview.mdx
+++ b/apps/web/content/docs/agents/overview.mdx
@@ -10,13 +10,14 @@ polished deck is mostly the runtime — which open-slide provides.
 ## What ships in the workspace
 
 `npx @open-slide/cli init` generates an `AGENTS.md` (and `CLAUDE.md`) at the
-root with the framework's hard rules, plus a `skills/` folder with four
+root with the framework's hard rules, plus a `skills/` folder with five
 skills the agent invokes by name:
 
 - [`/create-slide`](/docs/agents/skills#create-slide)
 - [`/slide-authoring`](/docs/agents/skills#slide-authoring)
 - [`/apply-comments`](/docs/agents/skills#apply-comments)
 - [`/create-theme`](/docs/agents/skills#create-theme)
+- [`/current-slide`](/docs/agents/skills#current-slide)
 
 The skills are kept inside the workspace (not the agent's global config) so
 they version with the project. `open-slide sync:skills` re-syncs them from

--- a/apps/web/content/docs/agents/skills.mdx
+++ b/apps/web/content/docs/agents/skills.mdx
@@ -1,9 +1,9 @@
 ---
 title: Skills
-description: The four agent skills shipped with every open-slide workspace.
+description: The agent skills shipped with every open-slide workspace.
 ---
 
-A skill is a markdown file the agent reads on demand. open-slide ships four;
+A skill is a markdown file the agent reads on demand. open-slide ships five;
 your agent invokes them by typing `/<skill-name>` in chat.
 
 ## `/create-slide`
@@ -42,3 +42,15 @@ with the palette, type stack, layout vocabulary, and voice notes that future
 
 Use it once your decks start sharing a visual language — turn the implicit
 recipe into a file the agent can read.
+
+## `/current-slide`
+
+Resolves deictic references — *"this page"*, *"this heading"*, *"the slide
+I'm on"* — to a concrete slide id, page index, and (when set) the JSX
+element you've picked in the [inspector](/docs/tools/inspector). The dev
+server writes the state to `node_modules/.open-slide/current.json` on every
+navigation and selection change; this skill teaches the agent to read it
+before asking *which slide?*
+
+You don't usually invoke it directly. `slide-authoring` cross-references it,
+so any "fix this" prompt routes through it automatically.

--- a/apps/web/content/docs/tools/inspector.mdx
+++ b/apps/web/content/docs/tools/inspector.mdx
@@ -36,3 +36,11 @@ marker travels with the element and is invisible at runtime.
 
 Run `/apply-comments` in your agent — see [apply-comments](/docs/tools/apply-comments)
 — and the agent rewrites exactly the flagged regions, then clears the markers.
+
+## Selection is visible to your agent
+
+The inspector publishes the currently picked element — source line/column,
+tag, and text snippet — to `node_modules/.open-slide/current.json` whenever
+you click. Ask your agent *"make this bigger"* and the
+[`/current-slide`](/docs/agents/skills#current-slide) skill reads that file
+to find the exact JSX node, no extra "which one?" round-trip.

--- a/packages/cli/template/.agents/skills/current-slide/SKILL.md
+++ b/packages/cli/template/.agents/skills/current-slide/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: current-slide
+description: Resolve which slide and page the user is currently viewing in the open-slide dev server. Consult this whenever the user references "this page", "this slide", "the slide I'm on", "the current page", or any deictic reference to slide content without naming it. Reads `node_modules/.open-slide/current.json`, which the dev server writes whenever the user navigates.
+---
+
+# Where is the user right now?
+
+When the user says "fix this page", "tweak the layout here", or "the slide I'm looking at", they almost never name the slide id or page number — they mean wherever they are in the dev viewer. Before asking "which slide?", check the file the dev server writes on every navigation.
+
+## How to read it
+
+```
+node_modules/.open-slide/current.json
+```
+
+Path is relative to the project root (the user's `cwd`, the directory that contains `slides/` and `package.json`). Use the `Read` tool. The file is JSON.
+
+## What you get
+
+```json
+{
+  "slideId": "q2-roadmap",
+  "pageIndex": 2,
+  "pageNumber": 3,
+  "totalPages": 8,
+  "slideTitle": "Q2 Roadmap",
+  "view": "slides",
+  "pagePath": "slides/q2-roadmap/index.tsx",
+  "updatedAt": "2026-05-09T14:32:11.123Z"
+}
+```
+
+- `slideId` — folder name under `slides/`. Use as-is for any `/__slides/<id>/...` API or as the URL segment.
+- `pageIndex` — 0-based, for use with the page array in `index.tsx` (`export default [Cover, Body, ...]`).
+- `pageNumber` — 1-based, for use in messages to the user ("page 3 of 8") and for the URL `?p=N`.
+- `pagePath` — relative path to the slide source. Hand straight to `Read` / `Edit`.
+- `view` — `"slides"` (canvas view) or `"assets"` (asset manager). If `"assets"`, the user is browsing files for that slide rather than viewing a page.
+- `updatedAt` — ISO timestamp of the last navigation. Use it to detect staleness.
+
+## When to use this
+
+- The user references the current slide/page deictically: "this", "here", "the page I'm on", "the slide I'm looking at", "what I'm working on".
+- Before asking "which slide?" as a clarifying question — check this file first.
+- Before guessing from `git log`, recently-edited files, or the most recent slide folder.
+
+## When NOT to use this
+
+- The user names a slide explicitly ("edit `q2-roadmap`") — use that name directly.
+- The `apply-comments` workflow already finds the right file via `@slide-comment` markers; it doesn't need this skill.
+- For listing or discovering slides — read `slides/` directly.
+
+## Staleness — verify before acting
+
+`updatedAt` is the last time the user navigated. Treat it like a cache:
+
+- **Fresh (under ~5 minutes old)**: trust it. Open `pagePath`, do the work.
+- **Older than ~5 minutes, or older than your last interaction with the user**: confirm with the user before editing. The dev server may not be running; the user may have switched contexts.
+- **Hours/days old**: ignore it. Ask the user which slide they mean.
+
+## When the file is missing
+
+- The dev server hasn't been opened on a slide yet, or has never run.
+- Don't create the file or guess. Ask the user which slide they mean, or suggest they open the slide in the dev server first.
+
+## Example
+
+User: "tighten the spacing on this page"
+
+1. Read `node_modules/.open-slide/current.json`.
+2. Check `updatedAt` is recent.
+3. Read `pagePath` (e.g. `slides/q2-roadmap/index.tsx`).
+4. Identify the page at `pageIndex` in the default-exported array.
+5. Consult the `slide-authoring` skill for spacing rules, then edit that page in place.
+
+If `current.json` is missing or stale, ask: "Which slide and page should I tighten? The dev server hasn't published a current page recently."

--- a/packages/cli/template/.agents/skills/current-slide/SKILL.md
+++ b/packages/cli/template/.agents/skills/current-slide/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: current-slide
-description: Resolve which slide and page the user is currently viewing in the open-slide dev server. Consult this whenever the user references "this page", "this slide", "the slide I'm on", "the current page", or any deictic reference to slide content without naming it. Reads `node_modules/.open-slide/current.json`, which the dev server writes whenever the user navigates.
+description: Resolve which slide, page, and (optionally) selected element the user is currently viewing in the open-slide dev server. Consult this whenever the user references "this page", "this slide", "this element", "the slide I'm on", "the current page", or any deictic reference to slide content without naming it. Reads `node_modules/.open-slide/current.json`, which the dev server writes whenever the user navigates or picks an element in the inspector.
 ---
 
 # Where is the user right now?
 
-When the user says "fix this page", "tweak the layout here", or "the slide I'm looking at", they almost never name the slide id or page number — they mean wherever they are in the dev viewer. Before asking "which slide?", check the file the dev server writes on every navigation.
+When the user says "fix this page", "tweak this heading", or "the slide I'm looking at", they almost never name the slide id, page number, or element — they mean wherever they are in the dev viewer. Before asking "which slide?" or "which element?", check the file the dev server writes on every navigation and inspector pick.
 
 ## How to read it
 
@@ -26,6 +26,12 @@ Path is relative to the project root (the user's `cwd`, the directory that conta
   "slideTitle": "Q2 Roadmap",
   "view": "slides",
   "pagePath": "slides/q2-roadmap/index.tsx",
+  "selection": {
+    "line": 42,
+    "column": 6,
+    "tagName": "h1",
+    "text": "Q2 Roadmap"
+  },
   "updatedAt": "2026-05-09T14:32:11.123Z"
 }
 ```
@@ -35,12 +41,18 @@ Path is relative to the project root (the user's `cwd`, the directory that conta
 - `pageNumber` — 1-based, for use in messages to the user ("page 3 of 8") and for the URL `?p=N`.
 - `pagePath` — relative path to the slide source. Hand straight to `Read` / `Edit`.
 - `view` — `"slides"` (canvas view) or `"assets"` (asset manager). If `"assets"`, the user is browsing files for that slide rather than viewing a page.
-- `updatedAt` — ISO timestamp of the last navigation. Use it to detect staleness.
+- `selection` — `null` if nothing is selected. Otherwise, the JSX element the user picked in the inspector overlay:
+  - `line` (1-indexed) and `column` (0-indexed) point to the JSX opening tag inside `pagePath`. This is the canonical handle — match against the source line, not the rendered DOM.
+  - `tagName` is the rendered DOM tag, lowercased (`"h1"`, `"div"`, `"img"`).
+  - `text` is a trimmed text snippet (≤120 chars) from the element's `textContent`, useful as a sanity check that you're looking at the right node.
+  - Selection auto-clears whenever the user navigates to a different slide or page.
+- `updatedAt` — ISO timestamp of the last navigation or selection change. Use it to detect staleness.
 
 ## When to use this
 
 - The user references the current slide/page deictically: "this", "here", "the page I'm on", "the slide I'm looking at", "what I'm working on".
-- Before asking "which slide?" as a clarifying question — check this file first.
+- The user references a specific element: "this heading", "this image", "the button I just clicked", "tighten this", "change the color of this". If `selection` is non-null, that's the element they mean.
+- Before asking "which slide?" or "which element?" as a clarifying question — check this file first.
 - Before guessing from `git log`, recently-edited files, or the most recent slide folder.
 
 ## When NOT to use this
@@ -62,7 +74,7 @@ Path is relative to the project root (the user's `cwd`, the directory that conta
 - The dev server hasn't been opened on a slide yet, or has never run.
 - Don't create the file or guess. Ask the user which slide they mean, or suggest they open the slide in the dev server first.
 
-## Example
+## Example — page-level reference
 
 User: "tighten the spacing on this page"
 
@@ -73,3 +85,14 @@ User: "tighten the spacing on this page"
 5. Consult the `slide-authoring` skill for spacing rules, then edit that page in place.
 
 If `current.json` is missing or stale, ask: "Which slide and page should I tighten? The dev server hasn't published a current page recently."
+
+## Example — element-level reference
+
+User: "make this bigger"
+
+1. Read `node_modules/.open-slide/current.json`.
+2. If `selection` is non-null, the user means that element. Read `pagePath`, jump to `selection.line`, and find the JSX opening tag near that line/column. Confirm with the snippet in `selection.text` and the `tagName`.
+3. Consult `slide-authoring` for type-scale and layout rules before editing.
+4. Edit the JSX node in place.
+
+If `selection` is null, fall back to the page-level flow above — and consider asking "which element?" since the user used a deictic but hasn't picked one in the inspector.

--- a/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
@@ -9,6 +9,7 @@ This skill is the **technical reference** for everything that happens inside `sl
 
 - `create-slide` owns "draft a new deck" — it asks the user scoping questions, then delegates the *how* to this skill.
 - `apply-comments` owns "process inspector markers" — it finds markers and applies edits, but the edits themselves follow the rules here.
+- `current-slide` resolves deictic references ("this page", "the slide I'm on") to a concrete `slideId` + `pageIndex`. Consult it **first** when the user references the current slide without naming it, then come back here for how to edit it.
 - Any ad-hoc slide edit (manual tweak, one-off fix) should also consult this skill before touching the file.
 
 When any of those paths reach the point of *writing React code for a page*, this is the source of truth. Do not duplicate the knowledge below into other skills — link here instead.
@@ -19,7 +20,7 @@ When any of those paths reach the point of *writing React code for a page*, this
 - Entry is `slides/<id>/index.tsx`. Images/videos/fonts go under `slides/<id>/assets/`.
 - Do **not** touch `package.json`, `open-slide.config.ts`, or other slides.
 - Do not add dependencies. Only `react` and standard web APIs are available.
-- Do not create `README.md` or other prose files inside the slide folder — just `index.tsx` + `assets/`.
+- A slide is **one `index.tsx` plus `assets/`** — nothing else. Do not create sibling `.tsx`/`.ts` files (`Card.tsx`, `components/`, `helpers.ts`, etc.); helper components and constants go inside `index.tsx`. Do not create `README.md` or other prose files either.
 
 ## File contract
 
@@ -264,6 +265,50 @@ The user uploads the real file via the Assets panel, then clicks the placeholder
 
 Size the placeholder to the slot it occupies. Pass `width`/`height` when the layout has a fixed image box; omit them when the placeholder fills a flex/grid cell. The `hint` should describe the *content* the user needs ("Q3 revenue chart") not the *role* ("hero image").
 
+## Repeated elements: component, not `map`
+
+When a page has visually repeated items — cards, logo rows, gallery tiles, list rows, step indicators — **define a small component and instantiate it once per item**. Do **not** render the group with `array.map` over a data array.
+
+Define the component **in the same `index.tsx`**, alongside the `Page` components. Never split it into a sibling file like `Card.tsx` — a slide is always a single `index.tsx` plus its `assets/`.
+
+```tsx
+// ✅ Each card is its own JSX node — inspector edits one at a time.
+const Card = ({ src, label }: { src: string; label: string }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <img src={src} style={{ width: 320, height: 320, objectFit: 'cover', borderRadius: 12 }} />
+    <p style={{ fontSize: 32 }}>{label}</p>
+  </div>
+);
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 64 }}>
+  <Card src={alpha} label="Alpha" />
+  <Card src={beta}  label="Beta"  />
+  <Card src={gamma} label="Gamma" />
+</div>
+```
+
+```tsx
+// ❌ One shared template — replacing the image or text in the inspector
+//    changes every rendered card at once.
+const items = [
+  { src: alpha, label: 'Alpha' },
+  { src: beta,  label: 'Beta'  },
+  { src: gamma, label: 'Gamma' },
+];
+items.map((item) => (
+  <div>
+    <img src={item.src} />
+    <p>{item.label}</p>
+  </div>
+));
+```
+
+The inspector edits source JSX in place. A `map` body is **one source location** shared by every rendered instance, so when the user replaces an image or tweaks a label there, every card mutates together. Explicit instances give each card its own JSX node and its own props — the unit the inspector can target.
+
+The component definition stays the single source of truth for layout/styling (change it once → all cards update). Only the per-instance data — `src`, `label`, accent color — lives at the call site.
+
+This applies whenever the *visual element* repeats, not whenever the *data* does. Pure-text lists (`<ul><li>` bullets) are fine: each `<li>` is already its own JSX node, so plain literal markup is the correct shape — no need to wrap them in a component.
+
 ## Runtime behavior you get for free
 
 - Home page lists every folder under `slides/`.
@@ -282,6 +327,7 @@ Size the placeholder to the slot it occupies. Pass `width`/`height` when the lay
 - [ ] One coherent visual direction across every page (palette + type scale).
 - [ ] Slide declares a top-level `export const design: DesignSystem = { … }` and references the values via `var(--osd-X)` (use `design.X` only when you need a JS number for arithmetic). Only omit the `design` const for a one-off slide whose palette is intentionally locked.
 - [ ] One idea per page.
+- [ ] Visually repeated elements (cards, tiles, logo rows) are rendered as explicit `<Component />` instances, not via `array.map` over a data list.
 - [ ] All imported assets exist on disk under `slides/<id>/assets/`.
 - [ ] Every `<ImagePlaceholder>` corresponds to a real image the user must supply — not decorative filler. If it could be replaced by typography or layout, it should be.
 - [ ] Nothing outside `slides/<id>/` was edited.
@@ -302,3 +348,4 @@ Size the placeholder to the slot it occupies. Pass `width`/`height` when the lay
 - ❌ Editing `package.json`, `open-slide.config.ts`, or other slides.
 - ❌ Sprinkling `<ImagePlaceholder>` across pages "for visual interest". Placeholders are for content the user owns; they're not stock-photo slots.
 - ❌ Using a placeholder for an icon or decorative shape — those are typography/SVG problems, not asset problems.
+- ❌ Rendering visually repeated elements with `array.map(...)` over a data array. Define a component and instantiate it explicitly per item (`<Card />`, `<Card />`, `<Card />`) so the inspector can edit each independently — a shared `map` body mutates every instance at once.

--- a/packages/cli/template/.claude/skills/current-slide
+++ b/packages/cli/template/.claude/skills/current-slide
@@ -1,0 +1,1 @@
+../../.agents/skills/current-slide

--- a/packages/cli/template/AGENTS.md
+++ b/packages/cli/template/AGENTS.md
@@ -15,6 +15,7 @@ You are authoring **slides** in this repo. Every slide is arbitrary React code t
 - **Drafting a new deck** — use the `create-slide` skill. It walks through scoping questions, structure, and hand-off.
 - **Applying inspector comments** (`@slide-comment` markers in a page) — use the `apply-comments` skill.
 - **Creating or extracting a theme** — use the `create-theme` skill. Themes live as markdown under `themes/<id>.md` and are read by `create-slide` before authoring.
+- **Resolving "this page" / "this element"** — when the user references the current slide or selection without naming it, consult the `current-slide` skill. It reads the dev server's `node_modules/.open-slide/current.json` to find which slide, page, and inspector-picked element they mean.
 - **Any other slide edit** — read the `slide-authoring` skill before writing. It is the technical reference for everything inside `slides/<id>/`: file contract, the 1920×1080 canvas, type scale, palette, layout, assets, self-review checklist, and anti-patterns. `create-slide` and `apply-comments` both defer to it for the *how*.
 
 Keep this file short: hard rules only. All deeper guidance lives in the skills above.

--- a/packages/core/skills/current-slide/SKILL.md
+++ b/packages/core/skills/current-slide/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: current-slide
+description: Resolve which slide and page the user is currently viewing in the open-slide dev server. Consult this whenever the user references "this page", "this slide", "the slide I'm on", "the current page", or any deictic reference to slide content without naming it. Reads `node_modules/.open-slide/current.json`, which the dev server writes whenever the user navigates.
+---
+
+# Where is the user right now?
+
+When the user says "fix this page", "tweak the layout here", or "the slide I'm looking at", they almost never name the slide id or page number — they mean wherever they are in the dev viewer. Before asking "which slide?", check the file the dev server writes on every navigation.
+
+## How to read it
+
+```
+node_modules/.open-slide/current.json
+```
+
+Path is relative to the project root (the user's `cwd`, the directory that contains `slides/` and `package.json`). Use the `Read` tool. The file is JSON.
+
+## What you get
+
+```json
+{
+  "slideId": "q2-roadmap",
+  "pageIndex": 2,
+  "pageNumber": 3,
+  "totalPages": 8,
+  "slideTitle": "Q2 Roadmap",
+  "view": "slides",
+  "pagePath": "slides/q2-roadmap/index.tsx",
+  "updatedAt": "2026-05-09T14:32:11.123Z"
+}
+```
+
+- `slideId` — folder name under `slides/`. Use as-is for any `/__slides/<id>/...` API or as the URL segment.
+- `pageIndex` — 0-based, for use with the page array in `index.tsx` (`export default [Cover, Body, ...]`).
+- `pageNumber` — 1-based, for use in messages to the user ("page 3 of 8") and for the URL `?p=N`.
+- `pagePath` — relative path to the slide source. Hand straight to `Read` / `Edit`.
+- `view` — `"slides"` (canvas view) or `"assets"` (asset manager). If `"assets"`, the user is browsing files for that slide rather than viewing a page.
+- `updatedAt` — ISO timestamp of the last navigation. Use it to detect staleness.
+
+## When to use this
+
+- The user references the current slide/page deictically: "this", "here", "the page I'm on", "the slide I'm looking at", "what I'm working on".
+- Before asking "which slide?" as a clarifying question — check this file first.
+- Before guessing from `git log`, recently-edited files, or the most recent slide folder.
+
+## When NOT to use this
+
+- The user names a slide explicitly ("edit `q2-roadmap`") — use that name directly.
+- The `apply-comments` workflow already finds the right file via `@slide-comment` markers; it doesn't need this skill.
+- For listing or discovering slides — read `slides/` directly.
+
+## Staleness — verify before acting
+
+`updatedAt` is the last time the user navigated. Treat it like a cache:
+
+- **Fresh (under ~5 minutes old)**: trust it. Open `pagePath`, do the work.
+- **Older than ~5 minutes, or older than your last interaction with the user**: confirm with the user before editing. The dev server may not be running; the user may have switched contexts.
+- **Hours/days old**: ignore it. Ask the user which slide they mean.
+
+## When the file is missing
+
+- The dev server hasn't been opened on a slide yet, or has never run.
+- Don't create the file or guess. Ask the user which slide they mean, or suggest they open the slide in the dev server first.
+
+## Example
+
+User: "tighten the spacing on this page"
+
+1. Read `node_modules/.open-slide/current.json`.
+2. Check `updatedAt` is recent.
+3. Read `pagePath` (e.g. `slides/q2-roadmap/index.tsx`).
+4. Identify the page at `pageIndex` in the default-exported array.
+5. Consult the `slide-authoring` skill for spacing rules, then edit that page in place.
+
+If `current.json` is missing or stale, ask: "Which slide and page should I tighten? The dev server hasn't published a current page recently."

--- a/packages/core/skills/current-slide/SKILL.md
+++ b/packages/core/skills/current-slide/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: current-slide
-description: Resolve which slide and page the user is currently viewing in the open-slide dev server. Consult this whenever the user references "this page", "this slide", "the slide I'm on", "the current page", or any deictic reference to slide content without naming it. Reads `node_modules/.open-slide/current.json`, which the dev server writes whenever the user navigates.
+description: Resolve which slide, page, and (optionally) selected element the user is currently viewing in the open-slide dev server. Consult this whenever the user references "this page", "this slide", "this element", "the slide I'm on", "the current page", or any deictic reference to slide content without naming it. Reads `node_modules/.open-slide/current.json`, which the dev server writes whenever the user navigates or picks an element in the inspector.
 ---
 
 # Where is the user right now?
 
-When the user says "fix this page", "tweak the layout here", or "the slide I'm looking at", they almost never name the slide id or page number — they mean wherever they are in the dev viewer. Before asking "which slide?", check the file the dev server writes on every navigation.
+When the user says "fix this page", "tweak this heading", or "the slide I'm looking at", they almost never name the slide id, page number, or element — they mean wherever they are in the dev viewer. Before asking "which slide?" or "which element?", check the file the dev server writes on every navigation and inspector pick.
 
 ## How to read it
 
@@ -26,6 +26,12 @@ Path is relative to the project root (the user's `cwd`, the directory that conta
   "slideTitle": "Q2 Roadmap",
   "view": "slides",
   "pagePath": "slides/q2-roadmap/index.tsx",
+  "selection": {
+    "line": 42,
+    "column": 6,
+    "tagName": "h1",
+    "text": "Q2 Roadmap"
+  },
   "updatedAt": "2026-05-09T14:32:11.123Z"
 }
 ```
@@ -35,12 +41,18 @@ Path is relative to the project root (the user's `cwd`, the directory that conta
 - `pageNumber` — 1-based, for use in messages to the user ("page 3 of 8") and for the URL `?p=N`.
 - `pagePath` — relative path to the slide source. Hand straight to `Read` / `Edit`.
 - `view` — `"slides"` (canvas view) or `"assets"` (asset manager). If `"assets"`, the user is browsing files for that slide rather than viewing a page.
-- `updatedAt` — ISO timestamp of the last navigation. Use it to detect staleness.
+- `selection` — `null` if nothing is selected. Otherwise, the JSX element the user picked in the inspector overlay:
+  - `line` (1-indexed) and `column` (0-indexed) point to the JSX opening tag inside `pagePath`. This is the canonical handle — match against the source line, not the rendered DOM.
+  - `tagName` is the rendered DOM tag, lowercased (`"h1"`, `"div"`, `"img"`).
+  - `text` is a trimmed text snippet (≤120 chars) from the element's `textContent`, useful as a sanity check that you're looking at the right node.
+  - Selection auto-clears whenever the user navigates to a different slide or page.
+- `updatedAt` — ISO timestamp of the last navigation or selection change. Use it to detect staleness.
 
 ## When to use this
 
 - The user references the current slide/page deictically: "this", "here", "the page I'm on", "the slide I'm looking at", "what I'm working on".
-- Before asking "which slide?" as a clarifying question — check this file first.
+- The user references a specific element: "this heading", "this image", "the button I just clicked", "tighten this", "change the color of this". If `selection` is non-null, that's the element they mean.
+- Before asking "which slide?" or "which element?" as a clarifying question — check this file first.
 - Before guessing from `git log`, recently-edited files, or the most recent slide folder.
 
 ## When NOT to use this
@@ -62,7 +74,7 @@ Path is relative to the project root (the user's `cwd`, the directory that conta
 - The dev server hasn't been opened on a slide yet, or has never run.
 - Don't create the file or guess. Ask the user which slide they mean, or suggest they open the slide in the dev server first.
 
-## Example
+## Example — page-level reference
 
 User: "tighten the spacing on this page"
 
@@ -73,3 +85,14 @@ User: "tighten the spacing on this page"
 5. Consult the `slide-authoring` skill for spacing rules, then edit that page in place.
 
 If `current.json` is missing or stale, ask: "Which slide and page should I tighten? The dev server hasn't published a current page recently."
+
+## Example — element-level reference
+
+User: "make this bigger"
+
+1. Read `node_modules/.open-slide/current.json`.
+2. If `selection` is non-null, the user means that element. Read `pagePath`, jump to `selection.line`, and find the JSX opening tag near that line/column. Confirm with the snippet in `selection.text` and the `tagName`.
+3. Consult `slide-authoring` for type-scale and layout rules before editing.
+4. Edit the JSX node in place.
+
+If `selection` is null, fall back to the page-level flow above — and consider asking "which element?" since the user used a deictic but hasn't picked one in the inspector.

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -9,6 +9,7 @@ This skill is the **technical reference** for everything that happens inside `sl
 
 - `create-slide` owns "draft a new deck" — it asks the user scoping questions, then delegates the *how* to this skill.
 - `apply-comments` owns "process inspector markers" — it finds markers and applies edits, but the edits themselves follow the rules here.
+- `current-slide` resolves deictic references ("this page", "the slide I'm on") to a concrete `slideId` + `pageIndex`. Consult it **first** when the user references the current slide without naming it, then come back here for how to edit it.
 - Any ad-hoc slide edit (manual tweak, one-off fix) should also consult this skill before touching the file.
 
 When any of those paths reach the point of *writing React code for a page*, this is the source of truth. Do not duplicate the knowledge below into other skills — link here instead.

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -33,6 +33,7 @@ import { Slider } from '@/components/ui/slider';
 import { Textarea } from '@/components/ui/textarea';
 import { Toggle } from '@/components/ui/toggle';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { type AssetEntry, useAssets } from '@/lib/assets';
 import { findSlideSource } from '@/lib/inspector/fiber';
 import type { EditOp } from '@/lib/inspector/use-editor';
@@ -150,15 +151,18 @@ export function InspectorPanel() {
               &lt;{pinSelected.anchor.tagName.toLowerCase()}&gt;
             </span>
           </div>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            className="text-muted-foreground hover:text-foreground"
-            onClick={() => setSelected(null)}
-            aria-label={t.inspector.deselect}
-          >
-            <X className="size-3.5" />
-          </Button>
+          <div className="flex items-center gap-1.5">
+            <AgentWatchingBadge />
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="text-muted-foreground hover:text-foreground"
+              onClick={() => setSelected(null)}
+              aria-label={t.inspector.deselect}
+            >
+              <X className="size-3.5" />
+            </Button>
+          </div>
         </>
       }
       footer={<CommentsSection selected={pinSelected} onAdd={add} />}
@@ -802,6 +806,31 @@ function AssetPickerDialog({
   );
 }
 
+function AgentWatchingBadge() {
+  const t = useLocale();
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="flex shrink-0 cursor-help items-center gap-1.5 rounded-[3px] border border-hairline bg-card px-1.5 py-px text-[10.5px] text-foreground/85 outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+          >
+            <span aria-hidden className="relative flex size-1.5 items-center justify-center">
+              <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-500 opacity-60" />
+              <span className="relative inline-flex size-1.5 rounded-full bg-emerald-500" />
+            </span>
+            {t.inspector.agentWatching}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" align="end" className="max-w-[260px] leading-relaxed">
+          {t.inspector.agentWatchingTooltip}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 function CommentsSection({
   selected,
   onAdd,
@@ -826,7 +855,7 @@ function CommentsSection({
   };
 
   return (
-    <Section title={t.inspector.noteForAgent}>
+    <Section title={t.inspector.leaveComment}>
       <div className="flex flex-col gap-2">
         <div className="comment-cue rounded-[6px]">
           <Textarea
@@ -838,16 +867,16 @@ function CommentsSection({
                 submit();
               }
             }}
-            placeholder={t.inspector.noteAgentPlaceholder}
+            placeholder={t.inspector.commentPlaceholder}
             className="min-h-16 resize-none text-[12px]"
           />
         </div>
         <div className="flex items-center justify-between gap-2">
           <span className="font-mono text-[10.5px] text-muted-foreground/70">
-            {t.inspector.noteShortcutHint}
+            {t.inspector.commentShortcutHint}
           </span>
           <Button size="sm" variant="brand" disabled={submitting || !draft.trim()} onClick={submit}>
-            {t.inspector.addNote}
+            {t.inspector.addComment}
           </Button>
         </div>
       </div>

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -24,6 +24,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useFolders } from '@/lib/folders';
 import { format, useLocale } from '@/lib/use-locale';
 import { useWheelPageNavigation } from '@/lib/use-wheel-page-navigation';
@@ -362,6 +363,7 @@ export function Slide() {
                   </TabsList>
                 </Tabs>
               )}
+              {import.meta.env.DEV && <AgentConnectedBadge />}
             </div>
 
             {/* Centered title — the rail and mobile pill carry the page count. */}
@@ -543,6 +545,31 @@ export function Slide() {
         </div>
       </InspectorProvider>
     </HistoryProvider>
+  );
+}
+
+function AgentConnectedBadge() {
+  const t = useLocale();
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="ml-1 flex shrink-0 cursor-help items-center gap-1.5 rounded-[3px] border border-hairline bg-card px-1.5 py-0.5 text-[10.5px] text-foreground/85 outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+          >
+            <span aria-hidden className="relative flex size-1.5 items-center justify-center">
+              <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-500 opacity-60" />
+              <span className="relative inline-flex size-1.5 rounded-full bg-emerald-500" />
+            </span>
+            {t.slide.agentConnected}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" align="start" className="max-w-[280px] leading-relaxed">
+          {t.slide.agentConnectedTooltip}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -79,6 +79,18 @@ export function Slide() {
   const index = Number.isFinite(rawIndex) ? Math.max(0, Math.min(pageCount - 1, rawIndex)) : 0;
   const view = searchParams.get('view') === 'assets' ? 'assets' : 'slides';
 
+  useEffect(() => {
+    if (!import.meta.hot) return;
+    if (!slideId || !slide || pageCount === 0) return;
+    import.meta.hot.send('open-slide:current', {
+      slideId,
+      pageIndex: index,
+      totalPages: pageCount,
+      slideTitle: slide.meta?.title ?? slideId,
+      view,
+    });
+  }, [slideId, index, pageCount, slide, view]);
+
   const goTo = useCallback(
     (i: number) => {
       const clamped = Math.max(0, Math.min(pageCount - 1, i));

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -328,6 +328,7 @@ export function Slide() {
   return (
     <HistoryProvider>
       <InspectorProvider slideId={slideId}>
+        <SelectionReporter />
         <div className="flex h-dvh flex-col overflow-hidden bg-background text-foreground">
           {/* Editorial toolbar — three zones, hairline separators, mono-folio center */}
           <header className="relative flex h-12 shrink-0 items-center justify-between border-b border-hairline bg-sidebar/85 px-2 backdrop-blur-md md:px-3">
@@ -543,6 +544,23 @@ export function Slide() {
       </InspectorProvider>
     </HistoryProvider>
   );
+}
+
+function SelectionReporter() {
+  const { selected } = useInspector();
+  useEffect(() => {
+    if (!import.meta.hot) return;
+    const selection = selected
+      ? {
+          line: selected.line,
+          column: selected.column,
+          tagName: selected.anchor.tagName.toLowerCase(),
+          text: (selected.anchor.textContent ?? '').replace(/\s+/g, ' ').trim().slice(0, 120),
+        }
+      : null;
+    import.meta.hot.send('open-slide:current', { selection });
+  }, [selected]);
+  return null;
 }
 
 function SlideWheelNavigation({

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -83,6 +83,9 @@ export const en: Locale = {
   slide: {
     home: 'Home',
     backToHome: 'Back to home',
+    agentConnected: 'Agent connected',
+    agentConnectedTooltip:
+      'The dev server is publishing your current slide and inspector selection to your agent. Ask "this slide" or "this element" in chat and it will resolve. Disappears in production builds.',
     download: 'Download',
     exportAsHtml: 'Export as HTML',
     exportAsPdf: 'Export as PDF',

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -156,6 +156,9 @@ export const en: Locale = {
   inspector: {
     inspect: 'Inspect',
     deselect: 'Deselect',
+    agentWatching: 'Agent is watching',
+    agentWatchingTooltip:
+      'Your agent already sees the selected element via the dev server — just ask it in chat. Leave comments here only when you want to queue a few before asking.',
     contentSection: 'Content',
     typographySection: 'Typography',
     colorSection: 'Color',
@@ -192,10 +195,10 @@ export const en: Locale = {
     cropFitContain: 'Fit',
     cropApply: 'Apply',
     cropResetAria: 'Reset crop',
-    noteForAgent: 'Note for the agent',
-    noteAgentPlaceholder: 'Describe a change for the agent…',
-    noteShortcutHint: '⌘↵ to send',
-    addNote: 'Add note',
+    leaveComment: 'Leave a comment',
+    commentPlaceholder: 'Describe a change for the agent…',
+    commentShortcutHint: '⌘↵ to add',
+    addComment: 'Add comment',
     unsavedChanges: {
       one: '{count} unsaved change',
       other: '{count} unsaved changes',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -81,6 +81,9 @@ export const ja: Locale = {
   },
 
   slide: {
+    agentConnected: 'エージェント接続中',
+    agentConnectedTooltip:
+      '現在のスライドと Inspector の選択状態を dev server がエージェントに公開しています。チャットで「このスライド」「この要素」と言えば認識されます。本番ビルドでは表示されません。',
     home: 'ホーム',
     backToHome: 'ホームへ戻る',
     download: 'ダウンロード',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -193,10 +193,13 @@ export const ja: Locale = {
     cropFitContain: '全体表示',
     cropApply: '適用',
     cropResetAria: 'トリミングをリセット',
-    noteForAgent: 'エージェントへのメモ',
-    noteAgentPlaceholder: 'エージェントに依頼する変更を記述…',
-    noteShortcutHint: '⌘↵ で送信',
-    addNote: 'メモを追加',
+    agentWatching: 'エージェント監視中',
+    agentWatchingTooltip:
+      'エージェントは選択中の要素を dev server 経由で把握しています。直接チャットで頼めます。ここにコメントを残すのは、複数の依頼をまとめて出したいときだけで OK。',
+    leaveComment: 'コメントを残す',
+    commentPlaceholder: 'エージェントに依頼する変更を記述…',
+    commentShortcutHint: '⌘↵ で追加',
+    addComment: 'コメントを追加',
     unsavedChanges: {
       one: '未保存の変更 {count} 件',
       other: '未保存の変更 {count} 件',

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -86,6 +86,8 @@ export type Locale = {
   slide: {
     home: string;
     backToHome: string;
+    agentConnected: string;
+    agentConnectedTooltip: string;
     download: string;
     exportAsHtml: string;
     exportAsPdf: string;

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -161,6 +161,8 @@ export type Locale = {
   inspector: {
     inspect: string;
     deselect: string;
+    agentWatching: string;
+    agentWatchingTooltip: string;
     contentSection: string;
     typographySection: string;
     colorSection: string;
@@ -198,10 +200,10 @@ export type Locale = {
     cropFitContain: string;
     cropApply: string;
     cropResetAria: string;
-    noteForAgent: string;
-    noteAgentPlaceholder: string;
-    noteShortcutHint: string;
-    addNote: string;
+    leaveComment: string;
+    commentPlaceholder: string;
+    commentShortcutHint: string;
+    addComment: string;
     /** templates: "{count} unsaved change" / "{count} unsaved changes" */
     unsavedChanges: Plural;
     /** templates: "{count} comment" / "{count} comments" */

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -81,6 +81,9 @@ export const zhCN: Locale = {
   },
 
   slide: {
+    agentConnected: 'Agent 已连接',
+    agentConnectedTooltip:
+      'Dev server 正在把你目前在哪张 slide、Inspector 选了哪个元素发布给 agent。直接到聊天说"这张 slide"或"这个元素"就行。Production build 不会出现。',
     home: '首页',
     backToHome: '返回首页',
     download: '下载',

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -192,10 +192,13 @@ export const zhCN: Locale = {
     cropFitContain: '完整显示',
     cropApply: '应用',
     cropResetAria: '重置裁剪',
-    noteForAgent: '给代理的备注',
-    noteAgentPlaceholder: '描述你希望代理执行的更改…',
-    noteShortcutHint: '⌘↵ 发送',
-    addNote: '添加备注',
+    agentWatching: 'Agent 正在关注',
+    agentWatchingTooltip:
+      'Agent 已经通过 dev server 看到你选的元素了，直接到聊天请它修改就行。想累积几个再一次问才需要在这里留 comments。',
+    leaveComment: '留个 comment',
+    commentPlaceholder: '描述你希望代理执行的更改…',
+    commentShortcutHint: '⌘↵ 添加',
+    addComment: '添加 comment',
     unsavedChanges: {
       one: '{count} 项未保存的更改',
       other: '{count} 项未保存的更改',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -81,6 +81,9 @@ export const zhTW: Locale = {
   },
 
   slide: {
+    agentConnected: 'Agent 已連線',
+    agentConnectedTooltip:
+      'Dev server 正在把你目前在哪張 slide、Inspector 選了哪個元素發布給 agent。直接到聊天說「這張 slide」或「這個元素」就行。Production build 不會出現。',
     home: '首頁',
     backToHome: '返回首頁',
     download: '下載',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -192,10 +192,13 @@ export const zhTW: Locale = {
     cropFitContain: '完整顯示',
     cropApply: '套用',
     cropResetAria: '重設裁切',
-    noteForAgent: '給代理的備註',
-    noteAgentPlaceholder: '描述你希望代理進行的修改…',
-    noteShortcutHint: '⌘↵ 送出',
-    addNote: '新增備註',
+    agentWatching: 'Agent 正在關注',
+    agentWatchingTooltip:
+      'Agent 已經透過 dev server 看到你選的元素了，直接到聊天請它修改就行。想累積幾個再一次問才需要在這裡留 comments。',
+    leaveComment: '留個 comment',
+    commentPlaceholder: '描述你希望代理進行的修改…',
+    commentShortcutHint: '⌘↵ 新增',
+    addComment: '新增 comment',
     unsavedChanges: {
       one: '{count} 項未儲存的變更',
       other: '{count} 項未儲存的變更',

--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -5,6 +5,7 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import type { InlineConfig } from 'vite';
 import { commentsPlugin } from './comments-plugin.ts';
+import { currentPlugin } from './current-plugin.ts';
 import { designPlugin } from './design-plugin.ts';
 import { filesPlugin } from './files-plugin.ts';
 import { locTagsPlugin } from './loc-tags-plugin.ts';
@@ -48,6 +49,7 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
       commentsPlugin({ userCwd, slidesDir }),
       notesPlugin({ userCwd, slidesDir }),
       filesPlugin({ userCwd, slidesDir }),
+      currentPlugin({ userCwd, slidesDir }),
     ],
     resolve: {
       alias: {

--- a/packages/core/src/vite/current-plugin.ts
+++ b/packages/core/src/vite/current-plugin.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { Plugin, ViteDevServer } from 'vite';
+
+const SLIDE_ID_RE = /^[a-z0-9_-]+$/i;
+
+export type CurrentPluginOptions = {
+  userCwd: string;
+  slidesDir?: string;
+};
+
+type IncomingPayload = {
+  slideId?: unknown;
+  pageIndex?: unknown;
+  totalPages?: unknown;
+  slideTitle?: unknown;
+  view?: unknown;
+};
+
+export function currentPlugin(opts: CurrentPluginOptions): Plugin {
+  const userCwd = opts.userCwd;
+  const slidesDir = opts.slidesDir ?? 'slides';
+  const outDir = path.join(userCwd, 'node_modules', '.open-slide');
+  const outFile = path.join(outDir, 'current.json');
+  const tmpFile = `${outFile}.tmp`;
+
+  return {
+    name: 'open-slide:current',
+    apply: 'serve',
+    configureServer(server: ViteDevServer) {
+      server.ws.on('open-slide:current', async (raw: IncomingPayload) => {
+        const slideId = typeof raw?.slideId === 'string' ? raw.slideId : '';
+        if (!slideId || !SLIDE_ID_RE.test(slideId)) return;
+
+        const totalPages =
+          typeof raw.totalPages === 'number' &&
+          Number.isFinite(raw.totalPages) &&
+          raw.totalPages > 0
+            ? Math.floor(raw.totalPages)
+            : 1;
+        const rawIndex =
+          typeof raw.pageIndex === 'number' && Number.isFinite(raw.pageIndex)
+            ? Math.floor(raw.pageIndex)
+            : 0;
+        const pageIndex = Math.max(0, Math.min(totalPages - 1, rawIndex));
+        const slideTitle = typeof raw.slideTitle === 'string' ? raw.slideTitle : slideId;
+        const view = raw.view === 'assets' ? 'assets' : 'slides';
+
+        const pagePath = path.join(slidesDir, slideId, 'index.tsx').split(path.sep).join('/');
+
+        const body = {
+          slideId,
+          pageIndex,
+          pageNumber: pageIndex + 1,
+          totalPages,
+          slideTitle,
+          view,
+          pagePath,
+          updatedAt: new Date().toISOString(),
+        };
+
+        try {
+          await fs.mkdir(outDir, { recursive: true });
+          await fs.writeFile(tmpFile, `${JSON.stringify(body, null, 2)}\n`, 'utf8');
+          await fs.rename(tmpFile, outFile);
+        } catch {
+          // Best-effort: a transient FS error here shouldn't crash the dev server.
+        }
+      });
+    },
+  };
+}

--- a/packages/core/src/vite/current-plugin.ts
+++ b/packages/core/src/vite/current-plugin.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { Plugin, ViteDevServer } from 'vite';
 
 const SLIDE_ID_RE = /^[a-z0-9_-]+$/i;
+const TEXT_SNIPPET_MAX = 120;
 
 export type CurrentPluginOptions = {
   userCwd: string;
@@ -15,7 +16,52 @@ type IncomingPayload = {
   totalPages?: unknown;
   slideTitle?: unknown;
   view?: unknown;
+  selection?: unknown;
 };
+
+type IncomingSelection = {
+  line?: unknown;
+  column?: unknown;
+  tagName?: unknown;
+  text?: unknown;
+};
+
+type Selection = {
+  line: number;
+  column: number;
+  tagName: string;
+  text: string;
+};
+
+type Cached = {
+  slideId: string;
+  pageIndex: number;
+  pageNumber: number;
+  totalPages: number;
+  slideTitle: string;
+  view: 'slides' | 'assets';
+  pagePath: string;
+  selection: Selection | null;
+};
+
+function parseSelection(raw: unknown): Selection | null {
+  if (raw == null || typeof raw !== 'object') return null;
+  const sel = raw as IncomingSelection;
+  if (typeof sel.line !== 'number' || !Number.isFinite(sel.line)) return null;
+  if (typeof sel.column !== 'number' || !Number.isFinite(sel.column)) return null;
+  const tagName =
+    typeof sel.tagName === 'string' ? sel.tagName.toLowerCase().slice(0, 32) : 'unknown';
+  const text =
+    typeof sel.text === 'string'
+      ? sel.text.replace(/\s+/g, ' ').trim().slice(0, TEXT_SNIPPET_MAX)
+      : '';
+  return {
+    line: Math.max(1, Math.floor(sel.line)),
+    column: Math.max(0, Math.floor(sel.column)),
+    tagName,
+    text,
+  };
+}
 
 export function currentPlugin(opts: CurrentPluginOptions): Plugin {
   const userCwd = opts.userCwd;
@@ -24,41 +70,66 @@ export function currentPlugin(opts: CurrentPluginOptions): Plugin {
   const outFile = path.join(outDir, 'current.json');
   const tmpFile = `${outFile}.tmp`;
 
+  let cached: Cached | null = null;
+
   return {
     name: 'open-slide:current',
     apply: 'serve',
     configureServer(server: ViteDevServer) {
       server.ws.on('open-slide:current', async (raw: IncomingPayload) => {
-        const slideId = typeof raw?.slideId === 'string' ? raw.slideId : '';
-        if (!slideId || !SLIDE_ID_RE.test(slideId)) return;
+        const next: Cached = cached
+          ? { ...cached }
+          : {
+              slideId: '',
+              pageIndex: 0,
+              pageNumber: 1,
+              totalPages: 1,
+              slideTitle: '',
+              view: 'slides',
+              pagePath: '',
+              selection: null,
+            };
 
-        const totalPages =
-          typeof raw.totalPages === 'number' &&
-          Number.isFinite(raw.totalPages) &&
-          raw.totalPages > 0
-            ? Math.floor(raw.totalPages)
-            : 1;
-        const rawIndex =
-          typeof raw.pageIndex === 'number' && Number.isFinite(raw.pageIndex)
-            ? Math.floor(raw.pageIndex)
-            : 0;
-        const pageIndex = Math.max(0, Math.min(totalPages - 1, rawIndex));
-        const slideTitle = typeof raw.slideTitle === 'string' ? raw.slideTitle : slideId;
-        const view = raw.view === 'assets' ? 'assets' : 'slides';
+        if (typeof raw?.slideId === 'string') {
+          if (!SLIDE_ID_RE.test(raw.slideId)) return;
 
-        const pagePath = path.join(slidesDir, slideId, 'index.tsx').split(path.sep).join('/');
+          const totalPages =
+            typeof raw.totalPages === 'number' &&
+            Number.isFinite(raw.totalPages) &&
+            raw.totalPages > 0
+              ? Math.floor(raw.totalPages)
+              : 1;
+          const rawIndex =
+            typeof raw.pageIndex === 'number' && Number.isFinite(raw.pageIndex)
+              ? Math.floor(raw.pageIndex)
+              : 0;
+          const pageIndex = Math.max(0, Math.min(totalPages - 1, rawIndex));
+          const slideTitle = typeof raw.slideTitle === 'string' ? raw.slideTitle : raw.slideId;
+          const view = raw.view === 'assets' ? 'assets' : 'slides';
+          const pagePath = path.join(slidesDir, raw.slideId, 'index.tsx').split(path.sep).join('/');
 
-        const body = {
-          slideId,
-          pageIndex,
-          pageNumber: pageIndex + 1,
-          totalPages,
-          slideTitle,
-          view,
-          pagePath,
-          updatedAt: new Date().toISOString(),
-        };
+          if (cached?.slideId !== raw.slideId || cached?.pageIndex !== pageIndex) {
+            next.selection = null;
+          }
 
+          next.slideId = raw.slideId;
+          next.pageIndex = pageIndex;
+          next.pageNumber = pageIndex + 1;
+          next.totalPages = totalPages;
+          next.slideTitle = slideTitle;
+          next.view = view;
+          next.pagePath = pagePath;
+        }
+
+        if ('selection' in raw) {
+          next.selection = parseSelection(raw.selection);
+        }
+
+        if (!next.slideId) return;
+
+        cached = next;
+
+        const body = { ...next, updatedAt: new Date().toISOString() };
         try {
           await fs.mkdir(outDir, { recursive: true });
           await fs.writeFile(tmpFile, `${JSON.stringify(body, null, 2)}\n`, 'utf8');


### PR DESCRIPTION
## Summary

- New Vite plugin (`current-plugin.ts`) listens for `open-slide:current` HMR pings and atomically writes `node_modules/.open-slide/current.json` on every navigation. Payload: `slideId`, `pageIndex` (0-based), `pageNumber` (1-based), `totalPages`, `slideTitle`, `view`, `pagePath` (relative), `updatedAt`.
- Slide route fires the HMR ping whenever `slideId` / page index / page count / view changes.
- New `current-slide` core skill documents how the agent reads the file, when to trust it (staleness rule), and what to do if it's missing. `slide-authoring` points at it for deictic references like "this page" or "the slide I'm on".
- Mirrored to `packages/cli/template/.agents/skills/` (and `.claude/skills/` symlink) so newly scaffolded projects get it. Existing projects pick it up via `open-slide sync:skills`.
- `node_modules/.open-slide/` is auto-gitignored, so nothing leaks into user repos.

## Test plan

- [ ] `pnpm dev` in `apps/demo`, navigate to a slide, check `apps/demo/node_modules/.open-slide/current.json` reflects the slide id and page number.
- [ ] Click through the thumbnail rail — file updates within the next tick.
- [ ] Switch between slides — `slideId` updates.
- [ ] Stop the dev server, edit `updatedAt` to an hour ago — agent sees stale file and asks before acting.
- [ ] Trigger `slide-authoring` via a "fix this page" prompt — agent consults `current-slide` first.
- [ ] `pnpm check` clean (only pre-existing `<img>` warning in `apps/web` remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)