### PR TITLE
fix(core): extend mutation guard to remaining dev-server endpoints

### DIFF
--- a/.changeset/extend-mutation-guard.md
+++ b/.changeset/extend-mutation-guard.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Extend cross-origin mutation guard to the design, notes, slides, assets, and folders dev-server endpoints.

--- a/packages/core/src/vite/design-plugin.ts
+++ b/packages/core/src/vite/design-plugin.ts
@@ -5,6 +5,7 @@ import { parse as babelParse } from '@babel/parser';
 import type { Connect, Plugin, ViteDevServer } from 'vite';
 import { type DesignSystem, defaultDesign } from '../app/lib/design.ts';
 import type { AstNode } from './babel-walk.ts';
+import { validateMutationRequest } from './request-guard.ts';
 
 const SLIDE_ID_RE = /^[a-z0-9_-]+$/i;
 
@@ -399,6 +400,10 @@ export function designPlugin(opts: DesignPluginOptions): Plugin {
           }
 
           if (method === 'PUT' && url.pathname === '/') {
+            const requestCheck = validateMutationRequest(req, { requireJsonBody: true });
+            if (!requestCheck.ok) {
+              return json(res, requestCheck.status, { error: requestCheck.error });
+            }
             const body = (await readBody(req)) as { patch?: Partial<DesignSystem> };
             const patch = body.patch;
             if (!patch || typeof patch !== 'object') {
@@ -423,6 +428,10 @@ export function designPlugin(opts: DesignPluginOptions): Plugin {
           }
 
           if (method === 'POST' && url.pathname === '/reset') {
+            const requestCheck = validateMutationRequest(req);
+            if (!requestCheck.ok) {
+              return json(res, requestCheck.status, { error: requestCheck.error });
+            }
             let source: string;
             try {
               source = await fs.readFile(file, 'utf8');

--- a/packages/core/src/vite/files-plugin.ts
+++ b/packages/core/src/vite/files-plugin.ts
@@ -4,6 +4,7 @@ import type { ServerResponse } from 'node:http';
 import path from 'node:path';
 import { parse as babelParse } from '@babel/parser';
 import type { Connect, Plugin, ViteDevServer } from 'vite';
+import { validateMutationRequest } from './request-guard.ts';
 
 const FOLDER_ID_RE = /^f-[a-f0-9]{8}$/;
 const SLIDE_ID_RE = /^[a-z0-9_-]+$/i;
@@ -626,6 +627,10 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
         try {
           const reorderMatch = url.pathname.match(/^\/([^/]+)\/reorder$/);
           if (reorderMatch && method === 'PUT') {
+            const requestCheck = validateMutationRequest(req, { requireJsonBody: true });
+            if (!requestCheck.ok) {
+              return json(res, requestCheck.status, { error: requestCheck.error });
+            }
             const slideId = reorderMatch[1];
             if (!SLIDE_ID_RE.test(slideId)) return json(res, 400, { error: 'invalid slideId' });
 
@@ -678,6 +683,10 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
             const isDelete = method === 'DELETE' && !op;
             const isDuplicate = method === 'POST' && op === 'duplicate';
             if (!isDelete && !isDuplicate) return next();
+            const requestCheck = validateMutationRequest(req);
+            if (!requestCheck.ok) {
+              return json(res, requestCheck.status, { error: requestCheck.error });
+            }
 
             const entry = resolveSlideEntry(slidesRoot, slideId);
             if (!entry) return json(res, 400, { error: 'invalid slideId' });
@@ -711,6 +720,10 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
           if (!SLIDE_ID_RE.test(slideId)) return json(res, 400, { error: 'invalid slideId' });
 
           if (method === 'PATCH') {
+            const requestCheck = validateMutationRequest(req, { requireJsonBody: true });
+            if (!requestCheck.ok) {
+              return json(res, requestCheck.status, { error: requestCheck.error });
+            }
             const body = (await readBody(req)) as SlidePatchBody;
             const name = validateSlideName(body.name);
             if (!name) return json(res, 400, { error: 'invalid name' });
@@ -742,6 +755,10 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
           }
 
           if (method === 'DELETE') {
+            const requestCheck = validateMutationRequest(req);
+            if (!requestCheck.ok) {
+              return json(res, requestCheck.status, { error: requestCheck.error });
+            }
             const removed = await rmSlideDir(slidesRoot, slideId);
             if (!removed) return json(res, 404, { error: 'slide not found' });
 
@@ -820,6 +837,10 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
             }
 
             if (method === 'POST') {
+              const requestCheck = validateMutationRequest(req);
+              if (!requestCheck.ok) {
+                return json(res, requestCheck.status, { error: requestCheck.error });
+              }
               const overwrite = url.searchParams.get('overwrite') === '1';
               const lenHeader = req.headers['content-length'];
               const len = typeof lenHeader === 'string' ? Number(lenHeader) : NaN;
@@ -869,6 +890,10 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
             }
 
             if (method === 'PATCH') {
+              const requestCheck = validateMutationRequest(req, { requireJsonBody: true });
+              if (!requestCheck.ok) {
+                return json(res, requestCheck.status, { error: requestCheck.error });
+              }
               const body = (await readBody(req)) as { name?: unknown };
               const target = validateAssetName(body.name);
               if (!target) return json(res, 400, { error: 'invalid name' });
@@ -896,6 +921,10 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
             }
 
             if (method === 'DELETE') {
+              const requestCheck = validateMutationRequest(req);
+              if (!requestCheck.ok) {
+                return json(res, requestCheck.status, { error: requestCheck.error });
+              }
               try {
                 await fs.unlink(file);
               } catch (err) {
@@ -971,6 +1000,10 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
           }
 
           if (method === 'POST' && url.pathname === '/') {
+            const requestCheck = validateMutationRequest(req, { requireJsonBody: true });
+            if (!requestCheck.ok) {
+              return json(res, requestCheck.status, { error: requestCheck.error });
+            }
             const body = (await readBody(req)) as CreateBody;
             const name = validateName(body.name);
             if (!name) return json(res, 400, { error: 'invalid name' });
@@ -985,6 +1018,10 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
           }
 
           if (method === 'PUT' && url.pathname === '/assign') {
+            const requestCheck = validateMutationRequest(req, { requireJsonBody: true });
+            if (!requestCheck.ok) {
+              return json(res, requestCheck.status, { error: requestCheck.error });
+            }
             const body = (await readBody(req)) as AssignBody;
             if (typeof body.slideId !== 'string' || !SLIDE_ID_RE.test(body.slideId)) {
               return json(res, 400, { error: 'invalid slideId' });
@@ -1018,6 +1055,10 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
             if (!FOLDER_ID_RE.test(id)) return json(res, 400, { error: 'invalid id' });
 
             if (method === 'PATCH') {
+              const requestCheck = validateMutationRequest(req, { requireJsonBody: true });
+              if (!requestCheck.ok) {
+                return json(res, requestCheck.status, { error: requestCheck.error });
+              }
               const body = (await readBody(req)) as PatchBody;
               const manifest = await readManifest(manifestPath);
               const folder = manifest.folders.find((f) => f.id === id);
@@ -1038,6 +1079,10 @@ export function filesPlugin(opts: FilesPluginOptions): Plugin {
             }
 
             if (method === 'DELETE') {
+              const requestCheck = validateMutationRequest(req);
+              if (!requestCheck.ok) {
+                return json(res, requestCheck.status, { error: requestCheck.error });
+              }
               const manifest = await readManifest(manifestPath);
               const before = manifest.folders.length;
               manifest.folders = manifest.folders.filter((f) => f.id !== id);

--- a/packages/core/src/vite/notes-plugin.ts
+++ b/packages/core/src/vite/notes-plugin.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { parse as babelParse } from '@babel/parser';
 import * as t from '@babel/types';
 import type { Connect, Plugin, ViteDevServer } from 'vite';
+import { validateMutationRequest } from './request-guard.ts';
 
 const SLIDE_ID_RE = /^[a-z0-9_-]+$/i;
 
@@ -212,6 +213,8 @@ export function notesPlugin(opts: NotesPluginOptions): Plugin {
         const url = new URL(req.url ?? '/', 'http://local');
         const method = req.method ?? 'GET';
         if (method !== 'PUT' || url.pathname !== '/') return next();
+        const requestCheck = validateMutationRequest(req, { requireJsonBody: true });
+        if (!requestCheck.ok) return json(res, requestCheck.status, { error: requestCheck.error });
 
         try {
           const body = (await readBody(req)) as NotesBody;


### PR DESCRIPTION
## Summary

Extends the cross-origin mutation guard introduced in #113 to every remaining mutation route on the dev server. Previously only `/__edit` and `/__comments` were protected; this PR wires `validateMutationRequest` into the design, notes, slides, assets, and folders endpoints so the full write surface enforces same-origin + JSON content-type.

Routes now guarded:

- **`/__design`** — `PUT /` (JSON), `POST /reset`
- **`/__notes`** — `PUT /` (JSON)
- **`/__slides`** — reorder `PUT` (JSON), page `POST duplicate` / `DELETE`, slide `PATCH` (JSON) / `DELETE`
- **`/__assets`** — `POST` (raw bytes, no JSON check), `PATCH` (JSON), `DELETE`
- **`/__folders`** — `POST` / `PUT /assign` / `PATCH` (JSON), `DELETE`

Followed the per-handler shape from `comments-plugin` so each branch validates right before reading the body. `requireJsonBody: true` is only set on routes that actually consume a JSON body — the asset upload `POST` reads raw bytes and uses the bare guard so multipart-ish payloads still work.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — all 195 tests pass
- [x] `pnpm check` — no new biome warnings (two pre-existing warnings unchanged)
- [ ] Click through each mutating UI flow in the demo app to confirm no same-origin regression (design edits, reset, notes, page reorder/duplicate/delete, slide rename/delete, asset upload/rename/delete, folder create/assign/rename/delete)
- [ ] Negative check: cross-origin `curl` (or DevTools fetch from another origin) returns 403 on one of the routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced request validation for mutation endpoints across design, notes, slides, assets, and folder management features to improve security and data integrity.
  * Extended cross-origin mutation guard coverage to additional development server endpoints, ensuring consistent protection across all mutation operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->