### PR TITLE
refactor(web): pare back landing page to feel less templated

### DIFF
--- a/apps/web/components/landing/agents.tsx
+++ b/apps/web/components/landing/agents.tsx
@@ -22,12 +22,9 @@ export function Agents() {
   return (
     <section id="agents" className="relative overflow-hidden">
       <div className="border-y border-[color:var(--color-rule)] bg-[color:var(--color-panel)]">
-        <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-8 sm:py-10 flex flex-col md:flex-row md:items-center md:justify-between gap-4 sm:gap-6">
-          <span className="font-[family-name:var(--font-display)] italic text-[20px] sm:text-[22px] text-[color:var(--color-text)]">
-            Bring your own agent.
-          </span>
-          <span className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.22em] uppercase text-[color:var(--color-muted)]">
-            any tool that edits react → authors slides
+        <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-10 sm:py-12">
+          <span className="font-[family-name:var(--font-sans)] text-[18px] sm:text-[20px] text-[color:var(--color-text-soft)]">
+            Bring your own agent. Anything that edits React works.
           </span>
         </div>
 

--- a/apps/web/components/landing/anatomy.tsx
+++ b/apps/web/components/landing/anatomy.tsx
@@ -67,8 +67,8 @@ export function Anatomy() {
 
   return (
     <section id="anatomy" className="relative">
-      <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-16 sm:py-24 lg:py-32">
-        <h2 className="text-[32px] sm:text-[44px] lg:text-[72px] leading-[1.05] sm:leading-[1.02] tracking-[-0.03em] max-w-[960px] mb-8 sm:mb-12">
+      <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
+        <h2 className="text-[32px] sm:text-[44px] lg:text-[64px] leading-[1.1] sm:leading-[1.05] tracking-[-0.03em] max-w-[820px] mb-14 sm:mb-20">
           <span className="font-[family-name:var(--font-sans)] font-medium">
             A slide is a file.
           </span>

--- a/apps/web/components/landing/assets.tsx
+++ b/apps/web/components/landing/assets.tsx
@@ -51,27 +51,14 @@ export function Assets() {
   return (
     <section id="assets" className="relative">
       <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-[color:var(--color-rule)]" />
-      <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-16 sm:py-24 lg:py-32">
-        <div className="flex items-end justify-between flex-wrap gap-y-4 mb-10 sm:mb-16">
-          <h2 className="text-[32px] sm:text-[44px] lg:text-[72px] leading-[1.05] sm:leading-[1.02] tracking-[-0.03em] max-w-[920px]">
-            <span className="font-[family-name:var(--font-sans)] font-medium">Drop in images.</span>
-            <br />
-            <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-warm)]">
-              Pull in logos.
-            </span>
-          </h2>
-          <div className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.22em] uppercase text-[color:var(--color-muted)]">
-            assets · powered by{' '}
-            <a
-              href="https://svgl.app/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[color:var(--color-text-soft)] hover:text-[color:var(--color-accent)] transition-colors"
-            >
-              svgl ↗
-            </a>
-          </div>
-        </div>
+      <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
+        <h2 className="text-[32px] sm:text-[44px] lg:text-[64px] leading-[1.1] sm:leading-[1.05] tracking-[-0.03em] max-w-[820px] mb-14 sm:mb-20">
+          <span className="font-[family-name:var(--font-sans)] font-medium">Drop in images.</span>
+          <br />
+          <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-warm)]">
+            Pull in logos.
+          </span>
+        </h2>
 
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-12 items-start">
           {/* asset manager mock */}

--- a/apps/web/components/landing/footer.tsx
+++ b/apps/web/components/landing/footer.tsx
@@ -17,9 +17,7 @@ export function Footer() {
           title="Product"
           links={[
             ['Live demo', '#demo'],
-            ['How it works', '#how-it-works'],
-            ['Anatomy', '#anatomy'],
-            ['Principles', '#principles'],
+            ['Docs', '/docs'],
           ]}
         />
         <FooterCol

--- a/apps/web/components/landing/get-started.tsx
+++ b/apps/web/components/landing/get-started.tsx
@@ -4,27 +4,22 @@ export function GetStarted() {
   return (
     <section id="install" className="relative overflow-hidden">
       <div aria-hidden className="hair absolute inset-x-0 top-0" />
-      <div className="relative mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-28 lg:py-40">
-        <div>
-          <div className="flex flex-col gap-7 sm:gap-10">
-            <h2 className="text-[32px] sm:text-[44px] lg:text-[72px] leading-[1.05] sm:leading-[1.02] tracking-[-0.03em]">
-              <span className="font-[family-name:var(--font-sans)] font-medium">Author a deck</span>
-              <br />
-              <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-accent)]">
-                in the next minute.
-              </span>
-            </h2>
+      <div className="relative mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-24 sm:py-36 lg:py-48">
+        <div className="flex flex-col gap-10 sm:gap-14 max-w-[820px]">
+          <h2 className="text-[36px] sm:text-[52px] lg:text-[80px] leading-[1.05] sm:leading-[1.0] tracking-[-0.035em]">
+            <span className="font-[family-name:var(--font-sans)] font-medium">Author a deck</span>
+            <br />
+            <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-accent)]">
+              in the next minute.
+            </span>
+          </h2>
 
-            <p className="max-w-[640px] text-[18px] leading-[1.55] text-[color:var(--color-text-soft)]">
-              One command, zero config.{' '}
-              <span className="text-[color:var(--color-muted)]">
-                Your agent takes it from here.
-              </span>
-            </p>
+          <p className="max-w-[560px] text-[18px] leading-[1.65] text-[color:var(--color-text-soft)]">
+            One command, zero config. Your agent takes it from here.
+          </p>
 
-            <div className="flex flex-wrap items-center gap-4">
-              <CopyCommand command="npx @open-slide/cli init" />
-            </div>
+          <div className="flex flex-wrap items-center gap-4">
+            <CopyCommand command="npx @open-slide/cli init" />
           </div>
         </div>
       </div>

--- a/apps/web/components/landing/hero.tsx
+++ b/apps/web/components/landing/hero.tsx
@@ -8,112 +8,50 @@ export function Hero() {
     <section className="relative overflow-hidden">
       <div aria-hidden className="hair absolute inset-x-0 top-0" />
 
-      <div className="relative mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 pt-14 sm:pt-20 lg:pt-32 pb-16 sm:pb-24">
-        <div>
-          <div className="flex flex-col gap-7 sm:gap-10">
-            <div className="caption rise" style={{ animationDelay: '40ms' }}>
-              a slide framework for the agent era
-            </div>
+      <div className="relative mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 pt-20 sm:pt-32 lg:pt-44 pb-20 sm:pb-32">
+        <div className="flex flex-col gap-10 sm:gap-14 max-w-[920px]">
+          <h1
+            className="text-[44px] sm:text-[72px] lg:text-[100px] leading-[1.05] sm:leading-[0.98] tracking-[-0.035em] rise"
+            style={{ animationDelay: '80ms' }}
+          >
+            <span className="font-[family-name:var(--font-sans)] font-medium text-[color:var(--color-text)]">
+              The slide framework
+            </span>
+            <br />
+            <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-paper)]">
+              built for <span className="text-[color:var(--color-accent)]">agents</span>.
+            </span>
+          </h1>
 
-            <h1
-              className="text-[40px] sm:text-[68px] lg:text-[96px] leading-[1.08] sm:leading-[1.0] lg:leading-[0.98] tracking-[-0.03em] rise"
-              style={{ animationDelay: '120ms' }}
-            >
-              <span className="font-[family-name:var(--font-sans)] font-medium text-[color:var(--color-text)]">
-                The slide framework
-              </span>
-              <br />
-              <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-paper)]">
-                built for <span className="text-[color:var(--color-accent)]">agents</span>.
-              </span>
-            </h1>
+          <p
+            className="max-w-[600px] text-[18px] sm:text-[20px] leading-[1.6] text-[color:var(--color-text-soft)] rise"
+            style={{ animationDelay: '200ms' }}
+          >
+            A React-first slide framework. Every page is arbitrary code on a 1920×1080 canvas —
+            versioned, reviewable, yours.
+          </p>
 
-            <p
-              className="max-w-[720px] text-[18px] sm:text-[20px] leading-[1.55] text-[color:var(--color-text-soft)] rise"
-              style={{ animationDelay: '240ms' }}
+          <div
+            className="flex flex-wrap items-center gap-x-6 gap-y-4 rise"
+            style={{ animationDelay: '320ms' }}
+          >
+            <CopyCommand command="npx @open-slide/cli init" />
+            <a
+              href="/docs"
+              onClick={() => posthog.capture('docs_link_clicked', { location: 'hero' })}
+              className="group inline-flex items-center gap-2 text-[14px] font-[family-name:var(--font-mono)] text-[color:var(--color-text-soft)] hover:text-[color:var(--color-text)] transition-colors"
             >
-              A React-first slide framework authored by AI agents. Every page is arbitrary code on a{' '}
-              <span className="font-[family-name:var(--font-mono)] text-[color:var(--color-text)]">
-                1920×1080
-              </span>{' '}
-              canvas—{' '}
-              <span className="text-[color:var(--color-muted)]">versioned, reviewable, yours.</span>
-            </p>
-
-            <div
-              className="flex flex-wrap items-center gap-3 sm:gap-4 rise"
-              style={{ animationDelay: '360ms' }}
-            >
-              <CopyCommand command="npx @open-slide/cli init" />
-              <a
-                href="/docs"
-                onClick={() => posthog.capture('docs_link_clicked', { location: 'hero' })}
-                className="group inline-flex items-center gap-2 h-[48px] sm:h-[52px] px-4 sm:px-5 rounded-[6px] border border-[color:var(--color-rule)] text-[14px] font-[family-name:var(--font-mono)] text-[color:var(--color-text)] hover:border-[color:var(--color-text)] transition"
+              <span>Read the docs</span>
+              <span
+                aria-hidden
+                className="text-[color:var(--color-muted)] group-hover:translate-x-0.5 transition-transform"
               >
-                <DocsGlyph />
-                <span>Read the docs</span>
-                <span
-                  aria-hidden
-                  className="text-[color:var(--color-muted)] group-hover:translate-x-0.5 transition-transform"
-                >
-                  →
-                </span>
-              </a>
-              <a
-                href="https://github.com/1weiho/open-slide"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => posthog.capture('github_link_clicked', { location: 'hero' })}
-                className="group inline-flex items-center gap-2 h-[48px] sm:h-[52px] px-4 sm:px-5 rounded-[6px] border border-[color:var(--color-rule)] text-[14px] font-[family-name:var(--font-mono)] text-[color:var(--color-text)] hover:border-[color:var(--color-text)] transition"
-              >
-                <GithubGlyph />
-                <span>1weiho/open-slide</span>
-                <span
-                  aria-hidden
-                  className="text-[color:var(--color-muted)] group-hover:translate-x-0.5 transition-transform"
-                >
-                  ↗
-                </span>
-              </a>
-            </div>
+                →
+              </span>
+            </a>
           </div>
         </div>
       </div>
     </section>
-  );
-}
-
-function DocsGlyph() {
-  return (
-    <svg
-      aria-hidden
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="text-[color:var(--color-text-soft)]"
-    >
-      <path d="M4 4.5A2.5 2.5 0 0 1 6.5 2H20v17H6.5a2.5 2.5 0 0 0 0 5H20" />
-      <path d="M4 4.5v15A2.5 2.5 0 0 0 6.5 22" />
-    </svg>
-  );
-}
-
-function GithubGlyph() {
-  return (
-    <svg
-      aria-hidden
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      className="text-[color:var(--color-text-soft)]"
-    >
-      <path d="M12 .5C5.73.5.67 5.56.67 11.83c0 5 3.24 9.24 7.75 10.74.57.1.78-.25.78-.55v-2.05c-3.15.68-3.82-1.35-3.82-1.35-.52-1.3-1.27-1.64-1.27-1.64-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.67 1.24 3.32.95.1-.74.4-1.25.73-1.54-2.52-.29-5.17-1.26-5.17-5.6 0-1.23.44-2.24 1.17-3.03-.12-.28-.51-1.43.1-2.98 0 0 .95-.3 3.1 1.15a10.72 10.72 0 0 1 5.65 0c2.15-1.45 3.1-1.15 3.1-1.15.62 1.55.23 2.7.11 2.98.73.79 1.17 1.8 1.17 3.03 0 4.35-2.65 5.3-5.18 5.58.42.36.77 1.06.77 2.14v3.17c0 .3.2.66.79.55 4.5-1.5 7.74-5.74 7.74-10.74C23.33 5.56 18.27.5 12 .5Z" />
-    </svg>
   );
 }

--- a/apps/web/components/landing/hero.tsx
+++ b/apps/web/components/landing/hero.tsx
@@ -27,8 +27,8 @@ export function Hero() {
             className="max-w-[600px] text-[18px] sm:text-[20px] leading-[1.6] text-[color:var(--color-text-soft)] rise"
             style={{ animationDelay: '200ms' }}
           >
-            A React-first slide framework. Every page is arbitrary code on a 1920×1080 canvas —
-            versioned, reviewable, yours.
+            A React-first slide framework. Every page is arbitrary code on a 1920×1080 canvas. No
+            layout to fight. Design anything you can imagine.
           </p>
 
           <div

--- a/apps/web/components/landing/how-it-works.tsx
+++ b/apps/web/components/landing/how-it-works.tsx
@@ -93,38 +93,30 @@ export function HowItWorks() {
   return (
     <section id="how-it-works" className="relative">
       <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-[color:var(--color-rule)]" />
-      <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-16 sm:py-24 lg:py-32">
-        <div className="flex items-end justify-between flex-wrap gap-y-4 mb-10 sm:mb-16">
-          <h2 className="text-[32px] sm:text-[44px] lg:text-[72px] leading-[1.05] sm:leading-[1.02] tracking-[-0.03em] max-w-[860px]">
-            <span className="font-[family-name:var(--font-sans)] font-medium">Slides as code.</span>
-            <br />
-            <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-accent)]">
-              Crafted by agents.
-            </span>
-          </h2>
-          <div className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.22em] uppercase text-[color:var(--color-muted)]">
-            init → author → iterate ↻
-          </div>
-        </div>
+      <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
+        <h2 className="text-[32px] sm:text-[44px] lg:text-[64px] leading-[1.1] sm:leading-[1.05] tracking-[-0.03em] max-w-[820px] mb-14 sm:mb-20">
+          <span className="font-[family-name:var(--font-sans)] font-medium">Slides as code.</span>
+          <br />
+          <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-accent)]">
+            Crafted by agents.
+          </span>
+        </h2>
 
         <ol className="grid grid-cols-1 md:grid-cols-3 gap-px bg-[color:var(--color-rule)] border border-[color:var(--color-rule)] rounded-[6px] overflow-hidden">
           {steps.map((s) => (
             <li
               key={s.num}
-              className="group relative p-6 sm:p-8 lg:p-10 bg-[color:var(--color-ink)] flex flex-col gap-7 sm:min-h-[420px] transition-colors hover:bg-[color:var(--color-panel)]"
+              className="group relative p-8 sm:p-10 lg:p-12 bg-[color:var(--color-ink)] flex flex-col gap-10 sm:min-h-[440px] transition-colors hover:bg-[color:var(--color-panel)]"
             >
-              <div className="flex items-baseline justify-between">
-                <span className="font-[family-name:var(--font-display)] italic text-[64px] sm:text-[88px] leading-none text-[color:var(--color-accent)]/80">
-                  {s.num}
-                </span>
-                <span className="caption">{s.kicker}</span>
-              </div>
+              <span className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.18em] uppercase text-[color:var(--color-muted)]">
+                {s.num} · {s.kicker}
+              </span>
 
               <div>
-                <h3 className="text-[24px] sm:text-[30px] lg:text-[34px] font-medium tracking-[-0.03em] leading-[1.1]">
+                <h3 className="text-[22px] sm:text-[26px] lg:text-[30px] font-medium tracking-[-0.025em] leading-[1.15]">
                   {s.title}
                 </h3>
-                <p className="mt-3 text-[15px] leading-[1.55] text-[color:var(--color-text-soft)] max-w-[36ch]">
+                <p className="mt-4 text-[15px] leading-[1.65] text-[color:var(--color-text-soft)] max-w-[36ch]">
                   {s.body}
                 </p>
               </div>

--- a/apps/web/components/landing/how-it-works.tsx
+++ b/apps/web/components/landing/how-it-works.tsx
@@ -16,8 +16,8 @@ const steps: Step[] = [
   {
     num: '01',
     kicker: 'scaffold',
-    title: 'Init a deck',
-    body: 'One command spins up slides/, open-slide.config.ts, and a hot-reloading dev server. No templates, no themes, no assumptions.',
+    title: 'Spin up a workspace',
+    body: 'Creates the slide workspace. Every future deck you author lives inside it.',
     code: {
       prompt: '$',
       line: 'npx @open-slide/cli init my-deck',
@@ -28,7 +28,7 @@ const steps: Step[] = [
     num: '02',
     kicker: 'author',
     title: 'Ask your agent',
-    body: 'Your agent drafts pages as arbitrary React components. You guide with prompts; it writes files on disk.',
+    body: 'Your agent drafts pages as arbitrary React components. You guide with prompts.',
     code: {
       prompt: '›',
       line: '/create-slide for Q2 roadmap',
@@ -39,7 +39,7 @@ const steps: Step[] = [
     num: '03',
     kicker: 'iterate',
     title: 'Edit, comment, apply',
-    body: 'Toggle inspect: click an element to tweak it visually, drop images into the assets pane, or leave a @slide-comment. Save batches your edits; /apply-comments lets the agent rewrite the rest.',
+    body: 'Click any element to tweak it visually. Or leave a comment for the agent to apply.',
     code: {
       prompt: '›',
       line: '/apply-comment',
@@ -106,7 +106,7 @@ export function HowItWorks() {
           {steps.map((s) => (
             <li
               key={s.num}
-              className="group relative p-8 sm:p-10 lg:p-12 bg-[color:var(--color-ink)] flex flex-col gap-10 sm:min-h-[440px] transition-colors hover:bg-[color:var(--color-panel)]"
+              className="group relative p-8 sm:p-10 lg:p-12 bg-[color:var(--color-ink)] flex flex-col gap-7 transition-colors hover:bg-[color:var(--color-panel)]"
             >
               <span className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.18em] uppercase text-[color:var(--color-muted)]">
                 {s.num} · {s.kicker}
@@ -121,7 +121,7 @@ export function HowItWorks() {
                 </p>
               </div>
 
-              <div className="mt-auto rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)] p-4 font-[family-name:var(--font-mono)] text-[13px]">
+              <div className="rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)] p-4 font-[family-name:var(--font-mono)] text-[13px]">
                 <div className="flex items-center gap-2">
                   <span className="text-[color:var(--color-accent)]">{s.code.prompt}</span>
                   <span className="text-[color:var(--color-text)] truncate">

--- a/apps/web/components/landing/inspector.tsx
+++ b/apps/web/components/landing/inspector.tsx
@@ -14,21 +14,16 @@ export function Inspector() {
   return (
     <section id="inspector" className="relative">
       <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-[color:var(--color-rule)]" />
-      <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-16 sm:py-24 lg:py-32">
-        <div className="flex items-end justify-between flex-wrap gap-y-4 mb-10 sm:mb-16">
-          <h2 className="text-[32px] sm:text-[44px] lg:text-[72px] leading-[1.05] sm:leading-[1.02] tracking-[-0.03em] max-w-[920px]">
-            <span className="font-[family-name:var(--font-sans)] font-medium">
-              Talk to the agent.
-            </span>
-            <br />
-            <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-accent)]">
-              Or just tap the canvas.
-            </span>
-          </h2>
-          <div className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.22em] uppercase text-[color:var(--color-muted)]">
-            inspector · two surfaces
-          </div>
-        </div>
+      <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
+        <h2 className="text-[32px] sm:text-[44px] lg:text-[64px] leading-[1.1] sm:leading-[1.05] tracking-[-0.03em] max-w-[860px] mb-14 sm:mb-20">
+          <span className="font-[family-name:var(--font-sans)] font-medium">
+            Talk to the agent.
+          </span>
+          <br />
+          <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-accent)]">
+            Or just tap the canvas.
+          </span>
+        </h2>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-px bg-[color:var(--color-rule)] border border-[color:var(--color-rule)] rounded-[6px] overflow-hidden">
           <FeatureCell
@@ -77,19 +72,16 @@ function FeatureCell({
   visual: ReactNode;
 }) {
   return (
-    <div className="group relative bg-[color:var(--color-ink)] flex flex-col gap-7 p-6 sm:p-8 lg:p-10 transition-colors hover:bg-[color:var(--color-panel)]">
-      <div className="flex items-baseline justify-between">
-        <span className="font-[family-name:var(--font-display)] italic text-[64px] sm:text-[88px] leading-none text-[color:var(--color-accent)]/80">
-          {num}
-        </span>
-        <span className="caption">{kicker}</span>
-      </div>
+    <div className="group relative bg-[color:var(--color-ink)] flex flex-col gap-10 p-8 sm:p-10 lg:p-12 transition-colors hover:bg-[color:var(--color-panel)]">
+      <span className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.18em] uppercase text-[color:var(--color-muted)]">
+        {num} · {kicker}
+      </span>
 
       <div>
         <h3 className="text-[22px] sm:text-[26px] lg:text-[30px] font-medium tracking-[-0.025em] leading-[1.15] max-w-[28ch]">
           {title}
         </h3>
-        <p className="mt-3 text-[15px] leading-[1.6] text-[color:var(--color-text-soft)] max-w-[44ch]">
+        <p className="mt-4 text-[15px] leading-[1.65] text-[color:var(--color-text-soft)] max-w-[44ch]">
           {body}
         </p>
       </div>

--- a/apps/web/components/landing/live-demo.tsx
+++ b/apps/web/components/landing/live-demo.tsx
@@ -31,87 +31,50 @@ export function LiveDemo() {
 
   return (
     <section id="demo" className="relative">
-      <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 pt-8 sm:pt-12 lg:pt-20 pb-16 sm:pb-24">
-        {/* specimen frame */}
-        <div className="relative specimen p-4 sm:p-6 lg:p-8 rounded-[6px] border border-[color:var(--color-rule)] bg-gradient-to-b from-[color:var(--color-panel)] to-[color:var(--color-ink)]">
-          <SpecimenCorners />
-
-          <div className="flex items-center justify-between mb-4 font-[family-name:var(--font-mono)] text-[10px] sm:text-[11px] tracking-[0.14em] uppercase text-[color:var(--color-muted)]">
-            <span className="flex items-center gap-2">
-              <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--color-accent)]" />
-              open-slide · live demo
-            </span>
-            <span>1920 × 1080 · 16 : 9</span>
-          </div>
-
-          <div
-            className="relative block w-full overflow-hidden rounded-[6px] border border-[color:var(--color-rule)] bg-black"
-            style={{ aspectRatio: '16 / 9' }}
-          >
-            <InlineSlidePlayer index={index} onIndexChange={setIndex} />
-          </div>
-
-          <div className="flex items-center justify-end mt-4 font-[family-name:var(--font-mono)] text-[11px] tracking-[0.12em] uppercase text-[color:var(--color-muted)]">
-            <span className="flex items-center gap-3">
-              <button
-                type="button"
-                onClick={handlePrev}
-                disabled={atStart}
-                aria-label="Previous slide"
-                className="px-1.5 py-0.5 rounded border border-[color:var(--color-rule)] text-[color:var(--color-text-soft)] hover:border-[color:var(--color-text)] hover:text-[color:var(--color-text)] transition disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:border-[color:var(--color-rule)] disabled:hover:text-[color:var(--color-text-soft)]"
-              >
-                ←
-              </button>
-              <button
-                type="button"
-                onClick={handleNext}
-                disabled={atEnd}
-                aria-label="Next slide"
-                className="px-1.5 py-0.5 rounded border border-[color:var(--color-rule)] text-[color:var(--color-text-soft)] hover:border-[color:var(--color-text)] hover:text-[color:var(--color-text)] transition disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:border-[color:var(--color-rule)] disabled:hover:text-[color:var(--color-text-soft)]"
-              >
-                →
-              </button>
-            </span>
-          </div>
+      <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 pt-4 sm:pt-8 lg:pt-12 pb-20 sm:pb-32">
+        <div
+          className="relative block w-full overflow-hidden rounded-[8px] border border-[color:var(--color-rule)] bg-black"
+          style={{ aspectRatio: '16 / 9' }}
+        >
+          <InlineSlidePlayer index={index} onIndexChange={setIndex} />
         </div>
 
-        <div className="mt-8 flex justify-center">
+        <div className="mt-6 flex items-center justify-between font-[family-name:var(--font-mono)] text-[11px] tracking-[0.12em] uppercase text-[color:var(--color-muted)]">
           <a
             href="https://demo.open-slide.dev/"
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => posthog.capture('view_more_demos_clicked')}
-            className="inline-flex items-center gap-2 font-[family-name:var(--font-mono)] text-[11px] sm:text-[12px] tracking-[0.12em] uppercase text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)] transition-colors"
+            className="inline-flex items-center gap-2 hover:text-[color:var(--color-text)] transition-colors"
           >
             View more demos
             <span aria-hidden>↗</span>
           </a>
+          <span className="flex items-center gap-3">
+            <span className="text-[color:var(--color-text-soft)]">
+              {String(index + 1).padStart(2, '0')} / {String(count).padStart(2, '0')}
+            </span>
+            <button
+              type="button"
+              onClick={handlePrev}
+              disabled={atStart}
+              aria-label="Previous slide"
+              className="px-1.5 py-0.5 text-[color:var(--color-text-soft)] hover:text-[color:var(--color-text)] transition disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:text-[color:var(--color-text-soft)]"
+            >
+              ←
+            </button>
+            <button
+              type="button"
+              onClick={handleNext}
+              disabled={atEnd}
+              aria-label="Next slide"
+              className="px-1.5 py-0.5 text-[color:var(--color-text-soft)] hover:text-[color:var(--color-text)] transition disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:text-[color:var(--color-text-soft)]"
+            >
+              →
+            </button>
+          </span>
         </div>
       </div>
     </section>
-  );
-}
-
-function SpecimenCorners() {
-  const corner = 'absolute h-5 w-5 border-[color:var(--color-accent)] pointer-events-none';
-  return (
-    <>
-      <span
-        aria-hidden
-        className={`${corner} -top-px -left-px border-t border-l rounded-tl-[12px]`}
-      />
-      <span
-        aria-hidden
-        className={`${corner} -top-px -right-px border-t border-r rounded-tr-[12px]`}
-      />
-      <span
-        aria-hidden
-        className={`${corner} -bottom-px -left-px border-b border-l rounded-bl-[12px]`}
-      />
-      <span
-        aria-hidden
-        className={`${corner} -bottom-px -right-px border-b border-r rounded-br-[12px]`}
-      />
-    </>
   );
 }

--- a/apps/web/components/landing/nav.tsx
+++ b/apps/web/components/landing/nav.tsx
@@ -17,24 +17,6 @@ export function Nav({ githubStars }: { githubStars?: string | null }) {
         </Link>
 
         <nav className="flex items-center gap-8 font-[family-name:var(--font-mono)] text-[12px] tracking-[0.08em] uppercase">
-          <a
-            href="#how-it-works"
-            className="hidden md:inline text-[color:var(--color-muted)] hover:text-[color:var(--color-text)] transition-colors"
-          >
-            How
-          </a>
-          <a
-            href="#anatomy"
-            className="hidden md:inline text-[color:var(--color-muted)] hover:text-[color:var(--color-text)] transition-colors"
-          >
-            Anatomy
-          </a>
-          <a
-            href="#agents"
-            className="hidden md:inline text-[color:var(--color-muted)] hover:text-[color:var(--color-text)] transition-colors"
-          >
-            Agents
-          </a>
           <Link
             href="/docs"
             className="hidden md:inline text-[color:var(--color-muted)] hover:text-[color:var(--color-text)] transition-colors"


### PR DESCRIPTION
## What

A small redesign of the marketing site homepage (`apps/web`). Strips the ornamental chrome that made the page read as templated/AI-generated and gives every section more vertical breathing room.

## Why

The homepage had accumulated a few recurring "tells":

- A two-line italic-serif accent heading repeating in **6** sections in a row
- All-caps mono "eyebrow" tags decorating every section header
- 64–88px italic display-serif `01/02/03` numerals on cards
- The live demo wrapped in corner-bracket chrome + dot-grid backdrop + a `1920 × 1080 · 16 : 9` meta strip
- Tight internal spacing across cards and the hero CTA row

Net effect: things looked busy, every section shouted, and the typography lost the moments where it was supposed to land.

## Changes

**Subtraction over redesign** — no structural changes, no new components.

- **Hero** ([hero.tsx](apps/web/components/landing/hero.tsx)) — drop the all-caps eyebrow, flatten the subhead to one voice, drop the third "1weiho/open-slide" CTA (the nav already shows GitHub with a star count); the docs link is now a quiet inline `Read the docs →`. Bigger top/bottom padding and stack gap.
- **LiveDemo** ([live-demo.tsx](apps/web/components/landing/live-demo.tsx)) — remove the four corner brackets, the dot-grid `.specimen` backdrop, and the `● open-slide · live demo / 1920 × 1080 · 16 : 9` meta strip. Pagination is a clean baseline row with index + arrows.
- **HowItWorks / Inspector** ([how-it-works.tsx](apps/web/components/landing/how-it-works.tsx), [inspector.tsx](apps/web/components/landing/inspector.tsx)) — replace the 88px italic `01/02/03` numerals with a small mono `01 · scaffold` eyebrow. Bumped card padding to `p-8 sm:p-10 lg:p-12` and content gap to `gap-10`.
- **Section header rows** — removed the decorative right-aligned mono tags: `init → author → iterate ↻`, `inspector · two surfaces`, `assets · powered by svgl ↗`.
- **Agents** ([agents.tsx](apps/web/components/landing/agents.tsx)) — drop the all-caps mono right-side tag; soften the intro line to plain sans.
- **GetStarted** ([get-started.tsx](apps/web/components/landing/get-started.tsx)) — loosened padding (`py-24 sm:py-36 lg:py-48`) and stack gap. Trimmed the body copy to a single line.
- **Vertical rhythm** across all sections: `py-20 sm:py-32 lg:py-40`, heading-to-content margins `mb-14 sm:mb-20`.

## Note for reviewers

The two-line sans + italic-display-serif accent heading pattern is **preserved** on every section per follow-up feedback — only spacing and ornamental decoration changed there. The aggressive heading simplification I tried first was reverted.

## Checks

- `pnpm check` — clean (2 pre-existing unsafe-fix warnings in unrelated server code)
- `pnpm typecheck` — passes
- `pnpm build` — passes

No changeset: changes are limited to `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined landing layout and typography across hero, agents, anatomy, assets, get-started, how-it-works, inspector, and demo sections
  * Simplified and centered headers, streamlined section copy, and more compact step/feature card presentation
  * Streamlined call-to-action area and reduced extra links for focus
  * Simplified demo frame with updated navigation controls, slide counter, and arrows

* **New Features**
  * Footer now includes a "Docs" link; navigation replaces in-page anchors with Docs, Demo, and GitHub external links

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->