### PR TITLE
fix(core): preserve backgrounds in PDF export

### DIFF
--- a/.changeset/preserve-pdf-backgrounds.md
+++ b/.changeset/preserve-pdf-backgrounds.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Preserve gradient and image backgrounds when exporting slides to PDF.

--- a/packages/core/src/app/lib/export-pdf.ts
+++ b/packages/core/src/app/lib/export-pdf.ts
@@ -63,19 +63,13 @@ const PRINT_STYLES = `
     transform: scale(0.5);
     transform-origin: top left;
   }
-  /* Chromium serializes box-shadow and CSS gradients as PDF transparency
-     groups / soft masks. macOS Preview re-composites those on every page
-     turn, causing 0.5–2s per-page lag. Strip them in the print container
-     only — gradients on pseudo-elements via CSS (DOM walk can't reach them),
-     inline-style gradients via neutralizeGradientBackgrounds() below. */
+  /* Chromium serializes box-shadow as PDF transparency groups / soft masks.
+     macOS Preview re-composites those on every page turn, causing lag. Strip
+     shadows in the print container while preserving authored backgrounds. */
   #${PRINT_ROOT_ID} *,
   #${PRINT_ROOT_ID} *::before,
   #${PRINT_ROOT_ID} *::after {
     box-shadow: none !important;
-  }
-  #${PRINT_ROOT_ID} *::before,
-  #${PRINT_ROOT_ID} *::after {
-    background-image: none !important;
   }
 }
 `;
@@ -174,7 +168,6 @@ export async function exportSlideAsPdf(
     }
 
     await waitForDataWaitfor(root);
-    neutralizeGradientBackgrounds(root);
     await sleep(100); // flush layout
 
     onProgress?.({ phase: 'printing', current: total, total, percent: 99 });
@@ -187,18 +180,6 @@ export async function exportSlideAsPdf(
     for (const r of reactRoots) r.unmount();
     root.remove();
     style.remove();
-  }
-}
-
-// Strip inline-style gradients from background-image so Chromium does not
-// emit them as PDF soft masks. url(...) backgrounds are preserved.
-function neutralizeGradientBackgrounds(root: HTMLElement): void {
-  const elements = root.querySelectorAll<HTMLElement>('*');
-  for (const el of elements) {
-    const bg = getComputedStyle(el).backgroundImage;
-    if (bg?.includes('gradient(')) {
-      el.style.backgroundImage = 'none';
-    }
   }
 }
 


### PR DESCRIPTION
Fixes #168

## What

Preserves authored `background-image` values when exporting slides to PDF.

- Keep CSS gradients in the print render tree.
- Keep layered backgrounds such as `linear-gradient(...), url(...)`.
- Continue stripping `box-shadow` in the print container to avoid expensive PDF soft-mask output.

## Why

The PDF exporter was neutralizing any element whose computed `backgroundImage` contained `gradient(` before calling `window.print()`. That turned the entire inline background into `none`, so layered backgrounds lost both the gradient and image layer. The print frame then fell back to white, making white text disappear on affected slides.

## How

- Remove the inline gradient cleanup pass before `window.print()`.
- Remove the print CSS rule that cleared pseudo-element background images.
- Narrow the existing print optimization comment to `box-shadow`, which is still stripped.

## Screenshots

| Before | After |
| --- | --- |
| ![Before: PDF background stripped](https://github.com/chentyke/open-slide/blob/2883fd6a2028c2737900b851c62e13a798d7eae5/before.png?raw=true) | ![After: PDF background preserved](https://github.com/chentyke/open-slide/blob/2883fd6a2028c2737900b851c62e13a798d7eae5/after.png?raw=true) |

## Test plan

- [x] `pnpm --filter @open-slide/core typecheck`
- [x] `pnpm --filter @open-slide/core build`
- [x] Manual repro with a slide containing a CSS gradient background
- [x] Manual repro with a layered `linear-gradient(...), url(...)` background
- [x] Verified the print DOM keeps both background values before PDF generation

## Reviewer notes

The original optimization was intended to avoid slow PDF rendering for gradients in macOS Preview, but it removed user-authored backgrounds. This keeps the shadow optimization while preserving slide visuals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PDF export now preserves gradient and image backgrounds when exporting slides, ensuring backgrounds appear correctly in generated documents.
  * Improved handling of print styling to retain background images while preventing unwanted shadow artifacts in exported PDFs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->