### PR TITLE
Support inline edits inside .map() with tuple destructure or bare identifier

### DIFF
--- a/.changeset/inspector-array-map-edits.md
+++ b/.changeset/inspector-array-map-edits.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Allow inline text edits inside `.map()` callbacks that destructure tuples (`([a, b, c]) => …`) or iterate plain string arrays (`(x) => …{x}`).

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -272,6 +272,44 @@ Size the placeholder to the slot it occupies. Pass `width`/`height` when the lay
 - In play mode: Space/→ next, ← prev, Esc exit.
 - Hot reload: edit `index.tsx` and the browser updates live.
 
+## Keep `.map()` content inline-editable
+
+The inspector's inline text editor splices values directly back into source. For text rendered through `.map()`, it can only locate the source string when the callback shape matches one of the supported patterns. Use these shapes:
+
+```tsx
+// ✅ Array of objects + member access
+{items.map((it) => <li key={it.id}>{it.label}</li>)}
+
+// ✅ Array of objects + shorthand object destructure
+{items.map(({ label }) => <li key={label}>{label}</li>)}
+
+// ✅ Tuple destructure over nested arrays
+{[
+  ['Consultoria', '1.200 €'],
+  ['Estoc',       '2.500 €'],
+].map(([title, price]) => <Row key={title} title={title} price={price} />)}
+
+// ✅ Bare identifier over a string array
+{['Documents', 'Protocols'].map((x) => <span key={x}>{x}</span>)}
+```
+
+Don't use shapes the splicer can't decode — they render fine but the inspector refuses to edit them with `element has no editable text`:
+
+```tsx
+// ❌ Computed value — call expression / template literal in the JSX child
+{items.map((it) => <span>{formatPrice(it.price)}</span>)}
+{items.map((it) => <span>{`${it.price} €`}</span>)}
+
+// ❌ Aliased object destructure
+{items.map(({ price: p }) => <span>{p}</span>)}
+
+// ❌ Array imported from another module — it must be a literal in the same file
+import { rows } from './data';
+{rows.map(({ title }) => <span>{title}</span>)}
+```
+
+If you need formatting (currency, dates, units), bake it into the source string (`'1.200 €'`) so the literal is what the user sees and edits.
+
 ## Self-review before finishing
 
 - [ ] `slides/<id>/index.tsx` `export default`s a non-empty `Page[]`.
@@ -284,6 +322,7 @@ Size the placeholder to the slot it occupies. Pass `width`/`height` when the lay
 - [ ] One idea per page.
 - [ ] All imported assets exist on disk under `slides/<id>/assets/`.
 - [ ] Every `<ImagePlaceholder>` corresponds to a real image the user must supply — not decorative filler. If it could be replaced by typography or layout, it should be.
+- [ ] `.map()` callbacks use a shape the inspector can edit (member access, shorthand destructure, tuple destructure, or bare identifier over a literal array — see "Keep `.map()` content inline-editable").
 - [ ] Nothing outside `slides/<id>/` was edited.
 
 ## Anti-patterns
@@ -300,5 +339,6 @@ Size the placeholder to the slot it occupies. Pass `width`/`height` when the lay
 - ❌ Writing CSS to a shared file. Inline styles or scoped classnames only.
 - ❌ Creating `README.md` or other prose files inside the slide folder.
 - ❌ Editing `package.json`, `open-slide.config.ts`, or other slides.
+- ❌ Rendering text through a call expression or template literal inside JSX (`{fmt(p)}`, `` {`${p} €`} ``). Inline edits will fail with `element has no editable text` — bake the formatted string into the source array instead.
 - ❌ Sprinkling `<ImagePlaceholder>` across pages "for visual interest". Placeholders are for content the user owns; they're not stock-photo slots.
 - ❌ Using a placeholder for an icon or decorative shape — those are typography/SVG problems, not asset problems.

--- a/packages/core/src/vite/comments-plugin.test.ts
+++ b/packages/core/src/vite/comments-plugin.test.ts
@@ -452,6 +452,46 @@ describe('applyEdit / set-text', () => {
     expect(r.source).toContain("word: 'b'");
   });
 
+  it('routes a `.map()` ArrayPattern destructure to the matching tuple slot', () => {
+    const src = [
+      'export default [() => (',
+      '  <>',
+      '    {[',
+      "      ['Consultoria', '1.200 €'],",
+      "      ['Estoc', '2.500 €'],",
+      '    ].map(([title, price]) => (',
+      '      <div key={title}><span>{title}</span><span>{price}</span></div>',
+      '    ))}',
+      '  </>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 7, 49, [{ kind: 'set-text', value: '2.400 €', prevText: '2.500 €' }]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("'1.200 €'");
+    expect(r.source).toContain("'2.400 €'");
+  });
+
+  it('routes a `.map()` bare identifier child to the iterated string element', () => {
+    const src = [
+      'export default [() => (',
+      '  <>',
+      "    {['Documents', 'Protocols', 'Estoc'].map((x) => (",
+      '      <span key={x}>{x}</span>',
+      '    ))}',
+      '  </>',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 4, 22, [
+      { kind: 'set-text', value: 'Protocoles', prevText: 'Protocols' },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("'Documents'");
+    expect(r.source).toContain("'Protocoles'");
+    expect(r.source).not.toContain("'Protocols'");
+  });
+
   it('bails on a `.map()` child when the prop is not a literal', () => {
     const src = [
       'const greet = "hi";',

--- a/packages/core/src/vite/comments-plugin.ts
+++ b/packages/core/src/vite/comments-plugin.ts
@@ -574,12 +574,22 @@ function findObjectProperty(obj: t.Node, name: string): t.ObjectProperty | null 
   return null;
 }
 
-// Decode `{p.field}` (MemberExpression) or `{field}` (Identifier
-// destructured from the callback param) into a single field name.
+type MapLookup =
+  | { kind: 'key'; name: string }
+  | { kind: 'index'; index: number }
+  | { kind: 'whole' };
+
+// Decode the single child expression of `element` plus the callback's first
+// param into a lookup that locates the editable value inside each array
+// element. Supports:
+//   `{p.field}` with `(p) => …`          → key 'field'
+//   `{field}`   with `({ field }) => …`  → key 'field' (shorthand only)
+//   `{field}`   with `([a, field]) => …` → index 1
+//   `{x}`       with `(x) => …`          → whole element
 function decodeMapPassthrough(
   element: t.JSXElement,
   callbackParam: t.Node | undefined,
-): string | null {
+): MapLookup | null {
   const meaningful = meaningfulChildren(element);
   if (meaningful.length !== 1) return null;
   const child = meaningful[0];
@@ -591,38 +601,67 @@ function decodeMapPassthrough(
     if (!t.isIdentifier(expr.object) || !t.isIdentifier(expr.property)) return null;
     if (!callbackParam || !t.isIdentifier(callbackParam)) return null;
     if (callbackParam.name !== expr.object.name) return null;
-    return expr.property.name;
+    return { kind: 'key', name: expr.property.name };
   }
 
   if (t.isIdentifier(expr)) {
-    const fieldName = expr.name;
-    // Param is `{ field, ... }` destructuring — the identifier names the
-    // destructured property. Skip alias/rename forms (`{ field: alias }`).
-    if (!callbackParam || !t.isObjectPattern(callbackParam)) return null;
-    for (const prop of callbackParam.properties) {
-      if (!t.isObjectProperty(prop) || prop.computed) continue;
-      if (!t.isIdentifier(prop.key) || prop.key.name !== fieldName) continue;
-      // Shorthand `{ field }` → value is also an Identifier with same name.
-      // Aliased `{ field: other }` → value is a different identifier; skip.
-      return t.isIdentifier(prop.value) && prop.value.name === fieldName ? fieldName : null;
+    const ident = expr.name;
+    if (!callbackParam) return null;
+
+    if (t.isIdentifier(callbackParam)) {
+      return callbackParam.name === ident ? { kind: 'whole' } : null;
+    }
+
+    if (t.isObjectPattern(callbackParam)) {
+      for (const prop of callbackParam.properties) {
+        if (!t.isObjectProperty(prop) || prop.computed) continue;
+        if (!t.isIdentifier(prop.key) || prop.key.name !== ident) continue;
+        // Shorthand `{ field }` → value is also an Identifier with same name.
+        // Aliased `{ field: other }` → value is a different identifier; skip.
+        return t.isIdentifier(prop.value) && prop.value.name === ident
+          ? { kind: 'key', name: ident }
+          : null;
+      }
+      return null;
+    }
+
+    if (t.isArrayPattern(callbackParam)) {
+      for (let i = 0; i < callbackParam.elements.length; i++) {
+        const el = callbackParam.elements[i];
+        if (el && t.isIdentifier(el) && el.name === ident) {
+          return { kind: 'index', index: i };
+        }
+      }
+      return null;
     }
   }
 
   return null;
 }
 
+function resolveLookup(element: t.Node, lookup: MapLookup): t.Node | null {
+  if (lookup.kind === 'whole') return element;
+  if (lookup.kind === 'key') {
+    const prop = findObjectProperty(element, lookup.name);
+    return prop ? prop.value : null;
+  }
+  if (!t.isArrayExpression(element)) return null;
+  const item = element.elements[lookup.index];
+  return item && !t.isSpreadElement(item) ? item : null;
+}
+
 function collectArrayMapCandidates(ast: t.Node, element: t.JSXElement): TextCandidate[] {
   const ctx = findEnclosingMapCallback(ast, element);
   if (!ctx) return [];
-  const fieldName = decodeMapPassthrough(element, ctx.fn.params[0]);
-  if (!fieldName) return [];
+  const lookup = decodeMapPassthrough(element, ctx.fn.params[0]);
+  if (!lookup) return [];
   const elements = resolveArrayLiteralElements(ast, ctx.arrayArg);
   if (!elements) return [];
   const out: TextCandidate[] = [];
-  for (const obj of elements) {
-    const prop = findObjectProperty(obj, fieldName);
-    if (!prop) continue;
-    const v = prop.value;
+  for (const item of elements) {
+    if (t.isSpreadElement(item)) continue;
+    const v = resolveLookup(item, lookup);
+    if (!v) continue;
     if (t.isStringLiteral(v)) {
       out.push({ current: v.value, splice: (s) => spliceRange(v, jsString(s)) });
     } else if (t.isNumericLiteral(v)) {


### PR DESCRIPTION
## Summary
- Inspector inline text edits were failing with `element has no editable text` for two common `.map()` shapes:
  - `([a, b, c]) => …{c}` over `[[…], […]]` (tuple destructure)
  - `(x) => …{x}` over `['a', 'b', …]` (bare identifier over a string array)
- Refactor `decodeMapPassthrough` in `packages/core/src/vite/comments-plugin.ts` to return a `MapLookup` discriminated union (`'key' | 'index' | 'whole'`) and add `resolveLookup` so `collectArrayMapCandidates` handles `ArrayExpression` tuples and whole-element identifiers in addition to the existing object-property path.
- Added two regression tests in `comments-plugin.test.ts`; the existing 56 tests still pass (131 / 131 total).

## Test plan
- [x] `pnpm test` (131 passed)
- [x] `pnpm check` clean for touched files
- [x] Manual repro on a slide using `.map(([a,b,c]) => …{c})` — price cells become editable inline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline text edits now work inside more `.map()` callback shapes, including array-destructured callbacks and simple iteration over string arrays.

* **Tests**
  * Added coverage to ensure edits target the correct element in varied `.map()` scenarios.

* **Documentation**
  * Authoring guidance updated with supported/unsupported `.map()` patterns and a checklist reminder for editability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->