### PR TITLE
Update badge styles to use for-the-badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # open-slide
 
-[![GitHub stars](https://img.shields.io/github/stars/1weiho/open-slide?style=social)](https://github.com/1weiho/open-slide/stargazers)
-[![GitHub forks](https://img.shields.io/github/forks/1weiho/open-slide?style=social)](https://github.com/1weiho/open-slide/network/members)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![GitHub stars](https://img.shields.io/github/stars/1weiho/open-slide?style=for-the-badge)](https://github.com/1weiho/open-slide/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/1weiho/open-slide?style=for-the-badge)](https://github.com/1weiho/open-slide/network/members)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 
 **The slide framework built for agents.** Describe your deck in natural language — your coding agent writes the React. open-slide handles the canvas, scaling, navigation, hot reload, and present mode so the agent can focus on content.
 


### PR DESCRIPTION
Update the GitHub stars, forks, and license badges in the README to use the `for-the-badge` style parameter instead of `social` for a more prominent, consistent visual appearance.

**Changes:**
- Changed GitHub stars badge style from `social` to `for-the-badge`
- Changed GitHub forks badge style from `social` to `for-the-badge`
- Added `for-the-badge` style parameter to the MIT license badge for consistency

This improves the visual hierarchy and consistency of the badges in the project README.

https://claude.ai/code/session_01TiHKVBikJ5oNPEa6uPotJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the visual styling of GitHub badges (stars, forks, and license) in the README for enhanced presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->