### PR TITLE
fix(core): prevent inspector content textarea from widening panel

### DIFF
--- a/.changeset/inspector-textarea-no-grow.md
+++ b/.changeset/inspector-textarea-no-grow.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Prevent inspector content textarea from expanding the panel width when typing long unbroken lines.

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -439,7 +439,7 @@ function ContentField({
       onSelect={(e) => reportSelection(e.currentTarget)}
       wrap="off"
       rows={3}
-      className="min-h-16 resize-none overflow-x-auto whitespace-pre text-xs"
+      className="field-sizing-fixed min-h-16 w-full resize-none overflow-x-auto whitespace-pre text-xs"
       placeholder={t.inspector.elementTextPlaceholder}
     />
   );


### PR DESCRIPTION
## Summary

- The inspector's Content textarea uses `wrap=\"off\"` + `whitespace-pre`, and the base `Textarea` ships with `field-sizing-content`. Typing a long unbroken line on one row made the textarea grow horizontally, stretching the whole inspector panel and producing left/right scroll on the panel.
- Override with `field-sizing-fixed` and `w-full` on the inspector's textarea so it stays at the container width and the existing `overflow-x-auto` handles horizontal scrolling inside the textarea instead.

## Test plan

- [ ] Open a slide, select a text element, focus the Content field in the inspector.
- [ ] Type a long line without spaces/newlines — textarea should scroll horizontally; panel width stays fixed.
- [ ] Type multi-line content — vertical behavior unchanged (`min-h-16`, `rows=3`).
- [ ] IME composition (Bopomofo/Pinyin) still commits correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inspector content textarea from expanding the panel width when typing long unbroken lines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/115)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->