### PR TITLE
chore: add package metadata fields to npm package.json

### DIFF
--- a/.changeset/package-metadata.md
+++ b/.changeset/package-metadata.md
@@ -1,0 +1,6 @@
+---
+'@open-slide/core': patch
+'@open-slide/cli': patch
+---
+
+Add `homepage`, `bugs`, and `author` fields to the published package metadata so npm shows links to the site, repo issues, and author.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,10 +27,18 @@
     "scaffold"
   ],
   "license": "MIT",
+  "author": {
+    "name": "1weiho",
+    "url": "https://github.com/1weiho"
+  },
+  "homepage": "https://open-slide.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/1weiho/open-slide.git",
     "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/1weiho/open-slide/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,10 +47,18 @@
     "vite"
   ],
   "license": "MIT",
+  "author": {
+    "name": "1weiho",
+    "url": "https://github.com/1weiho"
+  },
+  "homepage": "https://open-slide.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/1weiho/open-slide.git",
     "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/1weiho/open-slide/issues"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
This PR adds missing metadata fields to the package.json files for both `@open-slide/core` and `@open-slide/cli` packages to improve their presence on npm and provide better discoverability.

## Changes
- Added `author` field with name and GitHub profile URL to both packages
- Added `homepage` field pointing to https://open-slide.dev for both packages
- Added `bugs` field with link to the GitHub issues page for both packages
- Created a changeset entry documenting these metadata updates as patch versions

## Details
These metadata fields are standard npm package.json properties that enhance the package listing on npm.org by:
- Displaying author information and linking to their GitHub profile
- Providing a direct link to the project homepage
- Making it easy for users to report issues by linking to the GitHub issues page

All changes are applied consistently across both published packages.

https://claude.ai/code/session_018TBFFnqrzpRX2FzcxcqFwW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated package metadata to include author information, project homepage, and bug tracking links across published packages for improved npm visibility and user guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/102)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->