### PR TITLE
feat(core): drag folders in the sidebar to reorder them

### DIFF
--- a/.changeset/sidebar-folder-reorder.md
+++ b/.changeset/sidebar-folder-reorder.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Drag folders in the sidebar to reorder them.

--- a/packages/core/src/app/components/sidebar/sidebar.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar.tsx
@@ -5,12 +5,15 @@ import { ThemeToggle } from '@/components/theme-toggle';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import type { Folder, FolderIcon } from '@/lib/sdk';
 import { format, useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
 import { FolderIconChip, FolderItem } from './folder-item';
 import { IconPicker, PRESET_COLORS } from './icon-picker';
 
 export const DRAFT_ID = 'draft';
 export const THEMES_ID = '__themes__';
 export const ASSETS_ID = '__assets__';
+
+export const FOLDER_DND_MIME = 'application/x-folder-id';
 
 export function Sidebar({
   folders,
@@ -25,6 +28,7 @@ export function Sidebar({
   onDelete,
   onDropToFolder,
   onDropToDraft,
+  onReorder,
 }: {
   folders: Folder[];
   countFor: (folderId: string | null) => number;
@@ -38,7 +42,23 @@ export function Sidebar({
   onDelete: (id: string) => void;
   onDropToFolder: (folderId: string, slideId: string) => void;
   onDropToDraft: (slideId: string) => void;
+  onReorder: (ids: string[]) => void;
 }) {
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<{ id: string; before: boolean } | null>(null);
+
+  const finishReorder = (toId: string, before: boolean) => {
+    const fromId = dragId;
+    setDragId(null);
+    setDropTarget(null);
+    if (!fromId || fromId === toId) return;
+    const ids = folders.map((f) => f.id);
+    if (!ids.includes(fromId) || !ids.includes(toId)) return;
+    const next = ids.filter((id) => id !== fromId);
+    next.splice(next.indexOf(toId) + (before ? 0 : 1), 0, fromId);
+    if (next.every((id, i) => id === ids[i])) return;
+    onReorder(next);
+  };
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState('');
   const [newIcon, setNewIcon] = useState<FolderIcon>(() => ({
@@ -139,22 +159,73 @@ export function Sidebar({
       </div>
 
       <div className="flex-1 overflow-y-auto px-2 pb-2">
-        {folders.map((folder) => (
-          <FolderItem
-            key={folder.id}
-            row={{
-              kind: 'folder',
-              folder,
-              onRename: (name) => onRename(folder.id, name),
-              onChangeIcon: (icon) => onChangeIcon(folder.id, icon),
-              onDelete: () => onDelete(folder.id),
-            }}
-            count={countFor(folder.id)}
-            selected={selectedId === folder.id}
-            onSelect={() => onSelect(folder.id)}
-            onDropSlide={(slideId) => onDropToFolder(folder.id, slideId)}
-          />
-        ))}
+        {folders.map((folder) => {
+          const isDropTarget = dropTarget?.id === folder.id;
+          const before = isDropTarget && dropTarget.before;
+          const after = isDropTarget && !dropTarget.before;
+          return (
+            // biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop handle wraps the row
+            <div
+              key={folder.id}
+              className={cn(
+                'relative',
+                before &&
+                  'before:absolute before:inset-x-2 before:-top-px before:h-[2px] before:rounded-full before:bg-brand',
+                after &&
+                  'after:absolute after:inset-x-2 after:-bottom-px after:h-[2px] after:rounded-full after:bg-brand',
+                dragId === folder.id && 'opacity-50',
+              )}
+              draggable={import.meta.env.DEV}
+              onDragStart={(e) => {
+                if (!import.meta.env.DEV) return;
+                e.dataTransfer.setData(FOLDER_DND_MIME, folder.id);
+                e.dataTransfer.effectAllowed = 'move';
+                setDragId(folder.id);
+              }}
+              onDragEnd={() => {
+                setDragId(null);
+                setDropTarget(null);
+              }}
+              onDragOver={(e) => {
+                if (!e.dataTransfer.types.includes(FOLDER_DND_MIME)) return;
+                e.preventDefault();
+                e.dataTransfer.dropEffect = 'move';
+                const rect = e.currentTarget.getBoundingClientRect();
+                const isBefore = e.clientY < rect.top + rect.height / 2;
+                if (!dropTarget || dropTarget.id !== folder.id || dropTarget.before !== isBefore) {
+                  setDropTarget({ id: folder.id, before: isBefore });
+                }
+              }}
+              onDragLeave={(e) => {
+                if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+                if (dropTarget?.id === folder.id) setDropTarget(null);
+              }}
+              onDrop={(e) => {
+                const fromId = e.dataTransfer.getData(FOLDER_DND_MIME);
+                if (!fromId) return;
+                e.preventDefault();
+                e.stopPropagation();
+                const rect = e.currentTarget.getBoundingClientRect();
+                const isBefore = e.clientY < rect.top + rect.height / 2;
+                finishReorder(folder.id, isBefore);
+              }}
+            >
+              <FolderItem
+                row={{
+                  kind: 'folder',
+                  folder,
+                  onRename: (name) => onRename(folder.id, name),
+                  onChangeIcon: (icon) => onChangeIcon(folder.id, icon),
+                  onDelete: () => onDelete(folder.id),
+                }}
+                count={countFor(folder.id)}
+                selected={selectedId === folder.id}
+                onSelect={() => onSelect(folder.id)}
+                onDropSlide={(slideId) => onDropToFolder(folder.id, slideId)}
+              />
+            </div>
+          );
+        })}
 
         {import.meta.env.DEV &&
           (creating ? (

--- a/packages/core/src/app/lib/folders.ts
+++ b/packages/core/src/app/lib/folders.ts
@@ -88,12 +88,22 @@ async function putAssign(slideId: string, folderId: string | null): Promise<void
   if (!res.ok) throw new Error(`PUT /__folders/assign ${res.status}`);
 }
 
+async function putReorder(ids: string[]): Promise<void> {
+  const res = await fetch('/__folders/reorder', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ ids }),
+  });
+  if (!res.ok) throw new Error(`PUT /__folders/reorder ${res.status}`);
+}
+
 export type UseFoldersResult = {
   manifest: FoldersManifest;
   loading: boolean;
   create: (name: string, icon: FolderIcon) => Promise<Folder>;
   update: (id: string, patch: { name?: string; icon?: FolderIcon }) => Promise<void>;
   remove: (id: string) => Promise<void>;
+  reorder: (ids: string[]) => Promise<void>;
   assign: (slideId: string, folderId: string | null) => Promise<void>;
   renameSlide: (slideId: string, name: string) => Promise<void>;
   duplicateSlide: (slideId: string, newId?: string) => Promise<string>;
@@ -163,6 +173,23 @@ export function useFolders(): UseFoldersResult {
     [refresh],
   );
 
+  const reorder = useCallback(
+    async (ids: string[]) => {
+      const prev = manifest;
+      const byId = new Map(prev.folders.map((f) => [f.id, f]));
+      const next = ids.map((id) => byId.get(id)).filter((f): f is Folder => Boolean(f));
+      if (next.length !== prev.folders.length) return;
+      setManifest({ ...prev, folders: next });
+      try {
+        await putReorder(ids);
+      } catch (err) {
+        setManifest(prev);
+        throw err;
+      }
+    },
+    [manifest],
+  );
+
   const assign = useCallback(
     async (slideId: string, folderId: string | null) => {
       await putAssign(slideId, folderId);
@@ -202,6 +229,7 @@ export function useFolders(): UseFoldersResult {
     create,
     update,
     remove,
+    reorder,
     assign,
     renameSlide,
     duplicateSlide,

--- a/packages/core/src/app/routes/home-shell.tsx
+++ b/packages/core/src/app/routes/home-shell.tsx
@@ -39,6 +39,7 @@ export function HomeShell() {
     create,
     update,
     remove,
+    reorder,
     assign,
     renameSlide,
     duplicateSlide,
@@ -147,6 +148,13 @@ export function HomeShell() {
           }}
           onDropToFolder={(folderId, slideId) => moveSlideWithToast(slideId, folderId)}
           onDropToDraft={(slideId) => moveSlideWithToast(slideId, null)}
+          onReorder={async (ids) => {
+            try {
+              await reorder(ids);
+            } catch {
+              toast.error(t.home.toastFolderReorderFailed);
+            }
+          }}
         />
       </div>
 

--- a/packages/core/src/files/folders.test.ts
+++ b/packages/core/src/files/folders.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { validateIcon, validateName } from './folders.ts';
+import { type Folder, validateIcon, validateName, validateReorder } from './folders.ts';
 
 describe('validateName', () => {
   it('trims whitespace and accepts non-empty strings', () => {
@@ -52,5 +52,32 @@ describe('validateIcon', () => {
     expect(validateIcon({ type: 'image', value: 'foo' })).toBeNull();
     expect(validateIcon(null)).toBeNull();
     expect(validateIcon('emoji')).toBeNull();
+  });
+});
+
+describe('validateReorder', () => {
+  const folders: Folder[] = [
+    { id: 'f-00000001', name: 'a', icon: { type: 'color', value: '#aabbcc' } },
+    { id: 'f-00000002', name: 'b', icon: { type: 'color', value: '#aabbcc' } },
+    { id: 'f-00000003', name: 'c', icon: { type: 'color', value: '#aabbcc' } },
+  ];
+
+  it('accepts a permutation of the current ids', () => {
+    expect(validateReorder(['f-00000003', 'f-00000001', 'f-00000002'], folders)).toEqual([
+      'f-00000003',
+      'f-00000001',
+      'f-00000002',
+    ]);
+  });
+
+  it('rejects non-arrays and wrong-length arrays', () => {
+    expect(validateReorder(null, folders)).toBeNull();
+    expect(validateReorder(['f-00000001'], folders)).toBeNull();
+  });
+
+  it('rejects duplicate ids, unknown ids, and malformed ids', () => {
+    expect(validateReorder(['f-00000001', 'f-00000001', 'f-00000002'], folders)).toBeNull();
+    expect(validateReorder(['f-00000001', 'f-00000002', 'f-99999999'], folders)).toBeNull();
+    expect(validateReorder(['f-00000001', 'f-00000002', 'nope'], folders)).toBeNull();
   });
 });

--- a/packages/core/src/files/folders.ts
+++ b/packages/core/src/files/folders.ts
@@ -55,6 +55,20 @@ export function validateName(v: unknown): string | null {
   return trimmed;
 }
 
+export function validateReorder(v: unknown, current: Folder[]): string[] | null {
+  if (!Array.isArray(v) || v.length !== current.length) return null;
+  const known = new Set(current.map((f) => f.id));
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of v) {
+    if (typeof id !== 'string' || !FOLDER_ID_RE.test(id)) return null;
+    if (!known.has(id) || seen.has(id)) return null;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
 export function validateIcon(v: unknown): FolderIcon | null {
   if (!v || typeof v !== 'object') return null;
   const icon = v as { type?: unknown; value?: unknown };

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -86,6 +86,7 @@ export const en: Locale = {
     toastSlideMoveFailed: 'Failed to move slide',
     toastFolderDeleted: 'Deleted folder “{name}”',
     toastFolderDeleteFailed: 'Failed to delete folder',
+    toastFolderReorderFailed: 'Failed to reorder folders',
     pickIcon: 'Pick icon',
   },
 

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -86,6 +86,7 @@ export const ja: Locale = {
     toastSlideMoveFailed: 'スライドの移動に失敗しました',
     toastFolderDeleted: 'フォルダ「{name}」を削除しました',
     toastFolderDeleteFailed: 'フォルダの削除に失敗しました',
+    toastFolderReorderFailed: 'フォルダの並び替えに失敗しました',
     pickIcon: 'アイコンを選択',
   },
 

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -90,6 +90,7 @@ export type Locale = {
     /** template: "Deleted folder “{name}”" */
     toastFolderDeleted: string;
     toastFolderDeleteFailed: string;
+    toastFolderReorderFailed: string;
     pickIcon: string;
   };
 

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -86,6 +86,7 @@ export const zhCN: Locale = {
     toastSlideMoveFailed: '移动幻灯片失败',
     toastFolderDeleted: '已删除文件夹"{name}"',
     toastFolderDeleteFailed: '删除文件夹失败',
+    toastFolderReorderFailed: '文件夹排序失败',
     pickIcon: '选择图标',
   },
 

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -86,6 +86,7 @@ export const zhTW: Locale = {
     toastSlideMoveFailed: '移動投影片失敗',
     toastFolderDeleted: '已刪除資料夾「{name}」',
     toastFolderDeleteFailed: '刪除資料夾失敗',
+    toastFolderReorderFailed: '資料夾排序失敗',
     pickIcon: '選擇圖示',
   },
 

--- a/packages/core/src/vite/routes/folders.ts
+++ b/packages/core/src/vite/routes/folders.ts
@@ -7,6 +7,7 @@ import {
   readManifest,
   validateIcon,
   validateName,
+  validateReorder,
   writeManifest,
 } from '../../files/folders.ts';
 import { validateMutationRequest } from '../../http/request-guard.ts';
@@ -15,12 +16,14 @@ import { type ApiContext, json, readBody } from './context.ts';
 // GET    /__folders            list manifest
 // POST   /__folders            create folder { name, icon }
 // PUT    /__folders/assign     assign slide to folder { slideId, folderId | null }
+// PUT    /__folders/reorder    reorder folders { ids: string[] } (permutation)
 // PATCH  /__folders/:id        rename / re-icon folder { name?, icon? }
 // DELETE /__folders/:id        delete folder + drop its assignments
 
 type CreateFolderBody = { name?: unknown; icon?: unknown };
 type PatchFolderBody = { name?: unknown; icon?: unknown };
 type AssignFolderBody = { slideId?: unknown; folderId?: unknown };
+type ReorderFoldersBody = { ids?: unknown };
 
 export function registerFolderRoutes(server: ViteDevServer, ctx: ApiContext): void {
   server.middlewares.use('/__folders', async (req, res, next) => {
@@ -79,6 +82,21 @@ export function registerFolderRoutes(server: ViteDevServer, ctx: ApiContext): vo
         } else {
           manifest.assignments[slideId] = folderId;
         }
+        await writeManifest(ctx.manifestPath, manifest);
+        return json(res, 200, { ok: true });
+      }
+
+      if (method === 'PUT' && url.pathname === '/reorder') {
+        const requestCheck = validateMutationRequest(req, { requireJsonBody: true });
+        if (!requestCheck.ok) {
+          return json(res, requestCheck.status, { error: requestCheck.error });
+        }
+        const body = (await readBody(req)) as ReorderFoldersBody;
+        const manifest = await readManifest(ctx.manifestPath);
+        const ids = validateReorder(body.ids, manifest.folders);
+        if (!ids) return json(res, 400, { error: 'invalid ids' });
+        const byId = new Map(manifest.folders.map((f) => [f.id, f]));
+        manifest.folders = ids.map((id) => byId.get(id) as Folder);
         await writeManifest(ctx.manifestPath, manifest);
         return json(res, 200, { ok: true });
       }


### PR DESCRIPTION
## What

Adds drag-and-drop reordering for folders in the sidebar (dev mode only — matches the rest of the editing affordances).

- Grab any folder row and drag it up or down. A brand-color hairline appears above or below the hovered row showing where it'll land (top half = insert before, bottom half = insert after). The dragged row dims while it's in flight.
- Uses a dedicated `application/x-folder-id` MIME so it doesn't collide with the existing "drag a slide into a folder" interaction (`application/x-slide-id`).

## How

- **Backend** — new `PUT /__folders/reorder { ids }` route. `validateReorder` requires `ids` to be a permutation of current folder ids (same length, no dupes, no unknowns, well-formed); the route then rewrites `manifest.folders` in that order.
- **Client SDK** — `useFolders().reorder(ids)` updates `manifest.folders` optimistically and rolls back on failure.
- **HomeShell** — wires `reorder` to the new `onReorder` prop; surfaces failures via `toastFolderReorderFailed`.
- **Sidebar** — each folder row is wrapped in a draggable container that owns the reorder state (`dragId`, `dropTarget`). Drop position is computed from mouse Y vs. row midpoint; no-op if the resulting order matches the current order.
- **i18n** — `toastFolderReorderFailed` added to `en`, `zh-tw`, `zh-cn`, `ja`, and `types.ts`.
- **Tests** — `validateReorder` covered for the permutation case plus length/dup/unknown/malformed rejections.
- **Changeset** — `@open-slide/core` minor.

## Reviewer notes

- The reorder UI is gated on `import.meta.env.DEV` (consistent with the existing create/rename/delete/icon-picker controls on the same row), so prod builds remain non-draggable.
- The mobile pill list is read-only today — reorder lives on the desktop sidebar only, same as the other folder management actions.
- Verified: `pnpm check` (only the 2 pre-existing unrelated warnings), `pnpm typecheck`, `pnpm exec vitest run` (237/237).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now drag and drop folders in the sidebar to reorder them according to their preferences.
  * Added error notifications to alert users when folder reordering operations fail.

* **Tests**
  * Added comprehensive validation tests for folder reordering functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->