### PR TITLE
docs(core): add slide-authoring tip for editing large slide files

### DIFF
--- a/.changeset/slide-authoring-edit-large-files.md
+++ b/.changeset/slide-authoring-edit-large-files.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Add slide-authoring skill guidance for editing large existing slides: locate the target page with `grep`, then partial-read the range instead of loading the whole file.

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -39,6 +39,16 @@ export default [Cover, Body] satisfies Page[];
 - `meta.title` (optional) shows in the slide header. Default is the folder name.
 - The slide id is the kebab-case folder name. Pick something short and descriptive (`q2-roadmap`, `team-offsite-2026`).
 
+## Editing an existing slide
+
+A finished slide commonly runs 1000–1800 lines. When you only need to touch one page, **don't read the whole file** — locate the page first, then read just that range:
+
+```bash
+grep -n ": Page = " slides/<id>/index.tsx
+```
+
+This lists every `const Foo: Page = …` declaration with its line number. Read the target page with `Read` using `offset` + `limit` (~150 lines is usually enough to capture one page plus its helper components). Read the whole file only when you need cross-page context (palette audit, reordering, design const tweaks).
+
 ## Canvas
 
 Every page renders into a fixed **1920 × 1080** canvas. The framework scales it; you design as if the viewport is literally 1920×1080.


### PR DESCRIPTION
## Summary

- Adds an **Editing an existing slide** subsection to the `slide-authoring` skill explaining how to navigate large (1000+ line) slide files: `grep -n ": Page = "` to locate the target page, then `Read` with `offset`/`limit` to load just that range
- Patch-level changeset for `@open-slide/core`

## Why

Finished slides commonly run 1000–1800 lines. Loading the whole file into context to tweak one page is wasteful. The tip nudges agents toward partial reads without changing any framework behavior or the existing "one `index.tsx` plus `assets/`" rule.

## Test plan

- [ ] Skill change is documentation-only — no runtime impact
- [ ] `pnpm check` passes (verified locally; only a pre-existing unrelated `apps/web` warning remains)
- [ ] Changeset present (`.changeset/slide-authoring-edit-large-files.md`, patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the slide authoring workflow, including best practices for editing existing slides and efficient techniques for locating specific content in large slide files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/92)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->