### PR TITLE
fix(core): truncate long slide titles in the editor header

### DIFF
--- a/.changeset/header-title-truncate.md
+++ b/.changeset/header-title-truncate.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Truncate long slide titles in the editor header instead of letting them overlap the right-side controls.

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -344,8 +344,8 @@ export function Slide() {
         <SelectionReporter />
         <div className="flex h-dvh flex-col overflow-hidden bg-background text-foreground">
           {/* Editorial toolbar — three zones, hairline separators, mono-folio center */}
-          <header className="relative flex h-12 shrink-0 items-center justify-between border-b border-hairline bg-sidebar/85 px-2 backdrop-blur-md md:px-3">
-            <div className="flex items-center gap-1.5 md:gap-2">
+          <header className="flex h-12 shrink-0 items-center gap-2 border-b border-hairline bg-sidebar/85 px-2 backdrop-blur-md md:px-3">
+            <div className="flex shrink-0 items-center gap-1.5 md:gap-2">
               {showSlideBrowser && (
                 <Button asChild variant="ghost" size="icon-sm" title={t.slide.home}>
                   <Link to="/" aria-label={t.slide.backToHome}>
@@ -379,13 +379,13 @@ export function Slide() {
             </div>
 
             {/* Centered title — the rail and mobile pill carry the page count. */}
-            <div className="pointer-events-none absolute inset-x-0 top-1/2 flex -translate-y-1/2 justify-center px-2">
-              <div className="pointer-events-auto min-w-0 max-w-[min(34rem,calc(100vw-22rem))]">
+            <div className="flex min-w-0 flex-1 justify-center px-2">
+              <div className="min-w-0 max-w-[34rem]">
                 <InlineTitleEditor title={title} onSubmit={(next) => renameSlide(slideId, next)} />
               </div>
             </div>
 
-            <div className="flex items-center gap-1">
+            <div className="flex shrink-0 items-center gap-1">
               {view === 'slides' && (
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- Long deck titles overflowed the editor header and overlapped the right-side controls (Design / Inspect / Present).
- Swapped the absolute-positioned title overlay for a 3-zone flex layout: side zones are `shrink-0`, the title sits in a `flex-1 min-w-0` middle zone so `truncate` actually engages.
- Dropped the brittle `max-w-[min(34rem,calc(100vw-22rem))]` formula and the `pointer-events-none/auto` workaround that the absolute overlay needed.

## Before / after
At ~900px viewport with a long title, the title used to render in full on top of the Design / Inspect buttons. It now truncates with an ellipsis and leaves a clean gap to the right-side controls.

https://github.com/user-attachments/assets/12971fb0-85ce-4c34-be8c-2e68e2736a7c

## Test plan
- [x] `pnpm core typecheck`
- [x] `pnpm check`
- [x] Verified at 600 / 900 / 1100 / 1280 / 1900px with a long title — truncation triggers when needed, no overlap at any width.
- [x] Verified rename (pencil → input) still works without overlap.

## Trade-off
The title is now centered between the side zones rather than the viewport. When the right zone is wider than the left (typical), the title shifts a few dozen pixels left of the strict viewport center. This is the necessary trade-off for guaranteeing no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)