### PR TITLE
feat(core): add agent disconnection state to dev badge

### DIFF
--- a/.changeset/agent-disconnected-badge.md
+++ b/.changeset/agent-disconnected-badge.md
@@ -2,4 +2,4 @@
 '@open-slide/core': patch
 ---
 
-Show an "Agent disconnected" state on the dev badge when the Vite HMR socket drops, with a tooltip prompting to restart the dev server.
+Flip the dev-only "Agent connected" and "Agent is watching" badges to a disconnected state when the Vite HMR socket drops, with a tooltip prompting the user to restart the dev server.

--- a/.changeset/agent-disconnected-badge.md
+++ b/.changeset/agent-disconnected-badge.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Show an "Agent disconnected" state on the dev badge when the Vite HMR socket drops, with a tooltip prompting to restart the dev server.

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -41,6 +41,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { type AssetEntry, uploadWithAutoRename, useAssets } from '@/lib/assets';
 import { findSlideSource } from '@/lib/inspector/fiber';
 import type { EditOp } from '@/lib/inspector/use-editor';
+import { useAgentSocketConnected } from '@/lib/use-agent-socket';
 import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import type { Locale } from '../../../locale/types';
@@ -913,6 +914,7 @@ function hasFiles(e: React.DragEvent): boolean {
 
 function AgentWatchingBadge() {
   const t = useLocale();
+  const connected = useAgentSocketConnected();
   return (
     <TooltipProvider delayDuration={200}>
       <Tooltip>
@@ -922,14 +924,20 @@ function AgentWatchingBadge() {
             className="flex shrink-0 cursor-help items-center gap-1.5 rounded-[3px] border border-hairline bg-card px-1.5 py-px text-[10.5px] text-foreground/85 outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
           >
             <span aria-hidden className="relative flex size-1.5 items-center justify-center">
-              <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-500 opacity-60" />
-              <span className="relative inline-flex size-1.5 rounded-full bg-emerald-500" />
+              {connected ? (
+                <>
+                  <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-500 opacity-60" />
+                  <span className="relative inline-flex size-1.5 rounded-full bg-emerald-500" />
+                </>
+              ) : (
+                <span className="relative inline-flex size-1.5 rounded-full bg-rose-500" />
+              )}
             </span>
-            {t.inspector.agentWatching}
+            {connected ? t.inspector.agentWatching : t.inspector.agentNotWatching}
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom" align="end" className="max-w-[260px] leading-relaxed">
-          {t.inspector.agentWatchingTooltip}
+          {connected ? t.inspector.agentWatchingTooltip : t.inspector.agentNotWatchingTooltip}
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/packages/core/src/app/lib/use-agent-socket.ts
+++ b/packages/core/src/app/lib/use-agent-socket.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+export function useAgentSocketConnected() {
+  const [connected, setConnected] = useState(true);
+  useEffect(() => {
+    const hot = import.meta.hot;
+    if (!hot) return;
+    const onConnect = () => setConnected(true);
+    const onDisconnect = () => setConnected(false);
+    hot.on('vite:ws:connect', onConnect);
+    hot.on('vite:ws:disconnect', onDisconnect);
+    return () => {
+      hot.off('vite:ws:connect', onConnect);
+      hot.off('vite:ws:disconnect', onDisconnect);
+    };
+  }, []);
+  return connected;
+}

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -26,6 +26,7 @@ import {
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useFolders } from '@/lib/folders';
+import { useAgentSocketConnected } from '@/lib/use-agent-socket';
 import { format, useLocale } from '@/lib/use-locale';
 import { useWheelPageNavigation } from '@/lib/use-wheel-page-navigation';
 import { cn } from '@/lib/utils';
@@ -705,23 +706,6 @@ function AgentConnectedBadge() {
       </Tooltip>
     </TooltipProvider>
   );
-}
-
-function useAgentSocketConnected() {
-  const [connected, setConnected] = useState(true);
-  useEffect(() => {
-    const hot = import.meta.hot;
-    if (!hot) return;
-    const onConnect = () => setConnected(true);
-    const onDisconnect = () => setConnected(false);
-    hot.on('vite:ws:connect', onConnect);
-    hot.on('vite:ws:disconnect', onDisconnect);
-    return () => {
-      hot.off('vite:ws:connect', onConnect);
-      hot.off('vite:ws:disconnect', onDisconnect);
-    };
-  }, []);
-  return connected;
 }
 
 function SelectionReporter() {

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -677,6 +677,7 @@ function ResizableRail(props: {
 
 function AgentConnectedBadge() {
   const t = useLocale();
+  const connected = useAgentSocketConnected();
   return (
     <TooltipProvider delayDuration={200}>
       <Tooltip>
@@ -686,18 +687,41 @@ function AgentConnectedBadge() {
             className="ml-1 flex shrink-0 cursor-help items-center gap-1.5 rounded-[3px] border border-hairline bg-card px-1.5 py-0.5 text-[10.5px] text-foreground/85 outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
           >
             <span aria-hidden className="relative flex size-1.5 items-center justify-center">
-              <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-500 opacity-60" />
-              <span className="relative inline-flex size-1.5 rounded-full bg-emerald-500" />
+              {connected ? (
+                <>
+                  <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-500 opacity-60" />
+                  <span className="relative inline-flex size-1.5 rounded-full bg-emerald-500" />
+                </>
+              ) : (
+                <span className="relative inline-flex size-1.5 rounded-full bg-rose-500" />
+              )}
             </span>
-            {t.slide.agentConnected}
+            {connected ? t.slide.agentConnected : t.slide.agentDisconnected}
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom" align="start" className="max-w-[280px] leading-relaxed">
-          {t.slide.agentConnectedTooltip}
+          {connected ? t.slide.agentConnectedTooltip : t.slide.agentDisconnectedTooltip}
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );
+}
+
+function useAgentSocketConnected() {
+  const [connected, setConnected] = useState(true);
+  useEffect(() => {
+    const hot = import.meta.hot;
+    if (!hot) return;
+    const onConnect = () => setConnected(true);
+    const onDisconnect = () => setConnected(false);
+    hot.on('vite:ws:connect', onConnect);
+    hot.on('vite:ws:disconnect', onDisconnect);
+    return () => {
+      hot.off('vite:ws:connect', onConnect);
+      hot.off('vite:ws:disconnect', onDisconnect);
+    };
+  }, []);
+  return connected;
 }
 
 function SelectionReporter() {

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -165,6 +165,9 @@ export const en: Locale = {
     agentWatching: 'Agent is watching',
     agentWatchingTooltip:
       'Your agent already sees the selected element via the dev server — just ask it in chat. Leave comments here only when you want to queue a few before asking.',
+    agentNotWatching: 'Agent not watching',
+    agentNotWatchingTooltip:
+      'Lost connection to the dev server, so your agent can no longer see the selected element. Restart the dev server to restore the connection.',
     contentSection: 'Content',
     typographySection: 'Typography',
     colorSection: 'Color',

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -86,6 +86,9 @@ export const en: Locale = {
     agentConnected: 'Agent connected',
     agentConnectedTooltip:
       'The dev server is publishing your current slide and inspector selection to your agent. Ask "this slide" or "this element" in chat and it will resolve. Disappears in production builds.',
+    agentDisconnected: 'Agent disconnected',
+    agentDisconnectedTooltip:
+      'Lost connection to the dev server, so your agent can no longer see the current slide or inspector selection. Restart the dev server to restore the connection.',
     download: 'Download',
     exportAsHtml: 'Export as HTML',
     exportAsPdf: 'Export as PDF',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -202,6 +202,9 @@ export const ja: Locale = {
     agentWatching: 'エージェント監視中',
     agentWatchingTooltip:
       'エージェントは選択中の要素を dev server 経由で把握しています。直接チャットで頼めます。ここにコメントを残すのは、複数の依頼をまとめて出したいときだけで OK。',
+    agentNotWatching: 'エージェント未接続',
+    agentNotWatchingTooltip:
+      'dev server との接続が切れたため、選択中の要素がエージェントに見えなくなっています。dev server を再起動して接続を復旧してください。',
     leaveComment: 'コメントを残す',
     commentPlaceholder: 'エージェントに依頼する変更を記述…',
     commentShortcutHint: '⌘↵ で追加',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -84,6 +84,9 @@ export const ja: Locale = {
     agentConnected: 'エージェント接続中',
     agentConnectedTooltip:
       '現在のスライドと Inspector の選択状態を dev server がエージェントに公開しています。チャットで「このスライド」「この要素」と言えば認識されます。本番ビルドでは表示されません。',
+    agentDisconnected: 'エージェント切断',
+    agentDisconnectedTooltip:
+      'dev server との接続が切れたため、現在のスライドや Inspector の選択がエージェントに届かなくなっています。dev server を再起動して接続を復旧してください。',
     home: 'ホーム',
     backToHome: 'ホームへ戻る',
     download: 'ダウンロード',

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -167,6 +167,8 @@ export type Locale = {
     deselect: string;
     agentWatching: string;
     agentWatchingTooltip: string;
+    agentNotWatching: string;
+    agentNotWatchingTooltip: string;
     contentSection: string;
     typographySection: string;
     colorSection: string;

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -88,6 +88,8 @@ export type Locale = {
     backToHome: string;
     agentConnected: string;
     agentConnectedTooltip: string;
+    agentDisconnected: string;
+    agentDisconnectedTooltip: string;
     download: string;
     exportAsHtml: string;
     exportAsPdf: string;

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -201,6 +201,9 @@ export const zhCN: Locale = {
     agentWatching: 'Agent 正在关注',
     agentWatchingTooltip:
       'Agent 已经通过 dev server 看到你选的元素了，直接到聊天请它修改就行。想累积几个再一次问才需要在这里留 comments。',
+    agentNotWatching: 'Agent 没在关注',
+    agentNotWatchingTooltip:
+      '已和 dev server 断开连接，agent 看不到你选的元素了。请重新启动 dev server 来恢复连接。',
     leaveComment: '留个 comment',
     commentPlaceholder: '描述你希望代理执行的更改…',
     commentShortcutHint: '⌘↵ 添加',

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -84,6 +84,9 @@ export const zhCN: Locale = {
     agentConnected: 'Agent 已连接',
     agentConnectedTooltip:
       'Dev server 正在把你目前在哪张 slide、Inspector 选了哪个元素发布给 agent。直接到聊天说"这张 slide"或"这个元素"就行。Production build 不会出现。',
+    agentDisconnected: 'Agent 已断开',
+    agentDisconnectedTooltip:
+      '已和 dev server 断开连接，agent 没办法再看到你目前的 slide 或 Inspector 选择。请重新启动 dev server 来恢复连接。',
     home: '首页',
     backToHome: '返回首页',
     download: '下载',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -201,6 +201,9 @@ export const zhTW: Locale = {
     agentWatching: 'Agent 正在關注',
     agentWatchingTooltip:
       'Agent 已經透過 dev server 看到你選的元素了，直接到聊天請它修改就行。想累積幾個再一次問才需要在這裡留 comments。',
+    agentNotWatching: 'Agent 沒在關注',
+    agentNotWatchingTooltip:
+      '已和 dev server 斷線，agent 看不到你選的元素了。請重新啟動 dev server 來恢復連線。',
     leaveComment: '留個 comment',
     commentPlaceholder: '描述你希望代理進行的修改…',
     commentShortcutHint: '⌘↵ 新增',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -84,6 +84,9 @@ export const zhTW: Locale = {
     agentConnected: 'Agent 已連線',
     agentConnectedTooltip:
       'Dev server 正在把你目前在哪張 slide、Inspector 選了哪個元素發布給 agent。直接到聊天說「這張 slide」或「這個元素」就行。Production build 不會出現。',
+    agentDisconnected: 'Agent 已斷線',
+    agentDisconnectedTooltip:
+      '已和 dev server 斷線，agent 沒辦法再看到你目前的 slide 或 Inspector 選擇。請重新啟動 dev server 來恢復連線。',
     home: '首頁',
     backToHome: '返回首頁',
     download: '下載',


### PR DESCRIPTION
## Summary
This PR adds visual feedback when the Vite HMR socket connection is lost, displaying a disconnected state on the agent badge with guidance to restart the dev server.

## Key Changes
- **New hook `useAgentSocketConnected()`**: Monitors Vite HMR socket connection status by listening to `vite:ws:connect` and `vite:ws:disconnect` events, defaulting to connected state
- **Updated `AgentConnectedBadge` component**: 
  - Now conditionally renders different visual states based on connection status
  - Connected state: green pulsing indicator with "Agent connected" label
  - Disconnected state: red static indicator with "Agent disconnected" label
  - Tooltip content updates to provide context-appropriate guidance
- **Localization updates**: Added `agentDisconnected` and `agentDisconnectedTooltip` strings across all supported languages (English, Japanese, Simplified Chinese, Traditional Chinese)
- **Type definitions**: Extended `Locale` type to include the new disconnection-related strings

## Implementation Details
- The hook properly cleans up event listeners on unmount to prevent memory leaks
- Connection state defaults to `true` to maintain the existing behavior when HMR is unavailable
- The disconnected tooltip explicitly instructs users to restart the dev server to restore functionality

https://claude.ai/code/session_01L6vA1jYExGRY7gZ8SherZ9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dev-mode "Agent disconnected" status for the dev-server badge that shows when the live connection drops, with a tooltip prompting users to restart the dev server.
  * Added localized messages for the new agent connection states in English, Japanese, Simplified Chinese, and Traditional Chinese.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/95)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->