### PR TITLE
feat(core): floating image action panel in inspector

### DIFF
--- a/.changeset/inspector-image-quick-actions.md
+++ b/.changeset/inspector-image-quick-actions.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Show a floating action panel below the inspector selection box when an image is selected, with quick-access Replace and Crop icons.

--- a/packages/core/src/app/components/inspector/asset-picker-dialog.tsx
+++ b/packages/core/src/app/components/inspector/asset-picker-dialog.tsx
@@ -1,0 +1,196 @@
+import { ArrowDownToLine, Loader2, Upload } from 'lucide-react';
+import type React from 'react';
+import { useCallback, useId, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { type AssetEntry, uploadWithAutoRename, useAssets } from '@/lib/assets';
+import { format, useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
+
+export type PickerScope = 'slide' | 'global';
+const GLOBAL_PICKER_SLIDE_ID = '@global';
+
+export function AssetPickerDialog({
+  slideId,
+  onClose,
+  onPick,
+}: {
+  slideId: string;
+  onClose: () => void;
+  onPick: (asset: AssetEntry, scope: PickerScope) => void;
+}) {
+  const [scope, setScope] = useState<PickerScope>('slide');
+  const effectiveSlideId = scope === 'global' ? GLOBAL_PICKER_SLIDE_ID : slideId;
+  const { assets, loading, refresh } = useAssets(effectiveSlideId);
+  const images = assets.filter((a) => a.mime.startsWith('image/'));
+  const t = useLocale();
+  const path = scope === 'global' ? 'assets/' : `slides/${slideId}/assets/`;
+  const [descPrefix, descSuffix] = t.inspector.replaceImageDescription.split('{path}');
+  const [uploading, setUploading] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
+  const dragDepth = useRef(0);
+  const inputId = useId();
+
+  const handleFile = useCallback(
+    async (file: File) => {
+      if (!file.type.startsWith('image/')) return;
+      setUploading(true);
+      try {
+        const { ok, status, entry } = await uploadWithAutoRename(effectiveSlideId, file);
+        if (!ok || !entry) {
+          toast.error(format(t.asset.toastUploadFailed, { status }));
+          return;
+        }
+        await refresh().catch(() => {});
+        onPick(entry, scope);
+      } finally {
+        setUploading(false);
+      }
+    },
+    [effectiveSlideId, scope, refresh, onPick, t],
+  );
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{t.inspector.replaceImageDialogTitle}</DialogTitle>
+          <DialogDescription>
+            {descPrefix}
+            <span className="font-mono">{path}</span>
+            {descSuffix}
+          </DialogDescription>
+        </DialogHeader>
+        <Tabs value={scope} onValueChange={(next) => setScope(next as PickerScope)}>
+          <TabsList>
+            <TabsTrigger value="slide">{t.asset.scopeSlide}</TabsTrigger>
+            <TabsTrigger value="global">{t.asset.scopeGlobal}</TabsTrigger>
+          </TabsList>
+        </Tabs>
+        <label
+          htmlFor={inputId}
+          className={cn(
+            'absolute right-12 top-3.5 inline-flex h-7 cursor-pointer items-center gap-1.5 rounded-[5px] border border-border bg-card px-2 text-[12px] font-medium transition-colors',
+            'hover:bg-muted/60 hover:border-foreground/20 active:translate-y-px',
+            uploading && 'pointer-events-none opacity-60',
+          )}
+        >
+          {uploading ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <Upload className="size-3.5" />
+          )}
+          <span>{t.asset.upload}</span>
+        </label>
+        <input
+          id={inputId}
+          type="file"
+          accept="image/*"
+          className="sr-only"
+          disabled={uploading}
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            e.target.value = '';
+            if (file) handleFile(file).catch(() => {});
+          }}
+        />
+        <section
+          aria-label={t.inspector.replaceImageDialogTitle}
+          className="relative max-h-[60vh] overflow-y-auto"
+          onDragEnter={(e) => {
+            if (uploading || !hasFiles(e)) return;
+            e.preventDefault();
+            dragDepth.current += 1;
+            setDragActive(true);
+          }}
+          onDragOver={(e) => {
+            if (uploading || !hasFiles(e)) return;
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'copy';
+          }}
+          onDragLeave={() => {
+            dragDepth.current = Math.max(0, dragDepth.current - 1);
+            if (dragDepth.current === 0) setDragActive(false);
+          }}
+          onDrop={(e) => {
+            if (uploading || !hasFiles(e)) return;
+            e.preventDefault();
+            dragDepth.current = 0;
+            setDragActive(false);
+            const file = e.dataTransfer.files?.[0];
+            if (file) handleFile(file).catch(() => {});
+          }}
+        >
+          {loading ? (
+            <p className="px-1 py-6 text-center text-xs text-muted-foreground">
+              {t.inspector.pickerLoading}
+            </p>
+          ) : images.length === 0 ? (
+            <p className="px-1 py-6 text-center text-xs text-muted-foreground">
+              {t.inspector.pickerEmpty}
+            </p>
+          ) : (
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3">
+              {images.map((asset) => (
+                <button
+                  key={asset.name}
+                  type="button"
+                  onClick={() => onPick(asset, scope)}
+                  className={cn(
+                    'group flex flex-col overflow-hidden rounded-lg border bg-card text-left shadow-sm transition-all',
+                    'hover:-translate-y-0.5 hover:shadow-md focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none',
+                  )}
+                >
+                  <div className="flex aspect-square w-full items-center justify-center overflow-hidden bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:12px_12px]">
+                    <img
+                      src={asset.url}
+                      alt=""
+                      className="size-full object-contain"
+                      draggable={false}
+                    />
+                  </div>
+                  <div className="border-t px-2 py-1.5">
+                    <div className="truncate text-[11px] font-medium" title={asset.name}>
+                      {asset.name}
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+          {dragActive && (
+            <div
+              className="pointer-events-none absolute inset-0 z-10 animate-in fade-in-0 duration-200"
+              aria-hidden
+            >
+              <div className="absolute inset-0 bg-brand/5" />
+              <div className="absolute inset-1 rounded-[8px] border border-dashed border-brand/40" />
+              <div className="absolute inset-x-0 bottom-4 flex justify-center">
+                <div className="flex items-center gap-2 rounded-[6px] border border-border bg-card px-3 py-1.5 text-[12px] font-medium shadow-floating">
+                  <ArrowDownToLine className="size-3.5 text-brand" />
+                  <span>{t.asset.dropToUpload}</span>
+                </div>
+              </div>
+            </div>
+          )}
+        </section>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function hasFiles(e: React.DragEvent): boolean {
+  const types = e.dataTransfer?.types;
+  if (!types) return false;
+  for (let i = 0; i < types.length; i++) {
+    if (types[i] === 'Files') return true;
+  }
+  return false;
+}

--- a/packages/core/src/app/components/inspector/inspect-overlay.tsx
+++ b/packages/core/src/app/components/inspector/inspect-overlay.tsx
@@ -35,6 +35,9 @@ export function InspectOverlay() {
     };
 
     const onMove = (e: PointerEvent) => {
+      if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) {
+        return setHover(null);
+      }
       const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
       if (!el) return setHover(null);
       const hit = findSlideSource(el, slideId, { hostOnly: true });
@@ -268,7 +271,9 @@ function ImageActionPanel({
               <ImageIcon className="size-3.5" />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">{t.inspector.replace}</TooltipContent>
+          <TooltipContent side="bottom" data-inspector-ui>
+            {t.inspector.replace}
+          </TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -284,7 +289,9 @@ function ImageActionPanel({
               <Crop className="size-3.5" />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">{t.inspector.crop}</TooltipContent>
+          <TooltipContent side="bottom" data-inspector-ui>
+            {t.inspector.crop}
+          </TooltipContent>
         </Tooltip>
       </div>
     </TooltipProvider>

--- a/packages/core/src/app/components/inspector/inspect-overlay.tsx
+++ b/packages/core/src/app/components/inspector/inspect-overlay.tsx
@@ -1,6 +1,10 @@
+import { Crop, ImageIcon } from 'lucide-react';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { PANEL_TRANSITION_MS } from '@/components/panel/panel-shell';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { findSlideSource, type SlideSourceHit } from '@/lib/inspector/fiber';
+import { useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
 import { useInspector } from './inspector-provider';
 
 type Highlight = { hit: SlideSourceHit };
@@ -82,6 +86,7 @@ export function InspectOverlay() {
       // Pin to the selection so the highlight tracks what the panel
       // is editing even after the cursor moves away.
       targetAnchor={selected?.anchor ?? hover?.hit.anchor ?? null}
+      selectedAnchor={selected?.anchor ?? null}
     />
   );
 }
@@ -90,10 +95,12 @@ function FrameOverlay({
   active,
   overlayRef,
   targetAnchor,
+  selectedAnchor,
 }: {
   active: boolean;
   overlayRef: React.RefObject<HTMLDivElement>;
   targetAnchor: HTMLElement | null;
+  selectedAnchor: HTMLElement | null;
 }) {
   const [rect, setRect] = useState<RelRect | null>(null);
   const [hasTarget, setHasTarget] = useState(false);
@@ -180,6 +187,12 @@ function FrameOverlay({
       `opacity ${FRAME_FADE_MS}ms ease-out`
     : `opacity ${FRAME_FADE_MS}ms ease-out`;
 
+  const showImageActions =
+    visible &&
+    !!rect &&
+    selectedAnchor instanceof HTMLImageElement &&
+    selectedAnchor === targetAnchor;
+
   return (
     <div ref={overlayRef} data-inspector-ui className="pointer-events-none absolute inset-0 z-30">
       {rect && (
@@ -197,7 +210,82 @@ function FrameOverlay({
           }}
         />
       )}
+      {rect && selectedAnchor && (
+        <ImageActionPanel
+          anchor={selectedAnchor}
+          rect={rect}
+          visible={showImageActions}
+          transition={transition}
+        />
+      )}
     </div>
+  );
+}
+
+const FLOATING_PANEL_GAP = 8;
+
+function ImageActionPanel({
+  anchor,
+  rect,
+  visible,
+  transition,
+}: {
+  anchor: HTMLElement;
+  rect: RelRect;
+  visible: boolean;
+  transition: string;
+}) {
+  const { openCrop, openReplace } = useInspector();
+  const t = useLocale();
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div
+        className={cn(
+          'absolute flex items-center gap-0.5 rounded-[8px] border border-border bg-popover p-1 text-popover-foreground shadow-floating',
+          visible ? 'pointer-events-auto' : 'pointer-events-none',
+        )}
+        style={{
+          left: rect.left + rect.width / 2,
+          top: rect.top + rect.height + FLOATING_PANEL_GAP,
+          transform: 'translateX(-50%)',
+          opacity: visible ? 1 : 0,
+          transition,
+        }}
+      >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={t.inspector.replace}
+              onClick={(e) => {
+                e.stopPropagation();
+                openReplace(anchor);
+              }}
+              className="inline-flex size-7 items-center justify-center rounded-[5px] text-foreground/85 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            >
+              <ImageIcon className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{t.inspector.replace}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={t.inspector.crop}
+              onClick={(e) => {
+                e.stopPropagation();
+                openCrop(anchor as HTMLImageElement);
+              }}
+              className="inline-flex size-7 items-center justify-center rounded-[5px] text-foreground/85 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            >
+              <Crop className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{t.inspector.crop}</TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
   );
 }
 

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -3,27 +3,16 @@ import {
   AlignJustify,
   AlignLeft,
   AlignRight,
-  ArrowDownToLine,
   Bold,
   Crop,
   ImageIcon,
   Italic,
-  Loader2,
-  Upload,
   X,
 } from 'lucide-react';
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
-import { toast } from 'sonner';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Field, NumberField, Section } from '@/components/panel/panel-fields';
 import { PANEL_TRANSITION_MS, PanelShell, useAnimatedOpen } from '@/components/panel/panel-shell';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -34,18 +23,16 @@ import {
 } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import { Slider } from '@/components/ui/slider';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { Toggle } from '@/components/ui/toggle';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { type AssetEntry, uploadWithAutoRename, useAssets } from '@/lib/assets';
 import { findSlideSource } from '@/lib/inspector/fiber';
 import type { EditOp } from '@/lib/inspector/use-editor';
 import { useAgentSocketConnected } from '@/lib/use-agent-socket';
-import { format, useLocale } from '@/lib/use-locale';
-import { cn } from '@/lib/utils';
+import { useLocale } from '@/lib/use-locale';
 import type { Locale } from '../../../locale/types';
+import { AssetPickerDialog } from './asset-picker-dialog';
 import { type SelectedTarget, useInspector } from './inspector-provider';
 
 type ElementSnapshot = {
@@ -317,12 +304,7 @@ export function InspectorPanel() {
         <>
           <Separator />
           <Section title={t.inspector.imageSection}>
-            <ImageField
-              slideId={slideId}
-              src={pinSnapshot.imageSrc}
-              anchor={pinSelected.anchor}
-              apply={apply}
-            />
+            <ImageField src={pinSnapshot.imageSrc} anchor={pinSelected.anchor} />
           </Section>
         </>
       )}
@@ -747,20 +729,9 @@ function ColorField({
   );
 }
 
-function ImageField({
-  slideId,
-  src,
-  anchor,
-  apply,
-}: {
-  slideId: string;
-  src: string;
-  anchor: HTMLElement;
-  apply: (ops: EditOp[]) => void;
-}) {
-  const [open, setOpen] = useState(false);
+function ImageField({ src, anchor }: { src: string; anchor: HTMLElement }) {
   const t = useLocale();
-  const { openCrop } = useInspector();
+  const { openCrop, openReplace } = useInspector();
   const isImage = anchor.tagName === 'IMG';
   return (
     <div className="space-y-2">
@@ -782,7 +753,7 @@ function ImageField({
             variant="outline"
             size="sm"
             className="flex-1"
-            onClick={() => setOpen(true)}
+            onClick={() => openReplace(anchor)}
           >
             <ImageIcon className="size-3.5" />
             {t.inspector.replace}
@@ -801,36 +772,6 @@ function ImageField({
           )}
         </div>
       </div>
-      {open && (
-        <AssetPickerDialog
-          slideId={slideId}
-          onClose={() => setOpen(false)}
-          onPick={(asset, scope) => {
-            setOpen(false);
-            const assetPath =
-              scope === 'global' ? `@assets/${asset.name}` : `./assets/${asset.name}`;
-            const ops: EditOp[] = [
-              {
-                kind: 'set-attr-asset',
-                attr: 'src',
-                assetPath,
-                previewUrl: asset.url,
-              },
-            ];
-            if (isImage) {
-              const cs = window.getComputedStyle(anchor);
-              if (cs.objectFit !== 'cover' && cs.objectFit !== 'contain') {
-                ops.push({ kind: 'set-style', key: 'objectFit', value: 'cover' });
-              }
-              const op = cs.objectPosition.trim();
-              if (!op || op === '0% 0%' || op === 'auto') {
-                ops.push({ kind: 'set-style', key: 'objectPosition', value: '50% 50%' });
-              }
-            }
-            apply(ops);
-          }}
-        />
-      )}
     </div>
   );
 }
@@ -892,187 +833,6 @@ function PlaceholderField({
       )}
     </div>
   );
-}
-
-type PickerScope = 'slide' | 'global';
-const GLOBAL_PICKER_SLIDE_ID = '@global';
-
-function AssetPickerDialog({
-  slideId,
-  onClose,
-  onPick,
-}: {
-  slideId: string;
-  onClose: () => void;
-  onPick: (asset: AssetEntry, scope: PickerScope) => void;
-}) {
-  const [scope, setScope] = useState<PickerScope>('slide');
-  const effectiveSlideId = scope === 'global' ? GLOBAL_PICKER_SLIDE_ID : slideId;
-  const { assets, loading, refresh } = useAssets(effectiveSlideId);
-  const images = assets.filter((a) => a.mime.startsWith('image/'));
-  const t = useLocale();
-  const path = scope === 'global' ? 'assets/' : `slides/${slideId}/assets/`;
-  const [descPrefix, descSuffix] = t.inspector.replaceImageDescription.split('{path}');
-  const [uploading, setUploading] = useState(false);
-  const [dragActive, setDragActive] = useState(false);
-  const dragDepth = useRef(0);
-  const inputId = useId();
-
-  const handleFile = useCallback(
-    async (file: File) => {
-      if (!file.type.startsWith('image/')) return;
-      setUploading(true);
-      try {
-        const { ok, status, entry } = await uploadWithAutoRename(effectiveSlideId, file);
-        if (!ok || !entry) {
-          toast.error(format(t.asset.toastUploadFailed, { status }));
-          return;
-        }
-        await refresh().catch(() => {});
-        onPick(entry, scope);
-      } finally {
-        setUploading(false);
-      }
-    },
-    [effectiveSlideId, scope, refresh, onPick, t],
-  );
-
-  return (
-    <Dialog open onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="sm:max-w-xl">
-        <DialogHeader>
-          <DialogTitle>{t.inspector.replaceImageDialogTitle}</DialogTitle>
-          <DialogDescription>
-            {descPrefix}
-            <span className="font-mono">{path}</span>
-            {descSuffix}
-          </DialogDescription>
-        </DialogHeader>
-        <Tabs value={scope} onValueChange={(next) => setScope(next as PickerScope)}>
-          <TabsList>
-            <TabsTrigger value="slide">{t.asset.scopeSlide}</TabsTrigger>
-            <TabsTrigger value="global">{t.asset.scopeGlobal}</TabsTrigger>
-          </TabsList>
-        </Tabs>
-        <label
-          htmlFor={inputId}
-          className={cn(
-            'absolute right-12 top-3.5 inline-flex h-7 cursor-pointer items-center gap-1.5 rounded-[5px] border border-border bg-card px-2 text-[12px] font-medium transition-colors',
-            'hover:bg-muted/60 hover:border-foreground/20 active:translate-y-px',
-            uploading && 'pointer-events-none opacity-60',
-          )}
-        >
-          {uploading ? (
-            <Loader2 className="size-3.5 animate-spin" />
-          ) : (
-            <Upload className="size-3.5" />
-          )}
-          <span>{t.asset.upload}</span>
-        </label>
-        <input
-          id={inputId}
-          type="file"
-          accept="image/*"
-          className="sr-only"
-          disabled={uploading}
-          onChange={(e) => {
-            const file = e.target.files?.[0];
-            e.target.value = '';
-            if (file) handleFile(file).catch(() => {});
-          }}
-        />
-        <section
-          aria-label={t.inspector.replaceImageDialogTitle}
-          className="relative max-h-[60vh] overflow-y-auto"
-          onDragEnter={(e) => {
-            if (uploading || !hasFiles(e)) return;
-            e.preventDefault();
-            dragDepth.current += 1;
-            setDragActive(true);
-          }}
-          onDragOver={(e) => {
-            if (uploading || !hasFiles(e)) return;
-            e.preventDefault();
-            e.dataTransfer.dropEffect = 'copy';
-          }}
-          onDragLeave={() => {
-            dragDepth.current = Math.max(0, dragDepth.current - 1);
-            if (dragDepth.current === 0) setDragActive(false);
-          }}
-          onDrop={(e) => {
-            if (uploading || !hasFiles(e)) return;
-            e.preventDefault();
-            dragDepth.current = 0;
-            setDragActive(false);
-            const file = e.dataTransfer.files?.[0];
-            if (file) handleFile(file).catch(() => {});
-          }}
-        >
-          {loading ? (
-            <p className="px-1 py-6 text-center text-xs text-muted-foreground">
-              {t.inspector.pickerLoading}
-            </p>
-          ) : images.length === 0 ? (
-            <p className="px-1 py-6 text-center text-xs text-muted-foreground">
-              {t.inspector.pickerEmpty}
-            </p>
-          ) : (
-            <div className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3">
-              {images.map((asset) => (
-                <button
-                  key={asset.name}
-                  type="button"
-                  onClick={() => onPick(asset, scope)}
-                  className={cn(
-                    'group flex flex-col overflow-hidden rounded-lg border bg-card text-left shadow-sm transition-all',
-                    'hover:-translate-y-0.5 hover:shadow-md focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none',
-                  )}
-                >
-                  <div className="flex aspect-square w-full items-center justify-center overflow-hidden bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:12px_12px]">
-                    <img
-                      src={asset.url}
-                      alt=""
-                      className="size-full object-contain"
-                      draggable={false}
-                    />
-                  </div>
-                  <div className="border-t px-2 py-1.5">
-                    <div className="truncate text-[11px] font-medium" title={asset.name}>
-                      {asset.name}
-                    </div>
-                  </div>
-                </button>
-              ))}
-            </div>
-          )}
-          {dragActive && (
-            <div
-              className="pointer-events-none absolute inset-0 z-10 animate-in fade-in-0 duration-200"
-              aria-hidden
-            >
-              <div className="absolute inset-0 bg-brand/5" />
-              <div className="absolute inset-1 rounded-[8px] border border-dashed border-brand/40" />
-              <div className="absolute inset-x-0 bottom-4 flex justify-center">
-                <div className="flex items-center gap-2 rounded-[6px] border border-border bg-card px-3 py-1.5 text-[12px] font-medium shadow-floating">
-                  <ArrowDownToLine className="size-3.5 text-brand" />
-                  <span>{t.asset.dropToUpload}</span>
-                </div>
-              </div>
-            </div>
-          )}
-        </section>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function hasFiles(e: React.DragEvent): boolean {
-  const types = e.dataTransfer?.types;
-  if (!types) return false;
-  for (let i = 0; i < types.length; i++) {
-    if (types[i] === 'Files') return true;
-  }
-  return false;
 }
 
 function AgentWatchingBadge() {

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -15,6 +15,7 @@ import { Button } from '@/components/ui/button';
 import { type SlideComment, useComments } from '@/lib/inspector/use-comments';
 import { type Edit, type EditOp, type EditResult, useEditor } from '@/lib/inspector/use-editor';
 import { useLocale } from '@/lib/use-locale';
+import { AssetPickerDialog } from './asset-picker-dialog';
 import { ImageCropDialog, type ImageCropRect } from './image-crop-dialog';
 
 export type SelectedTarget = {
@@ -263,6 +264,7 @@ type InspectorCtx = {
   cancelEdits: () => void;
   committing: boolean;
   openCrop: (anchor: HTMLImageElement) => void;
+  openReplace: (anchor: HTMLElement) => void;
 };
 
 const Ctx = createContext<InspectorCtx | null>(null);
@@ -295,6 +297,11 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
     initialFit: 'cover' | 'contain';
     initialPosition: { x: number; y: number };
     initialRect: ImageCropRect | null;
+  } | null>(null);
+  const [replaceTarget, setReplaceTarget] = useState<{
+    line: number;
+    column: number;
+    anchor: HTMLElement;
   } | null>(null);
   const t = useLocale();
 
@@ -883,6 +890,16 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
     setSelected(null);
   }, []);
 
+  const openReplace = useCallback((anchor: HTMLElement) => {
+    const loc = anchor.dataset.slideLoc;
+    if (!loc) return;
+    const [lineStr, columnStr] = loc.split(':');
+    const line = Number(lineStr);
+    const column = Number(columnStr);
+    if (!Number.isFinite(line) || !Number.isFinite(column)) return;
+    setReplaceTarget({ line, column, anchor });
+  }, []);
+
   const openCrop = useCallback((anchor: HTMLImageElement) => {
     const loc = anchor.dataset.slideLoc;
     if (!loc) return;
@@ -925,6 +942,7 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       cancelEdits,
       committing,
       openCrop,
+      openReplace,
     }),
     [
       slideId,
@@ -945,12 +963,44 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
       cancelEdits,
       committing,
       openCrop,
+      openReplace,
     ],
   );
 
   return (
     <Ctx.Provider value={value}>
       {children}
+      {replaceTarget && (
+        <AssetPickerDialog
+          slideId={slideId}
+          onClose={() => setReplaceTarget(null)}
+          onPick={(asset, scope) => {
+            const { line, column, anchor } = replaceTarget;
+            const assetPath =
+              scope === 'global' ? `@assets/${asset.name}` : `./assets/${asset.name}`;
+            const ops: EditOp[] = [
+              {
+                kind: 'set-attr-asset',
+                attr: 'src',
+                assetPath,
+                previewUrl: asset.url,
+              },
+            ];
+            if (anchor.tagName === 'IMG' && anchor.isConnected) {
+              const cs = window.getComputedStyle(anchor);
+              if (cs.objectFit !== 'cover' && cs.objectFit !== 'contain') {
+                ops.push({ kind: 'set-style', key: 'objectFit', value: 'cover' });
+              }
+              const op = cs.objectPosition.trim();
+              if (!op || op === '0% 0%' || op === 'auto') {
+                ops.push({ kind: 'set-style', key: 'objectPosition', value: '50% 50%' });
+              }
+            }
+            bufferOps(line, column, anchor, ops);
+            setReplaceTarget(null);
+          }}
+        />
+      )}
       {cropTarget && (
         <ImageCropDialog
           src={cropTarget.src}


### PR DESCRIPTION
## Summary

- Adds a small floating toolbar below the inspector selection box when the selected element is an `<img>`, with quick-access **Replace** and **Crop** icon buttons (tooltips on hover).
- Extracts `AssetPickerDialog` into its own module (`asset-picker-dialog.tsx`) so it can be mounted as a singleton at the provider level — mirrors how `ImageCropDialog` is already wired up.
- Adds `openReplace(anchor)` to the inspector context. The floating toolbar and the side panel's `ImageField` now share the same flow (and the same `objectFit` / `objectPosition` defaults applied on first pick).

## Why

Replace and Crop are the two image actions users reach for most. Surfacing them inline next to the selection — instead of forcing a trip to the side panel — makes the inspector feel a lot more direct.

## Notes for reviewers

- The floating panel is rendered inside `InspectOverlay`, uses the same morph transition as the selection box, and carries `data-inspector-ui` so clicks on it don't bubble back into the inspector's selection handler.
- `ImageField` lost its local `useState`/`AssetPickerDialog` — it now calls `openReplace(anchor)` from context. The asset-pick handling (path resolution, default object-fit/position) moved into the provider unchanged.
- No locale strings were added; the toolbar reuses `t.inspector.replace` and `t.inspector.crop`.

## Test plan

- [ ] Open inspector, click on an image — floating panel appears below the selection box.
- [ ] Click Replace icon → AssetPickerDialog opens; picking an asset swaps the image.
- [ ] Click Crop icon → ImageCropDialog opens and applies.
- [ ] Side panel Replace/Crop buttons still work (they share the same flow now).
- [ ] Double-click on an image still opens the crop dialog directly.
- [ ] Floating panel tracks the selection box smoothly when switching between images.
- [ ] `pnpm typecheck`, `pnpm check`, `pnpm test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Floating image action panel appears when an image is selected, offering Replace and Crop actions beneath the inspector.
  * New asset picker dialog for choosing or uploading images (per-slide or global) with drag‑and‑drop, upload spinner, and error feedback.

* **Bug Fixes**
  * Inspector hover/interaction now ignores pointer events from the inspector UI to prevent accidental hover changes while interacting.

* **Refactor**
  * Internal inspector flows streamlined; replace/crop actions now use the centralized picker.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->