### PR TITLE
fix(core): repair Inspect overlay on Windows

### DIFF
--- a/.changeset/fix-windows-inspect-overlay.md
+++ b/.changeset/fix-windows-inspect-overlay.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Fix Inspect overlay on Windows: normalize path separators and strip HMR query/hash when matching slide source files.

--- a/packages/core/src/app/lib/inspector/fiber.test.ts
+++ b/packages/core/src/app/lib/inspector/fiber.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { findSlideSource } from './fiber.ts';
+
+class FakeHTMLElement {
+  dataset: Record<string, string> = {};
+  private closestSelf: FakeHTMLElement | null = null;
+  setClosestSelfForSlideLoc() {
+    this.closestSelf = this;
+  }
+  closest(selector: string): FakeHTMLElement | null {
+    if (selector === '[data-slide-loc]') return this.closestSelf;
+    return null;
+  }
+}
+
+type DebugSource = { fileName?: string; lineNumber?: number; columnNumber?: number };
+type FakeFiber = {
+  return: FakeFiber | null;
+  stateNode?: unknown;
+  _debugSource?: DebugSource;
+};
+
+function makeEl(opts: { slideLoc?: string; fiber?: FakeFiber } = {}): FakeHTMLElement {
+  const el = new FakeHTMLElement();
+  if (opts.slideLoc) {
+    el.dataset.slideLoc = opts.slideLoc;
+    el.setClosestSelfForSlideLoc();
+  }
+  if (opts.fiber) {
+    (el as unknown as Record<string, FakeFiber>).__reactFiber$test = opts.fiber;
+  }
+  return el;
+}
+
+function makeFiber(opts: {
+  fileName?: string;
+  line?: number;
+  column?: number;
+  host?: boolean;
+  parent?: FakeFiber | null;
+}): FakeFiber {
+  const source: DebugSource | undefined =
+    opts.fileName !== undefined
+      ? { fileName: opts.fileName, lineNumber: opts.line, columnNumber: opts.column }
+      : undefined;
+  return {
+    return: opts.parent ?? null,
+    stateNode: opts.host ? new FakeHTMLElement() : undefined,
+    _debugSource: source,
+  };
+}
+
+beforeAll(() => {
+  vi.stubGlobal('HTMLElement', FakeHTMLElement);
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('findSlideSource primary path', () => {
+  it('reads line:column from data-slide-loc', () => {
+    const el = makeEl({ slideLoc: '42:7' });
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(42);
+    expect(hit?.column).toBe(7);
+    expect(hit?.anchor).toBe(el as unknown as HTMLElement);
+  });
+});
+
+describe('findSlideSource fallback', () => {
+  it('matches a POSIX fileName', () => {
+    const fiber = makeFiber({
+      fileName: '/repo/slides/cover/index.tsx',
+      line: 10,
+      column: 4,
+      host: true,
+    });
+    const el = makeEl({ fiber });
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(10);
+    expect(hit?.column).toBe(4);
+  });
+
+  it('matches a Windows-backslash fileName', () => {
+    const fiber = makeFiber({
+      fileName: 'C:\\repo\\slides\\cover\\index.tsx',
+      line: 11,
+      column: 2,
+      host: true,
+    });
+    const el = makeEl({ fiber });
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(11);
+    expect(hit?.column).toBe(2);
+  });
+
+  it('matches a fileName carrying an HMR ?t= query', () => {
+    const fiber = makeFiber({
+      fileName: '/repo/slides/cover/index.tsx?t=1700000000000',
+      line: 12,
+      column: 0,
+      host: true,
+    });
+    const el = makeEl({ fiber });
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(12);
+  });
+
+  it('matches a Windows fileName with an HMR query', () => {
+    const fiber = makeFiber({
+      fileName: 'C:\\repo\\slides\\cover\\index.tsx?t=1700000000000',
+      line: 13,
+      column: 1,
+      host: true,
+    });
+    const el = makeEl({ fiber });
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(13);
+    expect(hit?.column).toBe(1);
+  });
+
+  it('returns null when the fiber fileName points at a different slideId', () => {
+    const fiber = makeFiber({
+      fileName: '/repo/slides/other/index.tsx',
+      line: 10,
+      column: 4,
+      host: true,
+    });
+    const el = makeEl({ fiber });
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).toBeNull();
+  });
+
+  it('walks up the fiber chain until it finds a matching source', () => {
+    const parent = makeFiber({
+      fileName: '/repo/slides/cover/index.tsx',
+      line: 99,
+      column: 3,
+      host: true,
+    });
+    const leaf = makeFiber({ parent, host: true });
+    const el = makeEl({ fiber: leaf });
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(99);
+    expect(hit?.column).toBe(3);
+  });
+});

--- a/packages/core/src/app/lib/inspector/fiber.ts
+++ b/packages/core/src/app/lib/inspector/fiber.ts
@@ -28,6 +28,12 @@ function getSource(fiber: FiberLike) {
   return fiber._debugSource ?? fiber.memoizedProps?.__source;
 }
 
+// `_debugSource.fileName` may carry Vite's HMR query (`?t=…`) and, on
+// Windows, backslash separators. Both break the naive `endsWith` match.
+function normalizeDebugFileName(fileName: string): string {
+  return fileName.split(/[?#]/)[0].replace(/\\/g, '/');
+}
+
 export function findSlideSource(
   el: HTMLElement,
   slideId: string,
@@ -58,7 +64,12 @@ export function findSlideSource(
   while (fiber) {
     const src = getSource(fiber);
     const isHost = fiber.stateNode instanceof HTMLElement;
-    if (src?.fileName?.endsWith(needle) && src.lineNumber && (!opts?.hostOnly || isHost)) {
+    if (
+      src?.fileName &&
+      normalizeDebugFileName(src.fileName).endsWith(needle) &&
+      src.lineNumber &&
+      (!opts?.hostOnly || isHost)
+    ) {
       return {
         line: src.lineNumber,
         column: src.columnNumber ?? 0,

--- a/packages/core/src/vite/loc-tags-plugin.test.ts
+++ b/packages/core/src/vite/loc-tags-plugin.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { injectLocTags, locTagsPlugin } from './loc-tags-plugin.ts';
 
 const pluginTransformSource = 'export default [() => <div />];';
@@ -6,10 +7,17 @@ const pluginTransformSource = 'export default [() => <div />];';
 type LocTagsTransformResult = null | { code: string; map: null };
 
 function transformWithLocTags(id: string) {
-  const plugin = locTagsPlugin({ userCwd: '/repo' });
-  const transform = plugin.transform;
-  if (typeof transform !== 'function') throw new Error('expected transform function');
-  return transform.call({} as never, pluginTransformSource, id) as LocTagsTransformResult;
+  // Force `path.resolve` to return a POSIX slidesRoot so this suite
+  // exercises the same code path regardless of host OS.
+  const resolveSpy = vi.spyOn(path, 'resolve').mockReturnValue('/repo/slides');
+  try {
+    const plugin = locTagsPlugin({ userCwd: '/repo' });
+    const transform = plugin.transform;
+    if (typeof transform !== 'function') throw new Error('expected transform function');
+    return transform.call({} as never, pluginTransformSource, id) as LocTagsTransformResult;
+  } finally {
+    resolveSpy.mockRestore();
+  }
 }
 
 function expectTaggedTransform(id: string) {
@@ -151,5 +159,55 @@ describe('locTagsPlugin', () => {
 
   it('skips colocated test files', () => {
     expect(transformWithLocTags('/repo/slides/cover/index.test.tsx')).toBeNull();
+  });
+});
+
+describe('locTagsPlugin on Windows-style paths', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function transformWithMockedResolve(resolvedSlidesRoot: string, id: string) {
+    vi.spyOn(path, 'resolve').mockReturnValue(resolvedSlidesRoot);
+    const plugin = locTagsPlugin({ userCwd: 'C:\\repo' });
+    const transform = plugin.transform;
+    if (typeof transform !== 'function') throw new Error('expected transform function');
+    return transform.call({} as never, pluginTransformSource, id) as LocTagsTransformResult;
+  }
+
+  function expectTagged(resolvedSlidesRoot: string, id: string) {
+    const out = transformWithMockedResolve(resolvedSlidesRoot, id);
+    if (out === null) throw new Error(`expected tagged transform result for ${id}`);
+    expect(out.code).toContain('data-slide-loc');
+  }
+
+  it('tags slide index files with forward-slash ids under a Windows slidesRoot', () => {
+    expectTagged('C:\\repo\\slides', 'C:/repo/slides/cover/index.tsx');
+  });
+
+  it('strips HMR ?t= query before matching', () => {
+    expectTagged('C:\\repo\\slides', 'C:/repo/slides/cover/index.tsx?t=1700000000000');
+  });
+
+  it('tags nested slide source files under a Windows slidesRoot', () => {
+    expectTagged('C:\\repo\\slides', 'C:/repo/slides/cover/components/Card.tsx');
+  });
+
+  it('skips tsx files directly under the Windows slides directory', () => {
+    expect(transformWithMockedResolve('C:\\repo\\slides', 'C:/repo/slides/index.tsx')).toBeNull();
+  });
+
+  it('skips tsx files outside the Windows slides directory', () => {
+    expect(transformWithMockedResolve('C:\\repo\\slides', 'C:/repo/apps/demo/foo.tsx')).toBeNull();
+  });
+
+  it('skips colocated test files under a Windows slidesRoot', () => {
+    expect(
+      transformWithMockedResolve('C:\\repo\\slides', 'C:/repo/slides/cover/index.test.tsx'),
+    ).toBeNull();
+  });
+
+  it('still tags POSIX ids when path.resolve returns a POSIX slidesRoot (regression guard)', () => {
+    expectTagged('/repo/slides', '/repo/slides/cover/index.tsx');
   });
 });

--- a/packages/core/src/vite/loc-tags-plugin.ts
+++ b/packages/core/src/vite/loc-tags-plugin.ts
@@ -62,8 +62,21 @@ export type LocTagsPluginOptions = {
   slidesDir?: string;
 };
 
+// Vite normally hands `id` to plugins with forward slashes, but other
+// plugins or virtual modules can pass through Windows-style paths.
+// Compare both sides in POSIX shape so the match doesn't depend on
+// which separator the caller happened to use.
+export function isSlideSourceFile(id: string, slidesRootPosix: string): boolean {
+  const filePath = id.split(/[?#]/)[0].replace(/\\/g, '/');
+  if (!filePath.startsWith(`${slidesRootPosix}/`)) return false;
+  if (!filePath.endsWith('.tsx')) return false;
+  if (filePath.endsWith('.d.ts') || filePath.endsWith('.test.tsx')) return false;
+  const rel = filePath.slice(slidesRootPosix.length + 1);
+  return rel.includes('/');
+}
+
 export function locTagsPlugin(opts: LocTagsPluginOptions): Plugin {
-  const slidesRoot = path.resolve(opts.userCwd, opts.slidesDir ?? 'slides');
+  const slidesRoot = path.resolve(opts.userCwd, opts.slidesDir ?? 'slides').replace(/\\/g, '/');
   return {
     name: 'open-slide:loc-tags',
     apply: 'serve',
@@ -71,12 +84,7 @@ export function locTagsPlugin(opts: LocTagsPluginOptions): Plugin {
     // sees our injected attributes.
     enforce: 'pre',
     transform(code, id) {
-      const filePath = id.split('?')[0];
-      if (!filePath.startsWith(slidesRoot + path.sep)) return null;
-      if (!filePath.endsWith('.tsx')) return null;
-      if (filePath.endsWith('.d.ts') || filePath.endsWith('.test.tsx')) return null;
-      const rel = filePath.slice(slidesRoot.length + path.sep.length);
-      if (!rel.includes(path.sep)) return null;
+      if (!isSlideSourceFile(id, slidesRoot)) return null;
       const next = injectLocTags(code);
       if (next === null) return null;
       return { code: next, map: null };


### PR DESCRIPTION
Normalize path separators and strip HMR query/hash when matching slide source files. The loc-tags Vite plugin and the inspector fiber fallback both compared paths with native separators, so on Windows `data-slide-loc` was never injected and `_debugSource` matches failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Inspect overlay not functioning correctly on Windows by normalizing file path separators and removing HMR-related query parameters when matching slide source files.

* **Tests**
  * Added comprehensive test coverage for Windows path handling scenarios and HMR query parameter handling in the Inspect overlay feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->