### PR TITLE
docs(web): surface GitHub stars in README and landing nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # open-slide
 
+[![GitHub stars](https://img.shields.io/github/stars/1weiho/open-slide?style=social)](https://github.com/1weiho/open-slide/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/1weiho/open-slide?style=social)](https://github.com/1weiho/open-slide/network/members)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 **The slide framework built for agents.** Describe your deck in natural language — your coding agent writes the React. open-slide handles the canvas, scaling, navigation, hot reload, and present mode so the agent can focus on content.
 
 Every slide renders into a fixed **1920 × 1080** canvas. Pages are arbitrary React components, not a constrained DSL.
@@ -80,6 +84,12 @@ pnpm build    # builds all packages
 pnpm check    # type-checks all packages
 pnpm lint     # lints via biome
 ```
+
+## Star history
+
+If open-slide is useful to you, please [star the repo on GitHub](https://github.com/1weiho/open-slide) — it helps other people find the project.
+
+[![Star History Chart](https://api.star-history.com/svg?repos=1weiho/open-slide&type=Date)](https://star-history.com/#1weiho/open-slide&Date)
 
 ## Support
 

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -8,6 +8,7 @@ import { HowItWorks } from '@/components/landing/how-it-works';
 import { Inspector } from '@/components/landing/inspector';
 import { LiveDemo } from '@/components/landing/live-demo';
 import { Nav } from '@/components/landing/nav';
+import { fetchGitHubStars, formatStarCount } from '@/lib/github';
 import { appName, gitConfig, siteUrl } from '@/lib/shared';
 
 const jsonLd = [
@@ -35,7 +36,10 @@ const jsonLd = [
   },
 ];
 
-export default function HomePage() {
+export default async function HomePage() {
+  const stars = await fetchGitHubStars();
+  const githubStars = stars !== null ? formatStarCount(stars) : null;
+
   return (
     <>
       <script
@@ -43,7 +47,7 @@ export default function HomePage() {
         // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD payload is built from static, server-only constants
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <Nav />
+      <Nav githubStars={githubStars} />
       <main className="relative flex-1">
         <Hero />
         <LiveDemo />

--- a/apps/web/components/landing/nav.tsx
+++ b/apps/web/components/landing/nav.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import posthog from 'posthog-js';
 import { ThemeToggle } from './theme-toggle';
 
-export function Nav() {
+export function Nav({ githubStars }: { githubStars?: string | null }) {
   return (
     <header className="sticky top-0 z-40 bg-[color:var(--color-ink)]/80 backdrop-blur-md border-b border-[color:var(--color-rule-soft)]">
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 h-16 flex items-center justify-between">
@@ -55,9 +55,18 @@ export function Nav() {
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => posthog.capture('nav_external_link_clicked', { label: 'github' })}
-            className="hidden md:inline text-[color:var(--color-muted)] hover:text-[color:var(--color-text)] transition-colors"
+            className="hidden md:inline-flex items-center gap-2 text-[color:var(--color-muted)] hover:text-[color:var(--color-text)] transition-colors"
           >
-            GitHub ↗
+            <span>GitHub ↗</span>
+            {githubStars ? (
+              <span
+                aria-label={`${githubStars} GitHub stars`}
+                className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-rule-soft)] px-2 py-[2px] text-[10px] tracking-[0.06em] text-[color:var(--color-text)]"
+              >
+                <span aria-hidden>★</span>
+                {githubStars}
+              </span>
+            ) : null}
           </a>
           <ThemeToggle />
         </nav>

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -2,13 +2,10 @@ import { gitConfig } from './shared';
 
 export async function fetchGitHubStars(): Promise<number | null> {
   try {
-    const res = await fetch(
-      `https://api.github.com/repos/${gitConfig.user}/${gitConfig.repo}`,
-      {
-        next: { revalidate: 3600 },
-        headers: { Accept: 'application/vnd.github+json' },
-      },
-    );
+    const res = await fetch(`https://api.github.com/repos/${gitConfig.user}/${gitConfig.repo}`, {
+      next: { revalidate: 3600 },
+      headers: { Accept: 'application/vnd.github+json' },
+    });
     if (!res.ok) return null;
     const data = (await res.json()) as { stargazers_count?: number };
     return typeof data.stargazers_count === 'number' ? data.stargazers_count : null;

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -1,0 +1,26 @@
+import { gitConfig } from './shared';
+
+export async function fetchGitHubStars(): Promise<number | null> {
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${gitConfig.user}/${gitConfig.repo}`,
+      {
+        next: { revalidate: 3600 },
+        headers: { Accept: 'application/vnd.github+json' },
+      },
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as { stargazers_count?: number };
+    return typeof data.stargazers_count === 'number' ? data.stargazers_count : null;
+  } catch {
+    return null;
+  }
+}
+
+export function formatStarCount(count: number): string {
+  if (count >= 1000) {
+    const k = count / 1000;
+    return `${k.toFixed(k >= 10 ? 0 : 1).replace(/\.0$/, '')}k`;
+  }
+  return String(count);
+}


### PR DESCRIPTION
Add stars/forks/license badges and a star-history chart to the README, and render a star-count pill next to the GitHub link in the landing nav. Star count is fetched server-side with a 1-hour ISR cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub star count badge now displays next to the GitHub link in navigation (shows formatted count when available).
* **Documentation**
  * Added a "Star history" section with a Star History Chart badge and short call-to-action.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->