### PR TITLE
fix: invalid YAML in create-theme skill frontmatter

### DIFF
--- a/.changeset/fix-create-theme-skill-yaml.md
+++ b/.changeset/fix-create-theme-skill-yaml.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Fix invalid YAML in the create-theme skill frontmatter so it loads correctly.

--- a/packages/core/skills/create-theme/SKILL.md
+++ b/packages/core/skills/create-theme/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-theme
-description: Use this skill when the user wants to create, draft, author, or extract a slide theme in this open-slide repo. Triggers on phrases like "create a theme", "make a theme called X", "extract a theme from <slide>", "build a theme from these images". Produces two paired files under `themes/`: `<id>.md` (palette, typography, layout, fixed Title/Footer components, motion) and `<id>.demo.tsx` (a runnable demo slide that the dev-UI Themes panel previews). Do NOT use for editing real slides — only for authoring the theme bundle.
+description: Use this skill when the user wants to create, draft, author, or extract a slide theme in this open-slide repo. Triggers on phrases like "create a theme", "make a theme called X", "extract a theme from <slide>", "build a theme from these images". Produces two paired files under `themes/` — `<id>.md` (palette, typography, layout, fixed Title/Footer components, motion) and `<id>.demo.tsx` (a runnable demo slide that the dev-UI Themes panel previews). Do NOT use for editing real slides — only for authoring the theme bundle.
 ---
 
 # Create a slide theme


### PR DESCRIPTION
Fixes a YAML syntax error in the `create-theme` skill's frontmatter that prevented it from loading correctly.

## Changes

- **SKILL.md**: Corrected the `description` field by replacing an invalid colon (`:`) with an em dash (`—`) to maintain valid YAML syntax while preserving the intended meaning.

The description field was using a colon in the middle of the text, which YAML interprets as a key-value separator. This caused parsing to fail. The em dash maintains the semantic pause in the description while keeping the YAML valid.

https://claude.ai/code/session_018nksMgF8sMCvAdvJw4obSu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed invalid YAML formatting in the "create-theme" skill configuration to ensure proper functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->