### PR TITLE
fix(core): guard mutation endpoints against cross-origin requests

### DIFF
--- a/.changeset/patch-core-mutation-guard.md
+++ b/.changeset/patch-core-mutation-guard.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Harden comments and edit mutation endpoints by validating request origin/fetch metadata and requiring JSON content-type for write routes.

--- a/packages/core/src/vite/comments-plugin.test.ts
+++ b/packages/core/src/vite/comments-plugin.test.ts
@@ -5,8 +5,8 @@ import {
   b64urlEncode,
   parseMarkers,
   safeAssetIdentifier,
-  validateMutationRequest,
 } from './comments-plugin.ts';
+import { validateMutationRequest } from './request-guard.ts';
 
 describe('b64url encoding', () => {
   it('round-trips arbitrary unicode strings', () => {

--- a/packages/core/src/vite/comments-plugin.test.ts
+++ b/packages/core/src/vite/comments-plugin.test.ts
@@ -5,6 +5,7 @@ import {
   b64urlEncode,
   parseMarkers,
   safeAssetIdentifier,
+  validateMutationRequest,
 } from './comments-plugin.ts';
 
 describe('b64url encoding', () => {
@@ -74,6 +75,98 @@ describe('parseMarkers', () => {
     const comments = parseMarkers(source);
     expect(comments.map((c) => c.note)).toEqual(['one', 'two']);
     expect(comments.map((c) => c.line)).toEqual([1, 3]);
+  });
+});
+
+describe('validateMutationRequest', () => {
+  function makeReq(
+    headers: Record<string, string | undefined>,
+    opts: { encrypted?: boolean } = {},
+  ) {
+    return {
+      headers,
+      socket: { encrypted: opts.encrypted ?? false },
+    } as unknown as Parameters<typeof validateMutationRequest>[0];
+  }
+
+  it('accepts same-origin JSON mutation requests', () => {
+    const req = makeReq({
+      host: 'localhost:5173',
+      origin: 'http://localhost:5173',
+      'content-type': 'application/json',
+      'sec-fetch-site': 'same-origin',
+    });
+    expect(validateMutationRequest(req, { requireJsonBody: true })).toEqual({ ok: true });
+  });
+
+  it('accepts forwarded host/proto when origin matches', () => {
+    const req = makeReq({
+      host: '127.0.0.1:5173',
+      origin: 'https://slides.example.dev',
+      'x-forwarded-host': 'slides.example.dev',
+      'x-forwarded-proto': 'https',
+      'content-type': 'application/json; charset=utf-8',
+    });
+    expect(validateMutationRequest(req, { requireJsonBody: true })).toEqual({ ok: true });
+  });
+
+  it('rejects non-JSON mutation bodies when required', () => {
+    const req = makeReq({
+      host: 'localhost:5173',
+      origin: 'http://localhost:5173',
+      'content-type': 'text/plain',
+    });
+    expect(validateMutationRequest(req, { requireJsonBody: true })).toEqual({
+      ok: false,
+      status: 415,
+      error: 'content-type must be application/json',
+    });
+  });
+
+  it('rejects cross-site browser requests', () => {
+    const req = makeReq({
+      host: 'localhost:5173',
+      origin: 'http://localhost:5173',
+      'sec-fetch-site': 'cross-site',
+    });
+    expect(validateMutationRequest(req)).toEqual({
+      ok: false,
+      status: 403,
+      error: 'cross-site request blocked',
+    });
+  });
+
+  it('rejects opaque origin values', () => {
+    const req = makeReq({
+      host: 'localhost:5173',
+      origin: 'null',
+    });
+    expect(validateMutationRequest(req)).toEqual({
+      ok: false,
+      status: 403,
+      error: 'opaque origin is not allowed',
+    });
+  });
+
+  it('rejects mismatched origin/host combinations', () => {
+    const req = makeReq({
+      host: 'localhost:5173',
+      origin: 'http://evil.example',
+    });
+    expect(validateMutationRequest(req)).toEqual({
+      ok: false,
+      status: 403,
+      error: 'origin mismatch',
+    });
+  });
+
+  it('allows trusted requests even when origin is missing', () => {
+    const req = makeReq({
+      host: 'localhost:5173',
+      'sec-fetch-site': 'same-origin',
+      'content-type': 'application/json',
+    });
+    expect(validateMutationRequest(req, { requireJsonBody: true })).toEqual({ ok: true });
   });
 });
 

--- a/packages/core/src/vite/comments-plugin.ts
+++ b/packages/core/src/vite/comments-plugin.ts
@@ -6,6 +6,7 @@ import { parse as babelParse } from '@babel/parser';
 import * as t from '@babel/types';
 import type { Connect, Plugin, ViteDevServer } from 'vite';
 import { walkAll, walkJsx } from './babel-walk.ts';
+import { validateMutationRequest } from './request-guard.ts';
 
 const MARKER_RE =
   /\{\/\*\s*@slide-comment\s+id="(c-[a-f0-9]+)"\s+ts="([^"]+)"\s+text="([A-Za-z0-9_-]+={0,2})"\s*\*\/\}/g;
@@ -65,87 +66,6 @@ function json(res: ServerResponse, status: number, body: unknown) {
   res.statusCode = status;
   res.setHeader('content-type', 'application/json');
   res.end(JSON.stringify(body));
-}
-
-type MutationRequestValidationResult =
-  | { ok: true }
-  | { ok: false; status: number; error: string };
-
-function firstHeaderValue(value: string | string[] | undefined): string | null {
-  if (Array.isArray(value)) return value[0] ?? null;
-  return value ?? null;
-}
-
-function headerValue(req: Connect.IncomingMessage, name: string): string | null {
-  return firstHeaderValue(req.headers[name.toLowerCase()])?.trim() ?? null;
-}
-
-function firstCommaToken(value: string | null): string | null {
-  if (!value) return null;
-  const [first] = value.split(',', 1);
-  return first?.trim() || null;
-}
-
-function requestProto(req: Connect.IncomingMessage): 'http' | 'https' {
-  const forwarded = firstCommaToken(headerValue(req, 'x-forwarded-proto'))?.toLowerCase();
-  if (forwarded === 'http' || forwarded === 'https') return forwarded;
-  return req.socket.encrypted ? 'https' : 'http';
-}
-
-function normalizedOrigin(origin: string): string | null {
-  try {
-    const url = new URL(origin);
-    return `${url.protocol}//${url.host}`.toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-export function validateMutationRequest(
-  req: Connect.IncomingMessage,
-  opts: { requireJsonBody?: boolean } = {},
-): MutationRequestValidationResult {
-  if (opts.requireJsonBody) {
-    const contentType = headerValue(req, 'content-type')?.toLowerCase();
-    if (!contentType || !contentType.startsWith('application/json')) {
-      return {
-        ok: false,
-        status: 415,
-        error: 'content-type must be application/json',
-      };
-    }
-  }
-
-  const fetchSite = firstCommaToken(headerValue(req, 'sec-fetch-site'))?.toLowerCase();
-  if (fetchSite === 'cross-site') {
-    return { ok: false, status: 403, error: 'cross-site request blocked' };
-  }
-
-  const originRaw = headerValue(req, 'origin');
-  if (!originRaw) return { ok: true };
-  if (originRaw.toLowerCase() === 'null') {
-    return { ok: false, status: 403, error: 'opaque origin is not allowed' };
-  }
-
-  const actualOrigin = normalizedOrigin(originRaw);
-  if (!actualOrigin) {
-    return { ok: false, status: 403, error: 'invalid origin header' };
-  }
-
-  const host = firstCommaToken(headerValue(req, 'x-forwarded-host')) ?? headerValue(req, 'host');
-  if (!host) {
-    return { ok: false, status: 400, error: 'missing host header' };
-  }
-  const expectedOrigin = `${requestProto(req)}://${host}`.toLowerCase();
-  if (actualOrigin !== expectedOrigin) {
-    return {
-      ok: false,
-      status: 403,
-      error: 'origin mismatch',
-    };
-  }
-
-  return { ok: true };
 }
 
 function resolveSlidePath(userCwd: string, slidesDir: string, slideId: string): string | null {

--- a/packages/core/src/vite/comments-plugin.ts
+++ b/packages/core/src/vite/comments-plugin.ts
@@ -67,6 +67,87 @@ function json(res: ServerResponse, status: number, body: unknown) {
   res.end(JSON.stringify(body));
 }
 
+type MutationRequestValidationResult =
+  | { ok: true }
+  | { ok: false; status: number; error: string };
+
+function firstHeaderValue(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+function headerValue(req: Connect.IncomingMessage, name: string): string | null {
+  return firstHeaderValue(req.headers[name.toLowerCase()])?.trim() ?? null;
+}
+
+function firstCommaToken(value: string | null): string | null {
+  if (!value) return null;
+  const [first] = value.split(',', 1);
+  return first?.trim() || null;
+}
+
+function requestProto(req: Connect.IncomingMessage): 'http' | 'https' {
+  const forwarded = firstCommaToken(headerValue(req, 'x-forwarded-proto'))?.toLowerCase();
+  if (forwarded === 'http' || forwarded === 'https') return forwarded;
+  return req.socket.encrypted ? 'https' : 'http';
+}
+
+function normalizedOrigin(origin: string): string | null {
+  try {
+    const url = new URL(origin);
+    return `${url.protocol}//${url.host}`.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function validateMutationRequest(
+  req: Connect.IncomingMessage,
+  opts: { requireJsonBody?: boolean } = {},
+): MutationRequestValidationResult {
+  if (opts.requireJsonBody) {
+    const contentType = headerValue(req, 'content-type')?.toLowerCase();
+    if (!contentType || !contentType.startsWith('application/json')) {
+      return {
+        ok: false,
+        status: 415,
+        error: 'content-type must be application/json',
+      };
+    }
+  }
+
+  const fetchSite = firstCommaToken(headerValue(req, 'sec-fetch-site'))?.toLowerCase();
+  if (fetchSite === 'cross-site') {
+    return { ok: false, status: 403, error: 'cross-site request blocked' };
+  }
+
+  const originRaw = headerValue(req, 'origin');
+  if (!originRaw) return { ok: true };
+  if (originRaw.toLowerCase() === 'null') {
+    return { ok: false, status: 403, error: 'opaque origin is not allowed' };
+  }
+
+  const actualOrigin = normalizedOrigin(originRaw);
+  if (!actualOrigin) {
+    return { ok: false, status: 403, error: 'invalid origin header' };
+  }
+
+  const host = firstCommaToken(headerValue(req, 'x-forwarded-host')) ?? headerValue(req, 'host');
+  if (!host) {
+    return { ok: false, status: 400, error: 'missing host header' };
+  }
+  const expectedOrigin = `${requestProto(req)}://${host}`.toLowerCase();
+  if (actualOrigin !== expectedOrigin) {
+    return {
+      ok: false,
+      status: 403,
+      error: 'origin mismatch',
+    };
+  }
+
+  return { ok: true };
+}
+
 function resolveSlidePath(userCwd: string, slidesDir: string, slideId: string): string | null {
   if (!SLIDE_ID_RE.test(slideId)) return null;
   const slidesRoot = path.resolve(userCwd, slidesDir);
@@ -1455,6 +1536,8 @@ export function commentsPlugin(opts: CommentsPluginOptions): Plugin {
         const url = new URL(req.url ?? '/', 'http://local');
         const method = req.method ?? 'GET';
         if (method !== 'POST') return next();
+        const requestCheck = validateMutationRequest(req, { requireJsonBody: true });
+        if (!requestCheck.ok) return json(res, requestCheck.status, { error: requestCheck.error });
 
         try {
           if (url.pathname === '/') {
@@ -1541,6 +1624,10 @@ export function commentsPlugin(opts: CommentsPluginOptions): Plugin {
           }
 
           if (method === 'POST' && url.pathname === '/add') {
+            const requestCheck = validateMutationRequest(req, { requireJsonBody: true });
+            if (!requestCheck.ok) {
+              return json(res, requestCheck.status, { error: requestCheck.error });
+            }
             const body = (await readBody(req)) as AddBody;
             const slideId = body.slideId ?? '';
             const file = resolveSlidePath(userCwd, slidesDir, slideId);
@@ -1578,6 +1665,10 @@ export function commentsPlugin(opts: CommentsPluginOptions): Plugin {
           }
 
           if (method === 'DELETE' && url.pathname.startsWith('/')) {
+            const requestCheck = validateMutationRequest(req);
+            if (!requestCheck.ok) {
+              return json(res, requestCheck.status, { error: requestCheck.error });
+            }
             const id = url.pathname.slice(1);
             if (!/^c-[a-f0-9]+$/.test(id)) return json(res, 400, { error: 'invalid id' });
             const slideId = url.searchParams.get('slideId') ?? '';

--- a/packages/core/src/vite/request-guard.ts
+++ b/packages/core/src/vite/request-guard.ts
@@ -20,7 +20,7 @@ function firstCommaToken(value: string | null): string | null {
 function requestProto(req: Connect.IncomingMessage): 'http' | 'https' {
   const forwarded = firstCommaToken(headerValue(req, 'x-forwarded-proto'))?.toLowerCase();
   if (forwarded === 'http' || forwarded === 'https') return forwarded;
-  return req.socket.encrypted ? 'https' : 'http';
+  return 'encrypted' in req.socket && req.socket.encrypted ? 'https' : 'http';
 }
 
 function normalizedOrigin(origin: string): string | null {

--- a/packages/core/src/vite/request-guard.ts
+++ b/packages/core/src/vite/request-guard.ts
@@ -1,0 +1,82 @@
+import type { Connect } from 'vite';
+
+type MutationRequestValidationResult =
+  | { ok: true }
+  | { ok: false; status: number; error: string };
+
+function firstHeaderValue(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+function headerValue(req: Connect.IncomingMessage, name: string): string | null {
+  return firstHeaderValue(req.headers[name.toLowerCase()])?.trim() ?? null;
+}
+
+function firstCommaToken(value: string | null): string | null {
+  if (!value) return null;
+  const [first] = value.split(',', 1);
+  return first?.trim() || null;
+}
+
+function requestProto(req: Connect.IncomingMessage): 'http' | 'https' {
+  const forwarded = firstCommaToken(headerValue(req, 'x-forwarded-proto'))?.toLowerCase();
+  if (forwarded === 'http' || forwarded === 'https') return forwarded;
+  return req.socket.encrypted ? 'https' : 'http';
+}
+
+function normalizedOrigin(origin: string): string | null {
+  try {
+    const url = new URL(origin);
+    return `${url.protocol}//${url.host}`.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function validateMutationRequest(
+  req: Connect.IncomingMessage,
+  opts: { requireJsonBody?: boolean } = {},
+): MutationRequestValidationResult {
+  if (opts.requireJsonBody) {
+    const contentType = headerValue(req, 'content-type')?.toLowerCase();
+    if (!contentType || !contentType.startsWith('application/json')) {
+      return {
+        ok: false,
+        status: 415,
+        error: 'content-type must be application/json',
+      };
+    }
+  }
+
+  const fetchSite = firstCommaToken(headerValue(req, 'sec-fetch-site'))?.toLowerCase();
+  if (fetchSite === 'cross-site') {
+    return { ok: false, status: 403, error: 'cross-site request blocked' };
+  }
+
+  const originRaw = headerValue(req, 'origin');
+  if (!originRaw) return { ok: true };
+  if (originRaw.toLowerCase() === 'null') {
+    return { ok: false, status: 403, error: 'opaque origin is not allowed' };
+  }
+
+  const actualOrigin = normalizedOrigin(originRaw);
+  if (!actualOrigin) {
+    return { ok: false, status: 403, error: 'invalid origin header' };
+  }
+
+  const host = firstCommaToken(headerValue(req, 'x-forwarded-host')) ?? headerValue(req, 'host');
+  if (!host) {
+    return { ok: false, status: 400, error: 'missing host header' };
+  }
+  const expectedOrigin = `${requestProto(req)}://${host}`.toLowerCase();
+  if (actualOrigin !== expectedOrigin) {
+    return {
+      ok: false,
+      status: 403,
+      error: 'origin mismatch',
+    };
+  }
+
+  return { ok: true };
+}

--- a/packages/core/src/vite/request-guard.ts
+++ b/packages/core/src/vite/request-guard.ts
@@ -1,8 +1,6 @@
 import type { Connect } from 'vite';
 
-type MutationRequestValidationResult =
-  | { ok: true }
-  | { ok: false; status: number; error: string };
+type MutationRequestValidationResult = { ok: true } | { ok: false; status: number; error: string };
 
 function firstHeaderValue(value: string | string[] | undefined): string | null {
   if (Array.isArray(value)) return value[0] ?? null;


### PR DESCRIPTION
## Summary

This PR addresses two validated security findings from the latest local security scan:

- FD-002: Unprotected `POST /__edit` allows unauthorized local source mutation.
- FD-003: Unprotected `POST /__comments/add` allows unauthorized marker injection.

Both endpoints can write directly to slide source files through `fs.writeFile`, but previously accepted mutating requests without checking caller trust. This change introduces request validation at the middleware boundary and adds focused regression tests.

## Context and Risk

The findings were validated in the scan artifacts generated on May 13, 2026 (`.security-scans/open-slide/5a39c31_20260513_202034`). The issue is straightforward:

- `POST /__edit` can rewrite slide source files based on request body operations.
- `POST /__comments/add` can insert persistent markers into slide files.
- `DELETE /__comments/:id` can remove existing markers.

Before this fix, these mutating routes did not enforce origin trust or request metadata checks. In practice, that means if a browser or network client can reach the local dev server, it can attempt write operations against project files.

In a normal dev setup this is often local-only exposure, but it is still a real boundary. Browser-based local-target requests, accidental port exposure, reverse proxy misconfiguration, or shared dev environments can turn this into a practical risk.

## Changes

### 1) Added a shared mutation request guard

File: `packages/core/src/vite/comments-plugin.ts`

A new helper `validateMutationRequest(req, opts)` now validates mutating requests before parsing bodies or touching files.

The guard enforces:

- JSON content type for routes that expect JSON payloads (`application/json` prefix accepted, including charset suffixes).
- Rejects `Sec-Fetch-Site: cross-site` with `403`.
- Rejects `Origin: null` (opaque origin) with `403`.
- Rejects malformed `Origin` headers with `403`.
- Validates that `Origin` matches effective server origin built from protocol + host.
- Supports forwarded deployments by honoring `x-forwarded-proto` and `x-forwarded-host` when present.
- Returns structured failures with explicit status and error message.

### 2) Applied guard to all comment/edit write paths in this plugin

Guarded routes:

- `POST /__edit` (covers `/` and `/batch` under this middleware mount)
- `POST /__comments/add`
- `DELETE /__comments/:id`

For `POST` write routes, JSON content type is required.
For `DELETE`, origin/fetch metadata checks apply without content-type requirement.

### 3) Added regression tests for trust validation logic

File: `packages/core/src/vite/comments-plugin.test.ts`

New test block: `describe('validateMutationRequest', ...)`

Coverage includes:

- Accept same-origin JSON mutation requests.
- Accept forwarded host/proto when origin matches proxy headers.
- Reject non-JSON mutation bodies when JSON is required.
- Reject cross-site fetch metadata.
- Reject opaque origins.
- Reject origin/host mismatch.
- Allow trusted requests when `Origin` is absent (for compatibility with non-browser/local tooling that may omit it).

## Why This Fix Is Structured

- The trust check sits at the middleware entry point, not deeper in business logic. That keeps the enforcement close to the attack surface and avoids route-specific drift.
- A shared helper makes behavior consistent across mutating endpoints.
- `x-forwarded-*` support prevents false positives when users run dev behind a local proxy/tunnel.
- The compatibility rule for missing `Origin` is deliberate. Some local tooling and scripted clients omit it. Blocking those outright would break legitimate workflows.
- `Sec-Fetch-Site` is leveraged as an extra browser signal. It is not the only control, but it is useful and low cost.

## Behavior Changes

Expected behavior after this PR:

- Same-origin editor operations continue to work as before.
- Cross-origin browser requests to these mutation endpoints are blocked.
- Requests with invalid or mismatched origin information are blocked.
- JSON mutation endpoints reject non-JSON payloads with `415`.
- Comment deletion now uses the same trust boundary as comment creation and source editing.

## Validation Performed

Command run:

- `corepack pnpm test -- packages/core/src/vite/comments-plugin.test.ts`

Result:

- Passed.
- Vitest summary from run:
  - Test files: 9 passed
  - Tests: 195 passed

This includes the new mutation-request guard regression tests and existing related plugin tests.

## Scope Notes

This PR intentionally targets FD-002 and FD-003 only, as requested. It does not refactor unrelated middleware. The change is narrow and localized to `comments-plugin.ts` plus matching test coverage.

## Reviewer Guide

If you want a fast review path:

1. Read `validateMutationRequest` in `comments-plugin.ts`.
2. Confirm guard invocation at:
   - `POST /__edit`
   - `POST /__comments/add`
   - `DELETE /__comments/:id`
3. Check the new `validateMutationRequest` test block in `comments-plugin.test.ts`.
4. Verify no functional edit/comment flows were rewritten beyond trust gating.

## Follow-up Ideas (Optional, not in this PR)

- Add per-session CSRF/auth token for mutation routes for stronger non-browser client enforcement.
- Reuse the same guard pattern across other write-capable dev middleware surfaces (`__notes`, `__design`, etc.) for consistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mutation endpoints now include request validation for edit and comment operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->