### PR TITLE
fix: loc-tags-plugin tags any .tsx under a slide dir (not just index.tsx)

### DIFF
--- a/.changeset/inspector-multi-tsx.md
+++ b/.changeset/inspector-multi-tsx.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Inspector now selects elements inside multi-file slide structures (e.g. slides composed of shared.tsx + 01-Cover.tsx).

--- a/packages/core/src/vite/loc-tags-plugin.test.ts
+++ b/packages/core/src/vite/loc-tags-plugin.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from 'vitest';
-import { injectLocTags } from './loc-tags-plugin.ts';
+import { injectLocTags, locTagsPlugin } from './loc-tags-plugin.ts';
+
+const pluginTransformSource = 'export default [() => <div />];';
+
+type LocTagsTransformResult = null | { code: string; map: null };
+
+function transformWithLocTags(id: string) {
+  const plugin = locTagsPlugin({ userCwd: '/repo' });
+  const transform = plugin.transform;
+  if (typeof transform !== 'function') throw new Error('expected transform function');
+  return transform.call({} as never, pluginTransformSource, id) as LocTagsTransformResult;
+}
+
+function expectTaggedTransform(id: string) {
+  const out = transformWithLocTags(id);
+  if (out === null) throw new Error('expected tagged transform result');
+  expect(out.code).toContain('data-slide-loc');
+}
 
 describe('injectLocTags', () => {
   it('adds data-slide-loc to host elements with the JSX start position', () => {
@@ -104,5 +121,35 @@ describe('injectLocTags', () => {
     expect(out).toContain('<ImagePlaceholder data-slide-loc="3:4"');
     expect(out).not.toContain('<Layout data-slide-loc');
     expect(out).not.toContain('<CustomThing data-slide-loc');
+  });
+});
+
+describe('locTagsPlugin', () => {
+  it('tags slide index files', () => {
+    expectTaggedTransform('/repo/slides/cover/index.tsx');
+  });
+
+  it('tags shared slide source files', () => {
+    expectTaggedTransform('/repo/slides/cover/shared.tsx');
+  });
+
+  it('tags numbered slide source files', () => {
+    expectTaggedTransform('/repo/slides/cover/01-Cover.tsx');
+  });
+
+  it('tags slide source files in nested folders', () => {
+    expectTaggedTransform('/repo/slides/cover/components/Card.tsx');
+  });
+
+  it('skips tsx files directly under the slides directory', () => {
+    expect(transformWithLocTags('/repo/slides/index.tsx')).toBeNull();
+  });
+
+  it('skips tsx files outside the slides directory', () => {
+    expect(transformWithLocTags('/repo/apps/demo/foo.tsx')).toBeNull();
+  });
+
+  it('skips colocated test files', () => {
+    expect(transformWithLocTags('/repo/slides/cover/index.test.tsx')).toBeNull();
   });
 });

--- a/packages/core/src/vite/loc-tags-plugin.ts
+++ b/packages/core/src/vite/loc-tags-plugin.ts
@@ -73,7 +73,10 @@ export function locTagsPlugin(opts: LocTagsPluginOptions): Plugin {
     transform(code, id) {
       const filePath = id.split('?')[0];
       if (!filePath.startsWith(slidesRoot + path.sep)) return null;
-      if (!filePath.endsWith(`${path.sep}index.tsx`)) return null;
+      if (!filePath.endsWith('.tsx')) return null;
+      if (filePath.endsWith('.d.ts') || filePath.endsWith('.test.tsx')) return null;
+      const rel = filePath.slice(slidesRoot.length + path.sep.length);
+      if (!rel.includes(path.sep)) return null;
       const next = injectLocTags(code);
       if (next === null) return null;
       return { code: next, map: null };


### PR DESCRIPTION
## Summary

Broadens the `loc-tags-plugin` to tag any `.tsx` file under a slide directory, not just `index.tsx`. Lets the inspector select elements rendered from companion files (`shared.tsx`, `01-Cover.tsx`, etc.).

## Why this matters

Issue #65 reports that elements rendered from non-index slide files aren't selectable in the inspector because the loc-tags transform was scoped to `index.tsx`. Broadening the file matcher fixes that without changing the transform itself. The residual edit-back limitation (round-tripping edits to companion files) is called out as a follow-up.

## Changes

- `packages/core/src/vite/loc-tags-plugin.ts`: match any `.tsx` under `slides/<id>/`
- `packages/core/src/vite/loc-tags-plugin.test.ts`: new coverage for multi-tsx case

Fixes #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inspector now selects elements inside multi-file slide structures composed of multiple source files.

* **Tests**
  * Added comprehensive test coverage for slide file processing and plugin behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->