### PR TITLE
fix(core): support rich text inspector edits

### DIFF
--- a/.changeset/minimal-formatted-text-inspector.md
+++ b/.changeset/minimal-formatted-text-inspector.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Support styling selected text ranges in inspector content fields.

--- a/packages/core/src/app/components/inspector/inspect-overlay.tsx
+++ b/packages/core/src/app/components/inspector/inspect-overlay.tsx
@@ -31,7 +31,7 @@ export function InspectOverlay() {
     };
 
     const onMove = (e: PointerEvent) => {
-      const el = pickElement(e.clientX, e.clientY);
+      const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
       if (!el) return setHover(null);
       const hit = findSlideSource(el, slideId, { hostOnly: true });
       if (!hit) return setHover(null);
@@ -40,7 +40,7 @@ export function InspectOverlay() {
 
     const onClick = (e: MouseEvent) => {
       if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) return;
-      const el = pickElement(e.clientX, e.clientY);
+      const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
       if (!el) return;
       const hit = findSlideSource(el, slideId, { hostOnly: true });
       if (!hit) return;
@@ -52,7 +52,7 @@ export function InspectOverlay() {
 
     const onDblClick = (e: MouseEvent) => {
       if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) return;
-      const el = pickElement(e.clientX, e.clientY);
+      const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
       if (!el) return;
       const hit = findSlideSource(el, slideId, { hostOnly: true });
       if (!hit) return;
@@ -220,4 +220,50 @@ function pickElement(x: number, y: number): HTMLElement | null {
     return el;
   }
   return null;
+}
+
+const INLINE_TEXT_TAGS = new Set([
+  'B',
+  'CODE',
+  'DEL',
+  'EM',
+  'I',
+  'INS',
+  'MARK',
+  'S',
+  'SMALL',
+  'SPAN',
+  'STRONG',
+  'SUB',
+  'SUP',
+  'U',
+]);
+
+function pickInspectorTarget(el: HTMLElement | null): HTMLElement | null {
+  if (!el) return null;
+  const root = el.closest('[data-inspector-root]');
+  const startedOnInlineText = INLINE_TEXT_TAGS.has(el.tagName);
+  for (let cur: HTMLElement | null = el; cur && root?.contains(cur); cur = cur.parentElement) {
+    if (startedOnInlineText && INLINE_TEXT_TAGS.has(cur.tagName)) continue;
+    if (isEditableTextContainer(cur)) return cur;
+  }
+  return el;
+}
+
+function isEditableTextContainer(el: HTMLElement): boolean {
+  if (!el.textContent?.trim()) return false;
+  return hasOnlyInlineTextChildren(el);
+}
+
+function hasOnlyInlineTextChildren(el: HTMLElement): boolean {
+  for (const child of Array.from(el.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      continue;
+    } else if (child instanceof HTMLElement) {
+      if (child.tagName === 'BR') continue;
+      if (INLINE_TEXT_TAGS.has(child.tagName) && hasOnlyInlineTextChildren(child)) continue;
+    }
+    return false;
+  }
+  return true;
 }

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -61,12 +61,20 @@ type ElementSnapshot = {
   placeholder: { hint: string; width?: number; height?: number } | null;
 };
 
+type ContentSelection = { start: number; end: number };
+
 export function InspectorPanel() {
   const { active, slideId, selected, setSelected, bufferOps, pendingCount, add, applyEdit } =
     useInspector();
   const [snapshot, setSnapshot] = useState<ElementSnapshot | null>(null);
+  const [contentSelection, setContentSelection] = useState<ContentSelection | null>(null);
+  const selectedKey = selected ? `${selected.line}:${selected.column}` : null;
   const reloadCounter = useReloadCounter();
   const t = useLocale();
+
+  useEffect(() => {
+    setContentSelection((current) => (selectedKey === null || current ? null : current));
+  }, [selectedKey]);
 
   useEffect(() => {
     void reloadCounter;
@@ -140,6 +148,39 @@ export function InspectorPanel() {
 
   if (!pinned) return null;
   const { s: pinSelected, n: pinSnapshot } = pinned;
+  const contentRange =
+    pinSnapshot.text !== null && contentSelection && contentSelection.end > contentSelection.start
+      ? contentSelection
+      : null;
+  const applyTextStyle = (ops: EditOp[]) => {
+    const styleOps = ops.flatMap((op) => (op.kind === 'set-style' ? [op] : []));
+    if (
+      contentRange &&
+      pinSnapshot.text !== null &&
+      styleOps.length === 1 &&
+      styleOps.length === ops.length &&
+      styleOps.every((op) => INLINE_CONTENT_STYLE_KEYS.has(op.key))
+    ) {
+      for (const op of styleOps) {
+        applyEdit(pinSelected.line, pinSelected.column, [
+          {
+            kind: 'set-text-range-style',
+            start: contentRange.start,
+            end: contentRange.end,
+            key: op.key,
+            value: op.value,
+            prevText: pinSnapshot.text,
+          },
+        ]).catch((err) => {
+          if (err instanceof Error && err.name === 'NoOpEditError') return;
+          const msg = err instanceof Error ? err.message : String(err);
+          toast.error(`${t.inspector.saveFailed} ${msg}`);
+        });
+      }
+      return;
+    }
+    apply(ops);
+  };
 
   return (
     <PanelShell
@@ -174,16 +215,20 @@ export function InspectorPanel() {
     >
       {pinSnapshot.text !== null && (
         <Section title={t.inspector.contentSection}>
-          <ContentField snapshot={pinSnapshot} apply={apply} />
+          <ContentField
+            snapshot={pinSnapshot}
+            apply={apply}
+            onSelectionChange={setContentSelection}
+          />
         </Section>
       )}
 
       <Separator />
 
       <Section title={t.inspector.typographySection}>
-        <FontSizeField snapshot={pinSnapshot} apply={apply} />
-        <FontWeightField snapshot={pinSnapshot} apply={apply} />
-        <StyleToggles snapshot={pinSnapshot} apply={apply} />
+        <FontSizeField snapshot={pinSnapshot} apply={applyTextStyle} />
+        <FontWeightField snapshot={pinSnapshot} apply={applyTextStyle} />
+        <StyleToggles snapshot={pinSnapshot} apply={applyTextStyle} />
         <LineHeightField snapshot={pinSnapshot} apply={apply} />
         <LetterSpacingField snapshot={pinSnapshot} apply={apply} />
         <TextAlignField snapshot={pinSnapshot} apply={apply} />
@@ -195,7 +240,7 @@ export function InspectorPanel() {
         <ColorField
           label={t.inspector.textColor}
           value={pinSnapshot.color}
-          onChange={(v) => apply([{ kind: 'set-style', key: 'color', value: v }])}
+          onChange={(v) => applyTextStyle([{ kind: 'set-style', key: 'color', value: v }])}
           clearable={false}
         />
         <ColorField
@@ -254,12 +299,22 @@ const EDITING_FREEZE_CSS = `
 }
 `;
 
+const INLINE_CONTENT_STYLE_KEYS = new Set([
+  'fontSize',
+  'fontWeight',
+  'fontStyle',
+  'fontFamily',
+  'color',
+]);
+
 function ContentField({
   snapshot,
   apply,
+  onSelectionChange,
 }: {
   snapshot: ElementSnapshot;
   apply: (ops: EditOp[]) => void;
+  onSelectionChange?: (selection: ContentSelection | null) => void;
 }) {
   // Mirror the value locally and skip syncs during IME composition;
   // a re-render mid-composition would otherwise clobber in-progress
@@ -272,6 +327,12 @@ function ContentField({
     if (!composingRef.current) setLocal(snapshot.text ?? '');
   }, [snapshot.text]);
 
+  const reportSelection = (el: HTMLTextAreaElement) => {
+    const start = el.selectionStart ?? 0;
+    const end = el.selectionEnd ?? start;
+    onSelectionChange?.(end > start ? { start, end } : null);
+  };
+
   return (
     <Textarea
       value={local}
@@ -282,15 +343,20 @@ function ContentField({
         composingRef.current = false;
         const v = e.currentTarget.value;
         setLocal(v);
+        reportSelection(e.currentTarget);
         apply([{ kind: 'set-text', value: v }]);
       }}
       onChange={(e) => {
         const v = e.target.value;
         setLocal(v);
+        reportSelection(e.currentTarget);
         if (!composingRef.current) {
           apply([{ kind: 'set-text', value: v }]);
         }
       }}
+      onKeyUp={(e) => reportSelection(e.currentTarget)}
+      onMouseUp={(e) => reportSelection(e.currentTarget)}
+      onSelect={(e) => reportSelection(e.currentTarget)}
       rows={3}
       className="min-h-16 resize-none text-xs"
       placeholder={t.inspector.elementTextPlaceholder}
@@ -999,7 +1065,7 @@ function CommentsSection({
 
 function readSnapshot(el: HTMLElement): ElementSnapshot {
   const cs = getComputedStyle(el);
-  const text = isSimpleTextElement(el) ? (el.textContent ?? '') : null;
+  const text = isSimpleTextElement(el) ? readEditableText(el) : null;
   const imageSrc =
     el.tagName === 'IMG'
       ? (el as HTMLImageElement).currentSrc || (el as HTMLImageElement).src || null
@@ -1031,8 +1097,51 @@ function readSnapshot(el: HTMLElement): ElementSnapshot {
 
 function isSimpleTextElement(el: HTMLElement): boolean {
   if (el.childNodes.length === 0) return true;
-  if (el.childNodes.length === 1 && el.firstChild?.nodeType === Node.TEXT_NODE) return true;
-  return false;
+  return hasOnlyInlineTextChildren(el);
+}
+
+const INLINE_TEXT_TAGS = new Set([
+  'B',
+  'CODE',
+  'DEL',
+  'EM',
+  'I',
+  'INS',
+  'MARK',
+  'S',
+  'SMALL',
+  'SPAN',
+  'STRONG',
+  'SUB',
+  'SUP',
+  'U',
+]);
+
+function hasOnlyInlineTextChildren(el: HTMLElement): boolean {
+  for (const child of Array.from(el.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      continue;
+    } else if (child instanceof HTMLElement) {
+      if (child.tagName === 'BR') continue;
+      if (INLINE_TEXT_TAGS.has(child.tagName) && hasOnlyInlineTextChildren(child)) continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+function readEditableText(el: HTMLElement): string {
+  let text = '';
+  for (const child of Array.from(el.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      text += child.textContent ?? '';
+    } else if (child instanceof HTMLBRElement) {
+      text += '\n';
+    } else if (child instanceof HTMLElement) {
+      text += readEditableText(child);
+    }
+  }
+  return text;
 }
 
 function rgbToHex(value: string): string | null {

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -62,19 +62,39 @@ type ElementSnapshot = {
 };
 
 type ContentSelection = { start: number; end: number };
+type StylePreview = Partial<
+  Pick<ElementSnapshot, 'fontSize' | 'fontWeight' | 'fontStyle' | 'color'>
+>;
+type RangeStylePreview = {
+  anchor: HTMLElement;
+  start: number;
+  end: number;
+  values: StylePreview;
+};
+
+function resolveSelectedTarget(target: SelectedTarget, slideId: string): SelectedTarget {
+  const hit = findSlideSource(target.anchor, slideId, { hostOnly: true });
+  if (!hit) return target;
+  if (hit.line === target.line && hit.column === target.column && hit.anchor === target.anchor) {
+    return target;
+  }
+  return { line: hit.line, column: hit.column, anchor: hit.anchor };
+}
 
 export function InspectorPanel() {
   const { active, slideId, selected, setSelected, bufferOps, pendingCount, add, applyEdit } =
     useInspector();
   const [snapshot, setSnapshot] = useState<ElementSnapshot | null>(null);
   const [contentSelection, setContentSelection] = useState<ContentSelection | null>(null);
-  const selectedKey = selected ? `${selected.line}:${selected.column}` : null;
+  const [rangeStylePreview, setRangeStylePreview] = useState<RangeStylePreview | null>(null);
   const reloadCounter = useReloadCounter();
   const t = useLocale();
 
   useEffect(() => {
-    setContentSelection((current) => (selectedKey === null || current ? null : current));
-  }, [selectedKey]);
+    void selected;
+    setContentSelection(null);
+    setRangeStylePreview(null);
+  }, [selected]);
 
   useEffect(() => {
     void reloadCounter;
@@ -123,10 +143,12 @@ export function InspectorPanel() {
   const apply = useCallback(
     (ops: EditOp[]) => {
       if (!selected) return;
-      bufferOps(selected.line, selected.column, selected.anchor, ops);
-      if (selected.anchor.isConnected) setSnapshot(readSnapshot(selected.anchor));
+      const target = resolveSelectedTarget(selected, slideId);
+      if (target !== selected) setSelected(target);
+      bufferOps(target.line, target.column, target.anchor, ops);
+      if (target.anchor.isConnected) setSnapshot(readSnapshot(target.anchor));
     },
-    [selected, bufferOps],
+    [selected, setSelected, slideId, bufferOps],
   );
 
   // `pinned` keeps the last selection rendered through the close-out
@@ -152,8 +174,19 @@ export function InspectorPanel() {
     pinSnapshot.text !== null && contentSelection && contentSelection.end > contentSelection.start
       ? contentSelection
       : null;
+  const rangePreviewApplies =
+    contentRange &&
+    rangeStylePreview &&
+    rangeStylePreview.anchor === pinSelected.anchor &&
+    rangeStylePreview.start === contentRange.start &&
+    rangeStylePreview.end === contentRange.end;
+  const typographySnapshot = rangePreviewApplies
+    ? withStylePreview(pinSnapshot, rangeStylePreview.values)
+    : pinSnapshot;
   const applyTextStyle = (ops: EditOp[]) => {
     const styleOps = ops.flatMap((op) => (op.kind === 'set-style' ? [op] : []));
+    const target = resolveSelectedTarget(pinSelected, slideId);
+    if (target !== pinSelected) setSelected(target);
     if (
       contentRange &&
       pinSnapshot.text !== null &&
@@ -161,22 +194,48 @@ export function InspectorPanel() {
       styleOps.length === ops.length &&
       styleOps.every((op) => INLINE_CONTENT_STYLE_KEYS.has(op.key))
     ) {
-      for (const op of styleOps) {
-        applyEdit(pinSelected.line, pinSelected.column, [
-          {
-            kind: 'set-text-range-style',
-            start: contentRange.start,
-            end: contentRange.end,
-            key: op.key,
-            value: op.value,
-            prevText: pinSnapshot.text,
-          },
-        ]).catch((err) => {
-          if (err instanceof Error && err.name === 'NoOpEditError') return;
-          const msg = err instanceof Error ? err.message : String(err);
-          toast.error(`${t.inspector.saveFailed} ${msg}`);
-        });
-      }
+      bufferOps(
+        target.line,
+        target.column,
+        target.anchor,
+        styleOps.map((op) => ({
+          kind: 'set-text-range-style',
+          start: contentRange.start,
+          end: contentRange.end,
+          key: op.key,
+          value: op.value,
+          prevText: pinSnapshot.text,
+        })),
+      );
+      setRangeStylePreview((current) => ({
+        anchor: target.anchor,
+        start: contentRange.start,
+        end: contentRange.end,
+        values: {
+          ...(current?.anchor === target.anchor &&
+          current.start === contentRange.start &&
+          current.end === contentRange.end
+            ? current.values
+            : {}),
+          ...stylePreviewFromOps(styleOps),
+        },
+      }));
+      if (target.anchor.isConnected) setSnapshot(readSnapshot(target.anchor));
+      return;
+    }
+    if (
+      pinSnapshot.text !== null &&
+      styleOps.length > 0 &&
+      styleOps.length === ops.length &&
+      styleOps.every((op) => INLINE_CONTENT_STYLE_KEYS.has(op.key))
+    ) {
+      bufferOps(
+        target.line,
+        target.column,
+        target.anchor,
+        styleOps.map((op) => ({ ...op, prevText: pinSnapshot.text ?? undefined })),
+      );
+      if (target.anchor.isConnected) setSnapshot(readSnapshot(target.anchor));
       return;
     }
     apply(ops);
@@ -226,9 +285,9 @@ export function InspectorPanel() {
       <Separator />
 
       <Section title={t.inspector.typographySection}>
-        <FontSizeField snapshot={pinSnapshot} apply={applyTextStyle} />
-        <FontWeightField snapshot={pinSnapshot} apply={applyTextStyle} />
-        <StyleToggles snapshot={pinSnapshot} apply={applyTextStyle} />
+        <FontSizeField snapshot={typographySnapshot} apply={applyTextStyle} />
+        <FontWeightField snapshot={typographySnapshot} apply={applyTextStyle} />
+        <StyleToggles snapshot={typographySnapshot} apply={applyTextStyle} />
         <LineHeightField snapshot={pinSnapshot} apply={apply} />
         <LetterSpacingField snapshot={pinSnapshot} apply={apply} />
         <TextAlignField snapshot={pinSnapshot} apply={apply} />
@@ -239,7 +298,7 @@ export function InspectorPanel() {
       <Section title={t.inspector.colorSection}>
         <ColorField
           label={t.inspector.textColor}
-          value={pinSnapshot.color}
+          value={typographySnapshot.color}
           onChange={(v) => applyTextStyle([{ kind: 'set-style', key: 'color', value: v }])}
           clearable={false}
         />
@@ -307,6 +366,27 @@ const INLINE_CONTENT_STYLE_KEYS = new Set([
   'color',
 ]);
 
+function stylePreviewFromOps(ops: Array<Extract<EditOp, { kind: 'set-style' }>>): StylePreview {
+  const preview: StylePreview = {};
+  for (const op of ops) {
+    if (op.key === 'fontSize' && op.value) {
+      const n = parseFloat(op.value);
+      if (Number.isFinite(n)) preview.fontSize = n;
+    } else if (op.key === 'fontWeight') {
+      preview.fontWeight = op.value ? Number(op.value) || 400 : 400;
+    } else if (op.key === 'fontStyle') {
+      preview.fontStyle = op.value === 'italic' ? 'italic' : 'normal';
+    } else if (op.key === 'color' && op.value) {
+      preview.color = op.value;
+    }
+  }
+  return preview;
+}
+
+function withStylePreview(snapshot: ElementSnapshot, preview: StylePreview): ElementSnapshot {
+  return { ...snapshot, ...preview };
+}
+
 function ContentField({
   snapshot,
   apply,
@@ -357,8 +437,9 @@ function ContentField({
       onKeyUp={(e) => reportSelection(e.currentTarget)}
       onMouseUp={(e) => reportSelection(e.currentTarget)}
       onSelect={(e) => reportSelection(e.currentTarget)}
+      wrap="off"
       rows={3}
-      className="min-h-16 resize-none text-xs"
+      className="min-h-16 resize-none overflow-x-auto whitespace-pre text-xs"
       placeholder={t.inspector.elementTextPlaceholder}
     />
   );
@@ -1131,17 +1212,38 @@ function hasOnlyInlineTextChildren(el: HTMLElement): boolean {
 }
 
 function readEditableText(el: HTMLElement): string {
-  let text = '';
+  const parts: string[] = [];
   for (const child of Array.from(el.childNodes)) {
     if (child.nodeType === Node.TEXT_NODE) {
-      text += child.textContent ?? '';
+      parts.push(renderedTextNodeValue(child as Text));
     } else if (child instanceof HTMLBRElement) {
-      text += '\n';
+      parts.push('\n');
     } else if (child instanceof HTMLElement) {
-      text += readEditableText(child);
+      parts.push(readEditableText(child));
     }
   }
-  return text;
+  return normalizeRenderedText(parts);
+}
+
+function normalizeRenderedText(parts: string[]): string {
+  return parts
+    .map((part, index) => {
+      if (part === '\n') return part;
+      let next = part;
+      if (parts[index - 1] === '\n') next = next.replace(/^\s+/, '');
+      if (parts[index + 1] === '\n') next = next.replace(/\s+$/, '');
+      return next;
+    })
+    .join('');
+}
+
+function renderedTextNodeValue(node: Text): string {
+  const value = node.textContent ?? '';
+  const whiteSpace = node.parentElement ? getComputedStyle(node.parentElement).whiteSpace : '';
+  if (whiteSpace === 'pre' || whiteSpace === 'pre-wrap' || whiteSpace === 'break-spaces') {
+    return value;
+  }
+  return value.replace(/\s+/g, ' ');
 }
 
 function rgbToHex(value: string): string | null {

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -48,6 +48,111 @@ function readInstanceId(el: HTMLElement): string | null {
   return el.getAttribute(INSTANCE_ID_ATTR);
 }
 
+type DomTextPart = { node: Text | HTMLBRElement; current: string };
+
+function readEditableText(el: HTMLElement): string {
+  const parts: DomTextPart[] = [];
+  collectDomTextParts(el, parts);
+  return parts.map((part) => part.current).join('');
+}
+
+function collectDomTextParts(node: Node, out: DomTextPart[]): void {
+  for (const child of Array.from(node.childNodes)) {
+    if (child instanceof Text) {
+      if (child.data) out.push({ node: child, current: child.data });
+    } else if (child instanceof HTMLBRElement) {
+      out.push({ node: child, current: '\n' });
+    } else if (child instanceof HTMLElement) {
+      collectDomTextParts(child, out);
+    }
+  }
+}
+
+function textDiff(prevText: string, nextText: string) {
+  let start = 0;
+  while (
+    start < prevText.length &&
+    start < nextText.length &&
+    prevText[start] === nextText[start]
+  ) {
+    start += 1;
+  }
+
+  let prevEnd = prevText.length;
+  let nextEnd = nextText.length;
+  while (prevEnd > start && nextEnd > start && prevText[prevEnd - 1] === nextText[nextEnd - 1]) {
+    prevEnd -= 1;
+    nextEnd -= 1;
+  }
+
+  return { start, end: prevEnd, value: nextText.slice(start, nextEnd) };
+}
+
+function textFragment(value: string): DocumentFragment {
+  const fragment = document.createDocumentFragment();
+  const lines = value.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]) fragment.append(document.createTextNode(lines[i]));
+    if (i < lines.length - 1) fragment.append(document.createElement('br'));
+  }
+  return fragment;
+}
+
+function replaceDomTextPart(part: DomTextPart, value: string) {
+  if (part.node instanceof Text && !value.includes('\n')) {
+    part.node.data = value;
+    return;
+  }
+  const fragment = textFragment(value);
+  part.node.replaceWith(fragment);
+}
+
+function setEditableText(el: HTMLElement, value: string) {
+  const parts: DomTextPart[] = [];
+  collectDomTextParts(el, parts);
+  const current = parts.map((part) => part.current).join('');
+  if (current === value) return;
+  if (parts.length === 0) {
+    el.replaceChildren(textFragment(value));
+    return;
+  }
+
+  const diff = textDiff(current, value);
+  let offset = 0;
+  let inserted = false;
+  for (const part of parts) {
+    const partStart = offset;
+    const partEnd = partStart + part.current.length;
+    offset = partEnd;
+
+    const overlaps = diff.start < partEnd && diff.end > partStart;
+    const insertsHere =
+      diff.start === diff.end && !inserted && diff.start >= partStart && diff.start <= partEnd;
+    if (!overlaps && !insertsHere) continue;
+
+    if (part.node instanceof Text) {
+      const localStart = Math.max(diff.start, partStart) - partStart;
+      const localEnd = overlaps ? Math.min(diff.end, partEnd) - partStart : localStart;
+      replaceDomTextPart(
+        part,
+        `${part.current.slice(0, localStart)}${inserted ? '' : diff.value}${part.current.slice(localEnd)}`,
+      );
+    } else if (overlaps) {
+      replaceDomTextPart(part, inserted ? '' : diff.value);
+    } else {
+      const fragment = textFragment(diff.value);
+      if (diff.start === partStart) part.node.before(fragment);
+      else part.node.after(fragment);
+    }
+
+    inserted = true;
+  }
+
+  if (!inserted && diff.start === diff.end && diff.start === offset) {
+    el.append(textFragment(diff.value));
+  }
+}
+
 type InspectorCtx = {
   slideId: string;
   active: boolean;
@@ -169,10 +274,10 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
           if (!anchor) continue;
           const instanceId = ensureInstanceId(anchor);
           if (!bucket.origTexts.has(instanceId)) {
-            bucket.origTexts.set(instanceId, { value: anchor.textContent ?? '' });
+            bucket.origTexts.set(instanceId, { value: readEditableText(anchor) });
           }
           bucket.textOps.set(instanceId, { value: op.value });
-          if (anchor.isConnected) anchor.textContent = op.value;
+          if (anchor.isConnected) setEditableText(anchor, op.value);
         } else if (op.kind === 'set-attr-asset') {
           if (anchor && !bucket.origAttrs.has(op.attr)) {
             bucket.origAttrs.set(
@@ -239,7 +344,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
             snaps.push({
               kind: 'text',
               instanceId,
-              value: anchor.textContent ?? '',
+              value: readEditableText(anchor),
               existed: false,
             });
           }
@@ -297,11 +402,11 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
           const textAnchor = findAnchor(line, column, snap.instanceId);
           if (snap.existed) {
             bucket.textOps.set(snap.instanceId, { value: snap.value ?? '' });
-            if (textAnchor?.isConnected) textAnchor.textContent = snap.value ?? '';
+            if (textAnchor?.isConnected) setEditableText(textAnchor, snap.value ?? '');
           } else {
             bucket.textOps.delete(snap.instanceId);
             const orig = bucket.origTexts.get(snap.instanceId);
-            if (textAnchor?.isConnected) textAnchor.textContent = orig?.value ?? '';
+            if (textAnchor?.isConnected) setEditableText(textAnchor, orig?.value ?? '');
           }
         } else if (snap.kind === 'attr') {
           if (snap.source === 'op') {
@@ -462,7 +567,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       for (const [instanceId, orig] of b.origTexts) {
         const textEl =
           root?.querySelector<HTMLElement>(`[${INSTANCE_ID_ATTR}="${instanceId}"]`) ?? null;
-        if (textEl?.isConnected) textEl.textContent = orig.value;
+        if (textEl?.isConnected) setEditableText(textEl, orig.value);
       }
     }
     pendingRef.current = new Map();
@@ -510,8 +615,8 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       const instanceId = readInstanceId(el);
       if (instanceId) {
         const textOp = bucket.textOps.get(instanceId);
-        if (textOp && el.textContent !== textOp.value) {
-          el.textContent = textOp.value;
+        if (textOp && readEditableText(el) !== textOp.value) {
+          setEditableText(el, textOp.value);
         }
       }
       for (const [attr, op] of bucket.attrOps) {

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -422,7 +422,12 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
   // Pre-edit snapshot for history: capture the *currently effective* value of
   // each touched field so undo can restore exactly the prior state, including
   // the case where the bucket already had a buffered edit before this op.
-  type StyleSnap = { kind: 'style'; key: string; value: string | null; existed: boolean };
+  type StyleSnap = {
+    kind: 'style';
+    key: string;
+    value: Sequenced<StyleOp> | string | null;
+    existed: boolean;
+  };
   type RangeStyleSnap = {
     kind: 'range-style';
     id: string;
@@ -452,11 +457,12 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       const snaps: Snap[] = [];
       for (const op of ops) {
         if (op.kind === 'set-style') {
-          if (bucket?.styleOps.has(op.key)) {
+          const existing = bucket?.styleOps.get(op.key);
+          if (existing) {
             snaps.push({
               kind: 'style',
               key: op.key,
-              value: bucket.styleOps.get(op.key)?.value ?? null,
+              value: { ...existing },
               existed: true,
             });
           } else {
@@ -533,8 +539,12 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       for (const snap of snaps) {
         if (snap.kind === 'style') {
           if (snap.existed) {
-            const v = snap.value ?? '';
-            bucket.styleOps.set(snap.key, { value: snap.value, seq: ++pendingSeqRef.current });
+            const prev =
+              typeof snap.value === 'object' && snap.value !== null
+                ? snap.value
+                : { value: snap.value };
+            const v = prev.value ?? '';
+            bucket.styleOps.set(snap.key, { ...prev, seq: ++pendingSeqRef.current });
             if (sharedAnchor?.isConnected) sharedStyle[snap.key] = v;
           } else {
             bucket.styleOps.delete(snap.key);
@@ -601,6 +611,11 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
 
   const bufferOps = useCallback(
     (line: number, column: number, anchor: HTMLElement, ops: EditOp[]) => {
+      const instanceId = ops.some(
+        (op) => op.kind === 'set-text' || op.kind === 'set-text-range-style',
+      )
+        ? ensureInstanceId(anchor)
+        : undefined;
       const snaps = snapshotForOps(line, column, anchor, ops);
       applyOpsRaw(line, column, anchor, ops);
       const first = ops[0];
@@ -615,10 +630,10 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       history.record({
         coalesceKey,
         undo: () => restoreSnapshot(line, column, snaps),
-        redo: () => applyOpsRaw(line, column, findAnchor(line, column), ops),
+        redo: () => applyOpsRaw(line, column, findAnchor(line, column, instanceId), ops),
       });
     },
-    [applyOpsRaw, snapshotForOps, restoreSnapshot, findAnchor, history],
+    [applyOpsRaw, snapshotForOps, restoreSnapshot, findAnchor, history, ensureInstanceId],
   );
 
   const commitEdits = useCallback(async () => {

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -24,11 +24,21 @@ export type SelectedTarget = {
 };
 
 type AssetAttrOp = { assetPath: string; previewUrl: string };
+type StyleOp = { value: string | null; prevText?: string };
+type TextRangeStyleOp = {
+  instanceId: string;
+  start: number;
+  end: number;
+  key: string;
+  value: string | null;
+  prevText?: string;
+};
 
 type Bucket = {
   line: number;
   column: number;
-  styleOps: Map<string, string | null>;
+  styleOps: Map<string, StyleOp>;
+  rangeStyleOps: Map<string, TextRangeStyleOp>;
   // Text edits are scoped per DOM instance: a reused component renders
   // the same JSX `<h2>{title}</h2>` at multiple call sites with the same
   // `data-slide-loc`, but each call site's prop literal is independent.
@@ -39,6 +49,7 @@ type Bucket = {
   // each style key / text / attribute. Used by `cancelEdits` to revert.
   origStyle: Map<string, string>;
   origTexts: Map<string /* instanceId */, { value: string }>;
+  origHtmls: Map<string /* instanceId */, string>;
   origAttrs: Map<string, string | null>;
 };
 
@@ -57,15 +68,40 @@ function readEditableText(el: HTMLElement): string {
 }
 
 function collectDomTextParts(node: Node, out: DomTextPart[]): void {
+  const parts: DomTextPart[] = [];
+  collectDomTextPartsRaw(node, parts);
+  out.push(...normalizeDomTextParts(parts));
+}
+
+function collectDomTextPartsRaw(node: Node, out: DomTextPart[]): void {
   for (const child of Array.from(node.childNodes)) {
     if (child instanceof Text) {
-      if (child.data) out.push({ node: child, current: child.data });
+      const current = renderedTextNodeValue(child);
+      if (current) out.push({ node: child, current });
     } else if (child instanceof HTMLBRElement) {
       out.push({ node: child, current: '\n' });
     } else if (child instanceof HTMLElement) {
-      collectDomTextParts(child, out);
+      collectDomTextPartsRaw(child, out);
     }
   }
+}
+
+function normalizeDomTextParts(parts: DomTextPart[]): DomTextPart[] {
+  return parts.flatMap((part, index) => {
+    if (part.current === '\n') return [part];
+    let current = part.current;
+    if (parts[index - 1]?.current === '\n') current = current.replace(/^\s+/, '');
+    if (parts[index + 1]?.current === '\n') current = current.replace(/\s+$/, '');
+    return current ? [{ ...part, current }] : [];
+  });
+}
+
+function renderedTextNodeValue(node: Text): string {
+  const whiteSpace = node.parentElement ? getComputedStyle(node.parentElement).whiteSpace : '';
+  if (whiteSpace === 'pre' || whiteSpace === 'pre-wrap' || whiteSpace === 'break-spaces') {
+    return node.data;
+  }
+  return node.data.replace(/\s+/g, ' ');
 }
 
 function textDiff(prevText: string, nextText: string) {
@@ -153,6 +189,56 @@ function setEditableText(el: HTMLElement, value: string) {
   }
 }
 
+function rangeStyleKey(
+  instanceId: string,
+  op: { start: number; end: number; key: string },
+): string {
+  return `${instanceId}:${op.start}:${op.end}:${op.key}`;
+}
+
+function applyDomTextRangeStyle(
+  el: HTMLElement,
+  op: Pick<TextRangeStyleOp, 'start' | 'end' | 'key' | 'value'>,
+) {
+  const value = op.value ?? resetValueForRangeStyle(op.key);
+  if (value === null) return;
+  const parts: DomTextPart[] = [];
+  collectDomTextParts(el, parts);
+  let offset = 0;
+  for (const part of parts) {
+    const partStart = offset;
+    const partEnd = partStart + part.current.length;
+    offset = partEnd;
+    if (!(part.node instanceof Text)) continue;
+    const selectedStart = Math.max(op.start, partStart);
+    const selectedEnd = Math.min(op.end, partEnd);
+    if (selectedStart >= selectedEnd) continue;
+
+    const localStart = selectedStart - partStart;
+    const localEnd = selectedEnd - partStart;
+    const before = part.current.slice(0, localStart);
+    const selected = part.current.slice(localStart, localEnd);
+    const after = part.current.slice(localEnd);
+    const span = document.createElement('span');
+    (span.style as unknown as Record<string, string>)[op.key] = value;
+    span.textContent = selected;
+    part.node.replaceWith(document.createTextNode(before), span, document.createTextNode(after));
+  }
+}
+
+function resetValueForRangeStyle(key: string): string | null {
+  if (key === 'fontWeight') return '400';
+  if (key === 'fontStyle') return 'normal';
+  return null;
+}
+
+function replayDomTextRangeStyles(el: HTMLElement, html: string, ops: TextRangeStyleOp[]) {
+  const preview = document.createElement('span');
+  preview.innerHTML = html;
+  for (const op of ops) applyDomTextRangeStyle(preview, op);
+  if (el.innerHTML !== preview.innerHTML) el.innerHTML = preview.innerHTML;
+}
+
 type InspectorCtx = {
   slideId: string;
   active: boolean;
@@ -221,7 +307,14 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
   const refreshCount = useCallback(() => {
     let n = 0;
     for (const b of pendingRef.current.values()) {
-      if (b.styleOps.size > 0 || b.textOps.size > 0 || b.attrOps.size > 0) n++;
+      if (
+        b.styleOps.size > 0 ||
+        b.rangeStyleOps.size > 0 ||
+        b.textOps.size > 0 ||
+        b.attrOps.size > 0
+      ) {
+        n++;
+      }
     }
     setPendingCount(n);
   }, []);
@@ -251,10 +344,12 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
           line,
           column,
           styleOps: new Map(),
+          rangeStyleOps: new Map(),
           textOps: new Map(),
           attrOps: new Map(),
           origStyle: new Map(),
           origTexts: new Map(),
+          origHtmls: new Map(),
           origAttrs: new Map(),
         };
         pendingRef.current.set(key, bucket);
@@ -265,8 +360,30 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
           if (anchor && !bucket.origStyle.has(op.key)) {
             bucket.origStyle.set(op.key, style[op.key] ?? '');
           }
-          bucket.styleOps.set(op.key, op.value);
+          bucket.styleOps.set(op.key, { value: op.value, prevText: op.prevText });
           if (anchor?.isConnected) style[op.key] = op.value ?? '';
+        } else if (op.kind === 'set-text-range-style') {
+          if (!anchor) continue;
+          const instanceId = ensureInstanceId(anchor);
+          if (!bucket.origHtmls.has(instanceId)) bucket.origHtmls.set(instanceId, anchor.innerHTML);
+          const nextOp: TextRangeStyleOp = {
+            instanceId,
+            start: op.start,
+            end: op.end,
+            key: op.key,
+            value: op.value,
+            prevText: op.prevText ?? readEditableText(anchor),
+          };
+          bucket.rangeStyleOps.set(rangeStyleKey(instanceId, op), nextOp);
+          if (anchor.isConnected) {
+            replayDomTextRangeStyles(
+              anchor,
+              bucket.origHtmls.get(instanceId) ?? anchor.innerHTML,
+              Array.from(bucket.rangeStyleOps.values()).filter(
+                (item) => item.instanceId === instanceId,
+              ),
+            );
+          }
         } else if (op.kind === 'set-text') {
           // Reused JSX renders multiple DOM nodes with the same
           // `data-slide-loc` but distinct call-site literals; without an
@@ -298,6 +415,13 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
   // each touched field so undo can restore exactly the prior state, including
   // the case where the bucket already had a buffered edit before this op.
   type StyleSnap = { kind: 'style'; key: string; value: string | null; existed: boolean };
+  type RangeStyleSnap = {
+    kind: 'range-style';
+    id: string;
+    instanceId: string;
+    value: TextRangeStyleOp | null;
+    existed: boolean;
+  };
   type TextSnap = {
     kind: 'text';
     instanceId: string;
@@ -310,7 +434,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
     value: AssetAttrOp | string | null;
     source: 'op' | 'orig' | 'dom-missing' | 'dom-present';
   };
-  type Snap = StyleSnap | TextSnap | AttrSnap;
+  type Snap = StyleSnap | RangeStyleSnap | TextSnap | AttrSnap;
 
   const snapshotForOps = useCallback(
     (line: number, column: number, anchor: HTMLElement, ops: EditOp[]): Snap[] => {
@@ -324,7 +448,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
             snaps.push({
               kind: 'style',
               key: op.key,
-              value: bucket.styleOps.get(op.key) ?? null,
+              value: bucket.styleOps.get(op.key)?.value ?? null,
               existed: true,
             });
           } else {
@@ -335,6 +459,17 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
               existed: false,
             });
           }
+        } else if (op.kind === 'set-text-range-style') {
+          const instanceId = ensureInstanceId(anchor);
+          const id = rangeStyleKey(instanceId, op);
+          const existing = bucket?.rangeStyleOps.get(id);
+          snaps.push({
+            kind: 'range-style',
+            id,
+            instanceId,
+            value: existing ? { ...existing } : null,
+            existed: !!existing,
+          });
         } else if (op.kind === 'set-text') {
           const instanceId = ensureInstanceId(anchor);
           const existing = bucket?.textOps.get(instanceId);
@@ -391,12 +526,29 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
         if (snap.kind === 'style') {
           if (snap.existed) {
             const v = snap.value ?? '';
-            bucket.styleOps.set(snap.key, snap.value);
+            bucket.styleOps.set(snap.key, { value: snap.value });
             if (sharedAnchor?.isConnected) sharedStyle[snap.key] = v;
           } else {
             bucket.styleOps.delete(snap.key);
             const orig = bucket.origStyle.get(snap.key);
             if (sharedAnchor?.isConnected) sharedStyle[snap.key] = orig ?? '';
+          }
+        } else if (snap.kind === 'range-style') {
+          const textAnchor = findAnchor(line, column, snap.instanceId);
+          if (snap.existed && snap.value) {
+            bucket.rangeStyleOps.set(snap.id, snap.value);
+          } else {
+            bucket.rangeStyleOps.delete(snap.id);
+          }
+          const html = bucket.origHtmls.get(snap.instanceId);
+          if (textAnchor?.isConnected && html !== undefined) {
+            replayDomTextRangeStyles(
+              textAnchor,
+              html,
+              Array.from(bucket.rangeStyleOps.values()).filter(
+                (op) => op.instanceId === snap.instanceId,
+              ),
+            );
           }
         } else if (snap.kind === 'text') {
           const textAnchor = findAnchor(line, column, snap.instanceId);
@@ -423,7 +575,12 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
           }
         }
       }
-      if (bucket.styleOps.size === 0 && bucket.textOps.size === 0 && bucket.attrOps.size === 0) {
+      if (
+        bucket.styleOps.size === 0 &&
+        bucket.rangeStyleOps.size === 0 &&
+        bucket.textOps.size === 0 &&
+        bucket.attrOps.size === 0
+      ) {
         pendingRef.current.delete(key);
       }
       refreshCount();
@@ -467,10 +624,17 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
     };
     const pending: PendingItem[] = [];
     for (const [key, bucket] of buckets) {
-      const { line, column, styleOps, textOps, attrOps, origTexts } = bucket;
+      const { line, column, styleOps, rangeStyleOps, textOps, attrOps, origTexts } = bucket;
       // Shared edit (style + asset attrs) — one per bucket.
       const sharedOps: EditOp[] = [];
-      for (const [k, v] of styleOps) sharedOps.push({ kind: 'set-style', key: k, value: v });
+      for (const [k, op] of styleOps) {
+        sharedOps.push({
+          kind: 'set-style',
+          key: k,
+          value: op.value,
+          prevText: op.prevText,
+        });
+      }
       for (const [attr, op] of attrOps) {
         sharedOps.push({
           kind: 'set-attr-asset',
@@ -486,6 +650,28 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
           onSuccess: (b) => {
             b.styleOps.clear();
             b.attrOps.clear();
+          },
+        });
+      }
+      for (const [id, op] of rangeStyleOps) {
+        pending.push({
+          key,
+          edit: {
+            line,
+            column,
+            ops: [
+              {
+                kind: 'set-text-range-style',
+                start: op.start,
+                end: op.end,
+                key: op.key,
+                value: op.value,
+                prevText: op.prevText,
+              },
+            ],
+          },
+          onSuccess: (b) => {
+            b.rangeStyleOps.delete(id);
           },
         });
       }
@@ -525,6 +711,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
             item.onSuccess(bucket);
             if (
               bucket.styleOps.size === 0 &&
+              bucket.rangeStyleOps.size === 0 &&
               bucket.textOps.size === 0 &&
               bucket.attrOps.size === 0
             ) {
@@ -564,6 +751,11 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
         }
       }
       // Each text edit has its own anchor — locate by instance id.
+      for (const [instanceId, html] of b.origHtmls) {
+        const textEl =
+          root?.querySelector<HTMLElement>(`[${INSTANCE_ID_ATTR}="${instanceId}"]`) ?? null;
+        if (textEl?.isConnected) textEl.innerHTML = html;
+      }
       for (const [instanceId, orig] of b.origTexts) {
         const textEl =
           root?.querySelector<HTMLElement>(`[${INSTANCE_ID_ATTR}="${instanceId}"]`) ?? null;
@@ -605,8 +797,8 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       const bucket = pendingRef.current.get(loc);
       if (!bucket) return;
       const style = el.style as unknown as Record<string, string>;
-      for (const [key, value] of bucket.styleOps) {
-        const v = value ?? '';
+      for (const [key, op] of bucket.styleOps) {
+        const v = op.value ?? '';
         if (style[key] !== v) style[key] = v;
       }
       // Text replays per-instance: only the originally clicked DOM node
@@ -614,6 +806,14 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       // value, so siblings of a reused component aren't clobbered.
       const instanceId = readInstanceId(el);
       if (instanceId) {
+        const html = bucket.origHtmls.get(instanceId);
+        if (html !== undefined) {
+          replayDomTextRangeStyles(
+            el,
+            html,
+            Array.from(bucket.rangeStyleOps.values()).filter((op) => op.instanceId === instanceId),
+          );
+        }
         const textOp = bucket.textOps.get(instanceId);
         if (textOp && readEditableText(el) !== textOp.value) {
           setEditableText(el, textOp.value);
@@ -624,15 +824,18 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       }
     };
 
+    let observer: MutationObserver | null = null;
     const replayAll = () => {
       if (pendingRef.current.size === 0) return;
+      observer?.disconnect();
       root.querySelectorAll<HTMLElement>('[data-slide-loc]').forEach(applyBuffered);
+      observer?.observe(root, { childList: true, subtree: true });
     };
 
     replayAll();
-    const observer = new MutationObserver(replayAll);
+    observer = new MutationObserver(replayAll);
     observer.observe(root, { childList: true, subtree: true });
-    return () => observer.disconnect();
+    return () => observer?.disconnect();
   }, []);
 
   const toggle = useCallback(() => {

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -24,6 +24,7 @@ export type SelectedTarget = {
 };
 
 type AssetAttrOp = { assetPath: string; previewUrl: string };
+type Sequenced<T> = T & { seq: number };
 type StyleOp = { value: string | null; prevText?: string };
 type TextRangeStyleOp = {
   instanceId: string;
@@ -37,14 +38,14 @@ type TextRangeStyleOp = {
 type Bucket = {
   line: number;
   column: number;
-  styleOps: Map<string, StyleOp>;
-  rangeStyleOps: Map<string, TextRangeStyleOp>;
+  styleOps: Map<string, Sequenced<StyleOp>>;
+  rangeStyleOps: Map<string, Sequenced<TextRangeStyleOp>>;
   // Text edits are scoped per DOM instance: a reused component renders
   // the same JSX `<h2>{title}</h2>` at multiple call sites with the same
   // `data-slide-loc`, but each call site's prop literal is independent.
   // Style/attr ops stay shared because they edit the JSX definition.
-  textOps: Map<string /* instanceId */, { value: string }>;
-  attrOps: Map<string, AssetAttrOp>;
+  textOps: Map<string /* instanceId */, Sequenced<{ value: string }>>;
+  attrOps: Map<string, Sequenced<AssetAttrOp>>;
   // Pre-edit snapshot of the DOM, captured the first time we touch
   // each style key / text / attribute. Used by `cancelEdits` to revert.
   origStyle: Map<string, string>;
@@ -281,6 +282,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
 
   const pendingRef = useRef<Map<string, Bucket>>(new Map());
   const instanceCounterRef = useRef(0);
+  const pendingSeqRef = useRef(0);
   const [pendingCount, setPendingCount] = useState(0);
   const [committing, setCommitting] = useState(false);
   const [cropTarget, setCropTarget] = useState<{
@@ -356,23 +358,25 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       }
       const style = (anchor?.style ?? {}) as unknown as Record<string, string>;
       for (const op of ops) {
+        const seq = ++pendingSeqRef.current;
         if (op.kind === 'set-style') {
           if (anchor && !bucket.origStyle.has(op.key)) {
             bucket.origStyle.set(op.key, style[op.key] ?? '');
           }
-          bucket.styleOps.set(op.key, { value: op.value, prevText: op.prevText });
+          bucket.styleOps.set(op.key, { value: op.value, prevText: op.prevText, seq });
           if (anchor?.isConnected) style[op.key] = op.value ?? '';
         } else if (op.kind === 'set-text-range-style') {
           if (!anchor) continue;
           const instanceId = ensureInstanceId(anchor);
           if (!bucket.origHtmls.has(instanceId)) bucket.origHtmls.set(instanceId, anchor.innerHTML);
-          const nextOp: TextRangeStyleOp = {
+          const nextOp: Sequenced<TextRangeStyleOp> = {
             instanceId,
             start: op.start,
             end: op.end,
             key: op.key,
             value: op.value,
             prevText: op.prevText ?? readEditableText(anchor),
+            seq,
           };
           bucket.rangeStyleOps.set(rangeStyleKey(instanceId, op), nextOp);
           if (anchor.isConnected) {
@@ -393,7 +397,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
           if (!bucket.origTexts.has(instanceId)) {
             bucket.origTexts.set(instanceId, { value: readEditableText(anchor) });
           }
-          bucket.textOps.set(instanceId, { value: op.value });
+          bucket.textOps.set(instanceId, { value: op.value, seq });
           if (anchor.isConnected) setEditableText(anchor, op.value);
         } else if (op.kind === 'set-attr-asset') {
           if (anchor && !bucket.origAttrs.has(op.attr)) {
@@ -402,7 +406,11 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
               anchor.hasAttribute(op.attr) ? anchor.getAttribute(op.attr) : null,
             );
           }
-          bucket.attrOps.set(op.attr, { assetPath: op.assetPath, previewUrl: op.previewUrl });
+          bucket.attrOps.set(op.attr, {
+            assetPath: op.assetPath,
+            previewUrl: op.previewUrl,
+            seq,
+          });
           if (anchor?.isConnected) anchor.setAttribute(op.attr, op.previewUrl);
         }
       }
@@ -419,7 +427,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
     kind: 'range-style';
     id: string;
     instanceId: string;
-    value: TextRangeStyleOp | null;
+    value: Sequenced<TextRangeStyleOp> | null;
     existed: boolean;
   };
   type TextSnap = {
@@ -431,7 +439,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
   type AttrSnap = {
     kind: 'attr';
     attr: string;
-    value: AssetAttrOp | string | null;
+    value: Sequenced<AssetAttrOp> | string | null;
     source: 'op' | 'orig' | 'dom-missing' | 'dom-present';
   };
   type Snap = StyleSnap | RangeStyleSnap | TextSnap | AttrSnap;
@@ -526,7 +534,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
         if (snap.kind === 'style') {
           if (snap.existed) {
             const v = snap.value ?? '';
-            bucket.styleOps.set(snap.key, { value: snap.value });
+            bucket.styleOps.set(snap.key, { value: snap.value, seq: ++pendingSeqRef.current });
             if (sharedAnchor?.isConnected) sharedStyle[snap.key] = v;
           } else {
             bucket.styleOps.delete(snap.key);
@@ -536,7 +544,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
         } else if (snap.kind === 'range-style') {
           const textAnchor = findAnchor(line, column, snap.instanceId);
           if (snap.existed && snap.value) {
-            bucket.rangeStyleOps.set(snap.id, snap.value);
+            bucket.rangeStyleOps.set(snap.id, { ...snap.value, seq: ++pendingSeqRef.current });
           } else {
             bucket.rangeStyleOps.delete(snap.id);
           }
@@ -553,7 +561,10 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
         } else if (snap.kind === 'text') {
           const textAnchor = findAnchor(line, column, snap.instanceId);
           if (snap.existed) {
-            bucket.textOps.set(snap.instanceId, { value: snap.value ?? '' });
+            bucket.textOps.set(snap.instanceId, {
+              value: snap.value ?? '',
+              seq: ++pendingSeqRef.current,
+            });
             if (textAnchor?.isConnected) setEditableText(textAnchor, snap.value ?? '');
           } else {
             bucket.textOps.delete(snap.instanceId);
@@ -562,8 +573,8 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
           }
         } else if (snap.kind === 'attr') {
           if (snap.source === 'op') {
-            const op = snap.value as AssetAttrOp;
-            bucket.attrOps.set(snap.attr, op);
+            const op = snap.value as Sequenced<AssetAttrOp>;
+            bucket.attrOps.set(snap.attr, { ...op, seq: ++pendingSeqRef.current });
             if (sharedAnchor?.isConnected) sharedAnchor.setAttribute(snap.attr, op.previewUrl);
           } else {
             bucket.attrOps.delete(snap.attr);
@@ -613,49 +624,54 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
   const commitEdits = useCallback(async () => {
     const buckets = pendingRef.current;
     if (buckets.size === 0) return;
-    // Each bucket flattens to one Edit per text instance plus one Edit
-    // for the shared style/attr ops. We track which entries in `pending`
-    // belong to which bucket so a per-edit failure can clear just the
-    // landed pieces while leaving the rest buffered for retry.
     type PendingItem = {
       key: string;
+      seq: number;
       edit: Edit;
       onSuccess: (bucket: Bucket) => void;
     };
     const pending: PendingItem[] = [];
     for (const [key, bucket] of buckets) {
       const { line, column, styleOps, rangeStyleOps, textOps, attrOps, origTexts } = bucket;
-      // Shared edit (style + asset attrs) — one per bucket.
-      const sharedOps: EditOp[] = [];
       for (const [k, op] of styleOps) {
-        sharedOps.push({
-          kind: 'set-style',
-          key: k,
-          value: op.value,
-          prevText: op.prevText,
+        pending.push({
+          key,
+          seq: op.seq,
+          edit: {
+            line,
+            column,
+            ops: [{ kind: 'set-style', key: k, value: op.value, prevText: op.prevText }],
+          },
+          onSuccess: (b) => {
+            b.styleOps.delete(k);
+          },
         });
       }
       for (const [attr, op] of attrOps) {
-        sharedOps.push({
-          kind: 'set-attr-asset',
-          attr,
-          assetPath: op.assetPath,
-          previewUrl: op.previewUrl,
-        });
-      }
-      if (sharedOps.length > 0) {
         pending.push({
           key,
-          edit: { line, column, ops: sharedOps },
+          seq: op.seq,
+          edit: {
+            line,
+            column,
+            ops: [
+              {
+                kind: 'set-attr-asset',
+                attr,
+                assetPath: op.assetPath,
+                previewUrl: op.previewUrl,
+              },
+            ],
+          },
           onSuccess: (b) => {
-            b.styleOps.clear();
-            b.attrOps.clear();
+            b.attrOps.delete(attr);
           },
         });
       }
       for (const [id, op] of rangeStyleOps) {
         pending.push({
           key,
+          seq: op.seq,
           edit: {
             line,
             column,
@@ -681,6 +697,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
         const orig = origTexts.get(instanceId);
         pending.push({
           key,
+          seq: textOp.seq,
           edit: {
             line,
             column,
@@ -692,6 +709,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
         });
       }
     }
+    pending.sort((a, b) => a.seq - b.seq);
     if (pending.length === 0) {
       pendingRef.current = new Map();
       setPendingCount(0);

--- a/packages/core/src/app/lib/inspector/use-editor.ts
+++ b/packages/core/src/app/lib/inspector/use-editor.ts
@@ -3,6 +3,14 @@ import { useCallback } from 'react';
 export type EditOp =
   | { kind: 'set-style'; key: string; value: string | null }
   | { kind: 'set-text'; value: string; prevText?: string }
+  | {
+      kind: 'set-text-range-style';
+      start: number;
+      end: number;
+      key: string;
+      value: string | null;
+      prevText?: string;
+    }
   | { kind: 'set-attr-asset'; attr: string; assetPath: string; previewUrl: string }
   | { kind: 'replace-placeholder-with-image'; assetPath: string };
 

--- a/packages/core/src/app/lib/inspector/use-editor.ts
+++ b/packages/core/src/app/lib/inspector/use-editor.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 export type EditOp =
-  | { kind: 'set-style'; key: string; value: string | null }
+  | { kind: 'set-style'; key: string; value: string | null; prevText?: string }
   | { kind: 'set-text'; value: string; prevText?: string }
   | {
       kind: 'set-text-range-style';

--- a/packages/core/src/app/lib/slides.ts
+++ b/packages/core/src/app/lib/slides.ts
@@ -15,3 +15,10 @@ export function slidesByTheme(themeId: string): string[] {
 export async function loadSlide(id: string): Promise<SlideModule> {
   return load(id);
 }
+
+export function slideChangeIncludes(data: unknown, slideId: string): boolean {
+  if (!data || typeof data !== 'object') return false;
+  const payload = data as { slideId?: unknown; slideIds?: unknown };
+  if (payload.slideId === slideId) return true;
+  return Array.isArray(payload.slideIds) && payload.slideIds.includes(slideId);
+}

--- a/packages/core/src/app/lib/use-slide-module.ts
+++ b/packages/core/src/app/lib/use-slide-module.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SlideModule } from './sdk';
+import { loadSlide, slideChangeIncludes } from './slides';
+
+export function useSlideModule(slideId: string) {
+  const [slide, setSlide] = useState<SlideModule | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const loadSeqRef = useRef(0);
+
+  const reload = useCallback(
+    (reset: boolean) => {
+      const seq = ++loadSeqRef.current;
+      if (reset) setSlide(null);
+      setError(null);
+      loadSlide(slideId)
+        .then((mod) => {
+          if (seq === loadSeqRef.current) setSlide(mod);
+        })
+        .catch((e) => {
+          if (seq === loadSeqRef.current) setError(String(e?.message ?? e));
+        });
+    },
+    [slideId],
+  );
+
+  useEffect(() => {
+    reload(true);
+  }, [reload]);
+
+  useEffect(() => {
+    if (!import.meta.hot) return;
+    let cancelled = false;
+    const handler = (data: unknown) => {
+      if (slideChangeIncludes(data, slideId)) {
+        queueMicrotask(() => {
+          if (!cancelled) reload(false);
+        });
+      }
+    };
+    import.meta.hot.on('open-slide:slide-changed', handler);
+    return () => {
+      cancelled = true;
+      import.meta.hot?.off('open-slide:slide-changed', handler);
+    };
+  }, [slideId, reload]);
+
+  return { slide, error, reload };
+}

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -9,14 +9,12 @@ import {
   usePresenterChannel,
 } from '../components/present/use-presenter-channel';
 import { SlideCanvas } from '../components/slide-canvas';
-import type { SlideModule } from '../lib/sdk';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
-import { loadSlide, slideChangeIncludes } from '../lib/slides';
+import { useSlideModule } from '../lib/use-slide-module';
 
 export function Presenter() {
   const { slideId = '' } = useParams();
-  const [slide, setSlide] = useState<SlideModule | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const { slide, error } = useSlideModule(slideId);
 
   // Presenter view is a passive mirror of the projection window. It only
   // tracks the index it last heard about; navigation buttons send commands
@@ -27,39 +25,7 @@ export function Presenter() {
   const [localStart] = useState(() => Date.now());
   const [hasProjection, setHasProjection] = useState(false);
   const requestedRef = useRef(false);
-  const loadSeqRef = useRef(0);
   const t = useLocale();
-
-  const reloadSlide = useCallback(
-    (reset: boolean) => {
-      const seq = ++loadSeqRef.current;
-      if (reset) setSlide(null);
-      setError(null);
-      loadSlide(slideId)
-        .then((mod) => {
-          if (seq === loadSeqRef.current) setSlide(mod);
-        })
-        .catch((e) => {
-          if (seq === loadSeqRef.current) setError(String(e?.message ?? e));
-        });
-    },
-    [slideId],
-  );
-
-  useEffect(() => {
-    reloadSlide(true);
-  }, [reloadSlide]);
-
-  useEffect(() => {
-    if (!import.meta.hot) return;
-    const handler = (data: unknown) => {
-      if (slideChangeIncludes(data, slideId)) reloadSlide(false);
-    };
-    import.meta.hot.on('open-slide:slide-changed', handler);
-    return () => {
-      import.meta.hot?.off('open-slide:slide-changed', handler);
-    };
-  }, [slideId, reloadSlide]);
 
   const channel = usePresenterChannel(slideId, (msg) => {
     if (msg.type === 'state') {

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -11,7 +11,7 @@ import {
 import { SlideCanvas } from '../components/slide-canvas';
 import type { SlideModule } from '../lib/sdk';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
-import { loadSlide } from '../lib/slides';
+import { loadSlide, slideChangeIncludes } from '../lib/slides';
 
 export function Presenter() {
   const { slideId = '' } = useParams();
@@ -27,23 +27,39 @@ export function Presenter() {
   const [localStart] = useState(() => Date.now());
   const [hasProjection, setHasProjection] = useState(false);
   const requestedRef = useRef(false);
+  const loadSeqRef = useRef(0);
   const t = useLocale();
 
+  const reloadSlide = useCallback(
+    (reset: boolean) => {
+      const seq = ++loadSeqRef.current;
+      if (reset) setSlide(null);
+      setError(null);
+      loadSlide(slideId)
+        .then((mod) => {
+          if (seq === loadSeqRef.current) setSlide(mod);
+        })
+        .catch((e) => {
+          if (seq === loadSeqRef.current) setError(String(e?.message ?? e));
+        });
+    },
+    [slideId],
+  );
+
   useEffect(() => {
-    let cancelled = false;
-    setSlide(null);
-    setError(null);
-    loadSlide(slideId)
-      .then((mod) => {
-        if (!cancelled) setSlide(mod);
-      })
-      .catch((e) => {
-        if (!cancelled) setError(String(e?.message ?? e));
-      });
-    return () => {
-      cancelled = true;
+    reloadSlide(true);
+  }, [reloadSlide]);
+
+  useEffect(() => {
+    if (!import.meta.hot) return;
+    const handler = (data: unknown) => {
+      if (slideChangeIncludes(data, slideId)) reloadSlide(false);
     };
-  }, [slideId]);
+    import.meta.hot.on('open-slide:slide-changed', handler);
+    return () => {
+      import.meta.hot?.off('open-slide:slide-changed', handler);
+    };
+  }, [slideId, reloadSlide]);
 
   const channel = usePresenterChannel(slideId, (msg) => {
     if (msg.type === 'state') {

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -39,54 +39,20 @@ import { type ThumbnailActions, ThumbnailRail } from '../components/thumbnail-ra
 import { exportSlideAsHtml } from '../lib/export-html';
 import { exportSlideAsPdf } from '../lib/export-pdf';
 import { remapNotesSessionCacheAfterReorder } from '../lib/inspector/use-notes';
-import type { SlideModule } from '../lib/sdk';
-import { loadSlide, slideChangeIncludes } from '../lib/slides';
+import { useSlideModule } from '../lib/use-slide-module';
 
 const { showSlideUi, showSlideBrowser, allowHtmlDownload } = config.build;
 
 export function Slide() {
   const { slideId = '' } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [slide, setSlide] = useState<SlideModule | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const { slide, error } = useSlideModule(slideId);
   const [playing, setPlaying] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [designOpen, setDesignOpen] = useState(false);
   const { renameSlide } = useFolders();
   const slideViewportRef = useRef<HTMLElement>(null);
-  const loadSeqRef = useRef(0);
   const t = useLocale();
-
-  const reloadSlide = useCallback(
-    (reset: boolean) => {
-      const seq = ++loadSeqRef.current;
-      if (reset) setSlide(null);
-      setError(null);
-      loadSlide(slideId)
-        .then((mod) => {
-          if (seq === loadSeqRef.current) setSlide(mod);
-        })
-        .catch((e) => {
-          if (seq === loadSeqRef.current) setError(String(e?.message ?? e));
-        });
-    },
-    [slideId],
-  );
-
-  useEffect(() => {
-    reloadSlide(true);
-  }, [reloadSlide]);
-
-  useEffect(() => {
-    if (!import.meta.hot) return;
-    const handler = (data: unknown) => {
-      if (slideChangeIncludes(data, slideId)) reloadSlide(false);
-    };
-    import.meta.hot.on('open-slide:slide-changed', handler);
-    return () => {
-      import.meta.hot?.off('open-slide:slide-changed', handler);
-    };
-  }, [slideId, reloadSlide]);
 
   const modulePages = useMemo(() => slide?.default ?? [], [slide]);
   const [pages, setPages] = useState<typeof modulePages>(modulePages);

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -40,7 +40,7 @@ import { exportSlideAsHtml } from '../lib/export-html';
 import { exportSlideAsPdf } from '../lib/export-pdf';
 import { remapNotesSessionCacheAfterReorder } from '../lib/inspector/use-notes';
 import type { SlideModule } from '../lib/sdk';
-import { loadSlide } from '../lib/slides';
+import { loadSlide, slideChangeIncludes } from '../lib/slides';
 
 const { showSlideUi, showSlideBrowser, allowHtmlDownload } = config.build;
 
@@ -54,23 +54,39 @@ export function Slide() {
   const [designOpen, setDesignOpen] = useState(false);
   const { renameSlide } = useFolders();
   const slideViewportRef = useRef<HTMLElement>(null);
+  const loadSeqRef = useRef(0);
   const t = useLocale();
 
+  const reloadSlide = useCallback(
+    (reset: boolean) => {
+      const seq = ++loadSeqRef.current;
+      if (reset) setSlide(null);
+      setError(null);
+      loadSlide(slideId)
+        .then((mod) => {
+          if (seq === loadSeqRef.current) setSlide(mod);
+        })
+        .catch((e) => {
+          if (seq === loadSeqRef.current) setError(String(e?.message ?? e));
+        });
+    },
+    [slideId],
+  );
+
   useEffect(() => {
-    let cancelled = false;
-    setSlide(null);
-    setError(null);
-    loadSlide(slideId)
-      .then((mod) => {
-        if (!cancelled) setSlide(mod);
-      })
-      .catch((e) => {
-        if (!cancelled) setError(String(e?.message ?? e));
-      });
-    return () => {
-      cancelled = true;
+    reloadSlide(true);
+  }, [reloadSlide]);
+
+  useEffect(() => {
+    if (!import.meta.hot) return;
+    const handler = (data: unknown) => {
+      if (slideChangeIncludes(data, slideId)) reloadSlide(false);
     };
-  }, [slideId]);
+    import.meta.hot.on('open-slide:slide-changed', handler);
+    return () => {
+      import.meta.hot?.off('open-slide:slide-changed', handler);
+    };
+  }, [slideId, reloadSlide]);
 
   const modulePages = useMemo(() => slide?.default ?? [], [slide]);
   const [pages, setPages] = useState<typeof modulePages>(modulePages);

--- a/packages/core/src/vite/comments-plugin.test.ts
+++ b/packages/core/src/vite/comments-plugin.test.ts
@@ -324,6 +324,30 @@ describe('applyEdit / set-text', () => {
     expect(r.source).toContain("<em style={{ color: '#bb7025' }}>agent</em>");
   });
 
+  it('does not style sibling content when a selected leaf has mixed parent content', () => {
+    const src = [
+      'export default [() => (',
+      '<h1><span>Hello <strong>world</strong></span></h1>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text-range-style',
+        start: 0,
+        end: 'Hello'.length,
+        key: 'color',
+        value: '#bb7025',
+        prevText: 'Hello world',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain(
+      "<span><span style={{ color: '#bb7025' }}>Hello</span> <strong>world</strong></span>",
+    );
+    expect(r.source).not.toContain("<span style={{ color: '#bb7025' }}>Hello <strong>world");
+  });
+
   it('applies selected text style across inline and plain text leaves', () => {
     const src = [
       'export default [() => (',

--- a/packages/core/src/vite/comments-plugin.test.ts
+++ b/packages/core/src/vite/comments-plugin.test.ts
@@ -109,6 +109,26 @@ describe('applyEdit / set-style', () => {
     expect(r.source).toContain("style={{ color: 'red', fontSize: '24px' }}");
   });
 
+  it('falls back to prevText for text style edits with a stale source location', () => {
+    const src = [
+      'export default [() => (',
+      '<div>',
+      '  <h1>',
+      '    Claude',
+      '    <br />',
+      "    <em style={{ color: 'var(--osd-accent)' }}>Code.</em>",
+      '  </h1>',
+      '</div>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      { kind: 'set-style', key: 'fontSize', value: '24px', prevText: 'Claude\nCode.' },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<h1 style={{ fontSize: '24px' }}>");
+  });
+
   it('removes a key when value is null', () => {
     const src = [
       'export default [() => (',
@@ -144,23 +164,63 @@ describe('applyEdit / set-style', () => {
     expect(r.source).toContain("style={{ fontSize: someVar, color: 'blue' }}");
   });
 
-  it('bails when style is a non-object expression', () => {
+  it('preserves dynamic style expressions when adding an override', () => {
     const src = ['export default [() => (', '<h1 style={someStyle}>Hi</h1>', ')];', ''].join('\n');
     const r = applyEdit(src, 2, 0, [{ kind: 'set-style', key: 'color', value: 'red' }]);
-    expect(r.ok).toBe(false);
-    if (r.ok) throw new Error('expected failure');
-    expect(r.status).toBe(422);
-    expect(r.error).toMatch(/literal object/);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("style={{ ...(someStyle), color: 'red' }}");
   });
 
-  it('bails when style object contains a spread', () => {
+  it('adds style keys after spreads so they override spread values', () => {
     const src = ['export default [() => (', '<h1 style={{ ...base }}>Hi</h1>', ')];', ''].join(
       '\n',
     );
     const r = applyEdit(src, 2, 0, [{ kind: 'set-style', key: 'color', value: 'red' }]);
-    expect(r.ok).toBe(false);
-    if (r.ok) throw new Error('expected failure');
-    expect(r.status).toBe(422);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("style={{ ...base, color: 'red' }}");
+  });
+
+  it('updates explicit style keys while preserving spreads', () => {
+    const src = [
+      'export default [() => (',
+      "<h1 style={{ ...base, color: 'red' }}>Hi</h1>",
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [{ kind: 'set-style', key: 'color', value: 'blue' }]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("style={{ ...base, color: 'blue' }}");
+  });
+
+  it('removes explicit style keys while still overriding spread values', () => {
+    const src = [
+      'export default [() => (',
+      "<h1 style={{ ...base, color: 'red' }}>Hi</h1>",
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [{ kind: 'set-style', key: 'color', value: null }]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain('style={{ ...base, color: undefined }}');
+  });
+
+  it('places new style attributes after prop spreads', () => {
+    const src = ['export default [() => (', '<h1 {...props}>Hi</h1>', ')];', ''].join('\n');
+    const r = applyEdit(src, 2, 0, [{ kind: 'set-style', key: 'color', value: 'red' }]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<h1 {...props} style={{ color: 'red' }}>Hi</h1>");
+  });
+
+  it('moves existing style attributes after later prop spreads', () => {
+    const src = [
+      'export default [() => (',
+      "<h1 style={{ fontSize: '24px' }} {...props}>Hi</h1>",
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [{ kind: 'set-style', key: 'color', value: 'red' }]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<h1 {...props} style={{ fontSize: '24px', color: 'red' }}>Hi</h1>");
   });
 
   it('escapes special characters in style values', () => {
@@ -193,6 +253,15 @@ describe('applyEdit / set-text', () => {
     expect(r.source).toContain("<h1>{'1 < 2 > 0'}</h1>");
   });
 
+  it('preserves inserted line breaks as JSX breaks', () => {
+    const src = ['export default [() => (', '<h1>Hello</h1>', ')];', ''].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      { kind: 'set-text', value: 'Hello\nworld', prevText: 'Hello' },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain('<h1>Hello<br />world</h1>');
+  });
+
   it('descends through wrapper elements to find the text leaf', () => {
     const src = ['export default [() => (', '<div><span>Hello</span></div>', ')];', ''].join('\n');
     const r = applyEdit(src, 2, 0, [{ kind: 'set-text', value: 'Goodbye' }]);
@@ -207,6 +276,25 @@ describe('applyEdit / set-text', () => {
     const r = applyEdit(src, 2, 0, [{ kind: 'set-text', value: 'planet', prevText: 'world' }]);
     if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
     expect(r.source).toContain('<h1>Hello <span>planet</span></h1>');
+  });
+
+  it('falls back to prevText for multiline content edits with a stale source location', () => {
+    const src = [
+      'const fill = {',
+      "  color: 'var(--osd-text)',",
+      '};',
+      'export default [() => (',
+      '<section style={fill}>',
+      '<p>Alpha<br />Beta</p>',
+      '</section>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 2, [
+      { kind: 'set-text', value: 'Alpha\nBeta\nGamma', prevText: 'Alpha\nBeta' },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain('<p>Alpha<br />Beta<br />Gamma</p>');
   });
 
   it('applies selected text style to an existing inline leaf', () => {
@@ -264,6 +352,33 @@ describe('applyEdit / set-text', () => {
     expect(r.source).toContain("<span style={{ color: '#bb7025' }}>{' that'}</span> does");
   });
 
+  it('applies selected text style inside folded JSX text', () => {
+    const src = [
+      'export default [() => (',
+      '<p>',
+      '  Claude Code reads your codebase, plans, edits files, runs commands, checks the result, and',
+      '  iterates — keeping you in the loop on the decisions that matter.',
+      '</p>',
+      ')];',
+      '',
+    ].join('\n');
+    const prevText =
+      'Claude Code reads your codebase, plans, edits files, runs commands, checks the result, and iterates — keeping you in the loop on the decisions that matter.';
+    const start = prevText.indexOf('iterates');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text-range-style',
+        start,
+        end: start + 'iterates'.length,
+        key: 'fontWeight',
+        value: '700',
+        prevText,
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<span style={{ fontWeight: '700' }}>iterates</span>");
+  });
+
   it('updates selected text style after a plain text leaf has been wrapped', () => {
     const src = [
       'export default [() => (',
@@ -290,6 +405,189 @@ describe('applyEdit / set-text', () => {
     if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
     expect(r.source).toContain("<em style={{ color: '#111111' }}>agent</em>");
     expect(r.source).toContain("<span style={{ color: '#111111' }}>{' that'}</span> does");
+  });
+
+  it('removes selected text style from a fully selected inline leaf', () => {
+    const src = [
+      'export default [() => (',
+      '<h2>',
+      "  <span style={{ fontWeight: '700' }}>agent</span> work.",
+      '</h2>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text-range-style',
+        start: 0,
+        end: 'agent'.length,
+        key: 'fontWeight',
+        value: null,
+        prevText: 'agent work.',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain('<span>agent</span> work.');
+  });
+
+  it('resets selected text style inside an inherited bold range', () => {
+    const src = [
+      'export default [() => (',
+      "<h2 style={{ fontWeight: '700' }}>An agent that works.</h2>",
+      ')];',
+      '',
+    ].join('\n');
+    const prevText = 'An agent that works.';
+    const start = prevText.indexOf('agent');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text-range-style',
+        start,
+        end: start + 'agent'.length,
+        key: 'fontWeight',
+        value: null,
+        prevText,
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<span style={{ fontWeight: '400' }}>agent</span>");
+  });
+
+  it('falls back to prevText when a stale source location no longer points at JSX', () => {
+    const src = [
+      'export default [() => (',
+      '<h1>',
+      "  <span style={{ fontStyle: 'italic' }}>Claude</span>",
+      '  <br />',
+      "  <em style={{ color: 'var(--osd-accent)' }}>Code.</em>",
+      '</h1>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 99, 0, [
+      {
+        kind: 'set-text-range-style',
+        start: 0,
+        end: 'Claude'.length,
+        key: 'fontSize',
+        value: '180px',
+        prevText: 'Claude\nCode.',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<span style={{ fontStyle: 'italic', fontSize: '180px' }}>");
+  });
+
+  it('falls back to prevText for direct JSX text with a stale source location', () => {
+    const src = [
+      'export default [() => (',
+      '<h1>',
+      '  Claude',
+      '  <br />',
+      "  <em style={{ color: 'var(--osd-accent)' }}>Code.</em>",
+      '</h1>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 99, 0, [
+      {
+        kind: 'set-text-range-style',
+        start: 0,
+        end: 'Claude'.length,
+        key: 'fontSize',
+        value: '180px',
+        prevText: 'Claude\nCode.',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<span style={{ fontSize: '180px' }}>Claude</span>");
+  });
+
+  it('falls back to prevText when a stale location points at an outer JSX element', () => {
+    const src = [
+      'export default [() => (',
+      '<div>',
+      '  <h1>',
+      '    Claude',
+      '    <br />',
+      "    <em style={{ color: 'var(--osd-accent)' }}>Code.</em>",
+      '  </h1>',
+      '</div>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text-range-style',
+        start: 0,
+        end: 'Claude'.length,
+        key: 'fontSize',
+        value: '180px',
+        prevText: 'Claude\nCode.',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<span style={{ fontSize: '180px' }}>Claude</span>");
+  });
+
+  it('styles the whole element when selected map text is expression-backed', () => {
+    const src = [
+      'const items = [',
+      "  { title: 'Read files' },",
+      "  { title: 'Run tools' },",
+      '];',
+      'export default [() => (',
+      '<div>',
+      '  {items.map((item) => (',
+      '    <div key={item.title}>',
+      '      <div style={{ fontWeight: 400 }}>{item.title}</div>',
+      '    </div>',
+      '  ))}',
+      '</div>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 9, 6, [
+      {
+        kind: 'set-text-range-style',
+        start: 0,
+        end: 'Run tools'.length,
+        key: 'fontSize',
+        value: '79px',
+        prevText: 'Run tools',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("style={{ fontWeight: 400, fontSize: '79px' }}");
+  });
+
+  it('falls back to element style for partial expression-backed map text', () => {
+    const src = [
+      'const steps = [',
+      "  { label: 'Read' },",
+      "  { label: 'Plan' },",
+      '];',
+      'export default [() => (',
+      '<div>',
+      '  {steps.map((step) => (',
+      '    <div key={step.label} style={{ fontWeight: 400 }}>{step.label}</div>',
+      '  ))}',
+      '</div>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 8, 4, [
+      {
+        kind: 'set-text-range-style',
+        start: 1,
+        end: 3,
+        key: 'fontSize',
+        value: '81px',
+        prevText: 'Plan',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("style={{ fontWeight: 400, fontSize: '81px' }}");
   });
 
   it('edits rich text content without flattening inline style', () => {
@@ -338,6 +636,80 @@ describe('applyEdit / set-text', () => {
     expect(r.source).not.toContain('<br />');
     expect(r.source).toContain("{' '}");
     expect(r.source).toContain("<em style={{ color: 'var(--osd-accent)' }}>agent</em>");
+  });
+
+  it('matches visible rich text when a string literal has whitespace before a line break', () => {
+    const src = [
+      'export default [() => (',
+      '<h2>',
+      "  an <span>agent <span>harness</span></span> is{' '}",
+      '  <span>',
+      '    {\'"everything \'}<br />in an AI agent except the model itself."',
+      '  </span>',
+      '</h2>',
+      ')];',
+      '',
+    ].join('\n');
+    const prevText = 'an agent harness is "everything\nin an AI agent except the model itself."';
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text',
+        value: 'an agent harness is "everything\nin a coding agent except the model itself."',
+        prevText,
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain('in a coding agent except the model itself.');
+    expect(r.source).toContain('<br />');
+  });
+
+  it('matches rich text content after line break positions changed in a pending edit', () => {
+    const src = [
+      'export default [() => (',
+      '<h2>',
+      '  Permissions, t<br />hen hooks.',
+      '</h2>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text',
+        value: 'Permissions, t\nhen hooks!',
+        prevText: 'Permissions, then hooks.',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain('hen hooks!');
+    expect(r.source).toContain('<br />');
+  });
+
+  it('styles visible rich text when a string literal has whitespace before a line break', () => {
+    const src = [
+      'export default [() => (',
+      '<h2>',
+      "  an <span>agent <span>harness</span></span> is{' '}",
+      '  <span>',
+      '    {\'"everything \'}<br />in an AI agent except the model itself."',
+      '  </span>',
+      '</h2>',
+      ')];',
+      '',
+    ].join('\n');
+    const prevText = 'an agent harness is "everything\nin an AI agent except the model itself."';
+    const start = prevText.indexOf('in an AI');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text-range-style',
+        start,
+        end: start + 'in an AI'.length,
+        key: 'fontWeight',
+        value: '700',
+        prevText,
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<span style={{ fontWeight: '700' }}>in an AI</span>");
   });
 
   it('bails when prevText is missing for an ambiguous element', () => {

--- a/packages/core/src/vite/comments-plugin.test.ts
+++ b/packages/core/src/vite/comments-plugin.test.ts
@@ -209,6 +209,137 @@ describe('applyEdit / set-text', () => {
     expect(r.source).toContain('<h1>Hello <span>planet</span></h1>');
   });
 
+  it('applies selected text style to an existing inline leaf', () => {
+    const src = [
+      'export default [() => (',
+      '<h2>',
+      '  Not autocomplete.',
+      '  <br />',
+      "  An <em style={{ color: 'var(--osd-accent)' }}>agent</em> that does the work.",
+      '</h2>',
+      ')];',
+      '',
+    ].join('\n');
+    const prevText = 'Not autocomplete.\nAn agent that does the work.';
+    const start = prevText.indexOf('agent');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text-range-style',
+        start,
+        end: start + 'agent'.length,
+        key: 'color',
+        value: '#bb7025',
+        prevText,
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<em style={{ color: '#bb7025' }}>agent</em>");
+  });
+
+  it('applies selected text style across inline and plain text leaves', () => {
+    const src = [
+      'export default [() => (',
+      '<h2>',
+      '  Not autocomplete.',
+      '  <br />',
+      "  An <em style={{ color: 'var(--osd-accent)' }}>agent</em> that does the work.",
+      '</h2>',
+      ')];',
+      '',
+    ].join('\n');
+    const prevText = 'Not autocomplete.\nAn agent that does the work.';
+    const start = prevText.indexOf('agent');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text-range-style',
+        start,
+        end: start + 'agent that'.length,
+        key: 'color',
+        value: '#bb7025',
+        prevText,
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<em style={{ color: '#bb7025' }}>agent</em>");
+    expect(r.source).toContain("<span style={{ color: '#bb7025' }}>{' that'}</span> does");
+  });
+
+  it('updates selected text style after a plain text leaf has been wrapped', () => {
+    const src = [
+      'export default [() => (',
+      '<h2>',
+      '  Not autocomplete.',
+      '  <br />',
+      "  An <em style={{ color: '#bb7025' }}>agent</em><span style={{ color: '#bb7025' }}>{' that'}</span> does the work.",
+      '</h2>',
+      ')];',
+      '',
+    ].join('\n');
+    const prevText = 'Not autocomplete.\nAn agent that does the work.';
+    const start = prevText.indexOf('agent');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text-range-style',
+        start,
+        end: start + 'agent that'.length,
+        key: 'color',
+        value: '#111111',
+        prevText,
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<em style={{ color: '#111111' }}>agent</em>");
+    expect(r.source).toContain("<span style={{ color: '#111111' }}>{' that'}</span> does");
+  });
+
+  it('edits rich text content without flattening inline style', () => {
+    const src = [
+      'export default [() => (',
+      '<h2>',
+      '  Not autocomplete.',
+      '  <br />',
+      "  An <em style={{ color: 'var(--osd-accent)' }}>agent</em> that does the work.",
+      '</h2>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text',
+        value: 'Not autocomplete.\nAn agent that does the real work.',
+        prevText: 'Not autocomplete.\nAn agent that does the work.',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("<em style={{ color: 'var(--osd-accent)' }}>agent</em>");
+    expect(r.source).toContain('that does the real work.');
+    expect(r.source).toContain('<br />');
+  });
+
+  it('edits rich text line breaks as newlines', () => {
+    const src = [
+      'export default [() => (',
+      '<h2>',
+      '  Not autocomplete.',
+      '  <br />',
+      "  An <em style={{ color: 'var(--osd-accent)' }}>agent</em> that does the work.",
+      '</h2>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 2, 0, [
+      {
+        kind: 'set-text',
+        value: 'Not autocomplete. An agent that does the work.',
+        prevText: 'Not autocomplete.\nAn agent that does the work.',
+      },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).not.toContain('<br />');
+    expect(r.source).toContain("{' '}");
+    expect(r.source).toContain("<em style={{ color: 'var(--osd-accent)' }}>agent</em>");
+  });
+
   it('bails when prevText is missing for an ambiguous element', () => {
     const src = ['export default [() => (', '<h1>Hello <span>world</span></h1>', ')];', ''].join(
       '\n',

--- a/packages/core/src/vite/comments-plugin.ts
+++ b/packages/core/src/vite/comments-plugin.ts
@@ -190,6 +190,14 @@ function offsetToLine(source: string, offset: number): number {
 export type EditOp =
   | { kind: 'set-style'; key: string; value: string | null }
   | { kind: 'set-text'; value: string; prevText?: string }
+  | {
+      kind: 'set-text-range-style';
+      start: number;
+      end: number;
+      key: string;
+      value: string | null;
+      prevText?: string;
+    }
   | { kind: 'set-attr-asset'; attr: string; assetPath: string }
   | { kind: 'replace-placeholder-with-image'; assetPath: string };
 
@@ -332,6 +340,15 @@ type TextCandidate = {
 };
 
 type JsxParent = t.JSXElement | t.JSXFragment;
+type TextRangeLeaf = {
+  node: t.JSXText | t.JSXExpressionContainer;
+  parent: JsxParent;
+  current: string;
+  raw: string;
+  text: (value: string) => string;
+};
+type TextRangeBreak = { node: t.JSXElement; current: '\n' };
+type TextRangePart = TextRangeLeaf | TextRangeBreak;
 
 function meaningfulChildren(parent: JsxParent): t.Node[] {
   return parent.children.filter((c) => {
@@ -347,6 +364,31 @@ function wrapSplice(parent: JsxParent, text: string): Splice {
   const first = parent.children[0];
   const last = parent.children[parent.children.length - 1];
   return { from: first.start ?? 0, to: last.end ?? 0, text };
+}
+
+function cleanJsxText(value: string): string {
+  const lines = value.split(/\r\n|\n|\r/);
+  let lastNonEmptyLine = 0;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim()) lastNonEmptyLine = i;
+  }
+
+  let text = '';
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i].replace(/\t/g, ' ');
+    if (i !== 0) line = line.replace(/^ +/, '');
+    if (i !== lines.length - 1) line = line.replace(/ +$/, '');
+    if (!line) continue;
+    if (i !== lastNonEmptyLine) line += ' ';
+    text += line;
+  }
+  return text;
+}
+
+function isJsxBrElement(node: t.Node): node is t.JSXElement {
+  if (!t.isJSXElement(node)) return false;
+  const name = node.openingElement.name;
+  return t.isJSXIdentifier(name) && name.name.toLowerCase() === 'br';
 }
 
 function collectTextCandidates(element: JsxParent, out: TextCandidate[]): void {
@@ -379,6 +421,230 @@ function collectTextCandidates(element: JsxParent, out: TextCandidate[]): void {
       collectTextCandidates(child, out);
     }
   }
+}
+
+function collectTextRangeParts(element: JsxParent, out: TextRangePart[]): void {
+  for (const child of element.children) {
+    if (t.isJSXText(child)) {
+      const current = cleanJsxText(child.value);
+      if (current) {
+        out.push({
+          node: child,
+          parent: element,
+          current,
+          raw: child.value,
+          text: formatJsxText,
+        });
+      }
+    } else if (t.isJSXExpressionContainer(child)) {
+      const expression = child.expression;
+      if (t.isStringLiteral(expression) || t.isNumericLiteral(expression)) {
+        const raw = String(expression.value);
+        const current = raw;
+        if (current) {
+          out.push({
+            node: child,
+            parent: element,
+            current,
+            raw,
+            text: (value) => `{${jsString(value)}}`,
+          });
+        }
+      }
+    } else if (isJsxBrElement(child)) {
+      out.push({ node: child, current: '\n' });
+    } else if (t.isJSXElement(child) || t.isJSXFragment(child)) {
+      collectTextRangeParts(child, out);
+    }
+  }
+}
+
+function styleSpanForText(text: string, key: string, value: string | null): string {
+  if (value === null) return formatJsxText(text);
+  return `<span style={{ ${key}: ${jsString(value)} }}>${formatJsxText(text)}</span>`;
+}
+
+function textRangeContent(parts: TextRangePart[]): string {
+  return parts.map((part) => part.current).join('');
+}
+
+function formatRichText(value: string, formatText = formatJsxText): string {
+  return value
+    .split('\n')
+    .map((part) => formatText(part))
+    .join('<br />');
+}
+
+function formatOptionalText(value: string, formatText = formatJsxText): string {
+  return value ? formatText(value) : '';
+}
+
+function textDiff(prevText: string, nextText: string) {
+  let start = 0;
+  while (
+    start < prevText.length &&
+    start < nextText.length &&
+    prevText[start] === nextText[start]
+  ) {
+    start += 1;
+  }
+
+  let prevEnd = prevText.length;
+  let nextEnd = nextText.length;
+  while (prevEnd > start && nextEnd > start && prevText[prevEnd - 1] === nextText[nextEnd - 1]) {
+    prevEnd -= 1;
+    nextEnd -= 1;
+  }
+
+  return { start, end: prevEnd, value: nextText.slice(start, nextEnd) };
+}
+
+function textLeafSplice(part: TextRangeLeaf, value: string): Splice {
+  const rawStart = part.raw.indexOf(part.current);
+  if (rawStart < 0) return spliceRange(part.node, part.text(value));
+  const rawEnd = rawStart + part.current.length;
+  return {
+    from: part.node.start ?? 0,
+    to: part.node.end ?? 0,
+    text: `${part.raw.slice(0, rawStart)}${formatRichText(value, part.text)}${part.raw.slice(rawEnd)}`,
+  };
+}
+
+function buildTextRangeReplaceSplices(
+  parts: TextRangePart[],
+  start: number,
+  end: number,
+  value: string,
+): Splice[] | { error: string } {
+  const splices: Splice[] = [];
+  let offset = 0;
+  let inserted = false;
+
+  for (const part of parts) {
+    const partStart = offset;
+    const partEnd = partStart + part.current.length;
+    offset = partEnd;
+
+    const overlaps = start < partEnd && end > partStart;
+    const insertsHere = start === end && !inserted && start >= partStart && start <= partEnd;
+    if (!overlaps && !insertsHere) continue;
+
+    if ('raw' in part) {
+      const localStart = Math.max(start, partStart) - partStart;
+      const localEnd = overlaps ? Math.min(end, partEnd) - partStart : localStart;
+      const nextText = `${part.current.slice(0, localStart)}${inserted ? '' : value}${part.current.slice(localEnd)}`;
+      splices.push(textLeafSplice(part, nextText));
+    } else if (overlaps) {
+      splices.push(spliceRange(part.node, inserted ? '' : formatRichText(value)));
+    } else if (insertsHere) {
+      const at = start === partStart ? (part.node.start ?? 0) : (part.node.end ?? 0);
+      splices.push({ from: at, to: at, text: formatRichText(value) });
+    }
+
+    inserted = true;
+  }
+
+  if (!inserted && start === end && start === offset) {
+    const last = parts[parts.length - 1];
+    if (!last) return { error: 'element has no editable text' };
+    if ('raw' in last) {
+      splices.push(textLeafSplice(last, `${last.current}${value}`));
+    } else {
+      splices.push({
+        from: last.node.end ?? 0,
+        to: last.node.end ?? 0,
+        text: formatRichText(value),
+      });
+    }
+  }
+
+  return splices;
+}
+
+function buildTextContentSplices(
+  element: t.JSXElement,
+  value: string,
+  prevText: string,
+): Splice[] | { error: string } {
+  const parts: TextRangePart[] = [];
+  collectTextRangeParts(element, parts);
+  const current = textRangeContent(parts);
+  if (current !== prevText) return { error: 'no text candidate matches the current value' };
+  const diff = textDiff(prevText, value);
+  if (diff.start === diff.end && diff.value === '') return [];
+  return buildTextRangeReplaceSplices(parts, diff.start, diff.end, diff.value);
+}
+
+function buildTextRangeStyleSplices(
+  source: string,
+  element: t.JSXElement,
+  start: number,
+  end: number,
+  op: { key: string; value: string | null },
+  prevText?: string,
+): Splice[] | { error: string } | null {
+  if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end <= start) {
+    return { error: 'invalid text range' };
+  }
+
+  const parts: TextRangePart[] = [];
+  collectTextRangeParts(element, parts);
+  const current = prevText ?? textRangeContent(parts);
+  if (!current) return { error: 'element has no editable text' };
+  if (end > current.length) return { error: 'text range is out of bounds' };
+  if (prevText !== undefined && textRangeContent(parts) !== prevText) {
+    return { error: 'no text candidate matches the current value' };
+  }
+
+  const splices: Splice[] = [];
+  let leafStart = 0;
+  for (const leaf of parts) {
+    const leafEnd = leafStart + leaf.current.length;
+    if (!('raw' in leaf)) {
+      leafStart = leafEnd;
+      continue;
+    }
+    const selectedStart = Math.max(start, leafStart);
+    const selectedEnd = Math.min(end, leafEnd);
+    if (selectedStart >= selectedEnd) {
+      leafStart = leafEnd;
+      continue;
+    }
+
+    if (
+      selectedStart === leafStart &&
+      selectedEnd === leafEnd &&
+      t.isJSXElement(leaf.parent) &&
+      leaf.parent !== element
+    ) {
+      const result = buildStyleSplice(source, leaf.parent, [op]);
+      if (result && 'error' in result) return result;
+      if (result) splices.push(result);
+      leafStart = leafEnd;
+      continue;
+    }
+
+    const raw = leaf.raw;
+    const currentStartInRaw = raw.indexOf(leaf.current);
+    if (currentStartInRaw < 0) return { error: 'text range source mismatch' };
+    const rawStart = currentStartInRaw + selectedStart - leafStart;
+    const rawEnd = currentStartInRaw + selectedEnd - leafStart;
+    const before = raw.slice(0, rawStart);
+    const selected = raw.slice(rawStart, rawEnd);
+    const after = raw.slice(rawEnd);
+    if (op.value === null) continue;
+    const beforeText = t.isJSXText(leaf.node) ? before : formatOptionalText(before, leaf.text);
+    const afterText = t.isJSXText(leaf.node) ? after : formatOptionalText(after, leaf.text);
+    splices.push(
+      spliceRange(
+        leaf.node,
+        `${beforeText}${styleSpanForText(selected, op.key, op.value)}${afterText}`,
+      ),
+    );
+    leafStart = leafEnd;
+  }
+
+  return splices.length > 0 ? splices : null;
 }
 
 // `<Wrap>{children}</Wrap>` and `<h2>{title}</h2>` — sole child is a
@@ -864,10 +1130,30 @@ export function applyEdit(
   }
 
   for (const op of ops) {
+    if (op.kind !== 'set-text-range-style') continue;
+    const result = buildTextRangeStyleSplices(
+      source,
+      element,
+      op.start,
+      op.end,
+      { key: op.key, value: op.value },
+      op.prevText,
+    );
+    if (result && 'error' in result) return { ok: false, status: 422, error: result.error };
+    if (result) splices.push(...result);
+  }
+
+  for (const op of ops) {
     if (op.kind !== 'set-text') continue;
     const result = buildTextSplice(ast, element, op.value, op.prevText);
-    if ('error' in result) return { ok: false, status: 422, error: result.error };
-    splices.push(result);
+    if ('error' in result) {
+      if (op.prevText === undefined) return { ok: false, status: 422, error: result.error };
+      const richResult = buildTextContentSplices(element, op.value, op.prevText);
+      if ('error' in richResult) return { ok: false, status: 422, error: result.error };
+      splices.push(...richResult);
+    } else {
+      splices.push(result);
+    }
   }
 
   const assetOps = ops.flatMap((op) => (op.kind === 'set-attr-asset' ? [op] : []));

--- a/packages/core/src/vite/comments-plugin.ts
+++ b/packages/core/src/vite/comments-plugin.ts
@@ -468,6 +468,11 @@ function meaningfulChildren(parent: JsxParent): t.Node[] {
   });
 }
 
+function isOnlyMeaningfulChild(parent: JsxParent, child: t.Node): boolean {
+  const meaningful = meaningfulChildren(parent);
+  return meaningful.length === 1 && meaningful[0] === child;
+}
+
 // Wrap-style splice: rewrite the whole children span of `parent`. Used
 // when the candidate is the parent's only meaningful child, so old
 // surrounding whitespace nodes don't leak into the new value.
@@ -833,7 +838,8 @@ function buildTextRangeStyleSplices(
       selectedStart === leafStart &&
       selectedEnd === leafEnd &&
       t.isJSXElement(leaf.parent) &&
-      leaf.parent !== element
+      leaf.parent !== element &&
+      isOnlyMeaningfulChild(leaf.parent, leaf.node)
     ) {
       const result = buildStyleSplice(source, leaf.parent, [op]);
       if (result && 'error' in result) return result;

--- a/packages/core/src/vite/comments-plugin.ts
+++ b/packages/core/src/vite/comments-plugin.ts
@@ -188,7 +188,7 @@ function offsetToLine(source: string, offset: number): number {
 }
 
 export type EditOp =
-  | { kind: 'set-style'; key: string; value: string | null }
+  | { kind: 'set-style'; key: string; value: string | null; prevText?: string }
   | { kind: 'set-text'; value: string; prevText?: string }
   | {
       kind: 'set-text-range-style';
@@ -209,11 +209,12 @@ type Splice = { from: number; to: number; text: string };
 
 function parseSource(source: string): t.File | null {
   try {
-    return babelParse(source, {
+    const ast = babelParse(source, {
       sourceType: 'module',
       plugins: ['typescript', 'jsx'],
       errorRecovery: true,
-    });
+    }) as t.File & { errors?: unknown[] };
+    return ast.errors && ast.errors.length > 0 ? null : ast;
   } catch {
     return null;
   }
@@ -232,6 +233,74 @@ function findInnermostJsxElement(ast: t.Node, line: number, column: number): t.J
     if (t.isJSXElement(n)) return n;
   }
   return null;
+}
+
+function findUniqueElementByText(ast: t.Node, prevText: string): t.JSXElement | null {
+  const hits: Array<{ node: t.JSXElement; size: number }> = [];
+  walkJsx(ast, (n) => {
+    if (!t.isJSXElement(n)) return;
+    const parts: TextRangePart[] = [];
+    collectTextRangeParts(n, parts);
+    if (textRangeContent(parts) !== prevText) return;
+    hits.push({ node: n, size: (n.end ?? 0) - (n.start ?? 0) });
+  });
+  if (hits.length === 0) return null;
+  hits.sort((a, b) => a.size - b.size);
+  const best = hits[0];
+  const bestStart = best.node.start ?? 0;
+  const bestEnd = best.node.end ?? 0;
+  const hasSiblingMatch = hits
+    .slice(1)
+    .some(({ node }) => (node.start ?? 0) > bestStart || (node.end ?? 0) < bestEnd);
+  return hasSiblingMatch ? null : best.node;
+}
+
+function fallbackTextForOps(ops: EditOp[]): string | null {
+  for (const op of ops) {
+    if (
+      (op.kind === 'set-style' || op.kind === 'set-text' || op.kind === 'set-text-range-style') &&
+      op.prevText !== undefined
+    ) {
+      return op.prevText;
+    }
+  }
+  return null;
+}
+
+function hasOnlyTextOps(ops: EditOp[]): boolean {
+  return ops.length > 0 && ops.every((op) => op.kind === 'set-text');
+}
+
+function elementTextMatches(element: t.JSXElement, prevText: string): boolean {
+  const parts: TextRangePart[] = [];
+  collectTextRangeParts(element, parts);
+  return textRangeContent(parts) === prevText;
+}
+
+function elementHasTextCandidate(ast: t.File, element: t.JSXElement, prevText: string): boolean {
+  const norm = prevText.trim();
+  return collectElementTextCandidates(ast, element).some((candidate) => candidate.current === norm);
+}
+
+function findElementForEdit(
+  ast: t.File,
+  line: number,
+  column: number,
+  ops: EditOp[],
+): t.JSXElement | null {
+  const element = findInnermostJsxElement(ast, line, column);
+  const prevText = fallbackTextForOps(ops);
+  if (prevText === null) return element;
+  if (
+    hasOnlyTextOps(ops) &&
+    element &&
+    (elementTextMatches(element, prevText) || elementHasTextCandidate(ast, element, prevText))
+  ) {
+    return element;
+  }
+  const textMatch = findUniqueElementByText(ast, prevText);
+  if (element && elementTextMatches(element, prevText)) return textMatch ?? element;
+  return textMatch ?? element;
 }
 
 function findJsxByStart(ast: t.Node, line: number, column: number): t.JSXElement | null {
@@ -269,9 +338,11 @@ function buildStyleSplice(
 ): Splice | { error: string } | null {
   const opening = element.openingElement;
   const existing = findJsxAttr(opening, 'style');
-  // Raw source slices, not parsed values — preserves variables and
-  // complex expressions exactly as authored.
-  const style = new Map<string, string>();
+  type StyleEntry =
+    | { kind: 'prop'; key: string; keyText: string; valueText: string }
+    | { kind: 'raw'; text: string };
+  const entries: StyleEntry[] = [];
+  let hasRawEntry = false;
 
   if (existing) {
     const value = existing.value;
@@ -280,46 +351,85 @@ function buildStyleSplice(
     }
     const expr = value.expression;
     if (!t.isObjectExpression(expr)) {
-      return { error: 'style is not a literal object' };
-    }
-    for (const prop of expr.properties) {
-      if (!t.isObjectProperty(prop)) {
-        return { error: 'style contains spread or method' };
-      }
-      if (prop.computed) return { error: 'style has computed key' };
-      let keyName: string | null = null;
-      if (t.isIdentifier(prop.key)) keyName = prop.key.name;
-      else if (t.isStringLiteral(prop.key)) keyName = prop.key.value;
-      if (!keyName) return { error: 'style has unsupported key' };
-      const v = prop.value;
-      if (typeof v.start !== 'number' || typeof v.end !== 'number') {
+      if (typeof expr.start !== 'number' || typeof expr.end !== 'number') {
         return { error: 'style value missing source range' };
       }
-      style.set(keyName, source.slice(v.start, v.end));
+      entries.push({ kind: 'raw', text: `...(${source.slice(expr.start, expr.end)})` });
+      hasRawEntry = true;
+    } else {
+      for (const prop of expr.properties) {
+        if (t.isObjectProperty(prop) && !prop.computed) {
+          let keyName: string | null = null;
+          if (t.isIdentifier(prop.key)) keyName = prop.key.name;
+          else if (t.isStringLiteral(prop.key)) keyName = prop.key.value;
+          if (!keyName) return { error: 'style has unsupported key' };
+          const v = prop.value;
+          if (
+            typeof prop.key.start !== 'number' ||
+            typeof prop.key.end !== 'number' ||
+            typeof v.start !== 'number' ||
+            typeof v.end !== 'number'
+          ) {
+            return { error: 'style value missing source range' };
+          }
+          entries.push({
+            kind: 'prop',
+            key: keyName,
+            keyText: source.slice(prop.key.start, prop.key.end),
+            valueText: source.slice(v.start, v.end),
+          });
+        } else {
+          if (typeof prop.start !== 'number' || typeof prop.end !== 'number') {
+            return { error: 'style value missing source range' };
+          }
+          entries.push({ kind: 'raw', text: source.slice(prop.start, prop.end) });
+          hasRawEntry = true;
+        }
+      }
     }
   }
 
   for (const op of ops) {
-    if (op.value === null) style.delete(op.key);
-    else style.set(op.key, jsString(op.value));
+    const matching = entries.filter((entry) => entry.kind === 'prop' && entry.key === op.key);
+    if (op.value === null) {
+      for (const entry of matching) entries.splice(entries.indexOf(entry), 1);
+      if (hasRawEntry) {
+        entries.push({ kind: 'prop', key: op.key, keyText: op.key, valueText: 'undefined' });
+      }
+    } else if (matching.length > 0) {
+      matching[matching.length - 1].valueText = jsString(op.value);
+    } else {
+      entries.push({ kind: 'prop', key: op.key, keyText: op.key, valueText: jsString(op.value) });
+    }
   }
 
-  if (style.size === 0) {
+  if (entries.length === 0) {
     if (!existing) return null;
     let from = existing.start ?? 0;
     if (from > 0 && source[from - 1] === ' ') from -= 1;
     return { from, to: existing.end ?? 0, text: '' };
   }
 
-  const propsText = Array.from(style.entries())
-    .map(([k, v]) => `${k}: ${v}`)
+  const propsText = entries
+    .map((entry) => (entry.kind === 'prop' ? `${entry.keyText}: ${entry.valueText}` : entry.text))
     .join(', ');
   const newAttr = `style={{ ${propsText} }}`;
 
   if (existing) {
+    const lastAttr = opening.attributes[opening.attributes.length - 1];
+    if (lastAttr && lastAttr !== existing && typeof lastAttr.end === 'number') {
+      const attrsAfterStyle = source.slice(existing.end ?? 0, lastAttr.end).replace(/^[ \t]+/, '');
+      return {
+        from: existing.start ?? 0,
+        to: lastAttr.end,
+        text: `${attrsAfterStyle} ${newAttr}`,
+      };
+    }
     return { from: existing.start ?? 0, to: existing.end ?? 0, text: newAttr };
   }
-  return { from: opening.name.end ?? 0, to: opening.name.end ?? 0, text: ` ${newAttr}` };
+  const lastAttr = opening.attributes[opening.attributes.length - 1];
+  const at = lastAttr?.end ?? opening.name.end ?? 0;
+  return { from: at, to: at, text: ` ${newAttr}` };
 }
 
 function formatJsxText(value: string): string {
@@ -346,6 +456,7 @@ type TextRangeLeaf = {
   current: string;
   raw: string;
   text: (value: string) => string;
+  offsets: Array<number | null>;
 };
 type TextRangeBreak = { node: t.JSXElement; current: '\n' };
 type TextRangePart = TextRangeLeaf | TextRangeBreak;
@@ -366,23 +477,56 @@ function wrapSplice(parent: JsxParent, text: string): Splice {
   return { from: first.start ?? 0, to: last.end ?? 0, text };
 }
 
-function cleanJsxText(value: string): string {
-  const lines = value.split(/\r\n|\n|\r/);
+function splitLinesWithOffsets(value: string): Array<{ text: string; start: number }> {
+  const lines: Array<{ text: string; start: number }> = [];
+  let start = 0;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (ch !== '\n' && ch !== '\r') continue;
+    lines.push({ text: value.slice(start, i), start });
+    if (ch === '\r' && value[i + 1] === '\n') i += 1;
+    start = i + 1;
+  }
+  lines.push({ text: value.slice(start), start });
+  return lines;
+}
+
+function cleanJsxTextWithOffsets(value: string): {
+  text: string;
+  offsets: Array<number | null>;
+} {
+  const lines = splitLinesWithOffsets(value);
   let lastNonEmptyLine = 0;
   for (let i = 0; i < lines.length; i++) {
-    if (lines[i].trim()) lastNonEmptyLine = i;
+    if (lines[i].text.trim()) lastNonEmptyLine = i;
   }
 
   let text = '';
+  const offsets: Array<number | null> = [];
   for (let i = 0; i < lines.length; i++) {
-    let line = lines[i].replace(/\t/g, ' ');
-    if (i !== 0) line = line.replace(/^ +/, '');
-    if (i !== lines.length - 1) line = line.replace(/ +$/, '');
-    if (!line) continue;
-    if (i !== lastNonEmptyLine) line += ' ';
-    text += line;
+    const chars = Array.from(lines[i].text, (ch, j) => ({
+      ch: ch === '\t' ? ' ' : ch,
+      offset: lines[i].start + j,
+    }));
+    let from = 0;
+    let to = chars.length;
+    if (i !== 0) {
+      while (from < to && chars[from].ch === ' ') from += 1;
+    }
+    if (i !== lines.length - 1) {
+      while (to > from && chars[to - 1].ch === ' ') to -= 1;
+    }
+    if (from >= to) continue;
+    for (const item of chars.slice(from, to)) {
+      text += item.ch;
+      offsets.push(item.offset);
+    }
+    if (i !== lastNonEmptyLine) {
+      text += ' ';
+      offsets.push(null);
+    }
   }
-  return text;
+  return { text, offsets };
 }
 
 function isJsxBrElement(node: t.Node): node is t.JSXElement {
@@ -424,9 +568,15 @@ function collectTextCandidates(element: JsxParent, out: TextCandidate[]): void {
 }
 
 function collectTextRangeParts(element: JsxParent, out: TextRangePart[]): void {
+  const parts: TextRangePart[] = [];
+  collectTextRangePartsRaw(element, parts);
+  out.push(...normalizeTextRangeParts(parts));
+}
+
+function collectTextRangePartsRaw(element: JsxParent, out: TextRangePart[]): void {
   for (const child of element.children) {
     if (t.isJSXText(child)) {
-      const current = cleanJsxText(child.value);
+      const { text: current, offsets } = cleanJsxTextWithOffsets(child.value);
       if (current) {
         out.push({
           node: child,
@@ -434,6 +584,7 @@ function collectTextRangeParts(element: JsxParent, out: TextRangePart[]): void {
           current,
           raw: child.value,
           text: formatJsxText,
+          offsets,
         });
       }
     } else if (t.isJSXExpressionContainer(child)) {
@@ -448,24 +599,63 @@ function collectTextRangeParts(element: JsxParent, out: TextRangePart[]): void {
             current,
             raw,
             text: (value) => `{${jsString(value)}}`,
+            offsets: Array.from({ length: current.length }, (_, i) => i),
           });
         }
       }
     } else if (isJsxBrElement(child)) {
       out.push({ node: child, current: '\n' });
     } else if (t.isJSXElement(child) || t.isJSXFragment(child)) {
-      collectTextRangeParts(child, out);
+      collectTextRangePartsRaw(child, out);
     }
   }
 }
 
+function normalizeTextRangeParts(parts: TextRangePart[]): TextRangePart[] {
+  return parts.flatMap((part, index) => {
+    if (!('raw' in part)) return [part];
+    let start = 0;
+    let end = part.current.length;
+    if (parts[index - 1]?.current === '\n') {
+      while (start < end && /\s/.test(part.current[start] ?? '')) start++;
+    }
+    if (parts[index + 1]?.current === '\n') {
+      while (end > start && /\s/.test(part.current[end - 1] ?? '')) end--;
+    }
+    if (start === 0 && end === part.current.length) return [part];
+    if (start >= end) return [];
+    return [
+      {
+        ...part,
+        current: part.current.slice(start, end),
+        offsets: part.offsets.slice(start, end),
+      },
+    ];
+  });
+}
+
+function resetValueForRangeStyle(key: string): string | null {
+  if (key === 'fontWeight') return '400';
+  if (key === 'fontStyle') return 'normal';
+  return null;
+}
+
 function styleSpanForText(text: string, key: string, value: string | null): string {
-  if (value === null) return formatJsxText(text);
-  return `<span style={{ ${key}: ${jsString(value)} }}>${formatJsxText(text)}</span>`;
+  const styleValue = value ?? resetValueForRangeStyle(key);
+  if (styleValue === null) return formatJsxText(text);
+  return `<span style={{ ${key}: ${jsString(styleValue)} }}>${formatJsxText(text)}</span>`;
 }
 
 function textRangeContent(parts: TextRangePart[]): string {
   return parts.map((part) => part.current).join('');
+}
+
+function compactText(value: string): string {
+  return value.replace(/\s+/g, '');
+}
+
+function textMatchesExpected(current: string, expected: string): boolean {
+  return current === expected || compactText(current) === compactText(expected);
 }
 
 function formatRichText(value: string, formatText = formatJsxText): string {
@@ -500,14 +690,33 @@ function textDiff(prevText: string, nextText: string) {
 }
 
 function textLeafSplice(part: TextRangeLeaf, value: string): Splice {
-  const rawStart = part.raw.indexOf(part.current);
-  if (rawStart < 0) return spliceRange(part.node, part.text(value));
-  const rawEnd = rawStart + part.current.length;
+  const rawRange = textLeafRawRange(part, 0, part.current.length);
+  if (!rawRange) return spliceRange(part.node, part.text(value));
+  const { rawStart, rawEnd } = rawRange;
   return {
     from: part.node.start ?? 0,
     to: part.node.end ?? 0,
     text: `${part.raw.slice(0, rawStart)}${formatRichText(value, part.text)}${part.raw.slice(rawEnd)}`,
   };
+}
+
+function textLeafRawRange(
+  part: TextRangeLeaf,
+  start: number,
+  end: number,
+): { rawStart: number; rawEnd: number } | null {
+  if (start >= end) return null;
+  let first: number | null = null;
+  let last: number | null = null;
+  for (let i = start; i < end; i++) {
+    const offset = part.offsets[i];
+    if (offset === undefined) return null;
+    if (offset === null) continue;
+    first ??= offset;
+    last = offset;
+  }
+  if (first === null || last === null) return null;
+  return { rawStart: first, rawEnd: last + 1 };
 }
 
 function buildTextRangeReplaceSplices(
@@ -569,13 +778,16 @@ function buildTextContentSplices(
   const parts: TextRangePart[] = [];
   collectTextRangeParts(element, parts);
   const current = textRangeContent(parts);
-  if (current !== prevText) return { error: 'no text candidate matches the current value' };
-  const diff = textDiff(prevText, value);
+  if (!textMatchesExpected(current, prevText)) {
+    return { error: 'no text candidate matches the current value' };
+  }
+  const diff = textDiff(current, value);
   if (diff.start === diff.end && diff.value === '') return [];
   return buildTextRangeReplaceSplices(parts, diff.start, diff.end, diff.value);
 }
 
 function buildTextRangeStyleSplices(
+  ast: t.File,
   source: string,
   element: t.JSXElement,
   start: number,
@@ -592,7 +804,13 @@ function buildTextRangeStyleSplices(
   const current = prevText ?? textRangeContent(parts);
   if (!current) return { error: 'element has no editable text' };
   if (end > current.length) return { error: 'text range is out of bounds' };
-  if (prevText !== undefined && textRangeContent(parts) !== prevText) {
+  const renderedText = textRangeContent(parts);
+  if (prevText !== undefined && renderedText !== prevText) {
+    if (elementTextCandidateMatches(ast, element, prevText)) {
+      const result = buildStyleSplice(source, element, [op]);
+      if (result && 'error' in result) return result;
+      return result ? [result] : [];
+    }
     return { error: 'no text candidate matches the current value' };
   }
 
@@ -624,15 +842,15 @@ function buildTextRangeStyleSplices(
       continue;
     }
 
+    const localStart = selectedStart - leafStart;
+    const localEnd = selectedEnd - leafStart;
+    const rawRange = textLeafRawRange(leaf, localStart, localEnd);
+    if (!rawRange) return { error: 'text range source mismatch' };
     const raw = leaf.raw;
-    const currentStartInRaw = raw.indexOf(leaf.current);
-    if (currentStartInRaw < 0) return { error: 'text range source mismatch' };
-    const rawStart = currentStartInRaw + selectedStart - leafStart;
-    const rawEnd = currentStartInRaw + selectedEnd - leafStart;
+    const { rawStart, rawEnd } = rawRange;
     const before = raw.slice(0, rawStart);
-    const selected = raw.slice(rawStart, rawEnd);
+    const selected = leaf.current.slice(localStart, localEnd);
     const after = raw.slice(rawEnd);
-    if (op.value === null) continue;
     const beforeText = t.isJSXText(leaf.node) ? before : formatOptionalText(before, leaf.text);
     const afterText = t.isJSXText(leaf.node) ? after : formatOptionalText(after, leaf.text);
     splices.push(
@@ -898,12 +1116,7 @@ function collectArrayMapCandidates(ast: t.Node, element: t.JSXElement): TextCand
   return out;
 }
 
-function buildTextSplice(
-  ast: t.File,
-  element: t.JSXElement,
-  value: string,
-  prevText?: string,
-): Splice | { error: string } {
+function collectElementTextCandidates(ast: t.File, element: t.JSXElement): TextCandidate[] {
   const candidates: TextCandidate[] = [];
   collectTextCandidates(element, candidates);
   if (candidates.length === 0) {
@@ -911,22 +1124,32 @@ function buildTextSplice(
     const enclosing = passthrough ? findEnclosingComponent(ast, element) : null;
     if (passthrough === 'children' && enclosing) {
       candidates.push(...collectCallSiteCandidates(ast, enclosing.name));
-    } else if (
-      // `<h2>{title}</h2>` — route to the matching prop literal at each
-      // call site so reused components are independently editable.
-      passthrough &&
-      enclosing &&
-      componentDestructuresProp(enclosing.fn, passthrough)
-    ) {
+    } else if (passthrough && enclosing && componentDestructuresProp(enclosing.fn, passthrough)) {
       candidates.push(...collectPropCallSiteCandidates(ast, enclosing.name, passthrough));
     }
   }
   if (candidates.length === 0) {
-    // `surfaces.map((s) => <div>{s.label}</div>)` and the destructured
-    // form `({ label }) => <div>{label}</div>` — text lives in the
-    // matching object literal of the iterated array.
     candidates.push(...collectArrayMapCandidates(ast, element));
   }
+  return candidates;
+}
+
+function elementTextCandidateMatches(
+  ast: t.File,
+  element: t.JSXElement,
+  prevText: string,
+): boolean {
+  const norm = prevText.trim();
+  return collectElementTextCandidates(ast, element).some((candidate) => candidate.current === norm);
+}
+
+function buildTextSplice(
+  ast: t.File,
+  element: t.JSXElement,
+  value: string,
+  prevText?: string,
+): Splice | { error: string } {
+  const candidates = collectElementTextCandidates(ast, element);
   if (candidates.length === 0) {
     return { error: 'element has no editable text' };
   }
@@ -1113,7 +1336,7 @@ export function applyEdit(
 
   const ast = parseSource(source);
   if (!ast) return { ok: false, status: 422, error: 'could not parse source' };
-  const element = findInnermostJsxElement(ast, line, column);
+  const element = findElementForEdit(ast, line, column, ops);
   if (!element) return { ok: false, status: 422, error: 'no JSX element at location' };
 
   const splices: Splice[] = [];
@@ -1132,6 +1355,7 @@ export function applyEdit(
   for (const op of ops) {
     if (op.kind !== 'set-text-range-style') continue;
     const result = buildTextRangeStyleSplices(
+      ast,
       source,
       element,
       op.start,
@@ -1145,6 +1369,13 @@ export function applyEdit(
 
   for (const op of ops) {
     if (op.kind !== 'set-text') continue;
+    if (op.prevText !== undefined && (op.value.includes('\n') || op.prevText.includes('\n'))) {
+      const richResult = buildTextContentSplices(element, op.value, op.prevText);
+      if (!('error' in richResult)) {
+        splices.push(...richResult);
+        continue;
+      }
+    }
     const result = buildTextSplice(ast, element, op.value, op.prevText);
     if ('error' in result) {
       if (op.prevText === undefined) return { ok: false, status: 422, error: result.error };
@@ -1192,6 +1423,9 @@ export function applyEdit(
   let next = source;
   for (const sp of splices) {
     next = next.slice(0, sp.from) + sp.text + next.slice(sp.to);
+  }
+  if (!parseSource(next)) {
+    return { ok: false, status: 422, error: 'edit would produce invalid source' };
   }
   return { ok: true, source: next };
 }

--- a/packages/core/src/vite/open-slide-plugin.ts
+++ b/packages/core/src/vite/open-slide-plugin.ts
@@ -119,10 +119,25 @@ async function generateSlidesModule(
     if (e.theme) themesMap[e.id] = e.theme;
   }
   const themesJson = JSON.stringify(themesMap);
+  const importTokens = JSON.stringify(Object.fromEntries(entries.map((e) => [e.id, 0])));
+  const devRuntime = isDev
+    ? `
+const slideImportTokens = ${importTokens};
+if (import.meta.hot) {
+  import.meta.hot.on('open-slide:slide-changed', (data) => {
+    const ids = Array.isArray(data?.slideIds) ? data.slideIds : data?.slideId ? [data.slideId] : [];
+    const token = Date.now();
+    for (const id of ids) {
+      if (Object.prototype.hasOwnProperty.call(slideImportTokens, id)) slideImportTokens[id] = token;
+    }
+  });
+}
+`
+    : '';
   const cases = entries
     .map((e) => {
       const importExpr = isDev
-        ? `import(/* @vite-ignore */ ${JSON.stringify(`${e.importPath}?t=`)} + Date.now())`
+        ? `import(/* @vite-ignore */ ${JSON.stringify(`${e.importPath}?t=`)} + slideImportTokens[${JSON.stringify(e.id)}])`
         : `import(${JSON.stringify(e.importPath)})`;
       return `    case ${JSON.stringify(e.id)}: return ${importExpr};`;
     })
@@ -131,6 +146,7 @@ async function generateSlidesModule(
   return `// virtual:open-slide/slides — generated
 export const slideIds = ${ids};
 export const slideThemes = ${themesJson};
+${devRuntime}
 
 export async function loadSlide(id) {
   switch (id) {

--- a/packages/core/src/vite/open-slide-plugin.ts
+++ b/packages/core/src/vite/open-slide-plugin.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import fg from 'fast-glob';
-import { loadConfigFromFile, type Plugin } from 'vite';
+import { loadConfigFromFile, type Plugin, type ViteDevServer } from 'vite';
 import type { OpenSlideConfig } from '../config.ts';
 
 export type { OpenSlideConfig };
@@ -120,7 +120,12 @@ async function generateSlidesModule(
   }
   const themesJson = JSON.stringify(themesMap);
   const cases = entries
-    .map((e) => `    case ${JSON.stringify(e.id)}: return import(${JSON.stringify(e.importPath)});`)
+    .map((e) => {
+      const importExpr = isDev
+        ? `import(/* @vite-ignore */ ${JSON.stringify(`${e.importPath}?t=`)} + Date.now())`
+        : `import(${JSON.stringify(e.importPath)})`;
+      return `    case ${JSON.stringify(e.id)}: return ${importExpr};`;
+    })
     .join('\n');
 
   return `// virtual:open-slide/slides — generated
@@ -143,6 +148,32 @@ export function openSlidePlugin(opts: OpenSlidePluginOptions): Plugin {
   const foldersManifestPath = path.join(slidesRoot, '.folders.json');
 
   let isDev = false;
+  const slideIdForEntry = (p: string): string | null => {
+    const rel = path.relative(slidesRoot, p);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+    const parts = rel.split(path.sep);
+    if (parts.length !== 2) return null;
+    if (!/^index\.(tsx|jsx|ts|js)$/.test(parts[1])) return null;
+    return parts[0];
+  };
+  let slideChangeTimer: ReturnType<typeof setTimeout> | null = null;
+  const pendingSlideChanges = new Set<string>();
+  const queueSlideChanged = (server: ViteDevServer, id: string) => {
+    pendingSlideChanges.add(id);
+    if (slideChangeTimer) clearTimeout(slideChangeTimer);
+    slideChangeTimer = setTimeout(() => {
+      slideChangeTimer = null;
+      const mod = server.moduleGraph.getModuleById(resolved(SLIDES_VMOD));
+      if (mod) server.moduleGraph.invalidateModule(mod);
+      const slideIds = Array.from(pendingSlideChanges);
+      pendingSlideChanges.clear();
+      server.ws.send({
+        type: 'custom',
+        event: 'open-slide:slide-changed',
+        data: { slideIds },
+      });
+    }, 100);
+  };
 
   return {
     name: 'open-slide',
@@ -181,14 +212,14 @@ export function openSlidePlugin(opts: OpenSlidePluginOptions): Plugin {
       }
       return null;
     },
+    handleHotUpdate(ctx) {
+      const slideId = slideIdForEntry(ctx.file);
+      if (!slideId) return;
+      queueSlideChanged(ctx.server, slideId);
+      return [];
+    },
     configureServer(server) {
-      const isSlideEntry = (p: string) => {
-        const rel = path.relative(slidesRoot, p);
-        if (rel.startsWith('..') || path.isAbsolute(rel)) return false;
-        const parts = rel.split(path.sep);
-        if (parts.length !== 2) return false;
-        return /^index\.(tsx|jsx|ts|js)$/.test(parts[1]);
-      };
+      const isSlideEntry = (p: string) => slideIdForEntry(p) !== null;
 
       let reloadTimer: ReturnType<typeof setTimeout> | null = null;
       const reload = () => {
@@ -210,19 +241,6 @@ export function openSlidePlugin(opts: OpenSlidePluginOptions): Plugin {
       });
       server.watcher.on('unlink', (p) => {
         if (isSlideEntry(p)) reload();
-      });
-
-      let slideThemeTimer: ReturnType<typeof setTimeout> | null = null;
-      const invalidateSlidesVmod = () => {
-        if (slideThemeTimer) clearTimeout(slideThemeTimer);
-        slideThemeTimer = setTimeout(() => {
-          slideThemeTimer = null;
-          const mod = server.moduleGraph.getModuleById(resolved(SLIDES_VMOD));
-          if (mod) server.moduleGraph.invalidateModule(mod);
-        }, 100);
-      };
-      server.watcher.on('change', (p) => {
-        if (isSlideEntry(p)) invalidateSlidesVmod();
       });
 
       let foldersTimer: ReturnType<typeof setTimeout> | null = null;


### PR DESCRIPTION
## Summary
Fixes content editing in the inspector when selected text is split across inline JSX formatting, and avoids full page refreshes when slide modules are updated during dev.

Fixes #70
Fixes #71

## Key Changes
- Preserve inline JSX text fragments when inspector content edits or selected range typography/color changes are saved
- Add selected text range styling support for typography and color controls, including multiline text, <br />, JSXText, string/numeric expression containers, style spreads, and dynamic style expressions
- Add fallback matching for stale source locations and whitespace-only line break changes to prevent save failures like no text candidate matches the current value and text range source mismatch
- Replace full page reloads for slide module edits with a custom slide-changed HMR event and cache-busted dynamic imports

## Implementation Details
- Adds text range edit operations in the inspector provider and routes selected content ranges from the inspector panel to those operations
- Extends the comments Vite plugin to splice text and style edits into mixed JSX/text structures while preserving existing formatting
- Keeps add/remove slide changes as full reloads, while regular slide edits update the active slide module in place

## Test plan
- [x] pnpm check
- [x] pnpm test -- comments-plugin
- [x] pnpm core build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for styling selected text ranges in inspector content fields.
  * New slide-loading hook for more robust slide hydration.

* **Improvements**
  * More precise text selection and richer inline text editing in the inspector.
  * Refined element targeting for hover/click selection and more reliable undo/redo of text edits.
  * Faster slide updates during development via improved hot reload behavior.

* **Tests**
  * Expanded coverage for text styling and rich-text edit scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/103)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->