### PR TITLE
feat: open-slide Duplicate slide action via slide-ops + UI dropdown

### DIFF
--- a/.changeset/duplicate-slide.md
+++ b/.changeset/duplicate-slide.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Add a Duplicate action to slide cards so you can use a deck as a template without destroying it.

--- a/packages/core/src/app/lib/folders.ts
+++ b/packages/core/src/app/lib/folders.ts
@@ -33,6 +33,19 @@ async function patchSlideName(slideId: string, name: string): Promise<void> {
   if (!res.ok) throw new Error(`PATCH /__slides/${slideId} ${res.status}`);
 }
 
+async function duplicateSlideReq(slideId: string, newId?: string): Promise<string> {
+  const init: RequestInit = { method: 'POST' };
+  if (newId !== undefined) {
+    init.headers = { 'content-type': 'application/json' };
+    init.body = JSON.stringify({ newId });
+  }
+  const res = await fetch(`/__slides/${slideId}/duplicate`, init);
+  if (!res.ok) throw new Error(`POST /__slides/${slideId}/duplicate ${res.status}`);
+  const body = (await res.json()) as { slideId?: unknown };
+  if (typeof body.slideId !== 'string') throw new Error('duplicate response missing slideId');
+  return body.slideId;
+}
+
 async function deleteSlideReq(slideId: string): Promise<void> {
   const res = await fetch(`/__slides/${slideId}`, { method: 'DELETE' });
   if (!res.ok) throw new Error(`DELETE /__slides/${slideId} ${res.status}`);
@@ -83,6 +96,7 @@ export type UseFoldersResult = {
   remove: (id: string) => Promise<void>;
   assign: (slideId: string, folderId: string | null) => Promise<void>;
   renameSlide: (slideId: string, name: string) => Promise<void>;
+  duplicateSlide: (slideId: string, newId?: string) => Promise<string>;
   deleteSlide: (slideId: string) => Promise<void>;
   refresh: () => Promise<void>;
 };
@@ -165,6 +179,15 @@ export function useFolders(): UseFoldersResult {
     [refresh],
   );
 
+  const duplicateSlide = useCallback(
+    async (slideId: string, newId?: string) => {
+      const duplicatedId = await duplicateSlideReq(slideId, newId);
+      await refresh();
+      return duplicatedId;
+    },
+    [refresh],
+  );
+
   const deleteSlide = useCallback(
     async (slideId: string) => {
       await deleteSlideReq(slideId);
@@ -173,5 +196,16 @@ export function useFolders(): UseFoldersResult {
     [refresh],
   );
 
-  return { manifest, loading, create, update, remove, assign, renameSlide, deleteSlide, refresh };
+  return {
+    manifest,
+    loading,
+    create,
+    update,
+    remove,
+    assign,
+    renameSlide,
+    duplicateSlide,
+    deleteSlide,
+    refresh,
+  };
 }

--- a/packages/core/src/app/routes/home-shell.tsx
+++ b/packages/core/src/app/routes/home-shell.tsx
@@ -22,6 +22,7 @@ export type HomeOutletContext = {
   titleMap: Record<string, string>;
   assign: (slideId: string, folderId: string | null) => Promise<void>;
   renameSlide: (slideId: string, name: string) => Promise<void>;
+  duplicateSlide: (slideId: string, newId?: string) => Promise<string>;
   deleteSlide: (slideId: string) => Promise<void>;
 };
 
@@ -32,8 +33,17 @@ function pathToSelectedId(pathname: string, search: URLSearchParams): string {
 }
 
 export function HomeShell() {
-  const { manifest, loading, create, update, remove, assign, renameSlide, deleteSlide } =
-    useFolders();
+  const {
+    manifest,
+    loading,
+    create,
+    update,
+    remove,
+    assign,
+    renameSlide,
+    duplicateSlide,
+    deleteSlide,
+  } = useFolders();
   const navigate = useNavigate();
   const location = useLocation();
   const [searchParams] = useSearchParams();
@@ -108,6 +118,7 @@ export function HomeShell() {
     titleMap,
     assign,
     renameSlide,
+    duplicateSlide,
     deleteSlide,
   };
 

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -2,6 +2,7 @@ import {
   ArrowDownAZ,
   ChevronDown,
   Clock,
+  Copy,
   FolderInput,
   FolderPlus,
   MoreHorizontal,
@@ -13,6 +14,7 @@ import {
 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useOutletContext } from 'react-router-dom';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -28,7 +30,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { useLocale } from '@/lib/use-locale';
+import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import { FolderIconChip, SLIDE_DND_MIME } from '../components/sidebar/folder-item';
 import { DRAFT_ID } from '../components/sidebar/sidebar';
@@ -77,6 +79,7 @@ export function Home() {
     titleMap,
     assign,
     renameSlide,
+    duplicateSlide,
     deleteSlide,
   } = useOutletContext<HomeOutletContext>();
   const t = useLocale();
@@ -163,6 +166,20 @@ export function Home() {
                 folders={manifest.folders}
                 currentFolderId={manifest.assignments[id] ?? null}
                 onRename={(name) => renameSlide(id, name)}
+                onDuplicate={async () => {
+                  const slideName = titleMap[id] ?? id;
+                  try {
+                    const newSlideId = await duplicateSlide(id);
+                    toast.success(
+                      format(t.home.toastSlideDuplicated, {
+                        slide: slideName,
+                        newSlide: newSlideId,
+                      }),
+                    );
+                  } catch {
+                    toast.error(t.home.toastSlideDuplicateFailed);
+                  }
+                }}
                 onMove={(folderId) => assign(id, folderId)}
                 onDelete={() => deleteSlide(id)}
                 onTitleResolved={reportTitle}
@@ -381,6 +398,7 @@ function SlideCard({
   folders,
   currentFolderId,
   onRename,
+  onDuplicate,
   onMove,
   onDelete,
   onTitleResolved,
@@ -389,6 +407,7 @@ function SlideCard({
   folders: Folder[];
   currentFolderId: string | null;
   onRename: (name: string) => Promise<void> | void;
+  onDuplicate: () => Promise<void> | void;
   onMove: (folderId: string | null) => Promise<void> | void;
   onDelete: () => Promise<void> | void;
   onTitleResolved?: (id: string, title: string) => void;
@@ -488,6 +507,10 @@ function SlideCard({
                 <DropdownMenuItem onSelect={() => setDialog('rename')}>
                   <Pencil />
                   {tCard.common.rename}
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => onDuplicate()}>
+                  <Copy />
+                  {tCard.home.duplicate}
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => setDialog('move')}>
                   <FolderInput />

--- a/packages/core/src/editing/slide-ops.test.ts
+++ b/packages/core/src/editing/slide-ops.test.ts
@@ -1,12 +1,91 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   duplicatePageInDefaultExportInSource,
+  duplicateSlideDir,
   removePageFromDefaultExportInSource,
   reorderDefaultExportPagesInSource,
   reorderNotesArrayInSource,
   updateMetaTitleInSource,
   validateSlideName,
 } from './slide-ops.ts';
+
+async function withSlidesRoot<T>(fn: (root: string) => Promise<T>): Promise<T> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'open-slide-test-'));
+  try {
+    return await fn(root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+async function writeSlide(root: string, id: string): Promise<void> {
+  await fs.mkdir(path.join(root, id, 'assets'), { recursive: true });
+  await fs.writeFile(path.join(root, id, 'index.tsx'), `export default [];\n`, 'utf8');
+  await fs.writeFile(path.join(root, id, 'assets', 'hero.txt'), 'hero', 'utf8');
+}
+
+describe('duplicateSlideDir', () => {
+  it('duplicates a slide directory with an automatic copy id', async () => {
+    await withSlidesRoot(async (root) => {
+      await writeSlide(root, 'cover');
+
+      const result = await duplicateSlideDir(root, 'cover');
+
+      expect(result).toEqual({ ok: true, slideId: 'cover-copy' });
+      await expect(fs.readFile(path.join(root, 'cover-copy', 'index.tsx'), 'utf8')).resolves.toBe(
+        `export default [];\n`,
+      );
+      await expect(
+        fs.readFile(path.join(root, 'cover-copy', 'assets', 'hero.txt'), 'utf8'),
+      ).resolves.toBe('hero');
+    });
+  });
+
+  it('increments the automatic copy id when a copy already exists', async () => {
+    await withSlidesRoot(async (root) => {
+      await writeSlide(root, 'cover');
+
+      expect(await duplicateSlideDir(root, 'cover')).toEqual({ ok: true, slideId: 'cover-copy' });
+      expect(await duplicateSlideDir(root, 'cover')).toEqual({
+        ok: true,
+        slideId: 'cover-copy-2',
+      });
+    });
+  });
+
+  it('rejects source slide ids with bad characters', async () => {
+    await withSlidesRoot(async (root) => {
+      expect(await duplicateSlideDir(root, 'bad id')).toMatchObject({ ok: false, status: 400 });
+    });
+  });
+
+  it('rejects an existing desired id', async () => {
+    await withSlidesRoot(async (root) => {
+      await writeSlide(root, 'cover');
+      await writeSlide(root, 'target');
+
+      expect(await duplicateSlideDir(root, 'cover', 'target')).toMatchObject({
+        ok: false,
+        status: 409,
+      });
+    });
+  });
+
+  it('rejects path traversal in the source slide id', async () => {
+    await withSlidesRoot(async (root) => {
+      expect(await duplicateSlideDir(root, '..')).toMatchObject({ ok: false, status: 400 });
+    });
+  });
+
+  it('returns not found when the source slide does not exist', async () => {
+    await withSlidesRoot(async (root) => {
+      expect(await duplicateSlideDir(root, 'missing')).toMatchObject({ ok: false, status: 404 });
+    });
+  });
+});
 
 describe('validateSlideName', () => {
   it('accepts longer slide names than folder names', () => {

--- a/packages/core/src/editing/slide-ops.test.ts
+++ b/packages/core/src/editing/slide-ops.test.ts
@@ -21,22 +21,26 @@ async function withSlidesRoot<T>(fn: (root: string) => Promise<T>): Promise<T> {
   }
 }
 
-async function writeSlide(root: string, id: string): Promise<void> {
+async function writeSlide(root: string, id: string, title = id): Promise<void> {
   await fs.mkdir(path.join(root, id, 'assets'), { recursive: true });
-  await fs.writeFile(path.join(root, id, 'index.tsx'), `export default [];\n`, 'utf8');
+  await fs.writeFile(
+    path.join(root, id, 'index.tsx'),
+    `export const meta = { title: '${title}' };\nexport default [];\n`,
+    'utf8',
+  );
   await fs.writeFile(path.join(root, id, 'assets', 'hero.txt'), 'hero', 'utf8');
 }
 
 describe('duplicateSlideDir', () => {
   it('duplicates a slide directory with an automatic copy id', async () => {
     await withSlidesRoot(async (root) => {
-      await writeSlide(root, 'cover');
+      await writeSlide(root, 'cover', 'Cover');
 
       const result = await duplicateSlideDir(root, 'cover');
 
       expect(result).toEqual({ ok: true, slideId: 'cover-copy' });
       await expect(fs.readFile(path.join(root, 'cover-copy', 'index.tsx'), 'utf8')).resolves.toBe(
-        `export default [];\n`,
+        `export const meta = { title: 'Cover (copy)' };\nexport default [];\n`,
       );
       await expect(
         fs.readFile(path.join(root, 'cover-copy', 'assets', 'hero.txt'), 'utf8'),

--- a/packages/core/src/editing/slide-ops.ts
+++ b/packages/core/src/editing/slide-ops.ts
@@ -41,14 +41,12 @@ function readMetaTitleInSource(source: string): MetaTitleRead {
     return { kind: 'unsupported' };
   }
 
-  const body =
-    (ast as { program?: { body?: Array<Record<string, unknown>> } }).program?.body ?? [];
+  const body = (ast as { program?: { body?: Array<Record<string, unknown>> } }).program?.body ?? [];
   for (const stmt of body) {
     if (stmt.type !== 'ExportNamedDeclaration') continue;
     const decl = stmt.declaration as Record<string, unknown> | undefined;
     if (!decl || decl.type !== 'VariableDeclaration') continue;
-    const declarations =
-      (decl.declarations as Array<Record<string, unknown>> | undefined) ?? [];
+    const declarations = (decl.declarations as Array<Record<string, unknown>> | undefined) ?? [];
     for (const d of declarations) {
       const id = d.id as Record<string, unknown> | undefined;
       if (!id || id.type !== 'Identifier' || id.name !== 'meta') continue;

--- a/packages/core/src/editing/slide-ops.ts
+++ b/packages/core/src/editing/slide-ops.ts
@@ -23,6 +23,66 @@ export async function rmSlideDir(slidesRoot: string, slideId: string): Promise<b
   }
 }
 
+export async function duplicateSlideDir(
+  slidesRoot: string,
+  slideId: string,
+  desiredId?: string,
+): Promise<{ ok: true; slideId: string } | { ok: false; status: number; error: string }> {
+  if (!SLIDE_ID_RE.test(slideId)) return { ok: false, status: 400, error: 'invalid slideId' };
+
+  const root = path.resolve(slidesRoot);
+  const srcDir = path.resolve(root, slideId);
+  if (!srcDir.startsWith(root + path.sep)) {
+    return { ok: false, status: 400, error: 'invalid slideId' };
+  }
+
+  try {
+    await fs.access(path.join(srcDir, 'index.tsx'));
+  } catch {
+    return { ok: false, status: 404, error: 'slide not found' };
+  }
+
+  let newId: string;
+  if (desiredId !== undefined) {
+    if (!SLIDE_ID_RE.test(desiredId)) return { ok: false, status: 400, error: 'invalid newId' };
+    newId = desiredId;
+    const dstDir = path.resolve(root, newId);
+    if (!dstDir.startsWith(root + path.sep)) {
+      return { ok: false, status: 400, error: 'invalid newId' };
+    }
+    try {
+      await fs.access(dstDir);
+      return { ok: false, status: 409, error: 'slide already exists' };
+    } catch {}
+  } else {
+    let suffix = 1;
+    while (true) {
+      newId = suffix === 1 ? `${slideId}-copy` : `${slideId}-copy-${suffix}`;
+      try {
+        await fs.access(path.resolve(root, newId));
+        suffix++;
+      } catch {
+        break;
+      }
+    }
+  }
+
+  const dstDir = path.resolve(root, newId);
+  if (!dstDir.startsWith(root + path.sep)) {
+    return { ok: false, status: 400, error: 'invalid newId' };
+  }
+
+  try {
+    await fs.cp(srcDir, dstDir, { recursive: true, errorOnExist: true, force: false });
+    return { ok: true, slideId: newId };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      return { ok: false, status: 409, error: 'slide already exists' };
+    }
+    return { ok: false, status: 500, error: String((err as Error).message ?? err) };
+  }
+}
+
 export function resolveSlideEntry(slidesRoot: string, slideId: string): string | null {
   if (!SLIDE_ID_RE.test(slideId)) return null;
   const dir = path.resolve(slidesRoot, slideId);

--- a/packages/core/src/editing/slide-ops.ts
+++ b/packages/core/src/editing/slide-ops.ts
@@ -4,11 +4,89 @@ import { parse as babelParse } from '@babel/parser';
 
 export const SLIDE_ID_RE = /^[a-z0-9_-]+$/i;
 
+type MetaTitleRead =
+  | { kind: 'found'; title: string }
+  | { kind: 'missing' }
+  | { kind: 'unsupported' };
+
 export function validateSlideName(v: unknown): string | null {
   if (typeof v !== 'string') return null;
   const trimmed = v.trim();
   if (trimmed.length < 1 || trimmed.length > 80) return null;
   return trimmed;
+}
+
+function unwrapExpression(
+  node: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  let current = node;
+  while (
+    current &&
+    (current.type === 'TSAsExpression' || current.type === 'TSSatisfiesExpression')
+  ) {
+    current = current.expression as Record<string, unknown> | undefined;
+  }
+  return current;
+}
+
+function readMetaTitleInSource(source: string): MetaTitleRead {
+  let ast: unknown;
+  try {
+    ast = babelParse(source, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+      errorRecovery: true,
+    });
+  } catch {
+    return { kind: 'unsupported' };
+  }
+
+  const body =
+    (ast as { program?: { body?: Array<Record<string, unknown>> } }).program?.body ?? [];
+  for (const stmt of body) {
+    if (stmt.type !== 'ExportNamedDeclaration') continue;
+    const decl = stmt.declaration as Record<string, unknown> | undefined;
+    if (!decl || decl.type !== 'VariableDeclaration') continue;
+    const declarations =
+      (decl.declarations as Array<Record<string, unknown>> | undefined) ?? [];
+    for (const d of declarations) {
+      const id = d.id as Record<string, unknown> | undefined;
+      if (!id || id.type !== 'Identifier' || id.name !== 'meta') continue;
+      const init = unwrapExpression(d.init as Record<string, unknown> | undefined);
+      if (!init || init.type !== 'ObjectExpression') return { kind: 'unsupported' };
+      const properties = (init.properties as Array<Record<string, unknown>> | undefined) ?? [];
+      for (const property of properties) {
+        if (property.type !== 'ObjectProperty' || property.computed) continue;
+        const key = property.key as Record<string, unknown> | undefined;
+        const keyName =
+          key?.type === 'Identifier'
+            ? key.name
+            : key?.type === 'StringLiteral'
+              ? key.value
+              : undefined;
+        if (keyName !== 'title') continue;
+
+        const value = property.value as Record<string, unknown> | undefined;
+        if (value?.type === 'StringLiteral' && typeof value.value === 'string') {
+          return { kind: 'found', title: value.value };
+        }
+        if (value?.type === 'TemplateLiteral') {
+          const expressions = (value.expressions as unknown[] | undefined) ?? [];
+          const quasis = (value.quasis as Array<Record<string, unknown>> | undefined) ?? [];
+          const firstValue = quasis[0]?.value as Record<string, unknown> | undefined;
+          const cooked = firstValue?.cooked;
+          const raw = firstValue?.raw;
+          if (expressions.length === 0 && typeof (cooked ?? raw) === 'string') {
+            return { kind: 'found', title: (cooked ?? raw) as string };
+          }
+        }
+        return { kind: 'unsupported' };
+      }
+      return { kind: 'missing' };
+    }
+  }
+
+  return { kind: 'missing' };
 }
 
 export async function rmSlideDir(slidesRoot: string, slideId: string): Promise<boolean> {
@@ -72,8 +150,27 @@ export async function duplicateSlideDir(
     return { ok: false, status: 400, error: 'invalid newId' };
   }
 
+  const srcEntry = path.join(srcDir, 'index.tsx');
+  let copiedEntrySource: string;
+  try {
+    const source = await fs.readFile(srcEntry, 'utf8');
+    const metaTitle = readMetaTitleInSource(source);
+    if (metaTitle.kind === 'unsupported') {
+      return { ok: false, status: 422, error: 'could not update copied slide title' };
+    }
+    const title = metaTitle.kind === 'found' ? metaTitle.title : slideId;
+    const updated = updateMetaTitleInSource(source, `${title} (copy)`);
+    if (updated === null) {
+      return { ok: false, status: 422, error: 'could not update copied slide title' };
+    }
+    copiedEntrySource = updated;
+  } catch {
+    return { ok: false, status: 404, error: 'slide not found' };
+  }
+
   try {
     await fs.cp(srcDir, dstDir, { recursive: true, errorOnExist: true, force: false });
+    await fs.writeFile(path.join(dstDir, 'index.tsx'), copiedEntrySource, 'utf8');
     return { ok: true, slideId: newId };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'EEXIST') {

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -38,6 +38,7 @@ export const en: Locale = {
   home: {
     appTitle: 'open-slide',
     draft: 'Draft',
+    duplicate: 'Duplicate',
     themes: 'Themes',
     assets: 'Assets',
     folders: 'Folders',
@@ -79,6 +80,8 @@ export const en: Locale = {
     deleteDialogDescriptionSuffix: 'This action cannot be undone.',
     toastFolderCreated: 'Created folder “{name}”',
     toastFolderCreateFailed: 'Failed to create folder',
+    toastSlideDuplicated: 'Duplicated “{slide}” as {newSlide}',
+    toastSlideDuplicateFailed: 'Could not duplicate slide',
     toastSlideMoved: 'Moved “{slide}” to {folder}',
     toastSlideMoveFailed: 'Failed to move slide',
     toastFolderDeleted: 'Deleted folder “{name}”',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -38,6 +38,7 @@ export const ja: Locale = {
   home: {
     appTitle: 'open-slide',
     draft: '下書き',
+    duplicate: '複製',
     themes: 'テーマ',
     assets: 'アセット',
     folders: 'フォルダ',
@@ -79,6 +80,8 @@ export const ja: Locale = {
     deleteDialogDescriptionSuffix: 'この操作は元に戻せません。',
     toastFolderCreated: 'フォルダ「{name}」を作成しました',
     toastFolderCreateFailed: 'フォルダの作成に失敗しました',
+    toastSlideDuplicated: '「{slide}」を {newSlide} として複製しました',
+    toastSlideDuplicateFailed: 'スライドを複製できませんでした',
     toastSlideMoved: '「{slide}」を {folder} に移動しました',
     toastSlideMoveFailed: 'スライドの移動に失敗しました',
     toastFolderDeleted: 'フォルダ「{name}」を削除しました',

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -38,6 +38,7 @@ export type Locale = {
   home: {
     appTitle: string;
     draft: string;
+    duplicate: string;
     themes: string;
     assets: string;
     folders: string;
@@ -80,6 +81,9 @@ export type Locale = {
     /** template: "Created folder “{name}”" */
     toastFolderCreated: string;
     toastFolderCreateFailed: string;
+    /** template: "Duplicated “{slide}” as {newSlide}" */
+    toastSlideDuplicated: string;
+    toastSlideDuplicateFailed: string;
     /** template: "Moved “{slide}” to {folder}" */
     toastSlideMoved: string;
     toastSlideMoveFailed: string;

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -38,6 +38,7 @@ export const zhCN: Locale = {
   home: {
     appTitle: 'open-slide',
     draft: '草稿',
+    duplicate: '复制',
     themes: '主题',
     assets: '素材',
     folders: '文件夹',
@@ -79,6 +80,8 @@ export const zhCN: Locale = {
     deleteDialogDescriptionSuffix: '此操作无法撤销。',
     toastFolderCreated: '已创建文件夹"{name}"',
     toastFolderCreateFailed: '创建文件夹失败',
+    toastSlideDuplicated: '已将"{slide}"复制为 {newSlide}',
+    toastSlideDuplicateFailed: '无法复制幻灯片',
     toastSlideMoved: '已将"{slide}"移至 {folder}',
     toastSlideMoveFailed: '移动幻灯片失败',
     toastFolderDeleted: '已删除文件夹"{name}"',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -38,6 +38,7 @@ export const zhTW: Locale = {
   home: {
     appTitle: 'open-slide',
     draft: '草稿',
+    duplicate: '複製',
     themes: '主題',
     assets: '素材',
     folders: '資料夾',
@@ -79,6 +80,8 @@ export const zhTW: Locale = {
     deleteDialogDescriptionSuffix: '此操作無法復原。',
     toastFolderCreated: '已建立資料夾「{name}」',
     toastFolderCreateFailed: '建立資料夾失敗',
+    toastSlideDuplicated: '已將「{slide}」複製為 {newSlide}',
+    toastSlideDuplicateFailed: '無法複製投影片',
     toastSlideMoved: '已將「{slide}」移至 {folder}',
     toastSlideMoveFailed: '移動投影片失敗',
     toastFolderDeleted: '已刪除資料夾「{name}」',

--- a/packages/core/src/vite/routes/slides.ts
+++ b/packages/core/src/vite/routes/slides.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import type { ViteDevServer } from 'vite';
 import {
   duplicatePageInDefaultExportInSource,
+  duplicateSlideDir,
   removePageFromDefaultExportInSource,
   reorderDefaultExportPagesInSource,
   reorderNotesArrayInSource,
@@ -18,9 +19,11 @@ import { type ApiContext, json, readBody } from './context.ts';
 // PUT    /__slides/:id/reorder            reorder pages { order: number[] }
 // DELETE /__slides/:id/pages/:i           remove page
 // POST   /__slides/:id/pages/:i/duplicate duplicate page
+// POST   /__slides/:id/duplicate          duplicate slide directory { newId? }
 // PATCH  /__slides/:id                    rename slide (writes meta.title)
 // DELETE /__slides/:id                    delete slide directory + folder assignment
 
+type DuplicateSlideBody = { newId?: unknown };
 type SlidePatchBody = { name?: unknown };
 
 export function registerSlideRoutes(server: ViteDevServer, ctx: ApiContext): void {
@@ -115,6 +118,32 @@ export function registerSlideRoutes(server: ViteDevServer, ctx: ApiContext): voi
           await fs.writeFile(entry, updated, 'utf8');
         }
         return json(res, 200, { ok: true, slideId, index: pageIndex });
+      }
+
+      const duplicateMatch = url.pathname.match(/^\/([^/]+)\/duplicate$/);
+      if (duplicateMatch && method === 'POST') {
+        const requestCheck = validateMutationRequest(req);
+        if (!requestCheck.ok) {
+          return json(res, requestCheck.status, { error: requestCheck.error });
+        }
+        const slideId = duplicateMatch[1];
+        if (!SLIDE_ID_RE.test(slideId)) return json(res, 400, { error: 'invalid slideId' });
+
+        const body = (await readBody(req)) as DuplicateSlideBody;
+        if (body.newId !== undefined && typeof body.newId !== 'string') {
+          return json(res, 400, { error: 'invalid newId' });
+        }
+
+        const duplicated = await duplicateSlideDir(ctx.slidesRoot, slideId, body.newId);
+        if (!duplicated.ok) return json(res, duplicated.status, { error: duplicated.error });
+
+        const manifest = await readManifest(ctx.manifestPath);
+        const folderId = manifest.assignments[slideId];
+        if (folderId) {
+          manifest.assignments[duplicated.slideId] = folderId;
+          await writeManifest(ctx.manifestPath, manifest);
+        }
+        return json(res, 200, { ok: true, slideId: duplicated.slideId });
       }
 
       const idMatch = url.pathname.match(/^\/([^/]+)$/);


### PR DESCRIPTION
## Summary

Adds a Duplicate slide action to open-slide: a new `POST /__slides/:id/duplicate` endpoint, a `duplicateSlide` operation in `slide-ops.ts`, a UI dropdown entry, and locale parity across en/ja/zh-cn/zh-tw.

## Why this matters

Issue #59 asks for a quick way to copy a slide as the starting point for the next one (a common slide-deck pattern). The implementation mirrors the existing folder/move/rename operations so the surface is consistent: same dev-server endpoint shape, same slide-ops API, same locale registration.

## Changes

- `packages/core/src/editing/slide-ops.ts`: `duplicateSlide` operation + test coverage
- `packages/core/src/vite/routes/slides.ts`: new `POST /__slides/:id/duplicate` endpoint
- `packages/core/src/app/routes/home.tsx` + `home-shell.tsx`: dropdown action
- `packages/core/src/locale/{en,ja,zh-cn,zh-tw,types}.ts`: locale entries
- `packages/core/src/app/lib/folders.ts`: folder integration

Fixes #59


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Duplicate" action on slide cards with success/failure toasts and a server-side duplicate endpoint so slides can be copied without altering originals.
* **Tests**
  * Introduced filesystem-backed integration tests validating slide duplication, naming collisions, input validation, and error cases.
* **Documentation**
  * Added English, Japanese, Simplified Chinese, and Traditional Chinese localization strings for the duplicate action and notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->