### PR TITLE
fix(core): hug preview width in present overview cards

### DIFF
--- a/.changeset/overview-card-fit.md
+++ b/.changeset/overview-card-fit.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Make the present overview thumbnail cards hug the preview width instead of stretching to fill the row.

--- a/packages/core/src/app/components/present/overview-grid.tsx
+++ b/packages/core/src/app/components/present/overview-grid.tsx
@@ -96,9 +96,9 @@ export function PresentOverviewGrid({ pages, design, open, current, onClose, onS
       </div>
       <div ref={gridRef} className="min-h-0 flex-1 overflow-auto px-8 pb-8">
         <div
-          className="grid gap-5"
+          className="grid justify-center gap-5"
           style={{
-            gridTemplateColumns: `repeat(auto-fill, minmax(${THUMB_W}px, 1fr))`,
+            gridTemplateColumns: `repeat(auto-fill, ${THUMB_W}px)`,
           }}
         >
           {pages.map((PageComp, i) => {


### PR DESCRIPTION
## Summary
- The present overview grid used `minmax(THUMB_W, 1fr)`, stretching each column to fill the row. The thumbnail container then exceeded the fixed-width slide canvas (`THUMB_W=320`), leaving empty black space to the right of the preview.
- Switch to a fixed `THUMB_W` track and center the grid so cards wrap the preview tightly.

## Test plan
- [ ] `pnpm dev` in `apps/demo`, enter present mode, open overview (`O`) and confirm cards no longer have empty space beside the preview.
- [ ] Resize viewport — cards stay 320px wide and the grid stays centered as columns wrap.
- [ ] Arrow-key navigation, Enter, and Esc still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)