### PR TITLE
fix(core): allow inspector edits on formatted text

### DIFF
--- a/.changeset/formatted-text-inspector.md
+++ b/.changeset/formatted-text-inspector.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Allow inspector content edits on text elements that contain inline formatting such as bold or underline.

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -1054,7 +1054,8 @@ function hasOnlyInlineTextChildren(el: HTMLElement): boolean {
     }
     if (!(child instanceof HTMLElement)) continue;
     if (!INLINE_TEXT_TAGS.has(child.tagName)) return false;
-    if (child.tagName !== 'BR' && !hasOnlyInlineTextChildren(child)) return false;
+    if (child.tagName === 'BR') continue;
+    if (!hasOnlyInlineTextChildren(child)) return false;
     sawText = true;
   }
   return sawText;

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -991,7 +991,7 @@ function CommentsSection({
 
 function readSnapshot(el: HTMLElement): ElementSnapshot {
   const cs = getComputedStyle(el);
-  const text = isSimpleTextElement(el) ? (el.textContent ?? '') : null;
+  const text = isEditableTextElement(el) ? (el.textContent ?? '') : null;
   const imageSrc =
     el.tagName === 'IMG'
       ? (el as HTMLImageElement).currentSrc || (el as HTMLImageElement).src || null
@@ -1021,10 +1021,43 @@ function readSnapshot(el: HTMLElement): ElementSnapshot {
   };
 }
 
-function isSimpleTextElement(el: HTMLElement): boolean {
+function isEditableTextElement(el: HTMLElement): boolean {
   if (el.childNodes.length === 0) return true;
   if (el.childNodes.length === 1 && el.firstChild?.nodeType === Node.TEXT_NODE) return true;
-  return false;
+  return hasOnlyInlineTextChildren(el);
+}
+
+const INLINE_TEXT_TAGS = new Set([
+  'B',
+  'BR',
+  'CODE',
+  'DEL',
+  'EM',
+  'I',
+  'INS',
+  'MARK',
+  'S',
+  'SMALL',
+  'SPAN',
+  'STRONG',
+  'SUB',
+  'SUP',
+  'U',
+]);
+
+function hasOnlyInlineTextChildren(el: HTMLElement): boolean {
+  let sawText = false;
+  for (const child of el.childNodes) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      if ((child.textContent ?? '').trim()) sawText = true;
+      continue;
+    }
+    if (!(child instanceof HTMLElement)) continue;
+    if (!INLINE_TEXT_TAGS.has(child.tagName)) return false;
+    if (child.tagName !== 'BR' && !hasOnlyInlineTextChildren(child)) return false;
+    sawText = true;
+  }
+  return sawText;
 }
 
 function rgbToHex(value: string): string | null {

--- a/packages/core/src/vite/comments-plugin.test.ts
+++ b/packages/core/src/vite/comments-plugin.test.ts
@@ -209,6 +209,24 @@ describe('applyEdit / set-text', () => {
     expect(r.source).toContain('<h1>Hello <span>planet</span></h1>');
   });
 
+  it('replaces a formatted inline text container when prevText matches the whole text', () => {
+    const src = [
+      'export default [() => (',
+      '<p>Hello <strong>world</strong> from <u>open-slide</u></p>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text',
+        value: 'Hello editor',
+        prevText: 'Hello world from open-slide',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain('<p>Hello editor</p>');
+  });
+
   it('bails when prevText is missing for an ambiguous element', () => {
     const src = ['export default [() => (', '<h1>Hello <span>world</span></h1>', ')];', ''].join(
       '\n',

--- a/packages/core/src/vite/comments-plugin.test.ts
+++ b/packages/core/src/vite/comments-plugin.test.ts
@@ -227,6 +227,28 @@ describe('applyEdit / set-text', () => {
     expect(r.source).toContain('<p>Hello editor</p>');
   });
 
+  it('matches formatted whole text when source whitespace spans lines', () => {
+    const src = [
+      'export default [() => (',
+      '<p>',
+      '  Hello',
+      '  <strong>world</strong>',
+      '  from open-slide',
+      '</p>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text',
+        value: 'Hello editor',
+        prevText: 'Hello world from open-slide',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain('<p>Hello editor</p>');
+  });
+
   it('bails when prevText is missing for an ambiguous element', () => {
     const src = ['export default [() => (', '<h1>Hello <span>world</span></h1>', ')];', ''].join(
       '\n',

--- a/packages/core/src/vite/comments-plugin.test.ts
+++ b/packages/core/src/vite/comments-plugin.test.ts
@@ -249,6 +249,28 @@ describe('applyEdit / set-text', () => {
     expect(r.source).toContain('<p>Hello editor</p>');
   });
 
+  it('matches formatted whole text with a br using DOM textContent spacing', () => {
+    const src = [
+      'export default [() => (',
+      '<h2>',
+      '  Not autocomplete.',
+      '  <br />',
+      '  An <em>agent</em> that does the work.',
+      '</h2>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text',
+        value: 'test',
+        prevText: 'Not autocomplete.An agent that does the work.',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain('<h2>test</h2>');
+  });
+
   it('bails when prevText is missing for an ambiguous element', () => {
     const src = ['export default [() => (', '<h1>Hello <span>world</span></h1>', ')];', ''].join(
       '\n',

--- a/packages/core/src/vite/comments-plugin.ts
+++ b/packages/core/src/vite/comments-plugin.ts
@@ -407,17 +407,44 @@ function staticRenderedText(parent: JsxParent): string | null {
   return normalized ? normalized : null;
 }
 
+function staticDomTextContent(parent: JsxParent): string | null {
+  let text = '';
+  // Match React's JSX whitespace cleanup before comparing with DOM textContent.
+  for (const child of t.react.buildChildren(parent)) {
+    if (t.isStringLiteral(child) || t.isNumericLiteral(child)) {
+      text += String(child.value);
+    } else if (t.isJSXElement(child) || t.isJSXFragment(child)) {
+      const childText = staticDomTextContent(child);
+      if (childText === null) return null;
+      text += childText;
+    } else {
+      return null;
+    }
+  }
+  return text;
+}
+
+function staticDomRenderedText(parent: JsxParent): string | null {
+  const text = staticDomTextContent(parent);
+  if (text === null) return null;
+  const normalized = normalizeRenderedText(text);
+  return normalized ? normalized : null;
+}
+
 function collectWholeTextCandidate(element: t.JSXElement, leafs: TextCandidate[]): TextCandidate[] {
   if (leafs.length < 2) return [];
-  const current = staticRenderedText(element);
-  if (!current) return [];
-  if (leafs.some((candidate) => candidate.current === current)) return [];
-  return [
-    {
-      current,
-      splice: (value) => wrapSplice(element, formatJsxText(value)),
-    },
-  ];
+  const seen = new Set(leafs.map((candidate) => candidate.current));
+  const currents: string[] = [];
+  for (const current of [staticRenderedText(element), staticDomRenderedText(element)]) {
+    if (!current || seen.has(current)) continue;
+    seen.add(current);
+    currents.push(current);
+  }
+  if (currents.length === 0) return [];
+  return currents.map((current) => ({
+    current,
+    splice: (value) => wrapSplice(element, formatJsxText(value)),
+  }));
 }
 
 // `<Wrap>{children}</Wrap>` and `<h2>{title}</h2>` — sole child is a

--- a/packages/core/src/vite/comments-plugin.ts
+++ b/packages/core/src/vite/comments-plugin.ts
@@ -710,9 +710,7 @@ function buildTextSplice(
   if (prevText === undefined) {
     return { error: 'element has multiple text candidates; missing prevText' };
   }
-  // Trim: JSX collapses surrounding whitespace at render time, so the
-  // DOM `prevText` won't have leading/trailing space the source might.
-  const norm = prevText.trim();
+  const norm = normalizeRenderedText(prevText);
   const matches = candidates.filter((c) => c.current === norm);
   if (matches.length === 0) {
     return { error: 'no text candidate matches the current value' };

--- a/packages/core/src/vite/comments-plugin.ts
+++ b/packages/core/src/vite/comments-plugin.ts
@@ -381,6 +381,45 @@ function collectTextCandidates(element: JsxParent, out: TextCandidate[]): void {
   }
 }
 
+function normalizeRenderedText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function staticRenderedText(parent: JsxParent): string | null {
+  let text = '';
+  for (const child of parent.children) {
+    if (t.isJSXText(child)) {
+      text += child.value;
+    } else if (t.isJSXExpressionContainer(child)) {
+      const expr = child.expression;
+      if (t.isStringLiteral(expr) || t.isNumericLiteral(expr)) {
+        text += String(expr.value);
+      } else {
+        return null;
+      }
+    } else if (t.isJSXElement(child) || t.isJSXFragment(child)) {
+      const childText = staticRenderedText(child);
+      if (childText === null) return null;
+      text += childText;
+    }
+  }
+  const normalized = normalizeRenderedText(text);
+  return normalized ? normalized : null;
+}
+
+function collectWholeTextCandidate(element: t.JSXElement, leafs: TextCandidate[]): TextCandidate[] {
+  if (leafs.length < 2) return [];
+  const current = staticRenderedText(element);
+  if (!current) return [];
+  if (leafs.some((candidate) => candidate.current === current)) return [];
+  return [
+    {
+      current,
+      splice: (value) => wrapSplice(element, formatJsxText(value)),
+    },
+  ];
+}
+
 // `<Wrap>{children}</Wrap>` and `<h2>{title}</h2>` — sole child is a
 // JSXExpressionContainer wrapping a bare Identifier. Returns the identifier
 // name; callers branch on `'children'` vs. a generic prop passthrough.
@@ -640,6 +679,7 @@ function buildTextSplice(
 ): Splice | { error: string } {
   const candidates: TextCandidate[] = [];
   collectTextCandidates(element, candidates);
+  candidates.push(...collectWholeTextCandidate(element, candidates));
   if (candidates.length === 0) {
     const passthrough = propPassthroughName(element);
     const enclosing = passthrough ? findEnclosingComponent(ast, element) : null;


### PR DESCRIPTION
## Summary

- Fixes #71 by treating text-only elements with inline formatting tags (for example `<strong>`, `<u>`, and `<code>`) as editable content in the inspector, so the Content textarea appears for formatted paragraphs.
- Adds a whole-text fallback in the edit plugin: when `prevText` matches the rendered text for a formatted inline container, `set-text` can rewrite that container instead of failing on multiple leaf text candidates.
- Patch changeset for `@open-slide/core`.

## Test plan

- [ ] `pnpm test -- comments-plugin` ✓ — 165 / 165
- [ ] `pnpm check` ✓ — only the pre-existing `apps/web` `<img>` warning remains
- [ ] `pnpm dev:demo` — open Image Placeholder Demo page 2, toggle Inspect, click the formatted paragraph, and confirm Content appears with the full paragraph text
- [ ] `pnpm typecheck` fails in this checkout with pre-existing React type-resolution errors (for example `Routes` / lucide icons cannot be used as JSX components)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inspector supports editing text elements with inline formatting (e.g., bold, underline) and can replace entire formatted or multi-line text blocks reliably.
* **Tests**
  * Added coverage for replacing formatted text, including nested formatting, multi-line/whitespace-normalized cases, and <br/> scenarios.
* **Chores**
  * Added a changeset entry documenting the patch release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/94)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->