### PR TITLE
feat(core): editor shortcuts and inspector polish

### DIFF
--- a/.changeset/editor-shortcuts-and-fixes.md
+++ b/.changeset/editor-shortcuts-and-fixes.md
@@ -2,8 +2,4 @@
 '@open-slide/core': minor
 ---
 
-- Add I and D shortcuts to toggle the inspector and design panel, matching the F-for-present convention.
-- Keep the inspector selection framed while a dashed hover frame follows the cursor over other elements.
-- Prevent the save bar's unsaved/saved label from wrapping onto two lines.
-- Add an icon next to the inspector panel title, matching the design tokens header.
-- Drop the stray hairline under the inspector header when the selected element has no editable text.
+Add I and D shortcuts for the inspector and design panel, show a dashed hover frame alongside the inspector selection, and polish the inspector header and save bar.

--- a/.changeset/editor-shortcuts-and-fixes.md
+++ b/.changeset/editor-shortcuts-and-fixes.md
@@ -1,0 +1,9 @@
+---
+'@open-slide/core': minor
+---
+
+- Add I and D shortcuts to toggle the inspector and design panel, matching the F-for-present convention.
+- Keep the inspector selection framed while a dashed hover frame follows the cursor over other elements.
+- Prevent the save bar's unsaved/saved label from wrapping onto two lines.
+- Add an icon next to the inspector panel title, matching the design tokens header.
+- Drop the stray hairline under the inspector header when the selected element has no editable text.

--- a/packages/core/src/app/components/inspector/inspect-overlay.tsx
+++ b/packages/core/src/app/components/inspector/inspect-overlay.tsx
@@ -75,37 +75,46 @@ export function InspectOverlay() {
     };
   }, [active, slideId, setSelected, cancel, openCrop]);
 
+  const hoverAnchor = hover?.hit.anchor.isConnected ? hover.hit.anchor : null;
+  const selectedAnchor = selected?.anchor.isConnected ? selected.anchor : null;
+  const dedupedHover = hoverAnchor && hoverAnchor !== selectedAnchor ? hoverAnchor : null;
+
+  if (!active) return null;
   return (
-    <FrameOverlay
-      active={active}
-      overlayRef={overlayRef}
-      // Pin to the selection so the highlight tracks what the panel
-      // is editing even after the cursor moves away.
-      targetAnchor={selected?.anchor ?? hover?.hit.anchor ?? null}
-    />
+    <div ref={overlayRef} data-inspector-ui className="pointer-events-none absolute inset-0 z-30">
+      <Frame anchor={selectedAnchor} overlayRef={overlayRef} variant="selected" />
+      <Frame anchor={dedupedHover} overlayRef={overlayRef} variant="hover" />
+    </div>
   );
 }
 
-function FrameOverlay({
-  active,
+type FrameVariant = 'selected' | 'hover';
+
+const FRAME_STYLES: Record<FrameVariant, React.CSSProperties> = {
+  selected: { outline: '2px solid #3b82f6', background: 'rgba(59,130,246,0.1)' },
+  hover: { outline: '1.5px dashed #3b82f6', background: 'rgba(59,130,246,0.05)' },
+};
+
+function Frame({
+  anchor,
   overlayRef,
-  targetAnchor,
+  variant,
 }: {
-  active: boolean;
+  anchor: HTMLElement | null;
   overlayRef: React.RefObject<HTMLDivElement>;
-  targetAnchor: HTMLElement | null;
+  variant: FrameVariant;
 }) {
   const [rect, setRect] = useState<RelRect | null>(null);
   const [hasTarget, setHasTarget] = useState(false);
 
   const measure = useCallback(() => {
     const overlay = overlayRef.current;
-    if (!active || !targetAnchor?.isConnected || !overlay) {
+    if (!anchor?.isConnected || !overlay) {
       setHasTarget(false);
       return;
     }
 
-    const targetRect = targetAnchor.getBoundingClientRect();
+    const targetRect = anchor.getBoundingClientRect();
     const overlayRect = overlay.getBoundingClientRect();
     const next = {
       left: targetRect.left - overlayRect.left,
@@ -116,14 +125,14 @@ function FrameOverlay({
 
     setHasTarget(true);
     setRect((prev) => (sameRect(prev, next) ? prev : next));
-  }, [active, overlayRef, targetAnchor]);
+  }, [overlayRef, anchor]);
 
   useLayoutEffect(() => {
     measure();
   }, [measure]);
 
   useEffect(() => {
-    if (!active) {
+    if (!anchor) {
       setHasTarget(false);
       return;
     }
@@ -139,7 +148,7 @@ function FrameOverlay({
     const root = document.querySelector<HTMLElement>('[data-inspector-root]');
     if (root) resizeObserver.observe(root);
     if (overlayRef.current) resizeObserver.observe(overlayRef.current);
-    if (targetAnchor) resizeObserver.observe(targetAnchor);
+    resizeObserver.observe(anchor);
 
     const stopAt = performance.now() + LAYOUT_TRACK_MS;
     const trackPanelTransition = () => {
@@ -157,9 +166,9 @@ function FrameOverlay({
       window.removeEventListener('resize', scheduleMeasure, true);
       window.removeEventListener('scroll', scheduleMeasure, true);
     };
-  }, [active, measure, overlayRef, targetAnchor]);
+  }, [measure, overlayRef, anchor]);
 
-  const visible = !!(active && hasTarget && rect);
+  const visible = !!(hasTarget && rect);
 
   // First render after appearing: snap to the new rect (no transition).
   // Subsequent rect changes in the same visible session: animate.
@@ -173,7 +182,7 @@ function FrameOverlay({
     return () => clearTimeout(t);
   }, [visible]);
 
-  if (!active) return null;
+  if (!rect) return null;
   const transition = morph
     ? `left ${FRAME_MORPH_MS}ms ease-out, top ${FRAME_MORPH_MS}ms ease-out, ` +
       `width ${FRAME_MORPH_MS}ms ease-out, height ${FRAME_MORPH_MS}ms ease-out, ` +
@@ -181,23 +190,18 @@ function FrameOverlay({
     : `opacity ${FRAME_FADE_MS}ms ease-out`;
 
   return (
-    <div ref={overlayRef} data-inspector-ui className="pointer-events-none absolute inset-0 z-30">
-      {rect && (
-        <div
-          className="absolute"
-          style={{
-            left: rect.left,
-            top: rect.top,
-            width: rect.width,
-            height: rect.height,
-            opacity: visible ? 1 : 0,
-            transition,
-            outline: '2px solid #3b82f6',
-            background: 'rgba(59,130,246,0.1)',
-          }}
-        />
-      )}
-    </div>
+    <div
+      className="absolute"
+      style={{
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height,
+        opacity: visible ? 1 : 0,
+        transition,
+        ...FRAME_STYLES[variant],
+      }}
+    />
   );
 }
 

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -6,6 +6,7 @@ import {
   ArrowDownToLine,
   Bold,
   Crop,
+  Crosshair,
   ImageIcon,
   Italic,
   Loader2,
@@ -249,6 +250,7 @@ export function InspectorPanel() {
       header={
         <>
           <div className="flex min-w-0 items-center gap-2">
+            <Crosshair className="size-3.5 text-muted-foreground" />
             <span className="font-heading text-[12px] font-semibold tracking-tight">
               {t.inspector.inspect}
             </span>
@@ -274,16 +276,17 @@ export function InspectorPanel() {
       footer={<CommentsSection selected={pinSelected} onAdd={add} />}
     >
       {pinSnapshot.text !== null && (
-        <Section title={t.inspector.contentSection}>
-          <ContentField
-            snapshot={pinSnapshot}
-            apply={apply}
-            onSelectionChange={setContentSelection}
-          />
-        </Section>
+        <>
+          <Section title={t.inspector.contentSection}>
+            <ContentField
+              snapshot={pinSnapshot}
+              apply={apply}
+              onSelectionChange={setContentSelection}
+            />
+          </Section>
+          <Separator />
+        </>
       )}
-
-      <Separator />
 
       <Section title={t.inspector.typographySection}>
         <FontSizeField snapshot={typographySnapshot} apply={applyTextStyle} />

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -273,7 +273,15 @@ export function useInspector(): InspectorCtx {
   return v;
 }
 
-export function InspectorProvider({ slideId, children }: { slideId: string; children: ReactNode }) {
+export function InspectorProvider({
+  slideId,
+  pageIndex,
+  children,
+}: {
+  slideId: string;
+  pageIndex: number;
+  children: ReactNode;
+}) {
   const [active, setActive] = useState(false);
   const [selected, setSelected] = useState<SelectedTarget | null>(null);
   const { comments, error, refetch, add, remove } = useComments(slideId);
@@ -871,6 +879,35 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
     return () => observer?.disconnect();
   }, []);
 
+  useEffect(() => {
+    void pageIndex;
+    setSelected(null);
+  }, [pageIndex]);
+
+  // Never clear `selected` on a miss: the observer can fire between an
+  // "old removed" and "new added" mutation batch, and clearing then would
+  // drop a selection that's about to reattach on the next fire.
+  useEffect(() => {
+    if (!selected) return;
+    const root = document.querySelector<HTMLElement>('[data-inspector-root]');
+    if (!root) return;
+
+    const revalidate = () => {
+      if (selected.anchor.isConnected) return;
+      const next = root.querySelector<HTMLElement>(
+        `[data-slide-loc="${selected.line}:${selected.column}"]`,
+      );
+      if (next && next !== selected.anchor) {
+        setSelected({ ...selected, anchor: next });
+      }
+    };
+
+    revalidate();
+    const observer = new MutationObserver(revalidate);
+    observer.observe(root, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [selected]);
+
   const toggle = useCallback(() => {
     setActive((a) => {
       if (a) setSelected(null);
@@ -882,6 +919,17 @@ export function InspectorProvider({ slideId, children }: { slideId: string; chil
     setActive(false);
     setSelected(null);
   }, []);
+
+  useEffect(() => {
+    if (import.meta.env.PROD) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLElement && e.target.matches('input, textarea')) return;
+      if (e.key !== 'i' && e.key !== 'I') return;
+      toggle();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [toggle]);
 
   const openCrop = useCallback((anchor: HTMLImageElement) => {
     const loc = anchor.dataset.slideLoc;
@@ -1064,6 +1112,9 @@ export function InspectToggleButton() {
     >
       <Crosshair className="size-3.5" />
       <span className="hidden md:inline">{t.inspector.inspect}</span>
+      <kbd className="ml-1 hidden rounded-[3px] bg-foreground/10 px-1 font-mono text-[9.5px] tracking-[0.04em] md:inline">
+        I
+      </kbd>
     </Button>
   );
 }

--- a/packages/core/src/app/components/panel/save-card.tsx
+++ b/packages/core/src/app/components/panel/save-card.tsx
@@ -91,15 +91,15 @@ export function SaveCard({
           </div>
         )}
         {justSaved ? (
-          <span className="flex items-center gap-1.5 px-2.5 text-[12px] font-medium text-foreground">
-            <Check className="size-3.5 text-[oklch(0.55_0.13_165)]" strokeWidth={2.5} />
+          <span className="flex items-center gap-1.5 whitespace-nowrap px-2.5 text-[12px] font-medium text-foreground">
+            <Check className="size-3.5 shrink-0 text-[oklch(0.55_0.13_165)]" strokeWidth={2.5} />
             {resolvedSavedLabel}
           </span>
         ) : dirty || committing ? (
-          <span className="inline-flex items-center gap-1.5 px-2.5 text-[12px] font-medium text-foreground">
+          <span className="inline-flex items-center gap-1.5 whitespace-nowrap px-2.5 text-[12px] font-medium text-foreground">
             <span
               aria-hidden
-              className="size-1.5 rounded-full bg-brand shadow-[0_0_0_3px_var(--brand-soft)]"
+              className="size-1.5 shrink-0 rounded-full bg-brand shadow-[0_0_0_3px_var(--brand-soft)]"
             />
             <span className="nums">{unsavedLabel}</span>
           </span>

--- a/packages/core/src/app/components/style-panel/style-panel.tsx
+++ b/packages/core/src/app/components/style-panel/style-panel.tsx
@@ -211,6 +211,9 @@ export function DesignToggleButton({
     >
       <Palette className="size-3.5" />
       <span className="hidden md:inline">{t.stylePanel.designToggle}</span>
+      <kbd className="ml-1 hidden rounded-[3px] bg-foreground/10 px-1 font-mono text-[9.5px] tracking-[0.04em] md:inline">
+        D
+      </kbd>
     </Button>
   );
 }

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -237,6 +237,8 @@ export function Slide() {
         goTo(index - 1);
       } else if (e.key === 'f' || e.key === 'F') {
         setPlayMode('fullscreen');
+      } else if (import.meta.env.DEV && (e.key === 'd' || e.key === 'D')) {
+        setDesignOpen((v) => !v);
       }
     };
     window.addEventListener('keydown', onKey);
@@ -340,7 +342,7 @@ export function Slide() {
 
   return (
     <HistoryProvider>
-      <InspectorProvider slideId={slideId}>
+      <InspectorProvider slideId={slideId} pageIndex={index}>
         <SelectionReporter />
         <div className="flex h-dvh flex-col overflow-hidden bg-background text-foreground">
           {/* Editorial toolbar — three zones, hairline separators, mono-folio center */}


### PR DESCRIPTION
## Summary
- Add `I` / `D` shortcuts to toggle the inspector and design panel, matching the `F`-for-present convention; keycap hints added to both toggle buttons.
- Split the inspector overlay into selected + hover frames so the selection stays framed while a dashed frame follows the cursor; re-resolve the selected anchor across DOM mutations and clear it on page change.

  https://github.com/user-attachments/assets/abb04581-cf9d-4223-a0ca-75de395cc76a
- Add a crosshair icon to the inspector panel header and only render the separator below content when there's editable text (drops the stray hairline).
- Prevent the save bar's unsaved/saved label from wrapping onto two lines.

## Test plan
- [ ] `pnpm dev` in `apps/demo`, toggle inspector with `I` and design panel with `D`; confirm shortcuts don't fire while typing in an input/textarea.
- [ ] In inspect mode, select an element, then hover other elements — verify selected frame stays solid while a dashed frame follows hover, and the dashed frame disappears when hovering the selected element.
- [ ] Switch slides while a selection is active and confirm the selection clears.
- [ ] Make an edit that re-renders the selected node (e.g. typography change) and confirm the frame re-anchors instead of disappearing.
- [ ] Narrow the viewport / resize the save card and confirm the unsaved/saved label stays on a single line.
- [ ] Open the inspector panel for an element with no text content and confirm there's no stray separator under the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts (`I` for inspector, `D` for design panel).
  * Added visual hover frame display alongside selected element in inspector.

* **Improvements**
  * Added keyboard shortcut hints in inspector and design panel headers.
  * Enhanced inspector header with new icon and improved layout.
  * Refined save bar styling for better visual clarity and text handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->