### PR TITLE
fix(core): resolve type errors in inspector, player, and comments plugin

### DIFF
--- a/.changeset/fix-core-type-errors.md
+++ b/.changeset/fix-core-type-errors.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Fix type errors across inspector, player, slide route, and comments plugin.

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -204,7 +204,7 @@ export function InspectorPanel() {
           end: contentRange.end,
           key: op.key,
           value: op.value,
-          prevText: pinSnapshot.text,
+          prevText: pinSnapshot.text ?? undefined,
         })),
       );
       setRangeStylePreview((current) => ({

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -44,7 +44,7 @@ export function Player({
   controls = false,
   slideId,
 }: Props) {
-  const rootRef = useRef<HTMLDivElement>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
   // Mirrored as state so descendants portaling *into* the player subtree
   // (tooltips, popovers — the body is outside the fullscreen tree) re-render
   // once the node mounts.

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -39,6 +39,7 @@ import { type ThumbnailActions, ThumbnailRail } from '../components/thumbnail-ra
 import { exportSlideAsHtml } from '../lib/export-html';
 import { exportSlideAsPdf } from '../lib/export-pdf';
 import { remapNotesSessionCacheAfterReorder } from '../lib/inspector/use-notes';
+import type { SlideModule } from '../lib/sdk';
 import { useSlideModule } from '../lib/use-slide-module';
 
 const { showSlideUi, showSlideBrowser, allowHtmlDownload } = config.build;

--- a/packages/core/src/vite/comments-plugin.ts
+++ b/packages/core/src/vite/comments-plugin.ts
@@ -390,7 +390,10 @@ function buildStyleSplice(
   }
 
   for (const op of ops) {
-    const matching = entries.filter((entry) => entry.kind === 'prop' && entry.key === op.key);
+    const matching = entries.filter(
+      (entry): entry is Extract<StyleEntry, { kind: 'prop' }> =>
+        entry.kind === 'prop' && entry.key === op.key,
+    );
     if (op.value === null) {
       for (const entry of matching) entries.splice(entries.indexOf(entry), 1);
       if (hasRawEntry) {
@@ -617,7 +620,7 @@ function collectTextRangePartsRaw(element: JsxParent, out: TextRangePart[]): voi
 }
 
 function normalizeTextRangeParts(parts: TextRangePart[]): TextRangePart[] {
-  return parts.flatMap((part, index) => {
+  return parts.flatMap((part, index): TextRangePart[] => {
     if (!('raw' in part)) return [part];
     let start = 0;
     let end = part.current.length;


### PR DESCRIPTION
## Summary
- Coerce nullable `pinSnapshot.text` to `undefined` for the `set-text-range-style` edit op so it matches `EditOp`'s `prevText?: string`
- Widen `Player`'s `rootRef` to `HTMLDivElement | null` so the callback ref can assign `.current`
- Import the missing `SlideModule` type in `routes/slide.tsx`
- Narrow `entries.filter(...)` in `comments-plugin` with a type predicate so `valueText` is in scope
- Annotate `normalizeTextRangeParts`' `flatMap` callback return as `TextRangePart[]` to avoid a `TextRangeBreak[] | TextRangeLeaf[]` union inference

## Test plan
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] Smoke inspector text-range styling in demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type errors in the inspector panel affecting text range styling operations
  * Resolved reference typing issues in the player component
  * Corrected type definitions in the slide route module
  * Fixed type inconsistencies in the comments plugin

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/110)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->