### PR TITLE
feat(cli): add package manager selection prompt during init

### DIFF
--- a/.changeset/init-package-manager-prompt.md
+++ b/.changeset/init-package-manager-prompt.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/cli': minor
+---
+
+Prompt for the package manager during `init` when no `--use-*` flag is passed, defaulting to the detected one.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import prompts from 'prompts';
 import { type InitOptions, init, isDirNonEmpty, LOCALE_CHOICES, type LocaleCode } from './init.ts';
-import { detectPackageManager, type PackageManager } from './package-manager.ts';
+import { detectPackageManager, PACKAGE_MANAGERS, type PackageManager } from './package-manager.ts';
 
 async function readVersion(): Promise<string> {
   const here = dirname(fileURLToPath(import.meta.url));
@@ -42,7 +42,7 @@ function onCancel(): never {
   process.exit(130);
 }
 
-function resolvePackageManager(flags: InitCliFlags): PackageManager {
+function packageManagerFromFlags(flags: InitCliFlags): PackageManager | undefined {
   const picks: PackageManager[] = [];
   if (flags.useNpm) picks.push('npm');
   if (flags.usePnpm) picks.push('pnpm');
@@ -54,7 +54,7 @@ function resolvePackageManager(flags: InitCliFlags): PackageManager {
       `Only one of --use-npm / --use-pnpm / --use-yarn / --use-bun may be specified (got ${picks.map((p) => `--use-${p}`).join(', ')}).`,
     );
   }
-  return picks[0] ?? detectPackageManager();
+  return picks[0];
 }
 
 async function runInit(dirArg: string | undefined, flags: InitCliFlags): Promise<void> {
@@ -64,6 +64,7 @@ async function runInit(dirArg: string | undefined, flags: InitCliFlags): Promise
   const name = flags.name;
   let force = flags.force ?? false;
   let locale: LocaleCode | undefined = parseLocale(flags.locale);
+  let packageManager = packageManagerFromFlags(flags);
 
   if (isTTY && dir === undefined) {
     const answers = await prompts(
@@ -90,6 +91,21 @@ async function runInit(dirArg: string | undefined, flags: InitCliFlags): Promise
       { onCancel },
     );
     locale = answers.locale as LocaleCode | undefined;
+  }
+
+  if (isTTY && packageManager === undefined && flags.install !== false) {
+    const detected = detectPackageManager();
+    const answers = await prompts(
+      {
+        type: 'select',
+        name: 'packageManager',
+        message: 'Package manager',
+        choices: PACKAGE_MANAGERS.map((pm) => ({ title: pm, value: pm })),
+        initial: PACKAGE_MANAGERS.indexOf(detected),
+      },
+      { onCancel },
+    );
+    packageManager = answers.packageManager as PackageManager | undefined;
   }
 
   const resolvedDir = dir ?? '.';
@@ -119,7 +135,7 @@ async function runInit(dirArg: string | undefined, flags: InitCliFlags): Promise
     dir: resolvedDir,
     force,
     name,
-    packageManager: resolvePackageManager(flags),
+    packageManager: packageManager ?? detectPackageManager(),
     install: flags.install !== false,
     git: flags.git !== false,
     locale: locale ?? 'en',


### PR DESCRIPTION
## Summary
This PR adds an interactive prompt for package manager selection during the `init` command when no explicit `--use-*` flag is provided, while maintaining backward compatibility with existing flag-based selection.

## Key Changes
- Renamed `resolvePackageManager()` to `packageManagerFromFlags()` to better reflect its purpose of extracting package manager from CLI flags only
- Changed `packageManagerFromFlags()` to return `undefined` instead of falling back to `detectPackageManager()`, allowing the caller to decide on fallback behavior
- Added `PACKAGE_MANAGERS` export from `package-manager.ts` to support the new prompt choices
- Introduced interactive prompt in `runInit()` that:
  - Only appears in TTY mode when no package manager flag is specified and `--install` is not disabled
  - Displays all available package managers as selectable options
  - Pre-selects the detected package manager as the default choice
- Maintained the final fallback to `detectPackageManager()` when no selection is made, ensuring non-interactive workflows continue to work seamlessly

## Implementation Details
The package manager resolution now follows this priority:
1. Explicit CLI flag (`--use-npm`, `--use-pnpm`, `--use-yarn`, `--use-bun`)
2. User prompt selection (in TTY mode, when applicable)
3. Auto-detected package manager (fallback)

This improves the user experience by providing guided selection while preserving existing behavior for CI/CD and non-interactive environments.

https://claude.ai/code/session_013hcZeRGv8njyFVzPRUJXoX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `open-slide init` command now prompts users to select a package manager when no explicit flag is provided, with automatic detection as the default option.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/100)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->