### PR TITLE
feat(core): make thumbnail rail width adjustable

### DIFF
--- a/.changeset/resizable-thumbnail-rail.md
+++ b/.changeset/resizable-thumbnail-rail.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': minor
+---
+
+Make the slide editor's thumbnail rail width adjustable via a drag handle. Width persists in localStorage and thumbnails scale to fit.

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -47,9 +47,13 @@ type Props = {
   onReorder?: (from: number, to: number) => void;
   actions?: ThumbnailActions;
   orientation?: Orientation;
+  /** Vertical-only: total rail width in px. Thumbnails scale to fit. */
+  width?: number;
 };
 
-const VERTICAL_THUMB_WIDTH = 184;
+const DEFAULT_VERTICAL_THUMB_WIDTH = 184;
+const VERTICAL_RAIL_CHROME = 80;
+const MIN_VERTICAL_THUMB_WIDTH = 120;
 const HORIZONTAL_THUMB_HEIGHT = 64;
 
 export function ThumbnailRail({
@@ -60,6 +64,7 @@ export function ThumbnailRail({
   onReorder,
   actions,
   orientation = 'vertical',
+  width,
 }: Props) {
   const activeRef = useRef<HTMLButtonElement | null>(null);
   const t = useLocale();
@@ -138,7 +143,11 @@ export function ThumbnailRail({
     );
   }
 
-  const scale = VERTICAL_THUMB_WIDTH / CANVAS_WIDTH;
+  const thumbWidth =
+    width != null
+      ? Math.max(MIN_VERTICAL_THUMB_WIDTH, width - VERTICAL_RAIL_CHROME)
+      : DEFAULT_VERTICAL_THUMB_WIDTH;
+  const scale = thumbWidth / CANVAS_WIDTH;
   const height = CANVAS_HEIGHT * scale;
 
   const renderThumb = (PageComp: Page, i: number) => {
@@ -150,6 +159,7 @@ export function ThumbnailRail({
         page={PageComp}
         design={design}
         scale={scale}
+        thumbWidth={thumbWidth}
         height={height}
       />
     );
@@ -230,6 +240,7 @@ function ThumbContents({
   page: PageComp,
   design,
   scale,
+  thumbWidth,
   height,
 }: {
   index: number;
@@ -237,6 +248,7 @@ function ThumbContents({
   page: Page;
   design?: DesignSystem;
   scale: number;
+  thumbWidth: number;
   height: number;
 }) {
   return (
@@ -256,7 +268,7 @@ function ThumbContents({
             ? 'border-brand shadow-[0_0_0_1px_var(--brand)]'
             : 'border-hairline group-hover/thumb:border-foreground/25',
         )}
-        style={{ width: VERTICAL_THUMB_WIDTH, height }}
+        style={{ width: thumbWidth, height }}
       >
         <SlideCanvas scale={scale} center={false} flat freezeMotion design={design}>
           <PageComp />

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -110,7 +110,7 @@ export function ThumbnailRail({
                   </span>
                   <div
                     className={cn(
-                      'relative shrink-0 overflow-hidden rounded-[4px] border bg-card motion-safe:transition-all',
+                      'relative shrink-0 overflow-hidden rounded-[4px] border bg-card motion-safe:transition-[border-color,box-shadow]',
                       active
                         ? 'border-brand shadow-[0_0_0_1px_var(--brand)]'
                         : 'border-hairline group-hover/thumb:border-foreground/25',
@@ -263,7 +263,7 @@ function ThumbContents({
       </span>
       <div
         className={cn(
-          'relative shrink-0 overflow-hidden rounded-[4px] border bg-card motion-safe:transition-all',
+          'relative shrink-0 overflow-hidden rounded-[4px] border bg-card motion-safe:transition-[border-color,box-shadow]',
           active
             ? 'border-brand shadow-[0_0_0_1px_var(--brand)]'
             : 'border-hairline group-hover/thumb:border-foreground/25',

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -483,16 +483,14 @@ export function Slide() {
             <DesignProvider slideId={slideId}>
               <div className="flex min-h-0 flex-1 flex-col">
                 <div className="flex min-h-0 flex-1 flex-col md:flex-row">
-                  <div className="hidden w-[16.5rem] shrink-0 md:block">
-                    <ThumbnailRail
-                      pages={pages}
-                      design={slide.design}
-                      current={index}
-                      onSelect={goTo}
-                      onReorder={import.meta.env.DEV ? reorderPage : undefined}
-                      actions={thumbnailActions}
-                    />
-                  </div>
+                  <ResizableRail
+                    pages={pages}
+                    design={slide.design}
+                    current={index}
+                    onSelect={goTo}
+                    onReorder={import.meta.env.DEV ? reorderPage : undefined}
+                    actions={thumbnailActions}
+                  />
                   <main
                     ref={slideViewportRef}
                     data-inspector-root
@@ -550,6 +548,129 @@ export function Slide() {
         </div>
       </InspectorProvider>
     </HistoryProvider>
+  );
+}
+
+const RAIL_WIDTH_STORAGE_KEY = 'open-slide:thumbnail-rail-width';
+const DEFAULT_RAIL_WIDTH = 264;
+const MIN_RAIL_WIDTH = 200;
+const MAX_RAIL_WIDTH = 480;
+
+function readStoredRailWidth(): number {
+  if (typeof window === 'undefined') return DEFAULT_RAIL_WIDTH;
+  const raw = window.localStorage.getItem(RAIL_WIDTH_STORAGE_KEY);
+  const parsed = raw == null ? Number.NaN : Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_RAIL_WIDTH;
+  return Math.min(MAX_RAIL_WIDTH, Math.max(MIN_RAIL_WIDTH, parsed));
+}
+
+function ResizableRail(props: {
+  pages: SlideModule['default'];
+  design?: SlideModule['design'];
+  current: number;
+  onSelect: (i: number) => void;
+  onReorder?: (from: number, to: number) => void;
+  actions?: ThumbnailActions;
+}) {
+  const t = useLocale();
+  const [width, setWidth] = useState<number>(readStoredRailWidth);
+  const [resizing, setResizing] = useState(false);
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, String(width));
+  }, [width]);
+
+  useEffect(() => {
+    if (!resizing) return;
+    const prev = {
+      cursor: document.body.style.cursor,
+      userSelect: document.body.style.userSelect,
+    };
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    return () => {
+      document.body.style.cursor = prev.cursor;
+      document.body.style.userSelect = prev.userSelect;
+    };
+  }, [resizing]);
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    dragRef.current = { startX: e.clientX, startWidth: width };
+    setResizing(true);
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    const delta = e.clientX - dragRef.current.startX;
+    const next = Math.min(
+      MAX_RAIL_WIDTH,
+      Math.max(MIN_RAIL_WIDTH, dragRef.current.startWidth + delta),
+    );
+    setWidth(next);
+  };
+
+  const onPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    dragRef.current = null;
+    setResizing(false);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const step = e.shiftKey ? 32 : 8;
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      e.stopPropagation();
+      setWidth((w) => Math.max(MIN_RAIL_WIDTH, w - step));
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      e.stopPropagation();
+      setWidth((w) => Math.min(MAX_RAIL_WIDTH, w + step));
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      e.stopPropagation();
+      setWidth(DEFAULT_RAIL_WIDTH);
+    }
+  };
+
+  return (
+    <div className="relative hidden shrink-0 md:block" style={{ width }}>
+      <ThumbnailRail width={width} {...props} />
+      {/* biome-ignore lint/a11y/useSemanticElements: focusable resize handle (splitter pattern), not a static <hr> */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={t.thumbnailRail.resizeRail}
+        aria-valuenow={width}
+        aria-valuemin={MIN_RAIL_WIDTH}
+        aria-valuemax={MAX_RAIL_WIDTH}
+        tabIndex={0}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        onKeyDown={onKeyDown}
+        onDoubleClick={() => setWidth(DEFAULT_RAIL_WIDTH)}
+        className={cn(
+          'group/resize absolute inset-y-0 right-0 z-20 w-1.5 translate-x-1/2 cursor-col-resize touch-none outline-none',
+          'focus-visible:bg-brand/20',
+        )}
+      >
+        <span
+          aria-hidden
+          className={cn(
+            'pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-brand opacity-0 transition-opacity',
+            'group-hover/resize:opacity-100 group-focus-visible/resize:opacity-100',
+            resizing && 'opacity-100',
+          )}
+        />
+      </div>
+    </div>
   );
 }
 

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -301,6 +301,7 @@ export const en: Locale = {
     toastDeleted: 'Deleted page {n}',
     toastDuplicateFailed: 'Could not duplicate page',
     toastDeleteFailed: 'Could not delete page',
+    resizeRail: 'Resize thumbnail rail',
   },
 
   pdfToast: {

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -305,6 +305,7 @@ export const ja: Locale = {
     toastDeleted: 'ページ {n} を削除しました',
     toastDuplicateFailed: 'ページを複製できませんでした',
     toastDeleteFailed: 'ページを削除できませんでした',
+    resizeRail: 'サムネイル幅を調整',
   },
 
   pdfToast: {

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -321,6 +321,7 @@ export type Locale = {
     toastDeleted: string;
     toastDuplicateFailed: string;
     toastDeleteFailed: string;
+    resizeRail: string;
   };
 
   pdfToast: {

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -301,6 +301,7 @@ export const zhCN: Locale = {
     toastDeleted: '已删除第 {n} 页',
     toastDuplicateFailed: '无法复制页面',
     toastDeleteFailed: '无法删除页面',
+    resizeRail: '调整缩略图栏宽度',
   },
 
   pdfToast: {

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -301,6 +301,7 @@ export const zhTW: Locale = {
     toastDeleted: '已刪除第 {n} 頁',
     toastDuplicateFailed: '無法複製頁面',
     toastDeleteFailed: '無法刪除頁面',
+    resizeRail: '調整縮圖欄寬度',
   },
 
   pdfToast: {


### PR DESCRIPTION
## Summary
- Drag handle on the right edge of the slide editor's thumbnail rail; resize between 200–480px (default 264). Thumbnails scale with the rail so wider = larger previews, not extra whitespace.
- Width persists in `localStorage` (`open-slide:thumbnail-rail-width`).
- Handle is keyboard-accessible (Tab to focus, ←/→ to resize ±8px, Shift+arrow ±32px, Home to reset, double-click to reset). Exposes `role=\"separator\"` + `aria-valuenow/min/max` for assistive tech.
- Adds `thumbnailRail.resizeRail` aria string across all 4 locales.

## Test plan
- [ ] Drag the handle: rail resizes smoothly, cursor stays `col-resize` even if pointer leaves the handle, thumbnails scale.
- [ ] Reload: width persists.
- [ ] Tab to handle, press ←/→/Shift+→/Home — verify each step + that arrow-key page-nav doesn't fire while the handle is focused.
- [ ] Double-click the handle — width resets to 264.
- [ ] Verify min (200) / max (480) clamps.
- [ ] Mobile (< md): no handle, horizontal rail unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The thumbnail rail in the slide editor is now resizable via a drag handle
  * Adjusted width is automatically saved and restored across sessions
  * Keyboard support for resizing: arrow keys (with Shift for larger adjustments, Home to reset)
  * Added localization support in English, Japanese, Simplified Chinese, and Traditional Chinese

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/90)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->