### PR TITLE
docs(web): document the .demo.tsx half of the theme bundle

### DIFF
--- a/apps/web/content/docs/core-feature/themes.mdx
+++ b/apps/web/content/docs/core-feature/themes.mdx
@@ -3,26 +3,37 @@ title: Themes
 description: Reusable design systems shared across decks.
 ---
 
-A theme is a markdown file under `themes/<id>.md`. The `create-slide` skill
-reads a theme before authoring so the agent matches the visual system you
-want.
+A theme is a **bundle of two paired files** under `themes/`:
+
+- `themes/<id>.md` — agent-facing recipe: palette, typography, layout,
+  fixed components, motion. `create-slide` reads this before authoring.
+- `themes/<id>.demo.tsx` — a runnable mini-slide that demonstrates the
+  theme. The dev UI's **Themes** panel imports it and renders it as the
+  theme's live preview card.
+
+Both files share the same stem so the runtime can pair them automatically.
 
 ## Why themes
 
 If you author more than two decks you'll want them to look related. A theme
 captures the *recipe* — palette, type stack, layout vocabulary, motion
-language — in one place that any deck can reference.
+language — in one place that any deck can reference. The demo TSX makes
+that recipe visible: you can flip through theme previews in the dev UI
+before picking one.
 
 ## File layout
 
 ```text
 themes/
 ├── corporate.md
+├── corporate.demo.tsx
 ├── editorial.md
-└── retro-print.md
+├── editorial.demo.tsx
+├── retro-print.md
+└── retro-print.demo.tsx
 ```
 
-Each file is free-form markdown. A useful template:
+The markdown is free-form. A useful template:
 
 ```md title="themes/corporate.md"
 # Corporate
@@ -40,6 +51,23 @@ Each file is free-form markdown. A useful template:
 - Tight, declarative, never coy.
 - One concept per slide.
 ```
+
+The demo is a normal slide module — same shape as `slides/<id>/index.tsx`,
+just placed under `themes/` so the runtime treats it as preview-only (it
+does not appear in the slides list):
+
+```tsx title="themes/corporate.demo.tsx"
+import type { Page } from '@open-slide/core';
+
+const Cover: Page = () => (/* …inline Title / Footer using theme tokens… */);
+const Content: Page = () => (/* … */);
+
+export default [Cover, Content];
+```
+
+Keep the demo's inline Title/Footer/Eyebrow components verbatim in sync
+with the snippets in the markdown — what authors see in the Themes panel
+should match what `create-slide` will paste into a real slide.
 
 ## Using a theme
 

--- a/apps/web/content/docs/skills/create-theme.mdx
+++ b/apps/web/content/docs/skills/create-theme.mdx
@@ -9,20 +9,32 @@ recipe into a file the agent can read.
 
 ## What it does
 
-Writes `themes/<id>.md` with the palette, type stack, layout vocabulary,
-and voice notes that future `/create-slide` calls can reference.
+Writes a **theme bundle** under `themes/` — two paired files that share a
+stem:
+
+- `themes/<id>.md` — palette, type stack, layout vocabulary, fixed
+  Title/Footer/Eyebrow components, motion, and voice notes that
+  `/create-slide` reads on its next run.
+- `themes/<id>.demo.tsx` — a runnable 2–3 page mini-slide that inlines
+  the same components from the markdown. The dev UI's **Themes** panel
+  imports it and renders it as the theme's live preview.
+
+Both files are always produced together — a theme without its demo can't
+preview, a demo without its markdown can't be picked by `/create-slide`.
 
 The input can be:
 
 - **An existing deck.** The skill scans `slides/<id>/index.tsx`, distils the
-  recurring tokens, and writes them as markdown.
+  recurring tokens, and writes them out.
 - **A brief.** Describe the system in chat (*"warm editorial, serif display,
-  high-contrast palette"*) and the skill bootstraps a theme file from
+  high-contrast palette"*) and the skill bootstraps the bundle from
   scratch.
+- **Image references.** Pass screenshots or mood-board images and the
+  skill extracts palette, type, and layout cues from them.
 
 ## Output
 
-A markdown file under `themes/`:
+A markdown recipe:
 
 ```md title="themes/corporate.md"
 # Corporate
@@ -39,6 +51,17 @@ A markdown file under `themes/`:
 ## Voice
 - Tight, declarative, never coy.
 - One concept per slide.
+```
+
+…paired with a preview module:
+
+```tsx title="themes/corporate.demo.tsx"
+import type { Page } from '@open-slide/core';
+
+const Cover: Page = () => (/* …inline Title / Footer using theme tokens… */);
+const Content: Page = () => (/* … */);
+
+export default [Cover, Content];
 ```
 
 See [Themes](/docs/core-feature/themes) for how a theme is consumed.


### PR DESCRIPTION
## Summary

- The Themes and `/create-theme` docs pages described `themes/<id>.md` as if it were the whole theme, but every theme is actually a **bundle**: the markdown recipe + a `themes/<id>.demo.tsx` that the dev UI's Themes panel renders as a live preview.
- Update [`themes.mdx`](apps/web/content/docs/core-feature/themes.mdx) to lead with the two-file bundle, show both files in the file-layout tree, and explain what the demo TSX is for.
- Update [`create-theme.mdx`](apps/web/content/docs/skills/create-theme.mdx) to describe both outputs in "What it does" / "Output", and add image references to the list of valid input sources (the skill already supports it).

## Test plan

- [ ] Build the docs site and skim `/docs/core-feature/themes` and `/docs/skills/create-theme` — confirm the new file-layout tree, demo snippet, and bundle wording render cleanly.
- [ ] Cross-check that the description matches the [`create-theme` skill](packages/core/skills/create-theme/SKILL.md) (which already produces both files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Themes documentation to clarify that themes consist of paired files with live preview rendering capabilities.
  * Enhanced Create-theme documentation to explain the paired theme bundle generation and live preview functionality for theme selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->