### PR TITLE
fix(core): skip wheel nav while visual viewport is pinch-zoomed

### DIFF
--- a/.changeset/wheel-nav-skip-when-pinch-zoomed.md
+++ b/.changeset/wheel-nav-skip-when-pinch-zoomed.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Skip wheel-based page navigation while the visual viewport is pinch-zoomed, so panning a zoomed slide no longer jumps to the next or previous page.

--- a/packages/core/src/app/lib/use-wheel-page-navigation.ts
+++ b/packages/core/src/app/lib/use-wheel-page-navigation.ts
@@ -31,6 +31,7 @@ export function useWheelPageNavigation<T extends HTMLElement>({
 
     const onWheel = (event: WheelEvent) => {
       if (event.defaultPrevented || event.ctrlKey || shouldIgnoreWheelTarget(event.target)) return;
+      if (isVisualViewportZoomed()) return;
 
       const deltaY = normalizeDeltaY(event);
       if (Math.abs(deltaY) <= Math.abs(normalizeDeltaX(event))) return;
@@ -82,6 +83,12 @@ function normalizeWheelDelta(delta: number, deltaMode: number) {
   if (deltaMode === WheelEvent.DOM_DELTA_LINE) return delta * 16;
   if (deltaMode === WheelEvent.DOM_DELTA_PAGE) return delta * 800;
   return delta;
+}
+
+function isVisualViewportZoomed() {
+  if (typeof window === 'undefined') return false;
+  const vv = window.visualViewport;
+  return vv != null && vv.scale > 1.01;
 }
 
 function shouldIgnoreWheelTarget(target: EventTarget | null) {


### PR DESCRIPTION
## Summary

When the user pinch-zooms a slide in present mode (or anywhere the player is mounted), panning the trackpad up or down after the pinch fires regular `wheel` events, which `useWheelPageNavigation` interprets as next/previous. The result: you zoom in to point something out, scroll to look around, and the deck jumps to another slide.

The pinch gesture itself was already safe (browsers fire `wheel` with `ctrlKey=true` during pinch, which the hook ignores). The gap was the post-pinch state, while `visualViewport.scale` stays above 1.

This adds a small guard: if `window.visualViewport.scale > 1.01`, the wheel handler returns early and lets the browser pan the zoomed viewport normally. As soon as you pinch back out, page navigation works again.

## Repro

1. `pnpm dev` in `apps/demo`, open any slide in present mode.
2. Pinch-zoom on the trackpad.
3. Two-finger scroll up/down to pan around the zoomed slide.

Before: each scroll jumps to the next/previous slide.
After: the viewport pans, the deck stays on the current slide.

## Notes

- Threshold is `> 1.01` rather than `> 1` to absorb the tiny float drift some browsers report at "100%".
- `visualViewport` is gated behind a `typeof window` check and a null check, so SSR and the (rare) browsers without VisualViewport API stay on the existing behavior.
- No new behavior for keyboard nav, touch swipe, or the explicit `data-wheel-nav-ignore` escape hatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where wheel-based page navigation would unintentionally trigger when panning a pinch-zoomed slide, preventing frustrating navigation jumps to adjacent pages when interacting with a zoomed view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/118)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->