### PR TITLE
fix(cli): scaffold with core's version, not CLI's

### DIFF
--- a/.changeset/init-core-version.md
+++ b/.changeset/init-core-version.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/cli": patch
+---
+
+Pin scaffolded `@open-slide/core` to the core version bundled at CLI build time instead of the CLI's own version.

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -43,11 +43,10 @@ export async function isDirNonEmpty(target: string): Promise<boolean> {
   return entries.some((e) => !e.startsWith('.'));
 }
 
-async function readCliVersion(): Promise<string> {
-  const pkg = JSON.parse(await readFile(resolve(HERE, '..', 'package.json'), 'utf8')) as {
-    version: string;
-  };
-  return pkg.version;
+declare const __CORE_VERSION_AT_BUILD__: string;
+
+function coreVersionRange(): string {
+  return `^${__CORE_VERSION_AT_BUILD__}`;
 }
 
 async function linkOrCopy(relSrc: string, dst: string): Promise<void> {
@@ -144,7 +143,7 @@ export async function init(opts: InitOptions): Promise<void> {
     pkg.version = '0.0.0';
     pkg.private = true;
     if (pkg.dependencies?.['@open-slide/core']) {
-      pkg.dependencies['@open-slide/core'] = `^${await readCliVersion()}`;
+      pkg.dependencies['@open-slide/core'] = coreVersionRange();
     }
     await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
   }

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,4 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'tsdown';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const corePkg = JSON.parse(readFileSync(resolve(here, '..', 'core', 'package.json'), 'utf8')) as {
+  version: string;
+};
 
 export default defineConfig({
   entry: {
@@ -10,4 +18,7 @@ export default defineConfig({
   clean: true,
   dts: false,
   shims: false,
+  define: {
+    __CORE_VERSION_AT_BUILD__: JSON.stringify(corePkg.version),
+  },
 });


### PR DESCRIPTION
## Summary
- `open-slide init` was writing `^${cliVersion}` into the scaffolded `package.json` for `@open-slide/core`. Since CLI (1.2.3) and core (1.5.0) version independently, every fresh scaffold pinned a stale/wrong core version.
- Inject core's version into the CLI bundle at build time (`tsdown` `define` → `__CORE_VERSION_AT_BUILD__`) and use that for the dependency range. No runtime network calls.
- Since `prepack` rebuilds the CLI before every publish, the published CLI always bakes in the core version current at CLI publish time.

## Caveats for the reviewer
- If core publishes a new minor/patch without a corresponding CLI release, scaffolds will lag until the next CLI publish. If we want to avoid that gap, every core changeset should also bump CLI patch — happy to wire that up in a follow-up.
- Smoke-tested locally: `node packages/cli/dist/cli.js init …` now writes `"@open-slide/core": "^1.5.0"`.

## Test plan
- [x] `pnpm cli typecheck`
- [x] `pnpm cli build`
- [x] `pnpm check` (clean — only pre-existing warnings)
- [x] Local `init` smoke test produces `"@open-slide/core": "^1.5.0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version pinning for `@open-slide/core` to ensure consistency with the bundled core version at build time, preventing version mismatches during project scaffolding.

* **Chores**
  * Patch release for `@open-slide/cli`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->