### PR TITLE
refactor(core): deduplicate internal helpers across plugins

### DIFF
--- a/.changeset/dedupe-internal-helpers.md
+++ b/.changeset/dedupe-internal-helpers.md
@@ -1,0 +1,6 @@
+---
+"@open-slide/core": patch
+"@open-slide/cli": patch
+---
+
+Remove duplicated internal helpers (HTTP `readBody`/`json`, slide-path resolution, the `SLIDE_ID_RE` pattern, and locale `format`/`plural`) by routing them through a single source.

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -24,7 +24,7 @@ async function run(cmd: string, args: string[], cwd: string): Promise<RunResult>
   });
 }
 
-export async function isGitAvailable(): Promise<boolean> {
+async function isGitAvailable(): Promise<boolean> {
   try {
     const res = await run('git', ['--version'], process.cwd());
     return res.code === 0;
@@ -33,7 +33,7 @@ export async function isGitAvailable(): Promise<boolean> {
   }
 }
 
-export async function isInsideWorkTree(cwd: string): Promise<boolean> {
+async function isInsideWorkTree(cwd: string): Promise<boolean> {
   try {
     const res = await run('git', ['rev-parse', '--is-inside-work-tree'], cwd);
     return res.code === 0 && res.stdout.trim() === 'true';

--- a/packages/core/src/app/lib/design-presets.ts
+++ b/packages/core/src/app/lib/design-presets.ts
@@ -7,7 +7,7 @@ const SERIF_GEORGIA = 'Georgia, "Times New Roman", serif';
 const SERIF_TIMES = '"Times New Roman", Times, serif';
 const MONO_SF = '"SF Mono", "JetBrains Mono", Menlo, monospace';
 
-export const designPresets: DesignSystem[] = [
+const designPresets: DesignSystem[] = [
   defaultDesign,
   {
     palette: { bg: '#0f1115', text: '#f5f3ee', accent: '#7cc4ff' },

--- a/packages/core/src/app/lib/use-locale.ts
+++ b/packages/core/src/app/lib/use-locale.ts
@@ -1,6 +1,6 @@
 import config from 'virtual:open-slide/config';
 import { en } from '../../locale/en';
-import type { Locale, Plural } from '../../locale/types';
+import type { Locale } from '../../locale/types';
 
 const resolved: Locale = (config.locale as Locale | undefined) ?? en;
 
@@ -8,13 +8,4 @@ export function useLocale(): Locale {
   return resolved;
 }
 
-export function format(template: string, vars: Record<string, string | number>): string {
-  return template.replace(/\{(\w+)\}/g, (m, key) => {
-    const v = vars[key];
-    return v === undefined ? m : String(v);
-  });
-}
-
-export function plural(count: number, forms: Plural): string {
-  return count === 1 ? forms.one : forms.other;
-}
+export { format, plural } from '../../locale/format';

--- a/packages/core/src/vite/current-plugin.ts
+++ b/packages/core/src/vite/current-plugin.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { Plugin, ViteDevServer } from 'vite';
+import { SLIDE_ID_RE } from '../editing/slide-ops.ts';
 
-const SLIDE_ID_RE = /^[a-z0-9_-]+$/i;
 const TEXT_SNIPPET_MAX = 120;
 
 export type CurrentPluginOptions = {

--- a/packages/core/src/vite/design-plugin.ts
+++ b/packages/core/src/vite/design-plugin.ts
@@ -1,44 +1,10 @@
 import fs from 'node:fs/promises';
-import type { ServerResponse } from 'node:http';
-import path from 'node:path';
 import { parse as babelParse } from '@babel/parser';
-import type { Connect, Plugin, ViteDevServer } from 'vite';
+import type { Plugin, ViteDevServer } from 'vite';
 import { type DesignSystem, defaultDesign } from '../app/lib/design.ts';
 import type { AstNode } from '../editing/babel-walk.ts';
 import { validateMutationRequest } from '../http/request-guard.ts';
-
-const SLIDE_ID_RE = /^[a-z0-9_-]+$/i;
-
-async function readBody(req: Connect.IncomingMessage): Promise<unknown> {
-  return await new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    req.on('data', (c: Buffer) => chunks.push(c));
-    req.on('end', () => {
-      const raw = Buffer.concat(chunks).toString('utf8');
-      if (!raw) return resolve({});
-      try {
-        resolve(JSON.parse(raw));
-      } catch (e) {
-        reject(e);
-      }
-    });
-    req.on('error', reject);
-  });
-}
-
-function json(res: ServerResponse, status: number, body: unknown) {
-  res.statusCode = status;
-  res.setHeader('content-type', 'application/json');
-  res.end(JSON.stringify(body));
-}
-
-function resolveSlidePath(userCwd: string, slidesDir: string, slideId: string): string | null {
-  if (!SLIDE_ID_RE.test(slideId)) return null;
-  const slidesRoot = path.resolve(userCwd, slidesDir);
-  const full = path.resolve(slidesRoot, slideId, 'index.tsx');
-  if (!full.startsWith(`${slidesRoot}${path.sep}`)) return null;
-  return full;
-}
+import { json, readBody, resolveSlidePath } from './routes/context.ts';
 
 function parseSource(source: string): AstNode | null {
   try {

--- a/packages/core/src/vite/loc-tags-plugin.ts
+++ b/packages/core/src/vite/loc-tags-plugin.ts
@@ -66,7 +66,7 @@ export type LocTagsPluginOptions = {
 // plugins or virtual modules can pass through Windows-style paths.
 // Compare both sides in POSIX shape so the match doesn't depend on
 // which separator the caller happened to use.
-export function isSlideSourceFile(id: string, slidesRootPosix: string): boolean {
+function isSlideSourceFile(id: string, slidesRootPosix: string): boolean {
   const filePath = id.split(/[?#]/)[0].replace(/\\/g, '/');
   if (!filePath.startsWith(`${slidesRootPosix}/`)) return false;
   if (!filePath.endsWith('.tsx')) return false;

--- a/packages/core/src/vite/notes-plugin.ts
+++ b/packages/core/src/vite/notes-plugin.ts
@@ -1,12 +1,9 @@
 import fs from 'node:fs/promises';
-import type { ServerResponse } from 'node:http';
-import path from 'node:path';
 import { parse as babelParse } from '@babel/parser';
 import * as t from '@babel/types';
-import type { Connect, Plugin, ViteDevServer } from 'vite';
+import type { Plugin, ViteDevServer } from 'vite';
 import { validateMutationRequest } from '../http/request-guard.ts';
-
-const SLIDE_ID_RE = /^[a-z0-9_-]+$/i;
+import { json, readBody, resolveSlidePath } from './routes/context.ts';
 
 type NotesBody = {
   slideId?: string;
@@ -17,37 +14,6 @@ type NotesBody = {
 export type ApplyNotesEditResult =
   | { ok: true; source: string }
   | { ok: false; status: number; error: string };
-
-async function readBody(req: Connect.IncomingMessage): Promise<unknown> {
-  return await new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    req.on('data', (c: Buffer) => chunks.push(c));
-    req.on('end', () => {
-      const raw = Buffer.concat(chunks).toString('utf8');
-      if (!raw) return resolve({});
-      try {
-        resolve(JSON.parse(raw));
-      } catch (e) {
-        reject(e);
-      }
-    });
-    req.on('error', reject);
-  });
-}
-
-function json(res: ServerResponse, status: number, body: unknown) {
-  res.statusCode = status;
-  res.setHeader('content-type', 'application/json');
-  res.end(JSON.stringify(body));
-}
-
-function resolveSlidePath(userCwd: string, slidesDir: string, slideId: string): string | null {
-  if (!SLIDE_ID_RE.test(slideId)) return null;
-  const slidesRoot = path.resolve(userCwd, slidesDir);
-  const full = path.resolve(slidesRoot, slideId, 'index.tsx');
-  if (!full.startsWith(slidesRoot + path.sep)) return null;
-  return full;
-}
 
 function parseSource(source: string): t.File | null {
   try {

--- a/packages/core/src/vite/routes/context.ts
+++ b/packages/core/src/vite/routes/context.ts
@@ -50,9 +50,18 @@ export function json(res: ServerResponse, status: number, body: unknown) {
   res.end(JSON.stringify(body));
 }
 
-export function resolveSlideEntryPath(ctx: ApiContext, slideId: string): string | null {
+export function resolveSlidePath(
+  userCwd: string,
+  slidesDir: string,
+  slideId: string,
+): string | null {
   if (!SLIDE_ID_RE.test(slideId)) return null;
-  const full = path.resolve(ctx.slidesRoot, slideId, 'index.tsx');
-  if (!full.startsWith(ctx.slidesRoot + path.sep)) return null;
+  const slidesRoot = path.resolve(userCwd, slidesDir);
+  const full = path.resolve(slidesRoot, slideId, 'index.tsx');
+  if (!full.startsWith(slidesRoot + path.sep)) return null;
   return full;
+}
+
+export function resolveSlideEntryPath(ctx: ApiContext, slideId: string): string | null {
+  return resolveSlidePath(ctx.userCwd, ctx.slidesDir, slideId);
 }


### PR DESCRIPTION
Consolidates duplicated utility functions (`readBody`, `json`, `resolveSlidePath`, and `SLIDE_ID_RE`) into a single source of truth in `packages/core/src/vite/routes/context.ts`, eliminating code duplication across the design and notes plugins.

**Key changes:**

- Moved `readBody()`, `json()`, `resolveSlidePath()`, and `SLIDE_ID_RE` from `design-plugin.ts` and `notes-plugin.ts` into `routes/context.ts`
- Updated both plugins to import these utilities from the shared context module
- Refactored `resolveSlideEntryPath()` in context.ts to delegate to the new `resolveSlidePath()` function
- Moved `format()` and `plural()` locale helpers in `use-locale.ts` to import from a dedicated `locale/format` module
- Moved `SLIDE_ID_RE` in `current-plugin.ts` to import from `editing/slide-ops.ts`
- Made internal helper functions in `git.ts` and `loc-tags-plugin.ts` private (removed `export`)
- Made `designPresets` in `design-presets.ts` private (removed `export`)

This reduces maintenance burden and ensures consistent behavior across the codebase.

https://claude.ai/code/session_01D9RGMYuTWbtEu3eikkDBNb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal helper functions to centralized shared locations for improved code organization.
  * Streamlined module dependencies by consolidating HTTP request/response, path resolution, and locale utilities into shared modules.
  * Made internal utility functions private to reduce public API surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1weiho/open-slide/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->