### PR TITLE
fix(core): strip shadows and gradients during PDF export

### DIFF
--- a/.changeset/pdf-export-strip-shadows.md
+++ b/.changeset/pdf-export-strip-shadows.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Strip box-shadows and CSS gradients during PDF export so macOS Preview pages through the file at full speed.

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -374,5 +374,4 @@ This applies whenever the *visual element* repeats, not whenever the *data* does
 - ❌ Editing `package.json`, `open-slide.config.ts`, or other slides.
 - ❌ Sprinkling `<ImagePlaceholder>` across pages "for visual interest". Placeholders are for content the user owns; they're not stock-photo slots.
 - ❌ Using a placeholder for an icon or decorative shape — those are typography/SVG problems, not asset problems.
-- ❌ Full-page `radial-gradient` / `linear-gradient` backgrounds, large `box-shadow` blurs, or many small `inset` / ring shadows. PDF export strips these so macOS Preview stays responsive, so the exported file will look different from the screen. Prefer solid fills, `1px solid` borders, and `backgroundColor` over `backgroundImage` when PDF fidelity matters.
 - ❌ Rendering visually repeated elements with `array.map(...)` over a data array. Define a component and instantiate it explicitly per item (`<Card />`, `<Card />`, `<Card />`) so the inspector can edit each independently — a shared `map` body mutates every instance at once.

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -374,4 +374,5 @@ This applies whenever the *visual element* repeats, not whenever the *data* does
 - ❌ Editing `package.json`, `open-slide.config.ts`, or other slides.
 - ❌ Sprinkling `<ImagePlaceholder>` across pages "for visual interest". Placeholders are for content the user owns; they're not stock-photo slots.
 - ❌ Using a placeholder for an icon or decorative shape — those are typography/SVG problems, not asset problems.
+- ❌ Full-page `radial-gradient` / `linear-gradient` backgrounds, large `box-shadow` blurs, or many small `inset` / ring shadows. PDF export strips these so macOS Preview stays responsive, so the exported file will look different from the screen. Prefer solid fills, `1px solid` borders, and `backgroundColor` over `backgroundImage` when PDF fidelity matters.
 - ❌ Rendering visually repeated elements with `array.map(...)` over a data array. Define a component and instantiate it explicitly per item (`<Card />`, `<Card />`, `<Card />`) so the inspector can edit each independently — a shared `map` body mutates every instance at once.

--- a/packages/core/src/app/lib/export-pdf.ts
+++ b/packages/core/src/app/lib/export-pdf.ts
@@ -62,6 +62,20 @@ const PRINT_STYLES = `
     transform: scale(0.5);
     transform-origin: top left;
   }
+  /* Chromium serializes box-shadow and CSS gradients as PDF transparency
+     groups / soft masks. macOS Preview re-composites those on every page
+     turn, causing 0.5–2s per-page lag. Strip them in the print container
+     only — gradients on pseudo-elements via CSS (DOM walk can't reach them),
+     inline-style gradients via neutralizeGradientBackgrounds() below. */
+  #${PRINT_ROOT_ID} *,
+  #${PRINT_ROOT_ID} *::before,
+  #${PRINT_ROOT_ID} *::after {
+    box-shadow: none !important;
+  }
+  #${PRINT_ROOT_ID} *::before,
+  #${PRINT_ROOT_ID} *::after {
+    background-image: none !important;
+  }
 }
 `;
 
@@ -155,6 +169,7 @@ export async function exportSlideAsPdf(
     }
 
     await waitForDataWaitfor(root);
+    neutralizeGradientBackgrounds(root);
     await sleep(100); // flush layout
 
     onProgress?.({ phase: 'printing', current: total, total, percent: 99 });
@@ -167,6 +182,18 @@ export async function exportSlideAsPdf(
     for (const r of reactRoots) r.unmount();
     root.remove();
     style.remove();
+  }
+}
+
+// Strip inline-style gradients from background-image so Chromium does not
+// emit them as PDF soft masks. url(...) backgrounds are preserved.
+function neutralizeGradientBackgrounds(root: HTMLElement): void {
+  const elements = root.querySelectorAll<HTMLElement>('*');
+  for (const el of elements) {
+    const bg = getComputedStyle(el).backgroundImage;
+    if (bg?.includes('gradient(')) {
+      el.style.backgroundImage = 'none';
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes slow page-turning in macOS Preview when viewing PDFs exported by `exportSlideAsPdf`. Pages were taking 0.5–2 s to redraw despite the file being only ~9 MB and the same PDF being smooth in Chrome / pdf.js / Adobe Reader.

### Root cause

Chromium's `print-to-PDF` pipeline serializes several CSS effects as PDF **transparency groups / soft masks**:

- `box-shadow` with non-trivial blur (large drop shadows, ring shadows `0 0 0 4px rgba(...)`, `inset 0 0 0 1px ...` highlights)
- `radial-gradient` / `linear-gradient` backgrounds (esp. full-page vignettes and semi-transparent stops)

macOS Preview's CoreGraphics renderer re-composites every soft mask on each page turn and doesn't cache page bitmaps. The slowdown is **PDF object-graph complexity, not file size** — stripping the effects produces a snappy PDF without changing bytes meaningfully.

## What changed

Inside the print container (`#os-print-root`), during export only:

- **CSS** — `@media print` rules zero out `box-shadow` on all descendants (including `::before` / `::after`) and `background-image` on pseudo-elements (gradients on pseudos can't be reached by a DOM walk).
- **DOM walk** — new `neutralizeGradientBackgrounds()` runs after `waitForDataWaitfor` and before the final layout flush. It reads `getComputedStyle(...).backgroundImage` and clears any value containing `gradient(`. Real `url(...)` backgrounds are preserved.

On-screen rendering (presenter / inspector / dev view) is completely unaffected.

Also:

- **Docs** — added an anti-pattern bullet to `packages/core/skills/slide-authoring/SKILL.md` so slide authors know exported PDFs may visually diverge from the screen when they use heavy gradients / shadows.
- **Changeset** — `patch` bump for `@open-slide/core`.

## Trade-offs

- Authors using full-page gradients or large blurs will see their PDFs render with solid fills instead. That's the intended behavior, but it's a visible change in exported output. Documented under Anti-patterns.
- The `os-print-supersample` CSS is unchanged — diagnostics showed removing it didn't help, and it still serves its documented purpose for filter-rasterized layers.

## Out of scope

- Ghostscript / mupdf post-processing (needs a CLI-driven export pipeline).
- Dev-server lint warning for heavy CSS effects (no slide-source scanning infrastructure today).

## Test plan

- [ ] `pnpm check` — biome clean (verified locally; 2 pre-existing warnings in `request-guard.ts` only).
- [ ] `pnpm typecheck` — tsc clean (verified locally).
- [ ] Manual: open a slide deck with `radial-gradient` / large `box-shadow` in `apps/demo`, export as PDF, confirm:
  - On-screen view still shows gradients + shadows.
  - PDF in **macOS Preview** pages instantly (no per-page repaint stall).
  - PDF in Chrome viewer still renders all text + layout correctly.
- [ ] Sanity-check: deck with `background-image: url(...)` still shows images in the exported PDF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF export now strips box-shadows and CSS gradients, improving rendering in macOS Preview.

* **Documentation**
  * Updated best practices guide warning against full-page gradients and heavy shadow effects in PDF exports. Solid fills, simple borders, and `backgroundColor` are recommended alternatives for designs requiring PDF fidelity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->