### PR TITLE
chore: add `.DS_Store` to scaffolded `.gitignore`

### DIFF
--- a/.changeset/scaffold-gitignore-ds-store.md
+++ b/.changeset/scaffold-gitignore-ds-store.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/cli": patch
+---
+
+Add `.DS_Store` to the scaffolded `.gitignore`.

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -153,7 +153,7 @@ export async function init(opts: InitOptions): Promise<void> {
     await writeFile(configPath, renderConfigFile(locale));
   }
 
-  await writeFile(join(target, '.gitignore'), 'node_modules\ndist\n');
+  await writeFile(join(target, '.gitignore'), 'node_modules\ndist\n.DS_Store\n');
 
   const cdTarget = dir === '.' ? basename(target) : dir;
   process.stdout.write(


### PR DESCRIPTION
Adds `.DS_Store` to the `.gitignore` file generated by `@open-slide/cli init`.

**Changes:**
- Updated the scaffolded `.gitignore` template to include `.DS_Store`, a macOS-specific file that should not be committed to version control

This prevents accidental commits of macOS system files in projects initialized with the CLI.

https://claude.ai/code/session_015LBf9DTVgbTjD2XptP9B1a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated project scaffolding to include `.DS_Store` in the generated `.gitignore`, preventing macOS system files from being accidentally committed to version control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->