### PR TITLE
fix(core): shorten agent-connected/watching tooltips

### DIFF
--- a/.changeset/shorten-agent-tooltips.md
+++ b/.changeset/shorten-agent-tooltips.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Shorten the agent-connected and agent-watching tooltips so they read at a glance.

--- a/.changeset/shorten-agent-tooltips.md
+++ b/.changeset/shorten-agent-tooltips.md
@@ -2,4 +2,4 @@
 '@open-slide/core': patch
 ---
 
-Shorten the agent-connected and agent-watching tooltips so they read at a glance.
+Pare back the agent-connected and agent-watching tooltips to a single status line.

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -85,7 +85,7 @@ export const en: Locale = {
     backToHome: 'Back to home',
     agentConnected: 'Agent connected',
     agentConnectedTooltip:
-      'The dev server is publishing your current slide and inspector selection to your agent. Ask "this slide" or "this element" in chat and it will resolve. Disappears in production builds.',
+      'Your agent can see the current slide and inspector selection — ask about "this slide" or "this element" in chat.',
     agentDisconnected: 'Agent disconnected',
     agentDisconnectedTooltip:
       'Lost connection to the dev server, so your agent can no longer see the current slide or inspector selection. Restart the dev server to restore the connection.',
@@ -164,7 +164,7 @@ export const en: Locale = {
     deselect: 'Deselect',
     agentWatching: 'Agent is watching',
     agentWatchingTooltip:
-      'Your agent already sees the selected element via the dev server — just ask it in chat. Leave comments here only when you want to queue a few before asking.',
+      'Your agent already sees the selected element — just ask in chat. Leave comments here only to queue a batch.',
     agentNotWatching: 'Agent not watching',
     agentNotWatchingTooltip:
       'Lost connection to the dev server, so your agent can no longer see the selected element. Restart the dev server to restore the connection.',

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -85,7 +85,7 @@ export const en: Locale = {
     backToHome: 'Back to home',
     agentConnected: 'Agent connected',
     agentConnectedTooltip:
-      'Your agent can see the current slide and inspector selection — ask about "this slide" or "this element" in chat.',
+      'The current slide and inspector selection are synced to your agent in real time.',
     agentDisconnected: 'Agent disconnected',
     agentDisconnectedTooltip:
       'Lost connection to the dev server, so your agent can no longer see the current slide or inspector selection. Restart the dev server to restore the connection.',
@@ -163,8 +163,7 @@ export const en: Locale = {
     inspect: 'Inspect',
     deselect: 'Deselect',
     agentWatching: 'Agent is watching',
-    agentWatchingTooltip:
-      'Your agent already sees the selected element — just ask in chat. Leave comments here only to queue a batch.',
+    agentWatchingTooltip: 'The selected element is synced to your agent in real time.',
     agentNotWatching: 'Agent not watching',
     agentNotWatchingTooltip:
       'Lost connection to the dev server, so your agent can no longer see the selected element. Restart the dev server to restore the connection.',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -83,7 +83,7 @@ export const ja: Locale = {
   slide: {
     agentConnected: 'エージェント接続中',
     agentConnectedTooltip:
-      '現在のスライドと Inspector の選択状態を dev server がエージェントに公開しています。チャットで「このスライド」「この要素」と言えば認識されます。本番ビルドでは表示されません。',
+      'エージェントは現在のスライドと Inspector の選択を把握しています。チャットで「このスライド」「この要素」と言えば伝わります。',
     agentDisconnected: 'エージェント切断',
     agentDisconnectedTooltip:
       'dev server との接続が切れたため、現在のスライドや Inspector の選択がエージェントに届かなくなっています。dev server を再起動して接続を復旧してください。',
@@ -201,7 +201,7 @@ export const ja: Locale = {
     cropResetAria: 'トリミングをリセット',
     agentWatching: 'エージェント監視中',
     agentWatchingTooltip:
-      'エージェントは選択中の要素を dev server 経由で把握しています。直接チャットで頼めます。ここにコメントを残すのは、複数の依頼をまとめて出したいときだけで OK。',
+      'エージェントは選択中の要素を把握しています。チャットで直接依頼できます。複数まとめたいときだけここにコメントを。',
     agentNotWatching: 'エージェント未接続',
     agentNotWatchingTooltip:
       'dev server との接続が切れたため、選択中の要素がエージェントに見えなくなっています。dev server を再起動して接続を復旧してください。',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -83,7 +83,7 @@ export const ja: Locale = {
   slide: {
     agentConnected: 'エージェント接続中',
     agentConnectedTooltip:
-      'エージェントは現在のスライドと Inspector の選択を把握しています。チャットで「このスライド」「この要素」と言えば伝わります。',
+      '現在のスライドと Inspector の選択はエージェントにリアルタイムで同期されています。',
     agentDisconnected: 'エージェント切断',
     agentDisconnectedTooltip:
       'dev server との接続が切れたため、現在のスライドや Inspector の選択がエージェントに届かなくなっています。dev server を再起動して接続を復旧してください。',
@@ -200,8 +200,7 @@ export const ja: Locale = {
     cropApply: '適用',
     cropResetAria: 'トリミングをリセット',
     agentWatching: 'エージェント監視中',
-    agentWatchingTooltip:
-      'エージェントは選択中の要素を把握しています。チャットで直接依頼できます。複数まとめたいときだけここにコメントを。',
+    agentWatchingTooltip: '選択中の要素はエージェントにリアルタイムで同期されています。',
     agentNotWatching: 'エージェント未接続',
     agentNotWatchingTooltip:
       'dev server との接続が切れたため、選択中の要素がエージェントに見えなくなっています。dev server を再起動して接続を復旧してください。',

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -83,7 +83,7 @@ export const zhCN: Locale = {
   slide: {
     agentConnected: 'Agent 已连接',
     agentConnectedTooltip:
-      'Dev server 正在把你目前在哪张 slide、Inspector 选了哪个元素发布给 agent。直接到聊天说"这张 slide"或"这个元素"就行。Production build 不会出现。',
+      'Agent 看得到你目前的 slide 和 Inspector 选择，直接到聊天说"这张 slide"或"这个元素"就行。',
     agentDisconnected: 'Agent 已断开',
     agentDisconnectedTooltip:
       '已和 dev server 断开连接，agent 没办法再看到你目前的 slide 或 Inspector 选择。请重新启动 dev server 来恢复连接。',
@@ -200,7 +200,7 @@ export const zhCN: Locale = {
     cropResetAria: '重置裁剪',
     agentWatching: 'Agent 正在关注',
     agentWatchingTooltip:
-      'Agent 已经通过 dev server 看到你选的元素了，直接到聊天请它修改就行。想累积几个再一次问才需要在这里留 comments。',
+      'Agent 已经看到你选的元素，直接到聊天请它修改就行。想累积几个一次问再来留 comments。',
     agentNotWatching: 'Agent 没在关注',
     agentNotWatchingTooltip:
       '已和 dev server 断开连接，agent 看不到你选的元素了。请重新启动 dev server 来恢复连接。',

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -82,8 +82,7 @@ export const zhCN: Locale = {
 
   slide: {
     agentConnected: 'Agent 已连接',
-    agentConnectedTooltip:
-      'Agent 看得到你目前的 slide 和 Inspector 选择，直接到聊天说"这张 slide"或"这个元素"就行。',
+    agentConnectedTooltip: '目前的 slide 与 Inspector 选择会即时同步给 agent。',
     agentDisconnected: 'Agent 已断开',
     agentDisconnectedTooltip:
       '已和 dev server 断开连接，agent 没办法再看到你目前的 slide 或 Inspector 选择。请重新启动 dev server 来恢复连接。',
@@ -199,8 +198,7 @@ export const zhCN: Locale = {
     cropApply: '应用',
     cropResetAria: '重置裁剪',
     agentWatching: 'Agent 正在关注',
-    agentWatchingTooltip:
-      'Agent 已经看到你选的元素，直接到聊天请它修改就行。想累积几个一次问再来留 comments。',
+    agentWatchingTooltip: '选取的元素会即时同步给 agent。',
     agentNotWatching: 'Agent 没在关注',
     agentNotWatchingTooltip:
       '已和 dev server 断开连接，agent 看不到你选的元素了。请重新启动 dev server 来恢复连接。',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -83,7 +83,7 @@ export const zhTW: Locale = {
   slide: {
     agentConnected: 'Agent 已連線',
     agentConnectedTooltip:
-      'Dev server 正在把你目前在哪張 slide、Inspector 選了哪個元素發布給 agent。直接到聊天說「這張 slide」或「這個元素」就行。Production build 不會出現。',
+      'Agent 看得到你目前的 slide 和 Inspector 選擇，直接到聊天說「這張 slide」或「這個元素」就行。',
     agentDisconnected: 'Agent 已斷線',
     agentDisconnectedTooltip:
       '已和 dev server 斷線，agent 沒辦法再看到你目前的 slide 或 Inspector 選擇。請重新啟動 dev server 來恢復連線。',
@@ -200,7 +200,7 @@ export const zhTW: Locale = {
     cropResetAria: '重設裁切',
     agentWatching: 'Agent 正在關注',
     agentWatchingTooltip:
-      'Agent 已經透過 dev server 看到你選的元素了，直接到聊天請它修改就行。想累積幾個再一次問才需要在這裡留 comments。',
+      'Agent 已經看到你選的元素，直接到聊天請它修改就行。想累積幾個一次問再來留 comments。',
     agentNotWatching: 'Agent 沒在關注',
     agentNotWatchingTooltip:
       '已和 dev server 斷線，agent 看不到你選的元素了。請重新啟動 dev server 來恢復連線。',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -82,8 +82,7 @@ export const zhTW: Locale = {
 
   slide: {
     agentConnected: 'Agent 已連線',
-    agentConnectedTooltip:
-      'Agent 看得到你目前的 slide 和 Inspector 選擇，直接到聊天說「這張 slide」或「這個元素」就行。',
+    agentConnectedTooltip: '目前的 slide 與 Inspector 選擇會即時同步給 agent。',
     agentDisconnected: 'Agent 已斷線',
     agentDisconnectedTooltip:
       '已和 dev server 斷線，agent 沒辦法再看到你目前的 slide 或 Inspector 選擇。請重新啟動 dev server 來恢復連線。',
@@ -199,8 +198,7 @@ export const zhTW: Locale = {
     cropApply: '套用',
     cropResetAria: '重設裁切',
     agentWatching: 'Agent 正在關注',
-    agentWatchingTooltip:
-      'Agent 已經看到你選的元素，直接到聊天請它修改就行。想累積幾個一次問再來留 comments。',
+    agentWatchingTooltip: '選取的元素會即時同步給 agent。',
     agentNotWatching: 'Agent 沒在關注',
     agentNotWatchingTooltip:
       '已和 dev server 斷線，agent 看不到你選的元素了。請重新啟動 dev server 來恢復連線。',


### PR DESCRIPTION
Trim the success-state tooltips for the agent-connected slide-header pill
and the agent-watching inspector pill so they read at a glance. Error-state
tooltips left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Shortened and clarified agent-related tooltips across English, Japanese, Simplified Chinese, and Traditional Chinese: replaced longer dev-server/production guidance with concise messages that the current slide and selected element are synchronized to the agent in real time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/111)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->