### PR TITLE
feat(core): drag-drop external images onto placeholders + upload from inspector

### DIFF
--- a/.changeset/placeholder-drag-upload.md
+++ b/.changeset/placeholder-drag-upload.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': minor
+---
+
+Drop external image files onto an `<ImagePlaceholder />` to upload + assign in one step, and upload images straight from the inspector's Replace dialog without switching to the Asset Manager.

--- a/apps/demo/slides/image-placeholder-demo/index.tsx
+++ b/apps/demo/slides/image-placeholder-demo/index.tsx
@@ -1,0 +1,140 @@
+import { ImagePlaceholder, type Page, type SlideMeta } from '@open-slide/core';
+
+const fill = {
+  width: '100%',
+  height: '100%',
+  background: '#FAFAF7',
+  color: '#1A1A1A',
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Inter", "SF Pro Display", system-ui, sans-serif',
+  position: 'relative',
+  overflow: 'hidden',
+} as const;
+
+const Eyebrow = ({ children }: { children: React.ReactNode }) => (
+  <div
+    style={{
+      fontSize: 18,
+      letterSpacing: '0.16em',
+      textTransform: 'uppercase',
+      color: '#888',
+      fontWeight: 600,
+    }}
+  >
+    {children}
+  </div>
+);
+
+const Hero: Page = () => (
+  <div style={fill}>
+    <div style={{ padding: '120px 140px', display: 'flex', flexDirection: 'column', gap: 28 }}>
+      <Eyebrow>Image placeholder demo</Eyebrow>
+      <h1
+        style={{
+          fontSize: 88,
+          fontWeight: 800,
+          letterSpacing: '-0.02em',
+          lineHeight: 1.05,
+          margin: 0,
+          maxWidth: 1500,
+        }}
+      >
+        Drop an image to try it.
+      </h1>
+      <p style={{ fontSize: 26, color: '#555', lineHeight: 1.5, maxWidth: 1100, margin: 0 }}>
+        Drag any image file from your file manager onto the placeholder below — it uploads to{' '}
+        <code style={{ background: '#EFEEEA', padding: '2px 8px', borderRadius: 6 }}>
+          slides/image-placeholder-demo/assets/
+        </code>{' '}
+        and slots in automatically.
+      </p>
+      <div style={{ marginTop: 24 }}>
+        <ImagePlaceholder hint="Hero image — drop a JPG or PNG here" width={1640} height={520} />
+      </div>
+    </div>
+  </div>
+);
+
+const Grid: Page = () => (
+  <div style={fill}>
+    <div style={{ padding: '120px 140px', display: 'flex', flexDirection: 'column', gap: 28 }}>
+      <Eyebrow>Multiple placeholders</Eyebrow>
+      <h2
+        style={{
+          fontSize: 64,
+          fontWeight: 800,
+          letterSpacing: '-0.02em',
+          lineHeight: 1.1,
+          margin: 0,
+        }}
+      >
+        Three slots, three drops.
+      </h2>
+      <p style={{ fontSize: 22, color: '#555', lineHeight: 1.5, margin: 0, maxWidth: 1100 }}>
+        Each placeholder is independent — drop a different image on each, or use the inspector's{' '}
+        <strong>Replace</strong> button to pick from your assets folder.
+      </p>
+      <div
+        style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 24, marginTop: 24 }}
+      >
+        <ImagePlaceholder hint="Portrait" width={520} height={680} />
+        <ImagePlaceholder hint="Square" width={520} height={680} />
+        <ImagePlaceholder hint="Landscape" width={520} height={680} />
+      </div>
+    </div>
+  </div>
+);
+
+const InspectorTest: Page = () => (
+  <div style={fill}>
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        alignItems: 'center',
+        padding: '0 140px',
+        gap: 80,
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+        <Eyebrow>Inspector flow</Eyebrow>
+        <h2
+          style={{
+            fontSize: 64,
+            fontWeight: 800,
+            letterSpacing: '-0.02em',
+            lineHeight: 1.1,
+            margin: 0,
+          }}
+        >
+          Or upload from
+          <br />
+          the inspector.
+        </h2>
+        <ol
+          style={{
+            fontSize: 22,
+            color: '#444',
+            lineHeight: 1.7,
+            margin: 0,
+            paddingLeft: 28,
+          }}
+        >
+          <li>Toggle Inspect, click the placeholder.</li>
+          <li>
+            Hit <strong>Replace</strong> in the inspector panel.
+          </li>
+          <li>
+            In the dialog, click <strong>Upload</strong> or drop a file directly into the grid.
+          </li>
+        </ol>
+      </div>
+      <ImagePlaceholder hint="Click me, then Replace" width={680} height={680} />
+    </div>
+  </div>
+);
+
+export const meta: SlideMeta = { title: 'Image Placeholder Demo' };
+
+export default [Hero, Grid, InspectorTest] satisfies Page[];

--- a/packages/core/src/app/components/asset-view.tsx
+++ b/packages/core/src/app/components/asset-view.tsx
@@ -33,6 +33,7 @@ import {
 import {
   type AssetEntry,
   fetchSvgAsFile,
+  renamedCopy,
   type SvglItem,
   searchSvgl,
   useAssets,
@@ -313,19 +314,6 @@ function hasFiles(e: React.DragEvent): boolean {
     if (types[i] === 'Files') return true;
   }
   return false;
-}
-
-function renamedCopy(file: File, taken: Set<string>): File {
-  const dot = file.name.lastIndexOf('.');
-  const stem = dot > 0 ? file.name.slice(0, dot) : file.name;
-  const ext = dot > 0 ? file.name.slice(dot) : '';
-  let i = 1;
-  let next = `${stem}-${i}${ext}`;
-  while (taken.has(next)) {
-    i += 1;
-    next = `${stem}-${i}${ext}`;
-  }
-  return new File([file], next, { type: file.type, lastModified: file.lastModified });
 }
 
 function AssetCard({

--- a/packages/core/src/app/components/image-placeholder.tsx
+++ b/packages/core/src/app/components/image-placeholder.tsx
@@ -1,4 +1,7 @@
-import type { CSSProperties, HTMLAttributes } from 'react';
+import { type CSSProperties, type HTMLAttributes, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { uploadWithAutoRename } from '@/lib/assets';
+import { useLocale } from '@/lib/use-locale';
 
 export type ImagePlaceholderProps = {
   hint: string;
@@ -17,9 +20,56 @@ export function ImagePlaceholder({
   ...rest
 }: ImagePlaceholderProps) {
   const dims = width && height ? `${width} × ${height}` : null;
+  const [dragActive, setDragActive] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const dragDepth = useRef(0);
+  const t = useLocale();
+
+  const dndProps = import.meta.env.DEV
+    ? {
+        onDragEnter: (e: React.DragEvent<HTMLDivElement>) => {
+          if (uploading || !hasImageFile(e)) return;
+          e.preventDefault();
+          dragDepth.current += 1;
+          setDragActive(true);
+        },
+        onDragOver: (e: React.DragEvent<HTMLDivElement>) => {
+          if (uploading || !hasImageFile(e)) return;
+          e.preventDefault();
+          e.dataTransfer.dropEffect = 'copy';
+        },
+        onDragLeave: () => {
+          dragDepth.current = Math.max(0, dragDepth.current - 1);
+          if (dragDepth.current === 0) setDragActive(false);
+        },
+        onDrop: (e: React.DragEvent<HTMLDivElement>) => {
+          if (uploading || !hasImageFile(e)) return;
+          e.preventDefault();
+          dragDepth.current = 0;
+          setDragActive(false);
+          const file = pickImageFile(e.dataTransfer.files);
+          if (!file) return;
+          const root = e.currentTarget;
+          const slideId = root.closest<HTMLElement>('[data-slide-id]')?.dataset.slideId;
+          const loc = root.dataset.slideLoc;
+          if (!slideId || !loc) return;
+          const idx = loc.indexOf(':');
+          if (idx <= 0) return;
+          const line = Number(loc.slice(0, idx));
+          const column = Number(loc.slice(idx + 1));
+          if (!Number.isFinite(line) || !Number.isFinite(column)) return;
+          setUploading(true);
+          handleDrop(slideId, file, line, column)
+            .catch(() => toast.error(t.imagePlaceholder.uploadFailed))
+            .finally(() => setUploading(false));
+        },
+      }
+    : null;
+
   return (
     <div
       {...rest}
+      {...dndProps}
       data-slide-placeholder={hint}
       data-placeholder-w={width}
       data-placeholder-h={height}
@@ -93,8 +143,80 @@ export function ImagePlaceholder({
           </span>
         )}
       </div>
+      {import.meta.env.DEV && (dragActive || uploading) && (
+        <DropOverlay
+          label={uploading ? t.imagePlaceholder.uploading : t.imagePlaceholder.dropOverlay}
+        />
+      )}
     </div>
   );
+}
+
+function DropOverlay({ label }: { label: string }) {
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: 'absolute',
+        inset: 0,
+        pointerEvents: 'none',
+        borderRadius: 12,
+        border: '2px dashed oklch(0.62 0.18 250)',
+        background: 'oklch(0.62 0.18 250 / 0.08)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <span
+        style={{
+          fontSize: 12,
+          fontWeight: 600,
+          letterSpacing: '0.02em',
+          color: 'oklch(0.45 0.16 250)',
+          background: 'rgba(255,255,255,0.92)',
+          padding: '6px 10px',
+          borderRadius: 6,
+          boxShadow: '0 1px 2px rgba(0,0,0,0.08)',
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function hasImageFile(e: React.DragEvent): boolean {
+  const types = e.dataTransfer?.types;
+  if (!types) return false;
+  for (let i = 0; i < types.length; i++) {
+    if (types[i] === 'Files') return true;
+  }
+  return false;
+}
+
+function pickImageFile(files: FileList): File | null {
+  for (let i = 0; i < files.length; i++) {
+    const f = files[i];
+    if (f.type.startsWith('image/')) return f;
+  }
+  return null;
+}
+
+async function handleDrop(slideId: string, file: File, line: number, column: number) {
+  const { ok, entry } = await uploadWithAutoRename(slideId, file);
+  if (!ok || !entry) throw new Error('upload failed');
+  const res = await fetch('/__edit', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      slideId,
+      line,
+      column,
+      ops: [{ kind: 'replace-placeholder-with-image', assetPath: `./assets/${entry.name}` }],
+    }),
+  });
+  if (!res.ok) throw new Error(`edit failed (${res.status})`);
 }
 
 function PlaceholderIcon() {

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -3,13 +3,17 @@ import {
   AlignJustify,
   AlignLeft,
   AlignRight,
+  ArrowDownToLine,
   Bold,
   Crop,
   ImageIcon,
   Italic,
+  Loader2,
+  Upload,
   X,
 } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { toast } from 'sonner';
 import { Field, NumberField, Section } from '@/components/panel/panel-fields';
 import { PANEL_TRANSITION_MS, PanelShell, useAnimatedOpen } from '@/components/panel/panel-shell';
 import { Button } from '@/components/ui/button';
@@ -34,10 +38,10 @@ import { Textarea } from '@/components/ui/textarea';
 import { Toggle } from '@/components/ui/toggle';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { type AssetEntry, useAssets } from '@/lib/assets';
+import { type AssetEntry, uploadWithAutoRename, useAssets } from '@/lib/assets';
 import { findSlideSource } from '@/lib/inspector/fiber';
 import type { EditOp } from '@/lib/inspector/use-editor';
-import { useLocale } from '@/lib/use-locale';
+import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import type { Locale } from '../../../locale/types';
 import { type SelectedTarget, useInspector } from './inspector-provider';
@@ -746,11 +750,35 @@ function AssetPickerDialog({
   onClose: () => void;
   onPick: (asset: AssetEntry) => void;
 }) {
-  const { assets, loading } = useAssets(slideId);
+  const { assets, loading, refresh } = useAssets(slideId);
   const images = assets.filter((a) => a.mime.startsWith('image/'));
   const t = useLocale();
   const path = `slides/${slideId}/assets/`;
   const [descPrefix, descSuffix] = t.inspector.replaceImageDescription.split('{path}');
+  const [uploading, setUploading] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
+  const dragDepth = useRef(0);
+  const inputId = useId();
+
+  const handleFile = useCallback(
+    async (file: File) => {
+      if (!file.type.startsWith('image/')) return;
+      setUploading(true);
+      try {
+        const { ok, status, entry } = await uploadWithAutoRename(slideId, file);
+        if (!ok || !entry) {
+          toast.error(format(t.asset.toastUploadFailed, { status }));
+          return;
+        }
+        await refresh().catch(() => {});
+        onPick(entry);
+      } finally {
+        setUploading(false);
+      }
+    },
+    [slideId, refresh, onPick, t],
+  );
+
   return (
     <Dialog open onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="sm:max-w-xl">
@@ -762,7 +790,60 @@ function AssetPickerDialog({
             {descSuffix}
           </DialogDescription>
         </DialogHeader>
-        <div className="max-h-[60vh] overflow-y-auto">
+        <label
+          htmlFor={inputId}
+          className={cn(
+            'absolute right-12 top-3.5 inline-flex h-7 cursor-pointer items-center gap-1.5 rounded-[5px] border border-border bg-card px-2 text-[12px] font-medium transition-colors',
+            'hover:bg-muted/60 hover:border-foreground/20 active:translate-y-px',
+            uploading && 'pointer-events-none opacity-60',
+          )}
+        >
+          {uploading ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <Upload className="size-3.5" />
+          )}
+          <span>{t.asset.upload}</span>
+        </label>
+        <input
+          id={inputId}
+          type="file"
+          accept="image/*"
+          className="sr-only"
+          disabled={uploading}
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            e.target.value = '';
+            if (file) handleFile(file).catch(() => {});
+          }}
+        />
+        <section
+          aria-label={t.inspector.replaceImageDialogTitle}
+          className="relative max-h-[60vh] overflow-y-auto"
+          onDragEnter={(e) => {
+            if (uploading || !hasFiles(e)) return;
+            e.preventDefault();
+            dragDepth.current += 1;
+            setDragActive(true);
+          }}
+          onDragOver={(e) => {
+            if (uploading || !hasFiles(e)) return;
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'copy';
+          }}
+          onDragLeave={() => {
+            dragDepth.current = Math.max(0, dragDepth.current - 1);
+            if (dragDepth.current === 0) setDragActive(false);
+          }}
+          onDrop={(e) => {
+            if (uploading || !hasFiles(e)) return;
+            e.preventDefault();
+            dragDepth.current = 0;
+            setDragActive(false);
+            const file = e.dataTransfer.files?.[0];
+            if (file) handleFile(file).catch(() => {});
+          }}
+        >
           {loading ? (
             <p className="px-1 py-6 text-center text-xs text-muted-foreground">
               {t.inspector.pickerLoading}
@@ -800,10 +881,34 @@ function AssetPickerDialog({
               ))}
             </div>
           )}
-        </div>
+          {dragActive && (
+            <div
+              className="pointer-events-none absolute inset-0 z-10 animate-in fade-in-0 duration-200"
+              aria-hidden
+            >
+              <div className="absolute inset-0 bg-brand/5" />
+              <div className="absolute inset-1 rounded-[8px] border border-dashed border-brand/40" />
+              <div className="absolute inset-x-0 bottom-4 flex justify-center">
+                <div className="flex items-center gap-2 rounded-[6px] border border-border bg-card px-3 py-1.5 text-[12px] font-medium shadow-floating">
+                  <ArrowDownToLine className="size-3.5 text-brand" />
+                  <span>{t.asset.dropToUpload}</span>
+                </div>
+              </div>
+            </div>
+          )}
+        </section>
       </DialogContent>
     </Dialog>
   );
+}
+
+function hasFiles(e: React.DragEvent): boolean {
+  const types = e.dataTransfer?.types;
+  if (!types) return false;
+  for (let i = 0; i < types.length; i++) {
+    if (types[i] === 'Files') return true;
+  }
+  return false;
 }
 
 function AgentWatchingBadge() {

--- a/packages/core/src/app/lib/assets.ts
+++ b/packages/core/src/app/lib/assets.ts
@@ -49,12 +49,16 @@ export async function uploadWithAutoRename(
   slideId: string,
   file: File,
 ): Promise<{ ok: boolean; status: number; entry: AssetEntry | null }> {
-  let res = await uploadAsset(slideId, file);
-  let uploaded = file;
+  // Vite's default `assetsInclude` matches asset extensions case-sensitively,
+  // so `<img src="./assets/foo.JPG" />` (which the placeholder edit rewrites
+  // into a real `import`) fails to parse. Lowercase the extension so the
+  // import path is always one Vite recognizes.
+  let uploaded = lowercaseExtension(file);
+  let res = await uploadAsset(slideId, uploaded);
   if (res.status === 409) {
     const list = await listAssets(slideId);
     const taken = new Set(list.map((a) => a.name));
-    uploaded = renamedCopy(file, taken);
+    uploaded = renamedCopy(uploaded, taken);
     res = await uploadAsset(slideId, uploaded);
   }
   if (!res.ok) return { ok: false, status: res.status, entry: null };
@@ -67,6 +71,18 @@ export async function uploadWithAutoRename(
     url: body?.url ?? `/__assets/${slideId}/${encodeURIComponent(uploaded.name)}`,
   };
   return { ok: true, status: res.status, entry };
+}
+
+function lowercaseExtension(file: File): File {
+  const dot = file.name.lastIndexOf('.');
+  if (dot <= 0) return file;
+  const ext = file.name.slice(dot);
+  const lower = ext.toLowerCase();
+  if (ext === lower) return file;
+  return new File([file], file.name.slice(0, dot) + lower, {
+    type: file.type,
+    lastModified: file.lastModified,
+  });
 }
 
 export function renamedCopy(file: File, taken: Set<string>): File {

--- a/packages/core/src/app/lib/assets.ts
+++ b/packages/core/src/app/lib/assets.ts
@@ -10,14 +10,14 @@ export type AssetEntry = {
 
 export type UploadOptions = { overwrite?: boolean };
 
-async function listAssets(slideId: string): Promise<AssetEntry[]> {
+export async function listAssets(slideId: string): Promise<AssetEntry[]> {
   const res = await fetch(`/__assets/${slideId}`);
   if (!res.ok) throw new Error(`GET /__assets/${slideId} ${res.status}`);
   const data = (await res.json()) as { assets?: AssetEntry[] };
   return data.assets ?? [];
 }
 
-async function uploadAsset(
+export async function uploadAsset(
   slideId: string,
   file: File,
   opts: UploadOptions = {},
@@ -43,6 +43,43 @@ async function renameAsset(slideId: string, from: string, to: string): Promise<R
 
 async function deleteAsset(slideId: string, name: string): Promise<Response> {
   return fetch(`/__assets/${slideId}/${encodeURIComponent(name)}`, { method: 'DELETE' });
+}
+
+export async function uploadWithAutoRename(
+  slideId: string,
+  file: File,
+): Promise<{ ok: boolean; status: number; entry: AssetEntry | null }> {
+  let res = await uploadAsset(slideId, file);
+  let uploaded = file;
+  if (res.status === 409) {
+    const list = await listAssets(slideId);
+    const taken = new Set(list.map((a) => a.name));
+    uploaded = renamedCopy(file, taken);
+    res = await uploadAsset(slideId, uploaded);
+  }
+  if (!res.ok) return { ok: false, status: res.status, entry: null };
+  const body = (await res.json().catch(() => null)) as Partial<AssetEntry> | null;
+  const entry: AssetEntry = {
+    name: body?.name ?? uploaded.name,
+    size: body?.size ?? uploaded.size,
+    mtime: body?.mtime ?? Date.now(),
+    mime: body?.mime ?? uploaded.type ?? 'application/octet-stream',
+    url: body?.url ?? `/__assets/${slideId}/${encodeURIComponent(uploaded.name)}`,
+  };
+  return { ok: true, status: res.status, entry };
+}
+
+export function renamedCopy(file: File, taken: Set<string>): File {
+  const dot = file.name.lastIndexOf('.');
+  const stem = dot > 0 ? file.name.slice(0, dot) : file.name;
+  const ext = dot > 0 ? file.name.slice(dot) : '';
+  let i = 1;
+  let next = `${stem}-${i}${ext}`;
+  while (taken.has(next)) {
+    i += 1;
+    next = `${stem}-${i}${ext}`;
+  }
+  return new File([file], next, { type: file.type, lastModified: file.lastModified });
 }
 
 export type SvglItem = {

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -494,6 +494,7 @@ export function Slide() {
                   <main
                     ref={slideViewportRef}
                     data-inspector-root
+                    data-slide-id={slideId}
                     className="paper relative min-h-0 min-w-0 flex-1 bg-canvas p-2 md:p-10"
                   >
                     <SlideWheelNavigation

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -324,6 +324,12 @@ export const en: Locale = {
     nextAria: 'Next page',
   },
 
+  imagePlaceholder: {
+    dropOverlay: 'Drop image to use here',
+    uploading: 'Uploading…',
+    uploadFailed: "Couldn't upload image",
+  },
+
   notesDrawer: {
     toggle: 'Notes',
     pageLabel: 'page {n}/{total}',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -328,6 +328,12 @@ export const ja: Locale = {
     nextAria: '次のページ',
   },
 
+  imagePlaceholder: {
+    dropOverlay: 'ここにドロップして使用',
+    uploading: 'アップロード中…',
+    uploadFailed: '画像のアップロードに失敗しました',
+  },
+
   notesDrawer: {
     toggle: '発表者ノート',
     pageLabel: '{n} / {total} ページ',

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -345,6 +345,12 @@ export type Locale = {
     nextAria: string;
   };
 
+  imagePlaceholder: {
+    dropOverlay: string;
+    uploading: string;
+    uploadFailed: string;
+  };
+
   notesDrawer: {
     toggle: string;
     /** template: "page {n}/{total}" */

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -324,6 +324,12 @@ export const zhCN: Locale = {
     nextAria: '下一页',
   },
 
+  imagePlaceholder: {
+    dropOverlay: '拖入图片以使用',
+    uploading: '上传中…',
+    uploadFailed: '图片上传失败',
+  },
+
   notesDrawer: {
     toggle: '演讲备注',
     pageLabel: '第 {n} / {total} 页',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -324,6 +324,12 @@ export const zhTW: Locale = {
     nextAria: '下一頁',
   },
 
+  imagePlaceholder: {
+    dropOverlay: '拖入圖片以使用',
+    uploading: '上傳中…',
+    uploadFailed: '圖片上傳失敗',
+  },
+
   notesDrawer: {
     toggle: '講稿',
     pageLabel: '第 {n} / {total} 頁',


### PR DESCRIPTION
## Summary

- Drop any image file from the OS directly onto an `<ImagePlaceholder />` — it uploads to `slides/<id>/assets/` and replaces the placeholder JSX in one step.
- The inspector's **Replace** dialog gains direct upload (button + drag-drop), so users no longer need to switch to the Asset Manager to pin a fresh image.
- Demo slide added at `apps/demo/slides/image-placeholder-demo/` to dogfood both flows.

Both interactions are dev-only — `import.meta.env.DEV` strips the drop handlers from production builds, and `ImagePlaceholder` keeps its current presentational behavior outside dev.

## How it works

- `ImagePlaceholder` reads `slideId` from a new `data-slide-id` on the slide root and `line:col` from its own `data-slide-loc` (already injected for it via `loc-tags-plugin`'s `FORWARDING_COMPONENTS`). On drop it uploads via `uploadWithAutoRename` (auto-renames on 409 collision) then POSTs `replace-placeholder-with-image` to `/__edit`.
- `AssetPickerDialog` (used by both `PlaceholderField` and `ImageField`) shares the same upload helper. After upload it calls the existing `onPick(asset)` so neither consumer needs changes.
- Conflict handling in the new flows auto-renames (`hero-1.png`, `hero-2.png`, …) rather than prompting — the user is mid-assignment, not curating, so a dialog would be friction. The Asset Manager's existing prompt-on-conflict behavior is unchanged.

## Test plan

- [ ] Open the **Image Placeholder Demo** slide.
- [ ] Drag a `.png` from Finder onto a placeholder — confirm the file lands in `slides/image-placeholder-demo/assets/` and the JSX is rewritten to `<img src="./assets/<name>" />`.
- [ ] Drop a second image with the same filename — auto-renamed (e.g. `hero-1.png`), no prompt.
- [ ] Drop a `.txt` file — silently rejected.
- [ ] Toggle Inspect, click a placeholder, hit **Replace** → click **Upload** in the dialog and pick a new image.
- [ ] Same dialog, drag-drop a file into the asset grid.
- [ ] Repeat the dialog flow on an existing `<img>` (not a placeholder) — `src` is rewritten to the new asset.
- [ ] Verify production build strips the drop handlers (`pnpm --filter @open-slide/core build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop image upload directly onto image placeholders for immediate assignment
  * Upload images from the inspector's Replace dialog without switching to the Asset Manager
  * Automatic filename conflict resolution during uploads
  * Demo pages showcasing Image Placeholder usage
  * Support for English, Japanese, and Chinese (Simplified & Traditional) interfaces

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/91)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->