### PR TITLE
feat(core): add useSlidePageNumber hook for dynamic page numbers

### DIFF
--- a/.changeset/minor-core-page-number-hook.md
+++ b/.changeset/minor-core-page-number-hook.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': minor
+---
+
+Add `useSlidePageNumber()` hook so slide pages can render their own page number without hardcoding.

--- a/apps/demo/slides/harness-engineering/index.tsx
+++ b/apps/demo/slides/harness-engineering/index.tsx
@@ -1,4 +1,4 @@
-import type { DesignSystem, Page, SlideMeta } from '@open-slide/core';
+import { type DesignSystem, type Page, type SlideMeta, useSlidePageNumber } from '@open-slide/core';
 
 export const design: DesignSystem = {
   palette: { bg: '#05070a', text: '#e6edf3', accent: '#39ff88' },
@@ -30,9 +30,6 @@ const tokens = {
   space: {
     padX: 100,
     padY: 80,
-  },
-  meta: {
-    totalPages: 8,
   },
 } as const;
 
@@ -121,31 +118,34 @@ const Cursor = ({ size = '0.55em', height = '0.92em' }: { size?: string; height?
   />
 );
 
-const Footer = ({ pageNum, section }: { pageNum: number; section?: string }) => (
-  <div
-    style={{
-      position: 'absolute',
-      left: tokens.space.padX,
-      right: tokens.space.padX,
-      bottom: 36,
-      display: 'flex',
-      justifyContent: 'space-between',
-      fontFamily: 'var(--osd-font-body)',
-      fontSize: 20,
-      color: tokens.color.faint,
-      borderTop: `1px solid ${tokens.color.line}`,
-      paddingTop: 14,
-    }}
-  >
-    <span>
-      <span style={{ color: 'var(--osd-accent)' }}>●</span> {section ?? 'main'} ·{' '}
-      <span style={{ color: tokens.color.accent2 }}>~/deck/harness-engineering</span>
-    </span>
-    <span>
-      {String(pageNum).padStart(2, '0')}/{String(tokens.meta.totalPages).padStart(2, '0')}
-    </span>
-  </div>
-);
+const Footer = ({ section }: { section?: string }) => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: tokens.space.padX,
+        right: tokens.space.padX,
+        bottom: 36,
+        display: 'flex',
+        justifyContent: 'space-between',
+        fontFamily: 'var(--osd-font-body)',
+        fontSize: 20,
+        color: tokens.color.faint,
+        borderTop: `1px solid ${tokens.color.line}`,
+        paddingTop: 14,
+      }}
+    >
+      <span>
+        <span style={{ color: 'var(--osd-accent)' }}>●</span> {section ?? 'main'} ·{' '}
+        <span style={{ color: tokens.color.accent2 }}>~/deck/harness-engineering</span>
+      </span>
+      <span>
+        {String(current).padStart(2, '0')}/{String(total).padStart(2, '0')}
+      </span>
+    </div>
+  );
+};
 
 const Scanlines = () => (
   <div
@@ -246,7 +246,7 @@ const Cover: Page = () => (
     >
       a brief tour · 8 pages · openai · anthropic · martinfowler.com · addyosmani · humanlayer
     </div>
-    <Footer pageNum={1} section="cover" />
+    <Footer section="cover" />
   </div>
 );
 
@@ -386,7 +386,7 @@ const Shift: Page = () => (
         — addy osmani · 19 apr 2026
       </div>
     </div>
-    <Footer pageNum={2} section="shift" />
+    <Footer section="shift" />
   </div>
 );
 
@@ -520,7 +520,7 @@ const Definition: Page = () => (
         </div>
       </div>
     </div>
-    <Footer pageNum={3} section="definition" />
+    <Footer section="definition" />
   </div>
 );
 
@@ -652,7 +652,7 @@ const Anatomy: Page = () => (
         </div>
       ))}
     </div>
-    <Footer pageNum={4} section="anatomy" />
+    <Footer section="anatomy" />
   </div>
 );
 
@@ -820,7 +820,7 @@ const ClaudeCodeExample: Page = () => (
         />
       </div>
     </div>
-    <Footer pageNum={5} section="example" />
+    <Footer section="example" />
   </div>
 );
 
@@ -929,7 +929,7 @@ const Principles: Page = () => (
         </div>
       ))}
     </div>
-    <Footer pageNum={6} section="principles" />
+    <Footer section="principles" />
   </div>
 );
 
@@ -1062,7 +1062,7 @@ const Layers: Page = () => (
         );
       })}
     </div>
-    <Footer pageNum={7} section="layers" />
+    <Footer section="layers" />
   </div>
 );
 
@@ -1176,7 +1176,7 @@ const Closing: Page = () => (
         </div>
       ))}
     </div>
-    <Footer pageNum={8} section="fin" />
+    <Footer section="fin" />
   </div>
 );
 

--- a/apps/demo/slides/llm-fundamentals/index.tsx
+++ b/apps/demo/slides/llm-fundamentals/index.tsx
@@ -1,4 +1,4 @@
-import type { DesignSystem, Page, SlideMeta } from '@open-slide/core';
+import { type DesignSystem, type Page, type SlideMeta, useSlidePageNumber } from '@open-slide/core';
 
 export const design: DesignSystem = {
   palette: { bg: '#f7f5f0', text: '#1a1814', accent: '#6d4cff' },
@@ -103,7 +103,6 @@ const Style = () => <style>{keyframes}</style>;
 
 const PAD_X = 140;
 const PAD_Y = 110;
-const TOTAL = 12;
 
 const Eyebrow = ({ children, delay = 0 }: { children: React.ReactNode; delay?: number }) => (
   <div
@@ -122,22 +121,25 @@ const Eyebrow = ({ children, delay = 0 }: { children: React.ReactNode; delay?: n
   </div>
 );
 
-const PageNumber = ({ n, total }: { n: number; total: number }) => (
-  <div
-    style={{
-      position: 'absolute',
-      left: PAD_X,
-      bottom: 60,
-      fontFamily: 'var(--osd-font-body)',
-      fontSize: 18,
-      letterSpacing: '0.3em',
-      textTransform: 'uppercase',
-      color: palette.faint,
-    }}
-  >
-    LLM · {String(n).padStart(2, '0')} / {String(total).padStart(2, '0')}
-  </div>
-);
+const PageNumber = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: PAD_X,
+        bottom: 60,
+        fontFamily: 'var(--osd-font-body)',
+        fontSize: 18,
+        letterSpacing: '0.3em',
+        textTransform: 'uppercase',
+        color: palette.faint,
+      }}
+    >
+      LLM · {String(current).padStart(2, '0')} / {String(total).padStart(2, '0')}
+    </div>
+  );
+};
 
 const SectionTitle = ({
   children,
@@ -290,7 +292,7 @@ const Cover: Page = () => (
         attention, and the art of guessing the next word.
       </p>
     </div>
-    <PageNumber n={1} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -328,7 +330,7 @@ const BigIdea: Page = () => (
       Everything else — context windows, attention, temperature, hallucinations — is a consequence
       of that one loop.
     </p>
-    <PageNumber n={2} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -423,7 +425,7 @@ const WhatIsToken: Page = () => (
         space — yes, it's part of the token.
       </div>
     </div>
-    <PageNumber n={3} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -540,7 +542,7 @@ const Tokenization: Page = () => (
         </div>
       ))}
     </div>
-    <PageNumber n={4} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -642,7 +644,7 @@ const VocabSize: Page = () => (
       For perspective: an unabridged English dictionary lists roughly 470,000 headwords. A model
       with 100k tokens can spell any of them.
     </p>
-    <PageNumber n={5} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -824,7 +826,7 @@ const ContextWindow: Page = () => {
           </div>
         ))}
       </div>
-      <PageNumber n={6} total={TOTAL} />
+      <PageNumber />
     </div>
   );
 };
@@ -949,7 +951,7 @@ const Attention: Page = () => {
           “mat” attends most strongly to “cat” and “sat” — the words that decide what follows.
         </div>
       </div>
-      <PageNumber n={7} total={TOTAL} />
+      <PageNumber />
     </div>
   );
 };
@@ -1058,7 +1060,7 @@ const Autoregressive: Page = () => (
         </div>
       ))}
     </div>
-    <PageNumber n={8} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -1257,7 +1259,7 @@ const Sampling: Page = () => (
         ))}
       </div>
     </div>
-    <PageNumber n={9} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -1361,7 +1363,7 @@ const Hallucinate: Page = () => (
         </div>
       ))}
     </div>
-    <PageNumber n={10} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -1446,7 +1448,7 @@ const Practical: Page = () => (
         </div>
       ))}
     </div>
-    <PageNumber n={11} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -1543,7 +1545,7 @@ const Closing: Page = () => (
         — thank you.
       </div>
     </div>
-    <PageNumber n={12} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 

--- a/apps/demo/slides/nextjs-ppr-cache/index.tsx
+++ b/apps/demo/slides/nextjs-ppr-cache/index.tsx
@@ -1,4 +1,4 @@
-import type { DesignSystem, Page, SlideMeta } from '@open-slide/core';
+import { type DesignSystem, type Page, type SlideMeta, useSlidePageNumber } from '@open-slide/core';
 import type { ReactNode } from 'react';
 import nextMark from './assets/next-js.svg';
 import vercelMark from './assets/vercel.svg';
@@ -98,32 +98,35 @@ const Logo = ({ size = 24 }: { size?: number }) => (
   </div>
 );
 
-const Footer = ({ page, total }: { page: number; total: number }) => (
-  <div
-    style={{
-      position: 'absolute',
-      bottom: 56,
-      left: 120,
-      right: 120,
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      fontSize: 20,
-      fontFamily: fontMono,
-      color: palette.subtle,
-      borderTop: `1px solid ${palette.border}`,
-      paddingTop: 22,
-    }}
-  >
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 10 }}>
-      <img src={nextMark} alt="Next.js" style={{ height: 22, width: 22, display: 'block' }} />
-      <span>Next.js · partial pre-rendering &amp; 'use cache'</span>
-    </span>
-    <span>
-      {String(page).padStart(2, '0')} / {String(total).padStart(2, '0')}
-    </span>
-  </div>
-);
+const Footer = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 56,
+        left: 120,
+        right: 120,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        fontSize: 20,
+        fontFamily: fontMono,
+        color: palette.subtle,
+        borderTop: `1px solid ${palette.border}`,
+        paddingTop: 22,
+      }}
+    >
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 10 }}>
+        <img src={nextMark} alt="Next.js" style={{ height: 22, width: 22, display: 'block' }} />
+        <span>Next.js · partial pre-rendering &amp; 'use cache'</span>
+      </span>
+      <span>
+        {String(current).padStart(2, '0')} / {String(total).padStart(2, '0')}
+      </span>
+    </div>
+  );
+};
 
 const Eyebrow = ({ index, label }: { index: string; label: string }) => (
   <div
@@ -150,8 +153,6 @@ const Eyebrow = ({ index, label }: { index: string; label: string }) => (
     <span>{label}</span>
   </div>
 );
-
-const TOTAL = 8;
 
 const Code = ({ children, fontSize = 20 }: { children: ReactNode; fontSize?: number }) => (
   <pre
@@ -182,125 +183,131 @@ const tag = (s: string) => <span style={{ color: palette.accent }}>{s}</span>;
 // ─────────────────────────────────────────────────────────────────────────────
 // 01 — Cover
 // ─────────────────────────────────────────────────────────────────────────────
-const Cover: Page = () => (
-  <div
-    style={{
-      ...fill,
-      padding: '0 120px',
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
-    }}
-  >
-    <Style />
-
-    <div style={{ position: 'absolute', top: 72, left: 120 }}>
-      <Logo size={28} />
-    </div>
+const Cover: Page = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
     <div
       style={{
-        position: 'absolute',
-        top: 78,
-        right: 120,
-        fontSize: 22,
-        fontFamily: fontMono,
-        color: palette.muted,
+        ...fill,
+        padding: '0 120px',
         display: 'flex',
-        alignItems: 'center',
-        gap: 10,
+        flexDirection: 'column',
+        justifyContent: 'center',
       }}
     >
-      <img src={nextMark} alt="Next.js" style={{ height: 26, width: 26, display: 'block' }} />
-      <span>Next.js · 2026</span>
-    </div>
+      <Style />
 
-    <div style={{ animation: 'ppr-fade-up 0.9s cubic-bezier(0.2, 0.8, 0.2, 1) both' }}>
+      <div style={{ position: 'absolute', top: 72, left: 120 }}>
+        <Logo size={28} />
+      </div>
       <div
         style={{
-          fontSize: 28,
+          position: 'absolute',
+          top: 78,
+          right: 120,
+          fontSize: 22,
           fontFamily: fontMono,
           color: palette.muted,
-          marginBottom: 32,
-          letterSpacing: '0.02em',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
         }}
       >
-        rendering, reimagined.
+        <img src={nextMark} alt="Next.js" style={{ height: 26, width: 26, display: 'block' }} />
+        <span>Next.js · 2026</span>
       </div>
-      <h1
-        style={{
-          fontSize: 'var(--osd-size-hero)',
-          fontWeight: 700,
-          margin: 0,
-          lineHeight: 0.92,
-          letterSpacing: '-0.045em',
-        }}
-      >
-        Partial
-        <br />
-        Pre-Rendering
-      </h1>
-      <div
-        style={{
-          marginTop: 48,
-          fontSize: 38,
-          color: palette.muted,
-          fontWeight: 400,
-          maxWidth: 1400,
-          lineHeight: 1.4,
-        }}
-      >
-        Plus{' '}
-        <code
+
+      <div style={{ animation: 'ppr-fade-up 0.9s cubic-bezier(0.2, 0.8, 0.2, 1) both' }}>
+        <div
           style={{
+            fontSize: 28,
             fontFamily: fontMono,
-            color: palette.text,
-            background: palette.surface,
-            border: `1px solid ${palette.border}`,
-            padding: '4px 14px',
-            borderRadius: 10,
-            fontSize: 32,
+            color: palette.muted,
+            marginBottom: 32,
+            letterSpacing: '0.02em',
           }}
         >
-          'use cache'
-        </code>
-        — the speed of static, the freshness of dynamic, in one request.
+          rendering, reimagined.
+        </div>
+        <h1
+          style={{
+            fontSize: 'var(--osd-size-hero)',
+            fontWeight: 700,
+            margin: 0,
+            lineHeight: 0.92,
+            letterSpacing: '-0.045em',
+          }}
+        >
+          Partial
+          <br />
+          Pre-Rendering
+        </h1>
+        <div
+          style={{
+            marginTop: 48,
+            fontSize: 38,
+            color: palette.muted,
+            fontWeight: 400,
+            maxWidth: 1400,
+            lineHeight: 1.4,
+          }}
+        >
+          Plus{' '}
+          <code
+            style={{
+              fontFamily: fontMono,
+              color: palette.text,
+              background: palette.surface,
+              border: `1px solid ${palette.border}`,
+              padding: '4px 14px',
+              borderRadius: 10,
+              fontSize: 32,
+            }}
+          >
+            'use cache'
+          </code>
+          — the speed of static, the freshness of dynamic, in one request.
+        </div>
+      </div>
+
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: 6,
+          background: `linear-gradient(90deg, ${palette.pink}, ${palette.purple}, ${palette.accent}, ${palette.purple}, ${palette.pink})`,
+          backgroundSize: '300% 100%',
+          animation: 'ppr-gradient-shift 7s ease-in-out infinite',
+        }}
+      />
+
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 56,
+          left: 120,
+          right: 120,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-end',
+          fontSize: 20,
+          fontFamily: fontMono,
+          color: palette.subtle,
+        }}
+      >
+        <span style={{ color: palette.text, fontWeight: 600 }}>
+          <span style={{ animation: 'ppr-blink 1.2s steps(1) infinite' }}>▍</span> ready when you
+          are
+        </span>
+        <span>
+          {String(current).padStart(2, '0')} / {String(total).padStart(2, '0')}
+        </span>
       </div>
     </div>
-
-    <div
-      style={{
-        position: 'absolute',
-        bottom: 0,
-        left: 0,
-        right: 0,
-        height: 6,
-        background: `linear-gradient(90deg, ${palette.pink}, ${palette.purple}, ${palette.accent}, ${palette.purple}, ${palette.pink})`,
-        backgroundSize: '300% 100%',
-        animation: 'ppr-gradient-shift 7s ease-in-out infinite',
-      }}
-    />
-
-    <div
-      style={{
-        position: 'absolute',
-        bottom: 56,
-        left: 120,
-        right: 120,
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'flex-end',
-        fontSize: 20,
-        fontFamily: fontMono,
-        color: palette.subtle,
-      }}
-    >
-      <span style={{ color: palette.text, fontWeight: 600 }}>
-        <span style={{ animation: 'ppr-blink 1.2s steps(1) infinite' }}>▍</span> ready when you are
-      </span>
-      <span>01 / {String(TOTAL).padStart(2, '0')}</span>
-    </div>
-  </div>
-);
+  );
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 02 — The old trade-off
@@ -428,7 +435,7 @@ const TradeOff: Page = () => {
         />
       </div>
 
-      <Footer page={2} total={TOTAL} />
+      <Footer />
     </div>
   );
 };
@@ -662,7 +669,7 @@ const PPRConcept: Page = () => {
         </div>
       </div>
 
-      <Footer page={3} total={TOTAL} />
+      <Footer />
     </div>
   );
 };
@@ -813,7 +820,7 @@ const PPRCode: Page = () => (
       </div>
     </div>
 
-    <Footer page={4} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -937,7 +944,7 @@ const UseCache: Page = () => (
       </span>
     </div>
 
-    <Footer page={5} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -1102,7 +1109,7 @@ const CacheScopes: Page = () => {
         <span>tag-based revalidation</span>
       </div>
 
-      <Footer page={6} total={TOTAL} />
+      <Footer />
     </div>
   );
 };
@@ -1341,7 +1348,7 @@ const Lifecycle: Page = () => {
         </div>
       </div>
 
-      <Footer page={7} total={TOTAL} />
+      <Footer />
     </div>
   );
 };
@@ -1456,7 +1463,7 @@ const TLDR: Page = () => {
         </div>
       </div>
 
-      <Footer page={8} total={TOTAL} />
+      <Footer />
     </div>
   );
 };

--- a/apps/demo/slides/open-slide-anatomy/index.tsx
+++ b/apps/demo/slides/open-slide-anatomy/index.tsx
@@ -1,4 +1,4 @@
-import type { DesignSystem, Page, SlideMeta } from '@open-slide/core';
+import { type DesignSystem, type Page, type SlideMeta, useSlidePageNumber } from '@open-slide/core';
 import type { ReactNode } from 'react';
 
 export const design: DesignSystem = {
@@ -19,8 +19,6 @@ const mint = '#84ffae';
 const warm = '#ffa860';
 const violet = '#c598ff';
 const danger = '#ff7a85';
-
-const TOTAL = 16;
 
 const keyframes = `
 @keyframes osa-fadeUp { from { opacity: 0; transform: translateY(22px); } to { opacity: 1; transform: translateY(0); } }
@@ -95,35 +93,38 @@ const Heading = ({
   </h2>
 );
 
-const Footer = ({ section, n }: { section: string; n: number }) => (
-  <div
-    style={{
-      position: 'absolute',
-      left: 100,
-      right: 100,
-      bottom: 48,
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'baseline',
-      fontFamily: 'var(--osd-font-display)',
-      fontSize: 22,
-      color: muted,
-      borderTop: `1px solid ${rule}`,
-      paddingTop: 18,
-      letterSpacing: '0.06em',
-    }}
-  >
-    <span>
-      <span style={{ color: 'var(--osd-accent)', marginRight: 12 }}>●</span>
-      {section}
-      <span style={{ color: rule, margin: '0 18px' }}>·</span>
-      <span style={{ color: text2 }}>open-slide</span>
-    </span>
-    <span style={{ fontVariantNumeric: 'tabular-nums' }}>
-      {String(n).padStart(2, '0')} / {String(TOTAL).padStart(2, '0')}
-    </span>
-  </div>
-);
+const Footer = ({ section }: { section: string }) => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 100,
+        right: 100,
+        bottom: 48,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'baseline',
+        fontFamily: 'var(--osd-font-display)',
+        fontSize: 22,
+        color: muted,
+        borderTop: `1px solid ${rule}`,
+        paddingTop: 18,
+        letterSpacing: '0.06em',
+      }}
+    >
+      <span>
+        <span style={{ color: 'var(--osd-accent)', marginRight: 12 }}>●</span>
+        {section}
+        <span style={{ color: rule, margin: '0 18px' }}>·</span>
+        <span style={{ color: text2 }}>open-slide</span>
+      </span>
+      <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+        {String(current).padStart(2, '0')} / {String(total).padStart(2, '0')}
+      </span>
+    </div>
+  );
+};
 
 const Cover: Page = () => (
   <div style={{ ...fill, padding: '120px 100px' }}>
@@ -238,7 +239,7 @@ const Cover: Page = () => (
         </span>
       </div>
     </div>
-    <Footer section="cover" n={1} />
+    <Footer section="cover" />
   </div>
 );
 
@@ -291,7 +292,7 @@ const Agenda: Page = () => {
           </li>
         ))}
       </ol>
-      <Footer section="agenda" n={2} />
+      <Footer section="agenda" />
     </div>
   );
 };
@@ -395,7 +396,7 @@ const MentalModel: Page = () => {
           ))}
         </div>
       </div>
-      <Footer section="foundation" n={3} />
+      <Footer section="foundation" />
     </div>
   );
 };
@@ -528,7 +529,7 @@ const FileContract: Page = () => {
           </div>
         ))}
       </div>
-      <Footer section="foundation" n={4} />
+      <Footer section="foundation" />
     </div>
   );
 };
@@ -665,7 +666,7 @@ const Discovery: Page = () => {
           </div>
         </div>
       </div>
-      <Footer section="discovery" n={5} />
+      <Footer section="discovery" />
     </div>
   );
 };
@@ -791,7 +792,7 @@ const VirtualModules: Page = () => {
           </div>
         ))}
       </div>
-      <Footer section="discovery" n={6} />
+      <Footer section="discovery" />
     </div>
   );
 };
@@ -871,7 +872,7 @@ const VitePluginHooks: Page = () => {
           </div>
         ))}
       </div>
-      <Footer section="plugin" n={7} />
+      <Footer section="plugin" />
     </div>
   );
 };
@@ -959,7 +960,7 @@ const RenderPipeline: Page = () => {
           </div>
         ))}
       </div>
-      <Footer section="render" n={8} />
+      <Footer section="render" />
     </div>
   );
 };
@@ -1124,7 +1125,7 @@ const CanvasScaling: Page = () => {
           </div>
         </div>
       </div>
-      <Footer section="render" n={9} />
+      <Footer section="render" />
     </div>
   );
 };
@@ -1209,7 +1210,7 @@ const HotReload: Page = () => {
           </div>
         ))}
       </div>
-      <Footer section="runtime" n={10} />
+      <Footer section="runtime" />
     </div>
   );
 };
@@ -1279,7 +1280,7 @@ const DesignSystemPage: Page = () => {
           </div>
         ))}
       </div>
-      <Footer section="design" n={11} />
+      <Footer section="design" />
     </div>
   );
 };
@@ -1372,7 +1373,7 @@ const DesignPanelWrite: Page = () => {
         <span style={{ color: mint }}>↻</span>
         round-trip: live preview never lies, but the file always wins.
       </div>
-      <Footer section="design" n={12} />
+      <Footer section="design" />
     </div>
   );
 };
@@ -1519,7 +1520,7 @@ const Inspector: Page = () => {
           ))}
         </div>
       </div>
-      <Footer section="tools" n={13} />
+      <Footer section="tools" />
     </div>
   );
 };
@@ -1592,7 +1593,7 @@ const PresentMode: Page = () => {
           </div>
         ))}
       </div>
-      <Footer section="tools" n={14} />
+      <Footer section="tools" />
     </div>
   );
 };
@@ -1671,7 +1672,7 @@ const Cli: Page = () => {
         <span style={{ color: 'var(--osd-accent)' }}>›</span> per-slide chunks come for free from{' '}
         <span style={{ color: mint }}>import()</span> — Vite handles splitting.
       </div>
-      <Footer section="tools" n={15} />
+      <Footer section="tools" />
     </div>
   );
 };
@@ -1759,7 +1760,7 @@ const Closing: Page = () => {
           ))}
         </div>
       </div>
-      <Footer section="closing" n={16} />
+      <Footer section="closing" />
     </div>
   );
 };

--- a/apps/demo/slides/raycast-api/index.tsx
+++ b/apps/demo/slides/raycast-api/index.tsx
@@ -1,4 +1,4 @@
-import type { DesignSystem, Page, SlideMeta } from '@open-slide/core';
+import { type DesignSystem, type Page, type SlideMeta, useSlidePageNumber } from '@open-slide/core';
 import raycastIcon from './assets/raycast.svg';
 
 export const design: DesignSystem = {
@@ -120,31 +120,32 @@ const Eyebrow = ({ children, delay = 0 }: { children: React.ReactNode; delay?: n
   </div>
 );
 
-const Footer = ({ index, total }: { index: number; total: number }) => (
-  <div
-    style={{
-      position: 'absolute',
-      bottom: 56,
-      left: 120,
-      right: 120,
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      fontSize: 22,
-      color: palette.muted,
-      fontFamily: fonts.mono,
-      letterSpacing: '0.04em',
-    }}
-  >
-    <span>raycast.com / developers</span>
-    <span>
-      {String(index).padStart(2, '0')}{' '}
-      <span style={{ opacity: 0.4 }}>/ {String(total).padStart(2, '0')}</span>
-    </span>
-  </div>
-);
-
-const TOTAL = 9;
+const Footer = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 56,
+        left: 120,
+        right: 120,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        fontSize: 22,
+        color: palette.muted,
+        fontFamily: fonts.mono,
+        letterSpacing: '0.04em',
+      }}
+    >
+      <span>raycast.com / developers</span>
+      <span>
+        {String(current).padStart(2, '0')}{' '}
+        <span style={{ opacity: 0.4 }}>/ {String(total).padStart(2, '0')}</span>
+      </span>
+    </div>
+  );
+};
 
 const CommandBar = ({
   query,
@@ -372,7 +373,7 @@ const Cover: Page = () => (
         />
       </div>
     </div>
-    <Footer index={1} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -431,7 +432,7 @@ const Pitch: Page = () => (
         ))}
       </div>
     </div>
-    <Footer index={2} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -504,7 +505,7 @@ const Stack: Page = () => (
         ))}
       </div>
     </div>
-    <Footer index={3} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -569,7 +570,7 @@ const UIPrimitives: Page = () => {
           ))}
         </div>
       </div>
-      <Footer index={4} total={TOTAL} />
+      <Footer />
     </div>
   );
 };
@@ -708,7 +709,7 @@ const ActionPanel: Page = () => (
         </div>
       </div>
     </div>
-    <Footer index={5} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -794,7 +795,7 @@ const AIApi: Page = () => (
         </div>
       </div>
     </div>
-    <Footer index={6} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -865,7 +866,7 @@ const Platform: Page = () => {
           ))}
         </div>
       </div>
-      <Footer index={7} total={TOTAL} />
+      <Footer />
     </div>
   );
 };
@@ -933,7 +934,7 @@ const DX: Page = () => (
         ))}
       </div>
     </div>
-    <Footer index={8} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -997,7 +998,7 @@ const Closing: Page = () => (
         Docs at <span style={{ color: 'var(--osd-text)' }}>developers.raycast.com</span>
       </p>
     </div>
-    <Footer index={9} total={TOTAL} />
+    <Footer />
   </div>
 );
 

--- a/apps/demo/slides/ssh-explained/index.tsx
+++ b/apps/demo/slides/ssh-explained/index.tsx
@@ -1,4 +1,4 @@
-import type { DesignSystem, Page, SlideMeta } from '@open-slide/core';
+import { type DesignSystem, type Page, type SlideMeta, useSlidePageNumber } from '@open-slide/core';
 
 export const design: DesignSystem = {
   palette: { bg: '#fafaf9', text: '#1c1917', accent: '#2563eb' },
@@ -145,24 +145,25 @@ const Eyebrow = ({ children, delay = 0 }: { children: React.ReactNode; delay?: n
   </div>
 );
 
-const PageNumber = ({ n, total }: { n: number; total: number }) => (
-  <div
-    style={{
-      position: 'absolute',
-      left: PAD_X,
-      bottom: 60,
-      fontFamily: 'var(--osd-font-body)',
-      fontSize: 18,
-      letterSpacing: '0.3em',
-      textTransform: 'uppercase',
-      color: palette.faint,
-    }}
-  >
-    SSH · {String(n).padStart(2, '0')} / {String(total).padStart(2, '0')}
-  </div>
-);
-
-const TOTAL = 10;
+const PageNumber = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: PAD_X,
+        bottom: 60,
+        fontFamily: 'var(--osd-font-body)',
+        fontSize: 18,
+        letterSpacing: '0.3em',
+        textTransform: 'uppercase',
+        color: palette.faint,
+      }}
+    >
+      SSH · {String(current).padStart(2, '0')} / {String(total).padStart(2, '0')}
+    </div>
+  );
+};
 
 /* ─────────────── 1. Cover ─────────────── */
 const Cover: Page = () => (
@@ -235,7 +236,7 @@ const Cover: Page = () => (
         to a fully encrypted shell — in nine quiet steps.
       </p>
     </div>
-    <PageNumber n={1} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -297,7 +298,7 @@ const WhatIs: Page = () => (
         </div>
       ))}
     </div>
-    <PageNumber n={2} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -459,7 +460,7 @@ const Problem: Page = () => (
       that nobody else on the wire ever sees.
     </p>
 
-    <PageNumber n={3} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -552,7 +553,7 @@ const Overview: Page = () => (
         </div>
       ))}
     </div>
-    <PageNumber n={4} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -800,7 +801,7 @@ const TCPHandshake: Page = () => (
         { dir: 'right', label: 'ACK', sub: '"connection established."', delay: 2200 },
       ]}
     />
-    <PageNumber n={5} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -1003,7 +1004,7 @@ const KeyExchange: Page = () => (
         </div>
       </div>
     </div>
-    <PageNumber n={6} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -1177,7 +1178,7 @@ const ServerAuth: Page = () => (
         </div>
       </div>
     </div>
-    <PageNumber n={7} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -1286,7 +1287,7 @@ const UserAuth: Page = () => (
         </div>
       ))}
     </div>
-    <PageNumber n={8} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -1498,7 +1499,7 @@ const EncryptedSession: Page = () => (
         <div style={{ fontFamily: fonts.mono, fontSize: 22, color: palette.muted }}>server</div>
       </div>
     </div>
-    <PageNumber n={9} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 
@@ -1587,7 +1588,7 @@ const Closing: Page = () => (
         — thank you.
       </div>
     </div>
-    <PageNumber n={10} total={TOTAL} />
+    <PageNumber />
   </div>
 );
 

--- a/apps/demo/themes/aurora.demo.tsx
+++ b/apps/demo/themes/aurora.demo.tsx
@@ -1,4 +1,4 @@
-import type { Page } from '@open-slide/core';
+import { type Page, useSlidePageNumber } from '@open-slide/core';
 import type { ReactNode } from 'react';
 
 const styles = `
@@ -25,37 +25,32 @@ const Title = ({ children }: { children: ReactNode }) => (
   </h1>
 );
 
-const Footer = ({
-  pageNum,
-  total,
-  path = '/docs',
-}: {
-  pageNum: number;
-  total: number;
-  path?: string;
-}) => (
-  <div
-    style={{
-      position: 'absolute',
-      left: 120,
-      right: 120,
-      bottom: 56,
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      fontFamily: MONO,
-      fontSize: 22,
-      letterSpacing: '0.04em',
-      color: '#8B8B8B',
-    }}
-  >
-    <span>{path}</span>
-    <span>
-      {String(pageNum).padStart(2, '0')}{' '}
-      <span style={{ opacity: 0.4 }}>/ {String(total).padStart(2, '0')}</span>
-    </span>
-  </div>
-);
+const Footer = ({ path = '/docs' }: { path?: string }) => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 120,
+        right: 120,
+        bottom: 56,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        fontFamily: MONO,
+        fontSize: 22,
+        letterSpacing: '0.04em',
+        color: '#8B8B8B',
+      }}
+    >
+      <span>{path}</span>
+      <span>
+        {String(current).padStart(2, '0')}{' '}
+        <span style={{ opacity: 0.4 }}>/ {String(total).padStart(2, '0')}</span>
+      </span>
+    </div>
+  );
+};
 
 const Eyebrow = ({ children }: { children: ReactNode }) => (
   <div
@@ -122,8 +117,6 @@ const pageBase: React.CSSProperties = {
   overflow: 'hidden',
 };
 
-const TOTAL = 3;
-
 const Cover: Page = () => (
   <div style={{ ...pageBase, justifyContent: 'center', gap: 32 }}>
     <style>{styles}</style>
@@ -150,7 +143,7 @@ const Cover: Page = () => (
         Three changes that landed this quarter — none of them flashy, all of them load-bearing.
       </p>
     </div>
-    <Footer pageNum={1} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -252,7 +245,7 @@ const Content: Page = () => (
         </li>
       ))}
     </ul>
-    <Footer pageNum={2} total={TOTAL} path="/docs/changelog" />
+    <Footer path="/docs/changelog" />
   </div>
 );
 
@@ -282,7 +275,7 @@ const Closer: Page = () => (
         Upgrade is one bumped dependency. Everything else can wait until you have time.
       </p>
     </div>
-    <Footer pageNum={TOTAL} total={TOTAL} path="/docs/upgrade" />
+    <Footer path="/docs/upgrade" />
   </div>
 );
 

--- a/apps/demo/themes/aurora.md
+++ b/apps/demo/themes/aurora.md
@@ -63,29 +63,34 @@ const Title = ({ children }: { children: React.ReactNode }) => (
 ### Footer
 
 ```tsx
-const Footer = ({ pageNum, total, path = '/docs' }: { pageNum: number; total: number; path?: string }) => (
-  <div
-    style={{
-      position: 'absolute',
-      left: 120,
-      right: 120,
-      bottom: 56,
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      fontFamily: "'SF Mono', 'JetBrains Mono', 'Menlo', monospace",
-      fontSize: 22,
-      letterSpacing: '0.04em',
-      color: '#8B8B8B',
-    }}
-  >
-    <span>{path}</span>
-    <span>
-      {String(pageNum).padStart(2, '0')}{' '}
-      <span style={{ opacity: 0.4 }}>/ {String(total).padStart(2, '0')}</span>
-    </span>
-  </div>
-);
+import { useSlidePageNumber } from '@open-slide/core';
+
+const Footer = ({ path = '/docs' }: { path?: string }) => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 120,
+        right: 120,
+        bottom: 56,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        fontFamily: "'SF Mono', 'JetBrains Mono', 'Menlo', monospace",
+        fontSize: 22,
+        letterSpacing: '0.04em',
+        color: '#8B8B8B',
+      }}
+    >
+      <span>{path}</span>
+      <span>
+        {String(current).padStart(2, '0')}{' '}
+        <span style={{ opacity: 0.4 }}>/ {String(total).padStart(2, '0')}</span>
+      </span>
+    </div>
+  );
+};
 ```
 
 ### Eyebrow (pill with glowing dot)
@@ -169,7 +174,7 @@ const Cover: Page = () => (
     <p style={{ fontSize: 26, lineHeight: 1.5, color: '#8B8B8B', maxWidth: 1180, margin: 0 }}>
       Three changes that landed this quarter — none of them flashy, all of them load-bearing.
     </p>
-    <Footer pageNum={1} total={6} />
+    <Footer />
   </div>
 );
 ```

--- a/apps/demo/themes/bright-sans.demo.tsx
+++ b/apps/demo/themes/bright-sans.demo.tsx
@@ -1,4 +1,4 @@
-import type { Page } from '@open-slide/core';
+import { type Page, useSlidePageNumber } from '@open-slide/core';
 import type { ReactNode } from 'react';
 
 const styles = `
@@ -22,42 +22,41 @@ const Title = ({ children }: { children: ReactNode }) => (
 );
 
 const Footer = ({
-  pageNum,
-  total,
   dotColor = '#1a73e8',
   label = 'Spring product update',
 }: {
-  pageNum: number;
-  total: number;
   dotColor?: string;
   label?: string;
-}) => (
-  <div
-    style={{
-      position: 'absolute',
-      left: 120,
-      right: 120,
-      bottom: 60,
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      fontFamily: "'Inter', system-ui, sans-serif",
-      fontSize: 18,
-      color: '#5f6368',
-    }}
-  >
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 12 }}>
-      <span
-        aria-hidden
-        style={{ width: 10, height: 10, borderRadius: '50%', background: dotColor }}
-      />
-      {label}
-    </span>
-    <span>
-      {pageNum} / {total}
-    </span>
-  </div>
-);
+}) => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 120,
+        right: 120,
+        bottom: 60,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        fontFamily: "'Inter', system-ui, sans-serif",
+        fontSize: 18,
+        color: '#5f6368',
+      }}
+    >
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 12 }}>
+        <span
+          aria-hidden
+          style={{ width: 10, height: 10, borderRadius: '50%', background: dotColor }}
+        />
+        {label}
+      </span>
+      <span>
+        {current} / {total}
+      </span>
+    </div>
+  );
+};
 
 const Eyebrow = ({
   children,
@@ -108,8 +107,6 @@ const pageBase: React.CSSProperties = {
   fontFamily: "'Inter', -apple-system, system-ui, sans-serif",
 };
 
-const TOTAL = 3;
-
 const Cover: Page = () => (
   <div
     style={{
@@ -125,7 +122,7 @@ const Cover: Page = () => (
     <p style={{ fontSize: 32, lineHeight: 1.5, color: '#5f6368', maxWidth: 1180, margin: 0 }}>
       Four small features that make the next eight months of work feel a little easier.
     </p>
-    <Footer pageNum={1} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -241,7 +238,7 @@ const Content: Page = () => (
         </li>
       ))}
     </ul>
-    <Footer pageNum={2} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -260,7 +257,7 @@ const Closer: Page = () => (
     <p style={{ fontSize: 28, lineHeight: 1.5, color: '#5f6368', maxWidth: 1180, margin: 0 }}>
       Everything in this deck is opt-in. Turn it on for one team, then the next, then the rest.
     </p>
-    <Footer pageNum={TOTAL} total={TOTAL} dotColor="#34a853" label="Available today" />
+    <Footer dotColor="#34a853" label="Available today" />
   </div>
 );
 

--- a/apps/demo/themes/bright-sans.md
+++ b/apps/demo/themes/bright-sans.md
@@ -62,33 +62,38 @@ const Title = ({ children }: { children: React.ReactNode }) => (
 ### Footer
 
 ```tsx
-const Footer = ({ pageNum, total }: { pageNum: number; total: number }) => (
-  <div
-    style={{
-      position: 'absolute',
-      left: 120,
-      right: 120,
-      bottom: 60,
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      fontFamily: "'Inter', system-ui, sans-serif",
-      fontSize: 18,
-      color: '#5f6368',
-    }}
-  >
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 12 }}>
-      <span
-        aria-hidden
-        style={{ width: 10, height: 10, borderRadius: '50%', background: '#1a73e8' }}
-      />
-      Spring product update
-    </span>
-    <span>
-      {pageNum} / {total}
-    </span>
-  </div>
-);
+import { useSlidePageNumber } from '@open-slide/core';
+
+const Footer = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 120,
+        right: 120,
+        bottom: 60,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        fontFamily: "'Inter', system-ui, sans-serif",
+        fontSize: 18,
+        color: '#5f6368',
+      }}
+    >
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 12 }}>
+        <span
+          aria-hidden
+          style={{ width: 10, height: 10, borderRadius: '50%', background: '#1a73e8' }}
+        />
+        Spring product update
+      </span>
+      <span>
+        {current} / {total}
+      </span>
+    </div>
+  );
+};
 ```
 
 ### Eyebrow
@@ -161,7 +166,7 @@ const Cover: Page = () => (
     <p style={{ fontSize: 32, lineHeight: 1.5, color: '#5f6368', maxWidth: 1180, margin: 0 }}>
       Four small features that make the next eight months of work feel a little easier.
     </p>
-    <Footer pageNum={1} total={6} />
+    <Footer />
   </div>
 );
 ```

--- a/apps/demo/themes/sticker-pop.demo.tsx
+++ b/apps/demo/themes/sticker-pop.demo.tsx
@@ -1,4 +1,4 @@
-import type { Page } from '@open-slide/core';
+import { type Page, useSlidePageNumber } from '@open-slide/core';
 import type { ReactNode } from 'react';
 
 const styles = `
@@ -33,50 +33,53 @@ const Title = ({ children }: { children: ReactNode }) => (
   </h1>
 );
 
-const Footer = ({ pageNum, total }: { pageNum: number; total: number }) => (
-  <div
-    style={{
-      position: 'absolute',
-      left: 110,
-      right: 110,
-      bottom: 60,
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      fontFamily: "'Inter', system-ui, sans-serif",
-      fontSize: 18,
-      fontWeight: 600,
-      color: '#9a8aa8',
-    }}
-  >
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 10 }}>
-      <span
-        aria-hidden
-        style={{ width: 12, height: 12, borderRadius: '50%', background: '#ff4d8d' }}
-      />
-      <span
-        aria-hidden
-        style={{ width: 12, height: 12, borderRadius: '50%', background: '#6d4cff' }}
-      />
-      <span
-        aria-hidden
-        style={{ width: 12, height: 12, borderRadius: '50%', background: '#ffd24c' }}
-      />
-      <span style={{ marginLeft: 8 }}>Sticker Pop</span>
-    </span>
-    <span
+const Footer = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
       style={{
-        background: '#2d1b4e',
-        color: '#fff2e8',
-        padding: '6px 14px',
-        borderRadius: 999,
-        fontVariantNumeric: 'tabular-nums',
+        position: 'absolute',
+        left: 110,
+        right: 110,
+        bottom: 60,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        fontFamily: "'Inter', system-ui, sans-serif",
+        fontSize: 18,
+        fontWeight: 600,
+        color: '#9a8aa8',
       }}
     >
-      {pageNum} / {total}
-    </span>
-  </div>
-);
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 10 }}>
+        <span
+          aria-hidden
+          style={{ width: 12, height: 12, borderRadius: '50%', background: '#ff4d8d' }}
+        />
+        <span
+          aria-hidden
+          style={{ width: 12, height: 12, borderRadius: '50%', background: '#6d4cff' }}
+        />
+        <span
+          aria-hidden
+          style={{ width: 12, height: 12, borderRadius: '50%', background: '#ffd24c' }}
+        />
+        <span style={{ marginLeft: 8 }}>Sticker Pop</span>
+      </span>
+      <span
+        style={{
+          background: '#2d1b4e',
+          color: '#fff2e8',
+          padding: '6px 14px',
+          borderRadius: 999,
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {current} / {total}
+      </span>
+    </div>
+  );
+};
 
 const Sticker = ({
   children,
@@ -164,8 +167,6 @@ const Dot = ({
   />
 );
 
-const TOTAL = 3;
-
 const Cover: Page = () => (
   <div style={{ ...pageBase, justifyContent: 'center', gap: 40 }}>
     <style>{styles}</style>
@@ -179,7 +180,7 @@ const Cover: Page = () => (
     <p style={{ fontSize: 34, lineHeight: 1.45, color: '#2d1b4e', maxWidth: 1200, margin: 0 }}>
       A short, cheerful tour of the small ideas we have been having lately.
     </p>
-    <Footer pageNum={1} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -257,7 +258,7 @@ const Content: Page = () => (
         </li>
       ))}
     </ul>
-    <Footer pageNum={2} total={TOTAL} />
+    <Footer />
   </div>
 );
 
@@ -275,7 +276,7 @@ const Closer: Page = () => (
     <p style={{ fontSize: 28, lineHeight: 1.45, color: '#2d1b4e', maxWidth: 1100, margin: 0 }}>
       Borrow whatever you like. The dot pattern is on the house.
     </p>
-    <Footer pageNum={TOTAL} total={TOTAL} />
+    <Footer />
   </div>
 );
 

--- a/apps/demo/themes/sticker-pop.md
+++ b/apps/demo/themes/sticker-pop.md
@@ -59,41 +59,46 @@ const Title = ({ children }: { children: React.ReactNode }) => (
 ### Footer
 
 ```tsx
-const Footer = ({ pageNum, total }: { pageNum: number; total: number }) => (
-  <div
-    style={{
-      position: 'absolute',
-      left: 110,
-      right: 110,
-      bottom: 60,
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      fontFamily: "'Inter', system-ui, sans-serif",
-      fontSize: 18,
-      fontWeight: 600,
-      color: '#9a8aa8',
-    }}
-  >
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 10 }}>
-      <span aria-hidden style={{ width: 12, height: 12, borderRadius: '50%', background: '#ff4d8d' }} />
-      <span aria-hidden style={{ width: 12, height: 12, borderRadius: '50%', background: '#6d4cff' }} />
-      <span aria-hidden style={{ width: 12, height: 12, borderRadius: '50%', background: '#ffd24c' }} />
-      <span style={{ marginLeft: 8 }}>Sticker Pop</span>
-    </span>
-    <span
+import { useSlidePageNumber } from '@open-slide/core';
+
+const Footer = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
       style={{
-        background: '#2d1b4e',
-        color: '#fff2e8',
-        padding: '6px 14px',
-        borderRadius: 999,
-        fontVariantNumeric: 'tabular-nums',
+        position: 'absolute',
+        left: 110,
+        right: 110,
+        bottom: 60,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        fontFamily: "'Inter', system-ui, sans-serif",
+        fontSize: 18,
+        fontWeight: 600,
+        color: '#9a8aa8',
       }}
     >
-      {pageNum} / {total}
-    </span>
-  </div>
-);
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 10 }}>
+        <span aria-hidden style={{ width: 12, height: 12, borderRadius: '50%', background: '#ff4d8d' }} />
+        <span aria-hidden style={{ width: 12, height: 12, borderRadius: '50%', background: '#6d4cff' }} />
+        <span aria-hidden style={{ width: 12, height: 12, borderRadius: '50%', background: '#ffd24c' }} />
+        <span style={{ marginLeft: 8 }}>Sticker Pop</span>
+      </span>
+      <span
+        style={{
+          background: '#2d1b4e',
+          color: '#fff2e8',
+          padding: '6px 14px',
+          borderRadius: 999,
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {current} / {total}
+      </span>
+    </div>
+  );
+};
 ```
 
 ### Eyebrow / sticker pill
@@ -176,7 +181,7 @@ const Cover: Page = () => (
     <p style={{ fontSize: 34, lineHeight: 1.45, color: '#2d1b4e', maxWidth: 1200, margin: 0 }}>
       A short, cheerful tour of the small ideas we have been having lately.
     </p>
-    <Footer pageNum={1} total={6} />
+    <Footer />
   </div>
 );
 ```

--- a/packages/cli/template/.agents/skills/create-theme/SKILL.md
+++ b/packages/cli/template/.agents/skills/create-theme/SKILL.md
@@ -101,24 +101,31 @@ const Title = ({ children }: { children: React.ReactNode }) => (
 
 ### Footer
 
+Pull the page number from `useSlidePageNumber()` — never hardcode `pageNum` / `total` props.
+
 ```tsx
-const Footer = ({ pageNum, total }: { pageNum: number; total: number }) => (
-  <div
-    style={{
-      position: 'absolute',
-      left: 120,
-      right: 120,
-      bottom: 60,
-      display: 'flex',
-      justifyContent: 'space-between',
-      fontSize: 24,
-      color: '#94a3b8',
-    }}
-  >
-    <span>EDITORIAL NOIR · 2026</span>
-    <span>{pageNum} / {total}</span>
-  </div>
-);
+import { useSlidePageNumber } from '@open-slide/core';
+
+const Footer = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 120,
+        right: 120,
+        bottom: 60,
+        display: 'flex',
+        justifyContent: 'space-between',
+        fontSize: 24,
+        color: '#94a3b8',
+      }}
+    >
+      <span>EDITORIAL NOIR · 2026</span>
+      <span>{current} / {total}</span>
+    </div>
+  );
+};
 ```
 
 ### Eyebrow / accents (optional)
@@ -157,7 +164,7 @@ const Cover: Page = () => (
     <p style={{ fontSize: 36, color: '#94a3b8', maxWidth: 1200, marginTop: 32 }}>
       A short subtitle that explains what this slide is about.
     </p>
-    <Footer pageNum={1} total={5} />
+    <Footer />
   </div>
 );
 ```

--- a/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
@@ -280,6 +280,23 @@ The user uploads the real file via the Assets panel, then clicks the placeholder
 
 Size the placeholder to the slot it occupies. Pass `width`/`height` when the layout has a fixed image box; omit them when the placeholder fills a flex/grid cell. The `hint` should describe the *content* the user needs ("Q3 revenue chart") not the *role* ("hero image").
 
+## Page numbers
+
+If a footer shows the current page (`03 / 12`, `Page 3`, etc.), read it from `useSlidePageNumber()` — **never hardcode** `n` / `TOTAL`. Inserting, reordering, or deleting a page would otherwise force you to retouch every footer.
+
+```tsx
+import { useSlidePageNumber } from '@open-slide/core';
+
+const Footer = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <span>{String(current).padStart(2, '0')} / {String(total).padStart(2, '0')}</span>
+  );
+};
+```
+
+`current` is 1-indexed (matches what readers see) and `total` is the slide's page count. The hook works in every render context (main viewer, thumbnails, overview grid, present mode, presenter window, HTML/PDF export) — the same `<Footer />` JSX is correct everywhere. Call the hook inside a component that's used **per page**; don't try to call it at module top level.
+
 ## Repeated elements: component, not `map`
 
 When a page has visually repeated items — cards, logo rows, gallery tiles, list rows, step indicators — **define a small component and instantiate it once per item**. Do **not** render the group with `array.map` over a data array.

--- a/packages/core/skills/create-theme/SKILL.md
+++ b/packages/core/skills/create-theme/SKILL.md
@@ -105,24 +105,31 @@ const Title = ({ children }: { children: React.ReactNode }) => (
 
 ### Footer
 
+Pull the page number from `useSlidePageNumber()` — never hardcode `pageNum` / `total` props.
+
 ```tsx
-const Footer = ({ pageNum, total }: { pageNum: number; total: number }) => (
-  <div
-    style={{
-      position: 'absolute',
-      left: 120,
-      right: 120,
-      bottom: 60,
-      display: 'flex',
-      justifyContent: 'space-between',
-      fontSize: 24,
-      color: '#94a3b8',
-    }}
-  >
-    <span>EDITORIAL NOIR · 2026</span>
-    <span>{pageNum} / {total}</span>
-  </div>
-);
+import { useSlidePageNumber } from '@open-slide/core';
+
+const Footer = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 120,
+        right: 120,
+        bottom: 60,
+        display: 'flex',
+        justifyContent: 'space-between',
+        fontSize: 24,
+        color: '#94a3b8',
+      }}
+    >
+      <span>EDITORIAL NOIR · 2026</span>
+      <span>{current} / {total}</span>
+    </div>
+  );
+};
 ```
 
 ### Eyebrow / accents (optional)
@@ -161,7 +168,7 @@ const Cover: Page = () => (
     <p style={{ fontSize: 36, color: '#94a3b8', maxWidth: 1200, marginTop: 32 }}>
       A short subtitle that explains what this slide is about.
     </p>
-    <Footer pageNum={1} total={5} />
+    <Footer />
   </div>
 );
 ```
@@ -173,7 +180,7 @@ The demo is a normal slide module — same shape as `slides/<id>/index.tsx`, jus
 
 Contract:
 
-- `import type { Page } from '@open-slide/core';`
+- `import { type Page, useSlidePageNumber } from '@open-slide/core';`
 - Inline the **same** `Title`, `Footer`, `Eyebrow` components defined in the theme markdown — verbatim, no abstractions, no imports from elsewhere. The demo and the markdown must stay in lockstep so what the user sees in the panel matches what `create-slide` will paste into a real slide.
 - Export 2–3 `Page` components and a default array. Aim for: a Cover (Eyebrow + Title + subtitle), one Content page exercising body type + accent, and a Closer or "End" card. The "Example usage" block at the bottom of the markdown is a good starting point — extend it.
 - If the theme has runtime-tweakable tokens worth surfacing in the Design panel later, also `export const design: DesignSystem = {...}`.
@@ -182,14 +189,15 @@ Contract:
 Skeleton:
 
 ```tsx
-import type { Page } from '@open-slide/core';
+import { type Page, useSlidePageNumber } from '@open-slide/core';
 
 const Title = ({ children }: { children: React.ReactNode }) => (
   // …same JSX as in themes/<id>.md
 );
-const Footer = ({ pageNum, total }: { pageNum: number; total: number }) => (
+const Footer = () => {
+  const { current, total } = useSlidePageNumber();
   // …
-);
+};
 const Eyebrow = ({ children }: { children: React.ReactNode }) => (
   // …
 );

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -291,6 +291,23 @@ The user uploads the real file via the Assets panel, then clicks the placeholder
 
 Size the placeholder to the slot it occupies. Pass `width`/`height` when the layout has a fixed image box; omit them when the placeholder fills a flex/grid cell. The `hint` should describe the *content* the user needs ("Q3 revenue chart") not the *role* ("hero image").
 
+## Page numbers
+
+If a footer shows the current page (`03 / 12`, `Page 3`, etc.), read it from `useSlidePageNumber()` — **never hardcode** `n` / `TOTAL`. Inserting, reordering, or deleting a page would otherwise force you to retouch every footer.
+
+```tsx
+import { useSlidePageNumber } from '@open-slide/core';
+
+const Footer = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <span>{String(current).padStart(2, '0')} / {String(total).padStart(2, '0')}</span>
+  );
+};
+```
+
+`current` is 1-indexed (matches what readers see) and `total` is the slide's page count. The hook works in every render context (main viewer, thumbnails, overview grid, present mode, presenter window, HTML/PDF export) — the same `<Footer />` JSX is correct everywhere. Call the hook inside a component that's used **per page**; don't try to call it at module top level.
+
 ## Repeated elements: component, not `map`
 
 When a page has visually repeated items — cards, logo rows, gallery tiles, list rows, step indicators — **define a small component and instantiate it once per item**. Do **not** render the group with `array.map` over a data array.

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useWheelPageNavigation } from '@/lib/use-wheel-page-navigation';
 import { cn } from '@/lib/utils';
 import type { DesignSystem } from '../lib/design';
+import { SlidePageProvider } from '../lib/page-context';
 import type { Page } from '../lib/sdk';
 import { PresentBlackoutOverlay } from './present/blackout-overlay';
 import { PresentControlBar } from './present/control-bar';
@@ -295,7 +296,11 @@ export function Player({
       )}
     >
       <SlideCanvas flat design={design}>
-        {PageComp ? <PageComp /> : null}
+        {PageComp ? (
+          <SlidePageProvider index={index} total={pages.length}>
+            <PageComp />
+          </SlidePageProvider>
+        ) : null}
       </SlideCanvas>
 
       <button

--- a/packages/core/src/app/components/present/overview-grid.tsx
+++ b/packages/core/src/app/components/present/overview-grid.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import type { DesignSystem } from '../../lib/design';
+import { SlidePageProvider } from '../../lib/page-context';
 import type { Page } from '../../lib/sdk';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../../lib/sdk';
 import { SlideCanvas } from '../slide-canvas';
@@ -136,7 +137,9 @@ export function PresentOverviewGrid({ pages, design, open, current, onClose, onS
                     freezeMotion
                     design={design}
                   >
-                    <PageComp />
+                    <SlidePageProvider index={i} total={pages.length}>
+                      <PageComp />
+                    </SlidePageProvider>
                   </SlideCanvas>
                   {isCurrent && (
                     <span

--- a/packages/core/src/app/components/themes/theme-detail.tsx
+++ b/packages/core/src/app/components/themes/theme-detail.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
+import { SlidePageProvider } from '../../lib/page-context';
 import type { SlideModule } from '../../lib/sdk';
 import { loadSlide, slidesByTheme } from '../../lib/slides';
 import { loadThemeDemo, type ThemeDemoModule, themes } from '../../lib/themes';
@@ -106,7 +107,9 @@ export function ThemeDetail({ themeId, onBack }: { themeId: string; onBack: () =
                 </div>
               ) : Current ? (
                 <SlideCanvas flat freezeMotion design={demo.design}>
-                  <Current />
+                  <SlidePageProvider index={pageIndex} total={totalPages}>
+                    <Current />
+                  </SlidePageProvider>
                 </SlideCanvas>
               ) : null}
             </div>
@@ -227,7 +230,9 @@ function ThemeSlideCard({ id }: { id: string }) {
         {FirstPage ? (
           <div className="h-full w-full motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]">
             <SlideCanvas flat freezeMotion design={slide?.design}>
-              <FirstPage />
+              <SlidePageProvider index={0} total={slide?.default.length ?? 1}>
+                <FirstPage />
+              </SlidePageProvider>
             </SlideCanvas>
           </div>
         ) : (

--- a/packages/core/src/app/components/themes/themes-gallery.tsx
+++ b/packages/core/src/app/components/themes/themes-gallery.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { format, useLocale } from '@/lib/use-locale';
+import { SlidePageProvider } from '../../lib/page-context';
 import { loadThemeDemo, type Theme, type ThemeDemoModule, themes } from '../../lib/themes';
 import { SlideCanvas } from '../slide-canvas';
 
@@ -78,7 +79,9 @@ function ThemePreview({ theme }: { theme: Theme }) {
   return (
     <div className="h-full w-full motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]">
       <SlideCanvas flat freezeMotion design={demo.design}>
-        <FirstPage />
+        <SlidePageProvider index={0} total={demo.default.length}>
+          <FirstPage />
+        </SlidePageProvider>
       </SlideCanvas>
     </div>
   );

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -28,6 +28,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import type { DesignSystem } from '../lib/design';
+import { SlidePageProvider } from '../lib/page-context';
 import type { Page } from '../lib/sdk';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
 import { SlideCanvas } from './slide-canvas';
@@ -118,7 +119,9 @@ export function ThumbnailRail({
                     style={{ width, height: HORIZONTAL_THUMB_HEIGHT }}
                   >
                     <SlideCanvas scale={scale} center={false} flat freezeMotion design={design}>
-                      <PageComp />
+                      <SlidePageProvider index={i} total={pages.length}>
+                        <PageComp />
+                      </SlidePageProvider>
                     </SlideCanvas>
                   </div>
                 </button>
@@ -155,6 +158,7 @@ export function ThumbnailRail({
     const inner = (
       <ThumbContents
         index={i}
+        total={pages.length}
         active={active}
         page={PageComp}
         design={design}
@@ -236,6 +240,7 @@ function thumbButtonClass(active: boolean): string {
 
 function ThumbContents({
   index,
+  total,
   active,
   page: PageComp,
   design,
@@ -244,6 +249,7 @@ function ThumbContents({
   height,
 }: {
   index: number;
+  total: number;
   active: boolean;
   page: Page;
   design?: DesignSystem;
@@ -271,7 +277,9 @@ function ThumbContents({
         style={{ width: thumbWidth, height }}
       >
         <SlideCanvas scale={scale} center={false} flat freezeMotion design={design}>
-          <PageComp />
+          <SlidePageProvider index={index} total={total}>
+            <PageComp />
+          </SlidePageProvider>
         </SlideCanvas>
         {active && (
           <span

--- a/packages/core/src/app/lib/export-html.ts
+++ b/packages/core/src/app/lib/export-html.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { designToCssVars } from './design';
+import { SlidePageProvider } from './page-context';
 import type { SlideModule } from './sdk';
 
 type AssetEntry = { name: string; bytes: Uint8Array };
@@ -82,13 +83,17 @@ async function renderPagesToHtml(pages: NonNullable<SlideModule['default']>): Pr
 
   const result: string[] = [];
   try {
-    for (const Page of pages) {
+    for (let i = 0; i < pages.length; i++) {
+      const Page = pages[i];
+      if (!Page) continue;
       const host = document.createElement('div');
       host.style.width = '1920px';
       host.style.height = '1080px';
       container.appendChild(host);
       const root = createRoot(host);
-      root.render(createElement(Page));
+      root.render(
+        createElement(SlidePageProvider, { index: i, total: pages.length }, createElement(Page)),
+      );
       await nextPaint();
       await nextPaint();
       result.push(host.innerHTML);

--- a/packages/core/src/app/lib/export-pdf.ts
+++ b/packages/core/src/app/lib/export-pdf.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { designToCssVars } from './design';
+import { SlidePageProvider } from './page-context';
 import { isFrameAnimationSettled, waitForDataWaitfor, waitForFonts } from './print-ready';
 import type { SlideModule } from './sdk';
 
@@ -109,7 +110,9 @@ export async function exportSlideAsPdf(
 
   const reactRoots: Root[] = [];
   const frames: HTMLElement[] = [];
-  for (const Page of pages) {
+  for (let i = 0; i < pages.length; i++) {
+    const Page = pages[i];
+    if (!Page) continue;
     const host = document.createElement('div');
     host.className = 'os-print-frame';
     host.setAttribute('data-osd-canvas', '');
@@ -126,7 +129,9 @@ export async function exportSlideAsPdf(
     root.appendChild(host);
     frames.push(host);
     const r = createRoot(inner);
-    r.render(createElement(Page));
+    r.render(
+      createElement(SlidePageProvider, { index: i, total: pages.length }, createElement(Page)),
+    );
     reactRoots.push(r);
   }
   // Yield once so React commits all pages and CSS animations actually start

--- a/packages/core/src/app/lib/page-context.tsx
+++ b/packages/core/src/app/lib/page-context.tsx
@@ -1,0 +1,38 @@
+import { type Context, createContext, type PropsWithChildren, useContext, useMemo } from 'react';
+
+type SlidePageContextValue = {
+  index: number;
+  total: number;
+};
+
+// Stored on globalThis so dev (src) and published (dist) copies of this module
+// share one context instance — otherwise the provider writes to one context and
+// the hook reads from another, and `useSlidePageNumber` always sees null.
+const GLOBAL_KEY = '__open_slide_page_context__';
+type GlobalWithCtx = typeof globalThis & {
+  [GLOBAL_KEY]?: Context<SlidePageContextValue | null>;
+};
+const g = globalThis as GlobalWithCtx;
+if (!g[GLOBAL_KEY]) {
+  g[GLOBAL_KEY] = createContext<SlidePageContextValue | null>(null);
+}
+const SlidePageContext = g[GLOBAL_KEY];
+
+export function SlidePageProvider({
+  index,
+  total,
+  children,
+}: PropsWithChildren<{ index: number; total: number }>) {
+  const value = useMemo(() => ({ index, total }), [index, total]);
+  return <SlidePageContext.Provider value={value}>{children}</SlidePageContext.Provider>;
+}
+
+export function useSlidePageNumber(): { current: number; total: number } {
+  const ctx = useContext(SlidePageContext);
+  if (!ctx) {
+    throw new Error(
+      'useSlidePageNumber must be called from a slide page rendered by @open-slide/core',
+    );
+  }
+  return { current: ctx.index + 1, total: ctx.total };
+}

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -33,6 +33,7 @@ import { cn } from '@/lib/utils';
 import { FolderIconChip, SLIDE_DND_MIME } from '../components/sidebar/folder-item';
 import { DRAFT_ID } from '../components/sidebar/sidebar';
 import { SlideCanvas } from '../components/slide-canvas';
+import { SlidePageProvider } from '../lib/page-context';
 import type { Folder, FolderIcon, SlideModule } from '../lib/sdk';
 import { loadSlide, slideCreatedAt } from '../lib/slides';
 import type { HomeOutletContext } from './home-shell';
@@ -441,7 +442,9 @@ function SlideCard({
             {FirstPage ? (
               <div className="h-full w-full motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]">
                 <SlideCanvas flat freezeMotion design={slide?.design}>
-                  <FirstPage />
+                  <SlidePageProvider index={0} total={slide?.default.length ?? 1}>
+                    <FirstPage />
+                  </SlidePageProvider>
                 </SlideCanvas>
               </div>
             ) : (

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -9,6 +9,7 @@ import {
   usePresenterChannel,
 } from '../components/present/use-presenter-channel';
 import { SlideCanvas } from '../components/slide-canvas';
+import { SlidePageProvider } from '../lib/page-context';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
 import { useSlideModule } from '../lib/use-slide-module';
 
@@ -138,7 +139,9 @@ export function Presenter() {
           <SectionLabel>{t.presenter.nowShowing}</SectionLabel>
           <div className="relative min-h-0 flex-1 overflow-hidden rounded-[8px] bg-black ring-1 ring-border">
             <SlideCanvas flat design={slide.design}>
-              <CurrentPage />
+              <SlidePageProvider index={index} total={total}>
+                <CurrentPage />
+              </SlidePageProvider>
             </SlideCanvas>
             {blackout && (
               <div
@@ -164,7 +167,9 @@ export function Presenter() {
             >
               {NextPage ? (
                 <SlideCanvas flat freezeMotion design={slide.design}>
-                  <NextPage />
+                  <SlidePageProvider index={nextIndex} total={total}>
+                    <NextPage />
+                  </SlidePageProvider>
                 </SlideCanvas>
               ) : (
                 <div className="grid h-full place-items-center text-[11.5px] text-muted-foreground">

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -52,6 +52,7 @@ import { type ThumbnailActions, ThumbnailRail } from '../components/thumbnail-ra
 import { exportSlideAsHtml } from '../lib/export-html';
 import { exportSlideAsPdf, isSafari } from '../lib/export-pdf';
 import { remapNotesSessionCacheAfterReorder } from '../lib/inspector/use-notes';
+import { SlidePageProvider } from '../lib/page-context';
 import type { SlideModule } from '../lib/sdk';
 import { useSlideModule } from '../lib/use-slide-module';
 
@@ -584,7 +585,9 @@ export function Slide() {
                       canNext={index < pageCount - 1}
                     />
                     <SlideCanvas design={slide.design}>
-                      <CurrentPage />
+                      <SlidePageProvider index={index} total={pageCount}>
+                        <CurrentPage />
+                      </SlidePageProvider>
                     </SlideCanvas>
                     <ClickNavZones
                       onPrev={() => goTo(index - 1)}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export type {
   DesignTypeScale,
 } from './app/lib/design.ts';
 export { cssVarsToString, defaultDesign, designToCssVars } from './app/lib/design.ts';
+export { useSlidePageNumber } from './app/lib/page-context.tsx';
 export type { Page, SlideMeta, SlideModule } from './app/lib/sdk.ts';
 export { CANVAS_HEIGHT, CANVAS_WIDTH } from './app/lib/sdk.ts';
 export type { OpenSlideConfig } from './config.ts';


### PR DESCRIPTION
## Summary

- Add a new `useSlidePageNumber()` hook to `@open-slide/core` so slide pages can render their own page number (`{ current, total }`) without hardcoding `n` / `TOTAL` on every page.
- Inserting, reordering, or deleting pages no longer requires touching every footer.
- Migrate `apps/demo/slides/llm-fundamentals` to use the hook as a reference.

## Why

A common pattern in slide decks is a footer like `03 / 12`. Today authors hardcode both numbers on every page (see `llm-fundamentals` before this PR), so any structural edit forces a tedious renumber across every page. Core already tracks the active index and page count internally — this just exposes them to the rendered page via React context.

## How it works

A new internal `SlidePageProvider` wraps every site in core that renders a `Page` component. The `useSlidePageNumber()` hook reads the same context and returns 1-indexed `{ current, total }`. Throws with a clear message if called outside a slide.

Wrapped render sites (so the hook is always correct, including in thumbnails):

- `app/routes/slide.tsx` — main viewer
- `app/components/player.tsx` — present mode
- `app/routes/presenter.tsx` — presenter window (current + up-next)
- `app/components/thumbnail-rail.tsx` — both vertical and horizontal layouts
- `app/components/present/overview-grid.tsx` — overview tiles
- `app/routes/home.tsx` — slide card thumbnails
- `app/components/themes/theme-detail.tsx` — theme demo + linked slide previews
- `app/components/themes/themes-gallery.tsx` — gallery cards
- `app/lib/export-html.ts` and `app/lib/export-pdf.ts` — export render loops

### Context module sharing

The provider/hook live in `packages/core/src/app/lib/page-context.tsx`. The context instance is pinned to `globalThis.__open_slide_page_context__` because in this workspace the dev server reads core from `src/` while consumers (e.g. `apps/demo`) import the published API from `dist/`. Without the global pin those are two separate `React.createContext` instances and the hook never sees the provider's value.

## Public API

```ts
import { useSlidePageNumber } from '@open-slide/core';

function Footer() {
  const { current, total } = useSlidePageNumber();
  return <span>{current} / {total}</span>;
}
```

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm check` — clean (only the two pre-existing warnings)
- [x] `pnpm test` — 207/207 pass
- [ ] `pnpm dev`, open `llm-fundamentals`, step through every page — footer shows `01 / 12` … `12 / 12`
- [ ] Reorder/duplicate a page in the slide array — page numbers update automatically with no further edits
- [ ] Open present mode (`P`), confirm page numbers render
- [ ] Open the presenter window — current + up-next both show correct numbers
- [ ] Open overview grid (`O` in present) — each tile shows its own correct page number
- [ ] Home page slide cards render without crashing
- [ ] Themes gallery / theme detail previews render without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic slide numbering: pages, footers, overlays and progress labels now show current/total automatically.

* **Refactor**
  * Pagination unified across viewer, presenter, thumbnails, previews, exports, and demo themes for consistent numbering.

* **Documentation**
  * Templates and authoring docs updated with examples and guidance for the new page-numbering approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->