### PR TITLE
chore: use `request` label for feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest a new capability for open-slide.
 title: "[Feature]: "
-labels: ["enhancement"]
+labels: ["request"]
 body:
   - type: textarea
     id: problem


### PR DESCRIPTION
## Summary
- Switch the feature request issue template's auto-applied label from `enhancement` to the existing `request` label so submissions land under the label we actually triage.
- Bug report template already uses `bug`, no change needed there.

Note: GitHub issue forms apply the `labels:` field at issue creation and submitters can't edit them in the form, which matches the intent of locking these to `bug` / `request`.

## Test plan
- [ ] Open the "New issue" page on GitHub and confirm Feature request previews the `request` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default label for feature request issue templates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->