### PR TITLE
fix: progress bar rendering artifact in fullscreen mode

### DIFF
--- a/.changeset/fix-present-line-artifacts.md
+++ b/.changeset/fix-present-line-artifacts.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Fix a vertical-line artifact that could appear during fullscreen playback: drive the laser pointer with `transform` instead of `left`/`top` so a moving box-shadow no longer leaves a compositor ghost, and animate the progress bar fill with `scaleX` so its opacity fade-out shares a layer with the parent.

--- a/.changeset/fix-present-progress-bar-artifact.md
+++ b/.changeset/fix-present-progress-bar-artifact.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Fix a vertical-line artifact that occasionally appeared during fullscreen playback after the controls faded out, caused by the progress bar's width transition leaving a compositor ghost.

--- a/.changeset/fix-present-progress-bar-artifact.md
+++ b/.changeset/fix-present-progress-bar-artifact.md
@@ -1,5 +1,0 @@
----
-'@open-slide/core': patch
----
-
-Fix a vertical-line artifact that occasionally appeared during fullscreen playback after the controls faded out, caused by the progress bar's width transition leaving a compositor ghost.

--- a/packages/core/src/app/components/present/laser-pointer.tsx
+++ b/packages/core/src/app/components/present/laser-pointer.tsx
@@ -24,13 +24,12 @@ export function PresentLaserPointer({ enabled }: { enabled: boolean }) {
   return (
     <div
       aria-hidden
-      className="pointer-events-none fixed z-[60]"
+      className="pointer-events-none fixed top-0 left-0 z-[60]"
       style={{
-        left: pos.x,
-        top: pos.y,
         width: 18,
         height: 18,
-        transform: 'translate(-50%, -50%)',
+        transform: `translate3d(${pos.x - 9}px, ${pos.y - 9}px, 0)`,
+        willChange: 'transform',
         borderRadius: '50%',
         background: 'radial-gradient(circle, oklch(0.66 0.24 28 / 0.95) 30%, transparent 70%)',
         boxShadow: '0 0 18px 4px oklch(0.66 0.24 28 / 0.55)',

--- a/packages/core/src/app/components/present/progress-bar.tsx
+++ b/packages/core/src/app/components/present/progress-bar.tsx
@@ -7,19 +7,19 @@ type Props = {
 };
 
 export function PresentProgressBar({ index, total, visible }: Props) {
-  const pct = total > 0 ? ((index + 1) / total) * 100 : 0;
+  const pct = total > 0 ? (index + 1) / total : 0;
   return (
     <div
       aria-hidden
       className={cn(
-        'pointer-events-none absolute inset-x-0 top-0 z-30 h-[2px] bg-white/8',
+        'pointer-events-none absolute inset-x-0 top-0 z-30 h-[2px] overflow-hidden bg-white/8',
         'motion-safe:transition-opacity motion-safe:duration-200',
         visible ? 'opacity-100' : 'opacity-0',
       )}
     >
       <div
-        className="h-full bg-[var(--brand,#ef4444)] transition-[width] duration-200 ease-out"
-        style={{ width: `${pct}%` }}
+        className="h-full w-full origin-left bg-[var(--brand,#ef4444)] transition-transform duration-200 ease-out"
+        style={{ transform: `scaleX(${pct})` }}
       />
     </div>
   );


### PR DESCRIPTION
Fixes a vertical-line artifact that occasionally appeared during fullscreen playback after the controls faded out. The issue was caused by the progress bar's width transition leaving a compositor ghost.

**Changes:**
- Removed the `* 100` multiplier from the progress calculation, storing the normalized 0–1 value instead of a percentage
- Added `overflow-hidden` to the progress bar container to clip any rendering artifacts
- Replaced the width-based animation with a `scaleX` transform, which is more efficient for the compositor and avoids the ghost artifact
- Updated the inner bar to use `w-full` and `origin-left` to support the transform-based approach

This approach is more performant (transforms don't trigger layout recalculations) and eliminates the visual glitch.

https://claude.ai/code/session_013BoFinUY8qxYHbRLPE9aDv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed vertical-line artifacts that appeared during fullscreen presentation playback, improving overall presentation quality and user experience
- Improved progress bar animation rendering by optimizing layer structure and eliminating opacity-related visual conflicts
- Enhanced laser pointer positioning and rendering to provide better accuracy, responsiveness, and clearer visual feedback during presentations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->