### PR TITLE
feat(core): warn when triggering PDF export on Safari

### DIFF
--- a/.changeset/safari-pdf-export-warning.md
+++ b/.changeset/safari-pdf-export-warning.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Show a toast when triggering PDF export on Safari, since the print pipeline isn't supported there.

--- a/packages/core/src/app/lib/export-pdf.ts
+++ b/packages/core/src/app/lib/export-pdf.ts
@@ -65,6 +65,12 @@ const PRINT_STYLES = `
 }
 `;
 
+export function isSafari(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent;
+  return /Safari/.test(ua) && !/Chrome|Chromium|Edg|OPR|Firefox/.test(ua);
+}
+
 export type PdfExportProgress = {
   phase: 'processing' | 'printing' | 'done';
   /** Number of pages whose intro animations have finished (0..total). */

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -37,7 +37,7 @@ import { Player } from '../components/player';
 import { SlideCanvas } from '../components/slide-canvas';
 import { type ThumbnailActions, ThumbnailRail } from '../components/thumbnail-rail';
 import { exportSlideAsHtml } from '../lib/export-html';
-import { exportSlideAsPdf } from '../lib/export-pdf';
+import { exportSlideAsPdf, isSafari } from '../lib/export-pdf';
 import { remapNotesSessionCacheAfterReorder } from '../lib/inspector/use-notes';
 import type { SlideModule } from '../lib/sdk';
 import { useSlideModule } from '../lib/use-slide-module';
@@ -400,6 +400,10 @@ export function Slide() {
                       disabled={exporting}
                       onSelect={async () => {
                         if (!slide || exporting) return;
+                        if (isSafari()) {
+                          toast.error(t.slide.pdfExportSafariUnsupported, { duration: 5000 });
+                          return;
+                        }
                         setExporting(true);
                         const toastId = `pdf-export-${slideId}`;
                         toast.custom(

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -94,6 +94,8 @@ export const en: Locale = {
     exportAsHtml: 'Export as HTML',
     exportAsPdf: 'Export as PDF',
     pdfExportFailed: 'PDF export failed',
+    pdfExportSafariUnsupported:
+      'Export as PDF is not supported on Safari. Please try a Chromium-based browser instead.',
     present: 'Present',
     slidesTab: 'Slides',
     assetsTab: 'Assets',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -94,6 +94,8 @@ export const ja: Locale = {
     exportAsHtml: 'HTML として書き出し',
     exportAsPdf: 'PDF として書き出し',
     pdfExportFailed: 'PDF の書き出しに失敗しました',
+    pdfExportSafariUnsupported:
+      'PDF の書き出しは現在 Safari では対応していません。Chromium ベースのブラウザでお試しください。',
     present: '発表',
     slidesTab: 'スライド',
     assetsTab: 'アセット',

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -95,6 +95,7 @@ export type Locale = {
     exportAsHtml: string;
     exportAsPdf: string;
     pdfExportFailed: string;
+    pdfExportSafariUnsupported: string;
     present: string;
     slidesTab: string;
     assetsTab: string;

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -93,6 +93,8 @@ export const zhCN: Locale = {
     exportAsHtml: '导出为 HTML',
     exportAsPdf: '导出为 PDF',
     pdfExportFailed: 'PDF 导出失败',
+    pdfExportSafariUnsupported:
+      '导出 PDF 目前不支持 Safari 设备，请尝试使用基于 Chromium 的浏览器替代。',
     present: '演示',
     slidesTab: '幻灯片',
     assetsTab: '素材',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -93,6 +93,8 @@ export const zhTW: Locale = {
     exportAsHtml: '匯出為 HTML',
     exportAsPdf: '匯出為 PDF',
     pdfExportFailed: 'PDF 匯出失敗',
+    pdfExportSafariUnsupported:
+      '匯出 PDF 目前不支援 Safari 裝置，請嘗試用 Chromium 基底瀏覽器替代。',
     present: '簡報',
     slidesTab: '投影片',
     assetsTab: '素材',


### PR DESCRIPTION
Detect Safari via userAgent and show a localized toast instead of
attempting the print pipeline, which doesn't produce a usable PDF on
WebKit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF export now includes Safari browser detection. When users attempt to export PDFs on Safari, they receive a localized notification message with guidance to use a Chromium-based browser instead.

* **Documentation**
  * Added localization support with new strings in English, Japanese, Simplified Chinese, and Traditional Chinese for the browser detection message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/117)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->