### PR TITLE
fix: properly handle Windows backslash paths in @fs imports

### DIFF
--- a/packages/core/src/vite/open-slide-plugin.ts
+++ b/packages/core/src/vite/open-slide-plugin.ts
@@ -65,7 +65,7 @@ function toId(absFile: string, slidesRoot: string): string {
 function generateSlidesModule(files: string[], slidesRoot: string, isDev: boolean): string {
   const entries = files.map((abs) => {
     const id = toId(abs, slidesRoot);
-    const importPath = isDev ? `/@fs/${abs.replace(/^\/+/, '')}` : abs;
+    const importPath = isDev ? `/@fs/${abs.replace(/^\/+/, "").replace(/\\/g, "/")}` : abs;
     return { id, importPath };
   });
 


### PR DESCRIPTION
On Windows, absolute file paths use backslashes (e.g. `D:\project\slides\index.tsx`). The current code only strips leading slashes for Unix paths but does not convert backslashes to forward slashes, which breaks Vite's `/@fs/` protocol on Windows.

Before: `/@fs/D:\project\slides\index.tsx`  (broken)
After:  `/@fs/D:/project/slides/index.tsx`  (correct)

This is a one-character fix: adding `.replace(/\\/g, '/')` after the existing `.replace(/^\/+/, '')` call.

Fixes the "Failed to resolve import /@fsD:/..." error on Windows systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path normalization in development mode to ensure consistent functionality across Windows, macOS, and Linux systems.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/98)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->