### PR TITLE
fix(core): keep cursor consistent in present mode

### DIFF
--- a/.changeset/laser-edge-nav-cursor.md
+++ b/.changeset/laser-edge-nav-cursor.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Force `cursor: default` and disable text selection across the present player so slide text no longer shows the I-beam, and keep the system cursor hidden over the edge prev/next buttons while the laser pointer is active.

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -272,7 +272,8 @@ export function Player({
       ref={setRoot}
       className={cn(
         'relative flex h-dvh w-screen items-center justify-center bg-black',
-        hideCursor && 'cursor-none',
+        controls && 'select-none',
+        controls && (hideCursor ? 'cursor-none' : 'cursor-default'),
       )}
     >
       <SlideCanvas flat design={design}>
@@ -284,14 +285,14 @@ export function Player({
         aria-label="Previous page"
         onClick={goPrev}
         disabled={!canPrev}
-        className="absolute inset-y-0 left-0 z-10 w-[30%]"
+        className={cn('absolute inset-y-0 left-0 z-10 w-[30%]', hideCursor && 'cursor-none')}
       />
       <button
         type="button"
         aria-label="Next page"
         onClick={goNext}
         disabled={!canNext}
-        className="absolute inset-y-0 right-0 z-10 w-[30%]"
+        className={cn('absolute inset-y-0 right-0 z-10 w-[30%]', hideCursor && 'cursor-none')}
       />
 
       {controls && (


### PR DESCRIPTION
## Summary
- Force `cursor: default` and `select-none` on the present player root so slide text no longer shows the I-beam and can't be highlighted.
- Apply `cursor-none` to the edge prev/next hit zones while the laser pointer is active, so the system cursor stops reappearing over those buttons.

## Test plan
- [ ] Enter present mode without laser → hovering text shows the default arrow, not the I-beam, and text can't be selected.
- [ ] Toggle laser on → cursor stays hidden everywhere, including the left/right edge nav zones.
- [ ] Idle / keyboard-driven cursor hiding still works as before; moving the mouse still reveals the chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)