### PR TITLE
chore(cli): trim init next-steps output

### DIFF
--- a/.changeset/fiery-pandas-lead.md
+++ b/.changeset/fiery-pandas-lead.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/cli': patch
+---
+
+Trim verbose follow-up text from `init` next-steps output.

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -206,16 +206,5 @@ export async function init(opts: InitOptions): Promise<void> {
     );
   }
   const devCommand = packageManager === 'npm' ? 'npm run dev' : `${packageManager} dev`;
-  process.stdout.write(`  ${chalk.cyan(devCommand)}\n\n`);
-  process.stdout.write(
-    chalk.dim('Then open the dev server and start authoring in slides/<your-slide>/.\n'),
-  );
-  const syncCommand =
-    packageManager === 'npm' ? 'npm run sync:skills' : `${packageManager} sync:skills`;
-  process.stdout.write(
-    chalk.dim(
-      `\nLater, run \`${syncCommand}\` after bumping @open-slide/core to pull skill updates.\n` +
-        '(or accept the prompt that appears when starting `dev`.)\n',
-    ),
-  );
+  process.stdout.write(`  ${chalk.cyan(devCommand)}\n`);
 }


### PR DESCRIPTION
## Summary
- Remove the "Then open the dev server and start authoring in slides/<your-slide>/." line from `open-slide init` output.
- Remove the follow-up paragraph about `sync:skills` after bumping `@open-slide/core`.
- The remaining `cd` + (optional) `install` + `dev` commands cover what the user needs right after init; the extra prose was redundant.

## Test plan
- [ ] `pnpm cli build` succeeds.
- [ ] Running `open-slide init` locally prints the trimmed next-steps block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined the CLI init command's next-steps output by removing redundant follow-up instructions and adjusting line spacing for a cleaner, more concise display format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->