### PR TITLE
fix(cli): sanitize init target directory

### DIFF
--- a/.changeset/sanitize-init-target-dir.md
+++ b/.changeset/sanitize-init-target-dir.md
@@ -2,4 +2,4 @@
 '@open-slide/cli': patch
 ---
 
-Sanitize the target directory name during `init` so the printed `cd` command always works — names with spaces or other shell-unfriendly characters are now suggested as a safe equivalent (e.g. `future of open slide` → `future-of-open-slide`).
+Sanitize `init` target directory names and suggest a safe equivalent for shell-unfriendly input.

--- a/.changeset/sanitize-init-target-dir.md
+++ b/.changeset/sanitize-init-target-dir.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/cli': patch
+---
+
+Sanitize the target directory name during `init` so the printed `cd` command always works — names with spaces or other shell-unfriendly characters are now suggested as a safe equivalent (e.g. `future of open slide` → `future-of-open-slide`).

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,14 @@ import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import prompts from 'prompts';
-import { type InitOptions, init, isDirNonEmpty, LOCALE_CHOICES, type LocaleCode } from './init.ts';
+import {
+  type InitOptions,
+  init,
+  isDirNonEmpty,
+  LOCALE_CHOICES,
+  type LocaleCode,
+  sanitizeDirName,
+} from './init.ts';
 import { detectPackageManager, PACKAGE_MANAGERS, type PackageManager } from './package-manager.ts';
 
 async function readVersion(): Promise<string> {
@@ -77,6 +84,31 @@ async function runInit(dirArg: string | undefined, flags: InitCliFlags): Promise
       { onCancel },
     );
     dir = answers.dir;
+  }
+
+  if (dir !== undefined) {
+    const safe = sanitizeDirName(dir);
+    if (safe !== dir) {
+      if (!isTTY) {
+        throw new Error(
+          `Target directory "${dir}" contains characters that break shell commands (spaces, quotes, etc.). Try "${safe}" instead.`,
+        );
+      }
+      process.stdout.write(
+        `${chalk.yellow('!')} ${chalk.bold(`"${dir}"`)} has characters that confuse shells.\n` +
+          `  Suggested: ${chalk.cyan(`"${safe}"`)}\n`,
+      );
+      const answers = await prompts(
+        {
+          type: 'text',
+          name: 'dir',
+          message: 'Directory name',
+          initial: safe,
+        },
+        { onCancel },
+      );
+      dir = sanitizeDirName(answers.dir ?? safe);
+    }
   }
 
   if (isTTY && locale === undefined) {

--- a/packages/cli/src/init.test.ts
+++ b/packages/cli/src/init.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeDirName } from './init.ts';
+
+describe('sanitizeDirName', () => {
+  it('leaves safe names untouched', () => {
+    expect(sanitizeDirName('my-slides')).toBe('my-slides');
+    expect(sanitizeDirName('decks/2026-q2')).toBe('decks/2026-q2');
+    expect(sanitizeDirName('Open_Slide.workspace')).toBe('Open_Slide.workspace');
+  });
+
+  it('preserves "." and ".."', () => {
+    expect(sanitizeDirName('.')).toBe('.');
+    expect(sanitizeDirName('..')).toBe('..');
+  });
+
+  it('replaces spaces with hyphens', () => {
+    expect(sanitizeDirName('future of open slide and how can i help')).toBe(
+      'future-of-open-slide-and-how-can-i-help',
+    );
+  });
+
+  it('collapses runs of whitespace into a single hyphen', () => {
+    expect(sanitizeDirName('foo   bar\tbaz')).toBe('foo-bar-baz');
+  });
+
+  it('replaces shell-unfriendly characters', () => {
+    expect(sanitizeDirName("my deck's notes")).toBe('my-deck-s-notes');
+    expect(sanitizeDirName('cool$deck')).toBe('cool-deck');
+    expect(sanitizeDirName('a&b|c;d')).toBe('a-b-c-d');
+  });
+
+  it('trims leading and trailing hyphens', () => {
+    expect(sanitizeDirName('  hello  ')).toBe('hello');
+    expect(sanitizeDirName('!!!hi!!!')).toBe('hi');
+  });
+
+  it('falls back to "my-slides" when nothing usable remains', () => {
+    expect(sanitizeDirName('!!!')).toBe('my-slides');
+    expect(sanitizeDirName('   ')).toBe('my-slides');
+  });
+
+  it('keeps path separators intact', () => {
+    expect(sanitizeDirName('decks/my new deck')).toBe('decks/my-new-deck');
+  });
+
+  it('is idempotent', () => {
+    const cases = [
+      'future of open slide and how can i help',
+      "my deck's notes",
+      'decks/my new deck',
+      '!!!hi!!!',
+      '!!!',
+      '.',
+      '..',
+    ];
+    for (const input of cases) {
+      const once = sanitizeDirName(input);
+      const twice = sanitizeDirName(once);
+      expect(twice).toBe(once);
+    }
+  });
+
+  it('preserves a trailing path separator', () => {
+    expect(sanitizeDirName('foo bar/')).toBe('foo-bar/');
+  });
+
+  it('collapses hyphens on both sides of a path separator', () => {
+    expect(sanitizeDirName('a-/-b')).toBe('a/b');
+    expect(sanitizeDirName('decks---/---my deck')).toBe('decks/my-deck');
+  });
+});

--- a/packages/cli/src/init.test.ts
+++ b/packages/cli/src/init.test.ts
@@ -68,4 +68,23 @@ describe('sanitizeDirName', () => {
     expect(sanitizeDirName('a-/-b')).toBe('a/b');
     expect(sanitizeDirName('decks---/---my deck')).toBe('decks/my-deck');
   });
+
+  it('preserves non-ASCII letters and digits', () => {
+    expect(sanitizeDirName('投影片')).toBe('投影片');
+    expect(sanitizeDirName('スライド')).toBe('スライド');
+    expect(sanitizeDirName('café')).toBe('café');
+    expect(sanitizeDirName('我的 投影片')).toBe('我的-投影片');
+  });
+
+  it('preserves Windows backslash separators', () => {
+    expect(sanitizeDirName('slides\\q2')).toBe('slides\\q2');
+    expect(sanitizeDirName('decks\\my new deck')).toBe('decks\\my-new-deck');
+    expect(sanitizeDirName('a-\\-b')).toBe('a\\b');
+  });
+
+  it('falls back when sanitization would produce a root-like path', () => {
+    expect(sanitizeDirName('!!!/!!!')).toBe('my-slides');
+    expect(sanitizeDirName('!!!\\!!!')).toBe('my-slides');
+    expect(sanitizeDirName('//')).toBe('my-slides');
+  });
 });

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -37,6 +37,18 @@ export interface InitOptions {
   locale: LocaleCode;
 }
 
+export function sanitizeDirName(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed === '.' || trimmed === '..') return trimmed;
+  const cleaned = trimmed
+    .replace(/\s+/g, '-')
+    .replace(/[^A-Za-z0-9_./-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .replace(/-*\/-*/g, '/');
+  return cleaned || 'my-slides';
+}
+
 export async function isDirNonEmpty(target: string): Promise<boolean> {
   if (!existsSync(target)) return false;
   const entries = await readdir(target);

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -42,11 +42,12 @@ export function sanitizeDirName(value: string): string {
   if (trimmed === '.' || trimmed === '..') return trimmed;
   const cleaned = trimmed
     .replace(/\s+/g, '-')
-    .replace(/[^A-Za-z0-9_./-]/g, '-')
+    .replace(/[^\\\p{L}\p{N}_./-]/gu, '-')
     .replace(/-+/g, '-')
     .replace(/(^-|-$)/g, '')
-    .replace(/-*\/-*/g, '/');
-  return cleaned || 'my-slides';
+    .replace(/-*([/\\])-*/g, '$1');
+  if (cleaned === '' || /^[/\\]+$/.test(cleaned)) return 'my-slides';
+  return cleaned;
 }
 
 export async function isDirNonEmpty(target: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- `npx @open-slide/cli init` previously accepted directory names with spaces (e.g. `future of open slide`), then printed a `cd ...` line in "Next steps" that the shell rejected (`cd: too many arguments`).
- Sanitize the entered name during `init` — spaces → hyphens, shell-unsafe characters stripped, leading/trailing hyphens trimmed, hyphens around path separators collapsed.
- In TTY mode, warn (showing the suggested safe name) and re-prompt with the safe suggestion prefilled so the user can accept or edit. In non-TTY mode, error out with a clear suggestion instead of silently rewriting.

## Test plan
- [x] `pnpm test` — 218/218 pass, includes 11 new tests in `packages/cli/src/init.test.ts` covering safe passthrough, `.`/`..`, whitespace, shell metacharacters, fallback when nothing usable remains, path separators, idempotence, trailing slash, and hyphens collapsing around separators.
- [x] `pnpm exec biome check packages/cli/src/...` — clean.
- [x] Manual non-TTY: `init "future of open slide..."` → errors with suggested safe name and exits 1.
- [ ] Manual TTY: `init` and enter a name with spaces → warning shows `Suggested: "..."` and re-prompts with the safe default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The init command now sanitizes directory names with spaces or shell-unfriendly characters. Spaces become hyphens and other unsafe characters are replaced; interactive runs show a suggested safe name, non-interactive runs fail with an error.
* **Tests**
  * Added comprehensive tests for sanitization behavior (edge cases, path segments, idempotency, Windows-style separators).
* **Chores**
  * Added a changeset documenting the behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->