### PR TITLE
fix(core): detect asset usage through wrapper components

### DIFF
--- a/.changeset/fix-asset-usage-detection.md
+++ b/.changeset/fix-asset-usage-detection.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Stop marking imported assets as unused when they are passed as props to wrapper components (e.g. `<DiagramImage src={img} />`) instead of consumed directly by `<img src={img}>`.

--- a/packages/core/src/editing/revert-asset.test.ts
+++ b/packages/core/src/editing/revert-asset.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyRevertAsset, findAssetUsages } from './revert-asset.ts';
+import { applyRevertAsset, findAssetUsages, findReferencedAssets } from './revert-asset.ts';
 
 describe('findAssetUsages', () => {
   it('returns 0 when the import is absent', () => {
@@ -35,6 +35,61 @@ describe('findAssetUsages', () => {
       '',
     ].join('\n');
     expect(findAssetUsages(src, './assets/hero.png')).toBe(0);
+  });
+});
+
+describe('findReferencedAssets', () => {
+  it('detects direct <img src={ident}> usage', () => {
+    const src = [
+      "import hero from './assets/hero.png';",
+      'export default [() => (<img src={hero} alt="h" />)];',
+      '',
+    ].join('\n');
+    const refs = findReferencedAssets(src, ['./assets/hero.png']);
+    expect(refs.has('./assets/hero.png')).toBe(true);
+  });
+
+  it('detects ident passed as a prop to a wrapper component', () => {
+    const src = [
+      "import diagram from './assets/diagram.webp';",
+      'const DiagramImage = ({ src }) => <img src={src} />;',
+      'export default [() => (<DiagramImage src={diagram} />)];',
+      '',
+    ].join('\n');
+    const refs = findReferencedAssets(src, ['./assets/diagram.webp']);
+    expect(refs.has('./assets/diagram.webp')).toBe(true);
+  });
+
+  it('detects ident used as a value in any expression position', () => {
+    const src = [
+      "import bg from './assets/bg.png';",
+      'export default [() => (<div style={{ backgroundImage: bg }} />)];',
+      '',
+    ].join('\n');
+    const refs = findReferencedAssets(src, ['./assets/bg.png']);
+    expect(refs.has('./assets/bg.png')).toBe(true);
+  });
+
+  it('returns empty set when the import is never referenced beyond the declaration', () => {
+    const src = [
+      "import unused from './assets/unused.png';",
+      'export default [() => (<div />)];',
+      '',
+    ].join('\n');
+    const refs = findReferencedAssets(src, ['./assets/unused.png']);
+    expect(refs.has('./assets/unused.png')).toBe(false);
+  });
+
+  it('only flags paths that appear in the wanted set', () => {
+    const src = [
+      "import hero from './assets/hero.png';",
+      "import logo from './assets/logo.svg';",
+      'export default [() => (<img src={hero} alt="h" />)];',
+      '',
+    ].join('\n');
+    const refs = findReferencedAssets(src, ['./assets/hero.png', './assets/logo.svg']);
+    expect(refs.has('./assets/hero.png')).toBe(true);
+    expect(refs.has('./assets/logo.svg')).toBe(false);
   });
 });
 

--- a/packages/core/src/editing/revert-asset.ts
+++ b/packages/core/src/editing/revert-asset.ts
@@ -113,21 +113,24 @@ export function findReferencedAssets(source: string, assetPaths: readonly string
   if (!ast) return referenced;
   const wanted = new Set(assetPaths);
   const identToPath = new Map<string, string>();
+  const importLocals = new Set<t.Identifier>();
   for (const imp of findImports(ast)) {
     if (!imp.defaultIdent) continue;
-    if (wanted.has(imp.source)) identToPath.set(imp.defaultIdent, imp.source);
+    if (!wanted.has(imp.source)) continue;
+    identToPath.set(imp.defaultIdent, imp.source);
+    for (const spec of imp.node.specifiers) {
+      if (t.isImportDefaultSpecifier(spec) && spec.local.name === imp.defaultIdent) {
+        importLocals.add(spec.local);
+      }
+    }
   }
   if (identToPath.size === 0) return referenced;
-  walkJsx(ast, (n) => {
-    if (!t.isJSXElement(n)) return;
-    const opening = n.openingElement;
-    if (!t.isJSXIdentifier(opening.name) || opening.name.name !== 'img') return;
-    const src = findJsxAttr(opening, 'src');
-    if (!src?.value || !t.isJSXExpressionContainer(src.value)) return;
-    const expr = src.value.expression;
-    if (!t.isIdentifier(expr)) return;
-    const p = identToPath.get(expr.name);
-    if (p) referenced.add(p);
+  walkAll(ast, (n) => {
+    if (!t.isIdentifier(n)) return;
+    const p = identToPath.get(n.name);
+    if (!p) return;
+    if (importLocals.has(n)) return;
+    referenced.add(p);
   });
   return referenced;
 }


### PR DESCRIPTION
## What

`findReferencedAssets` (the function that drives the "unused" flag in the asset panel) only matched `<img src={ident}>`. Any imported asset passed as a prop to a wrapper component — e.g. `<DiagramImage src={diagram} />`, `<BackgroundFrame image={bg} />` — or used in any other expression position (`style={{ backgroundImage: bg }}`, etc.) was incorrectly flagged as unused, even though it's clearly being consumed.

Reproduced on a 26-page slide where four diagram assets routed through a `DiagramImage` wrapper all showed up as "unused":

- `raycast-1-overview.webp`
- `raycast-2-overview.webp`
- `raycast-2-tech-stack.webp`
- `raycast-2-windows.webp`

## Fix

Broaden `findReferencedAssets` to count any reference to the import's default identifier anywhere in the AST (via `walkAll`), excluding the import-specifier local node itself. If the identifier is used outside the import declaration in any form, the asset is "used".

`findAssetUsages` and `applyRevertAsset` intentionally stay narrow — the revert action transforms `<img src={ident}>` into `<ImagePlaceholder ... />`, which is only safe for direct `<img>` consumers, so it can't be broadened.

## Tests

Added 5 cases to `revert-asset.test.ts` covering the new function:

- direct `<img src={ident}>` (regression baseline)
- ident passed as a prop to a wrapper component (the actual bug)
- ident used as an expression value (e.g. `style={{ backgroundImage: bg }}`)
- ident never referenced beyond the declaration → still flagged unused
- only paths in the wanted set are reported

All 239 tests pass; `pnpm typecheck` clean; biome clean on changed files.

## Changeset

`patch` bump on `@open-slide/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset-usage detection to correctly recognize imported assets passed through wrapper component props, preventing them from being incorrectly marked as unused.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->