### PR TITLE
fix(core): make sidebar icon clickable and close comment panel on outside click

### DIFF
--- a/.changeset/sidebar-icon-click.md
+++ b/.changeset/sidebar-icon-click.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Fix sidebar Draft/Themes/Assets rows not switching when clicking the icon — the whole icon area is now part of the select target. Also close the inspector comment panel when clicking outside it.

--- a/packages/core/src/app/components/inspector/comment-widget.tsx
+++ b/packages/core/src/app/components/inspector/comment-widget.tsx
@@ -1,5 +1,5 @@
 import { MessageSquare, Trash2, X } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { format, plural, useLocale } from '@/lib/use-locale';
 import { useInspector } from './inspector-provider';
 
@@ -8,9 +8,23 @@ export function CommentWidget() {
   const { comments, remove, error } = useInspector();
   const [open, setOpen] = useState(false);
   const count = comments.length;
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [open]);
 
   return (
-    <div data-inspector-ui className="absolute right-4 bottom-4 z-20 flex flex-col items-end gap-2">
+    <div
+      ref={ref}
+      data-inspector-ui
+      className="absolute right-4 bottom-4 z-20 flex flex-col items-end gap-2"
+    >
       {open && (
         <div className="w-80 rounded-md border bg-card shadow-xl animate-in fade-in-0 slide-in-from-bottom-2 duration-200">
           <div className="flex items-center justify-between border-b px-3 py-2">

--- a/packages/core/src/app/components/sidebar/folder-item.tsx
+++ b/packages/core/src/app/components/sidebar/folder-item.tsx
@@ -181,9 +181,14 @@ export function FolderItem({
           </PopoverContent>
         </Popover>
       ) : (
-        <span className="flex size-5 shrink-0 items-center justify-center">
+        <button
+          type="button"
+          onClick={onSelect}
+          aria-label={label}
+          className="flex size-5 shrink-0 items-center justify-center"
+        >
           <FolderIconChip icon={icon} />
-        </span>
+        </button>
       )}
 
       {renaming && row.kind === 'folder' ? (

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -242,7 +242,7 @@ function SortControl({ value, onChange }: { value: SortKey; onChange: (next: Sor
         <button
           type="button"
           aria-label={`${t.home.sortLabel}: ${labels[value]}`}
-          className="flex h-8 items-center gap-1.5 rounded-[6px] border border-border bg-background pl-2 pr-1.5 text-[12.5px] font-medium text-foreground outline-none hover:bg-muted focus-visible:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring/30"
+          className="flex h-8 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-[6px] border border-border bg-background pl-2 pr-1.5 text-[12.5px] font-medium text-foreground outline-none hover:bg-muted focus-visible:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring/30"
         >
           <FieldIcon k={value} className="size-3.5 text-muted-foreground" />
           <span>{labels[value]}</span>


### PR DESCRIPTION
## Summary
- Clicking the Draft/Themes/Assets icon in the sidebar now selects that row (previously only the text label was a select target).
- The inspector comment panel now closes when clicking outside it.
- `SortControl` button gets `shrink-0 whitespace-nowrap` so it doesn't get squeezed or wrap in tight layouts.

## Test plan
- [ ] Click each sidebar row's icon (Draft / Themes / Assets) and confirm the row switches
- [ ] Open the inspector comment panel, click outside it, confirm it closes
- [ ] Confirm the toggle button still opens/closes the panel as before
- [ ] Check the sort control stays on one line when space is tight

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Inspector comment panel now closes when clicking outside of it
  * Expanded clickable area for sidebar Draft, Themes, and Assets rows

* **UI Improvements**
  * Enhanced accessibility for sidebar icon interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->