### PR TITLE
docs: rename feature request auto-label to "request"

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest a new capability for open-slide.
 title: "[Feature]: "
-labels: ["enhancement"]
+labels: ["request"]
 body:
   - type: textarea
     id: problem


### PR DESCRIPTION
Stacked on top of #127.

## Summary
- Change the auto-applied label on the feature request template from `enhancement` to `request`.
- Bug report template already auto-applies `bug`. Both labels live at the top of the YAML so they're applied on submit and not editable from the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)