### PR TITLE
Make tooltip arrow inherit color from body

### DIFF
--- a/.changeset/patch-core-tooltip-arrow.md
+++ b/.changeset/patch-core-tooltip-arrow.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Make the tooltip arrow inherit its color from the tooltip body so custom backgrounds (e.g. the present-mode control bar) match.

--- a/packages/core/src/app/components/ui/tooltip.tsx
+++ b/packages/core/src/app/components/ui/tooltip.tsx
@@ -49,7 +49,7 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-inherit fill-inherit" />
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-inherit fill-transparent" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/packages/core/src/app/components/ui/tooltip.tsx
+++ b/packages/core/src/app/components/ui/tooltip.tsx
@@ -49,7 +49,7 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-inherit fill-inherit" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )


### PR DESCRIPTION
The tooltip arrow now inherits its background and fill colors from the tooltip body instead of using hardcoded foreground colors. This ensures custom tooltip backgrounds (such as in the present-mode control bar) have matching arrows.

**Changes:**
- Updated `TooltipPrimitive.Arrow` className to use `bg-inherit` and `fill-inherit` instead of `bg-foreground` and `fill-foreground`

This allows tooltips with non-standard backgrounds to display properly without color mismatches between the arrow and body.

https://claude.ai/code/session_01A6ycz8bgcRw9CMdHjWHTaf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltip arrow now inherits color from the tooltip body, ensuring the arrow matches custom tooltip backgrounds (improved consistency in present-mode and other styled tooltips).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->