### PR TITLE
fix(core): hot-reload home page when a new deck is created

### DIFF
--- a/.changeset/slides-dir-watcher.md
+++ b/.changeset/slides-dir-watcher.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Hot-reload the slide list when a new deck is created — previously the dev server had to be restarted before a new slide directory showed up on the home page.

--- a/packages/core/src/vite/open-slide-plugin.ts
+++ b/packages/core/src/vite/open-slide-plugin.ts
@@ -150,7 +150,11 @@ export function openSlidePlugin(opts: OpenSlidePluginOptions): Plugin {
           server.ws.send({ type: 'full-reload' });
         }, 150);
       };
-      server.watcher.add(path.join(slidesRoot, '*/index.{tsx,jsx,ts,js}'));
+      // Vite's `root` is the core app dir, so chokidar doesn't watch the
+      // user's slides folder by default. Add it explicitly — and pass the
+      // directory itself, since Vite sets `disableGlobbing: true` and would
+      // otherwise treat a glob pattern as a literal path.
+      if (existsSync(slidesRoot)) server.watcher.add(slidesRoot);
       server.watcher.on('add', (p) => {
         if (isSlideEntry(p)) reload();
       });


### PR DESCRIPTION
## Summary

- Vite's `root` is the core app dir, so chokidar doesn't watch the user's `slides/` folder by default. The plugin tried to compensate with `server.watcher.add(path.join(slidesRoot, '*/index.{tsx,jsx,ts,js}'))`, but Vite sets `disableGlobbing: true` on chokidar — the string is treated as a literal path containing `*` and `{}` and matches nothing.
- Existing slides still hot-reloaded via the module graph (they're imported), but **new** slide directories were never picked up — the homepage wouldn't show a newly created deck until the dev server was restarted.
- Fix: watch `slidesRoot` itself (a real directory). The existing `isSlideEntry(p)` filter already narrows `add`/`unlink` events to `slides/X/index.{ext}`.

## Test plan

- [ ] `pnpm dev` in `apps/demo`
- [ ] Create a new directory under `apps/demo/slides/` with an `index.tsx` (e.g. via the `create-slide` skill)
- [ ] Confirm the home page lists the new deck without restarting the dev server
- [ ] Delete the deck directory; confirm it disappears from the home list
- [ ] Edit an existing slide and confirm normal HMR still works