### PR TITLE
feat(core): add inspector comment shortcut and fix panel footer scroll

### DIFF
--- a/.changeset/inspector-comment-autofocus.md
+++ b/.changeset/inspector-comment-autofocus.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Add `⌘/` / `Ctrl+/` shortcut to focus the inspector comment input.

--- a/.changeset/inspector-comment-autofocus.md
+++ b/.changeset/inspector-comment-autofocus.md
@@ -2,4 +2,4 @@
 '@open-slide/core': patch
 ---
 
-Add `⌘/` / `Ctrl+/` shortcut to focus the inspector comment input.
+Add `⌘/` / `Ctrl+/` shortcut to focus the inspector comment input, and allow the inspector panel to scroll its comment input into view when the viewport is too short to fit the full panel.

--- a/.changeset/inspector-panel-footer-scroll.md
+++ b/.changeset/inspector-panel-footer-scroll.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Allow the inspector panel to scroll its comment input into view when the viewport is too short to fit the full panel.

--- a/.changeset/inspector-panel-footer-scroll.md
+++ b/.changeset/inspector-panel-footer-scroll.md
@@ -1,5 +1,0 @@
----
-'@open-slide/core': patch
----
-
-Allow the inspector panel to scroll its comment input into view when the viewport is too short to fit the full panel.

--- a/apps/demo/slides/vercel-labs-2026/index.tsx
+++ b/apps/demo/slides/vercel-labs-2026/index.tsx
@@ -1778,8 +1778,8 @@ const Closer: Page = () => (
 
 export default [
   Cover,
-  Thesis,
   AgentBrowser,
+  Thesis,
   JustBash,
   OpenAgents,
   Portless,

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -1116,7 +1116,22 @@ function CommentsSection({
 }) {
   const [draft, setDraft] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
   const t = useLocale();
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== '/') return;
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.altKey || e.shiftKey) return;
+      const ta = wrapRef.current?.querySelector('textarea');
+      if (!ta) return;
+      e.preventDefault();
+      ta.focus({ preventScroll: true });
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
 
   const submit = async () => {
     const trimmed = draft.trim();
@@ -1133,7 +1148,7 @@ function CommentsSection({
   return (
     <Section title={t.inspector.leaveComment}>
       <div className="flex flex-col gap-2">
-        <div className="comment-cue rounded-[6px]">
+        <div ref={wrapRef} className="comment-cue rounded-[6px]">
           <Textarea
             value={draft}
             onChange={(e) => setDraft(e.target.value)}

--- a/packages/core/src/app/components/panel/panel-shell.tsx
+++ b/packages/core/src/app/components/panel/panel-shell.tsx
@@ -68,10 +68,12 @@ export function PanelShell({
           {header}
         </header>
         {banner}
-        <ScrollArea className="flex flex-1 flex-col">
-          <div className="flex min-h-full flex-col">{children}</div>
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="flex min-h-full flex-col">
+            {children}
+            {footer && <div className="mt-auto border-t border-hairline">{footer}</div>}
+          </div>
         </ScrollArea>
-        {footer && <div className="shrink-0 border-t border-hairline">{footer}</div>}
       </div>
     </aside>
   );

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -222,7 +222,7 @@ export const en: Locale = {
     cropResetAria: 'Reset crop',
     leaveComment: 'Leave a comment',
     commentPlaceholder: 'Describe a change for the agent…',
-    commentShortcutHint: '⌘↵ to add',
+    commentShortcutHint: '⌘/ to focus · ⌘↵ to add',
     addComment: 'Add comment',
     unsavedChanges: {
       one: '{count} unsaved change',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -223,7 +223,7 @@ export const ja: Locale = {
       'dev server との接続が切れたため、選択中の要素がエージェントに見えなくなっています。dev server を再起動して接続を復旧してください。',
     leaveComment: 'コメントを残す',
     commentPlaceholder: 'エージェントに依頼する変更を記述…',
-    commentShortcutHint: '⌘↵ で追加',
+    commentShortcutHint: '⌘/ でフォーカス · ⌘↵ で追加',
     addComment: 'コメントを追加',
     unsavedChanges: {
       one: '未保存の変更 {count} 件',

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -221,7 +221,7 @@ export const zhCN: Locale = {
       '已和 dev server 断开连接，agent 看不到你选的元素了。请重新启动 dev server 来恢复连接。',
     leaveComment: '留个 comment',
     commentPlaceholder: '描述你希望代理执行的更改…',
-    commentShortcutHint: '⌘↵ 添加',
+    commentShortcutHint: '⌘/ 聚焦 · ⌘↵ 添加',
     addComment: '添加 comment',
     unsavedChanges: {
       one: '{count} 项未保存的更改',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -221,7 +221,7 @@ export const zhTW: Locale = {
       '已和 dev server 斷線，agent 看不到你選的元素了。請重新啟動 dev server 來恢復連線。',
     leaveComment: '留個 comment',
     commentPlaceholder: '描述你希望代理進行的修改…',
-    commentShortcutHint: '⌘↵ 新增',
+    commentShortcutHint: '⌘/ 聚焦 · ⌘↵ 新增',
     addComment: '新增 comment',
     unsavedChanges: {
       one: '{count} 項未儲存的變更',


### PR DESCRIPTION
## Summary

- Add `⌘/` / `Ctrl+/` keyboard shortcut to focus the inspector comment input from anywhere in the editor, and surface the hint next to the existing `⌘↵` cue across all four locales.
- Fix the inspector panel layout so the comment footer can scroll into view when the viewport is too short to fit the full panel — the footer now lives inside the scroll area instead of being pinned outside it.

   https://github.com/user-attachments/assets/f4c2953a-0607-4c0f-ad6d-407feb3c23d0

- Reorder the `vercel-labs-2026` demo deck so `AgentBrowser` comes before `Thesis`.

## Test plan

- [ ] `pnpm check` passes
- [ ] `pnpm typecheck` passes
- [ ] In a short viewport, open the inspector and confirm the comment input is reachable by scrolling
- [ ] Press `⌘/` (macOS) / `Ctrl+/` (Windows/Linux) and confirm the comment textarea receives focus
- [ ] Verify the shortcut hint renders correctly in `en`, `ja`, `zh-CN`, and `zh-TW`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ⌘/ (macOS) and Ctrl+/ (Windows/Linux) keyboard shortcut to focus the inspector comment input.
  * Inspector panel now scrolls to bring the comment input into view when the viewport is too short.

* **Localization**
  * Updated keyboard shortcut help text across English, Japanese, and Chinese locales to document the new shortcut.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->