### PR TITLE
feat(core): add image PDF export

### DIFF
--- a/.changeset/add-image-pdf-export.md
+++ b/.changeset/add-image-pdf-export.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Add an image PDF export option for rasterized slide output.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,6 +79,7 @@
     "emoji-picker-react": "^4.18.0",
     "fast-glob": "^3.3.2",
     "fflate": "^0.8.2",
+    "html2canvas-pro": "^2.0.4",
     "lucide-react": "^1.8.0",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",

--- a/packages/core/src/app/lib/export-image-pdf.ts
+++ b/packages/core/src/app/lib/export-image-pdf.ts
@@ -1,0 +1,245 @@
+import { createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { designToCssVars } from './design';
+import type { PdfExportProgress } from './export-pdf';
+import { SlidePageProvider } from './page-context';
+import { isFrameAnimationSettled, waitForDataWaitfor, waitForFonts } from './print-ready';
+import type { SlideModule } from './sdk';
+
+const IMAGE_SOURCE_ROOT_ID = 'os-image-pdf-source-root';
+const IMAGE_PRINT_ROOT_ID = 'os-image-pdf-print-root';
+const IMAGE_PRINT_STYLE_ID = 'os-image-pdf-print-style';
+const IMAGE_PDF_SCALE = 1;
+const ANIMATION_TIMEOUT_MS = 15_000;
+const POLL_INTERVAL_MS = 100;
+
+const IMAGE_PRINT_STYLES = `
+@page { size: 1920px 1080px; margin: 0; }
+
+@media screen {
+  #${IMAGE_SOURCE_ROOT_ID} {
+    position: fixed !important;
+    left: 0 !important;
+    top: 0 !important;
+    z-index: -1 !important;
+    pointer-events: none !important;
+  }
+  #${IMAGE_PRINT_ROOT_ID} {
+    position: fixed !important;
+    left: -99999px !important;
+    top: 0 !important;
+    pointer-events: none !important;
+  }
+  #${IMAGE_SOURCE_ROOT_ID} .os-image-pdf-source-frame {
+    width: 1920px !important;
+    height: 1080px !important;
+    background: #fff;
+    color: #000;
+    overflow: hidden;
+  }
+}
+
+@media print {
+  html, body {
+    margin: 0 !important;
+    padding: 0 !important;
+    background: #fff !important;
+  }
+  body > *:not(#${IMAGE_PRINT_ROOT_ID}) { display: none !important; }
+  #${IMAGE_PRINT_ROOT_ID} {
+    position: static !important;
+    left: 0 !important;
+    top: 0 !important;
+    pointer-events: auto !important;
+    display: block !important;
+    background: #fff !important;
+  }
+  #${IMAGE_PRINT_ROOT_ID} .os-image-pdf-frame {
+    width: 1920px !important;
+    height: 1080px !important;
+    overflow: hidden;
+    page-break-after: always;
+    break-after: page;
+  }
+  #${IMAGE_PRINT_ROOT_ID} .os-image-pdf-frame:last-child {
+    page-break-after: auto;
+    break-after: auto;
+  }
+  #${IMAGE_PRINT_ROOT_ID} .os-image-pdf-page {
+    display: block;
+    width: 1920px !important;
+    height: 1080px !important;
+    object-fit: fill;
+  }
+}
+`;
+
+export async function exportSlideAsImagePdf(
+  slide: SlideModule,
+  slideId: string,
+  onProgress?: (progress: PdfExportProgress) => void,
+): Promise<void> {
+  const pages = slide.default ?? [];
+  if (pages.length === 0) return;
+
+  const total = pages.length;
+
+  const style = document.createElement('style');
+  style.id = IMAGE_PRINT_STYLE_ID;
+  style.textContent = IMAGE_PRINT_STYLES;
+  document.head.appendChild(style);
+
+  const sourceRoot = document.createElement('div');
+  sourceRoot.id = IMAGE_SOURCE_ROOT_ID;
+  sourceRoot.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(sourceRoot);
+
+  const printRoot = document.createElement('div');
+  printRoot.id = IMAGE_PRINT_ROOT_ID;
+  printRoot.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(printRoot);
+
+  onProgress?.({ phase: 'processing', current: 0, total, percent: 0 });
+
+  const designVars = slide.design ? designToCssVars(slide.design) : null;
+
+  const reactRoots: Root[] = [];
+  const frames: HTMLElement[] = [];
+  for (let i = 0; i < pages.length; i++) {
+    const Page = pages[i];
+    if (!Page) continue;
+    const host = document.createElement('div');
+    host.className = 'os-image-pdf-source-frame';
+    host.setAttribute('data-osd-canvas', '');
+    host.style.width = '1920px';
+    host.style.height = '1080px';
+    if (designVars) {
+      for (const [k, v] of Object.entries(designVars)) host.style.setProperty(k, v);
+    }
+    sourceRoot.appendChild(host);
+    frames.push(host);
+    const r = createRoot(host);
+    r.render(
+      createElement(SlidePageProvider, { index: i, total: pages.length }, createElement(Page)),
+    );
+    reactRoots.push(r);
+  }
+
+  await nextPaint();
+
+  const previousTitle = document.title;
+  document.title = slide.meta?.title ?? slideId;
+
+  try {
+    await waitForFonts();
+
+    const deadline = performance.now() + ANIMATION_TIMEOUT_MS;
+    while (performance.now() < deadline) {
+      const settled = frames.reduce((n, frame) => (isFrameAnimationSettled(frame) ? n + 1 : n), 0);
+      onProgress?.({
+        phase: 'processing',
+        current: settled,
+        total,
+        percent: Math.min(75, (settled / total) * 75),
+      });
+      if (settled === total) break;
+      await sleep(POLL_INTERVAL_MS);
+    }
+
+    await waitForDataWaitfor(sourceRoot);
+    await sleep(100);
+
+    const { default: html2canvas } = await import('html2canvas-pro');
+    for (let i = 0; i < frames.length; i++) {
+      const canvas = await html2canvas(frames[i], {
+        allowTaint: false,
+        backgroundColor: '#ffffff',
+        height: 1080,
+        logging: false,
+        scale: IMAGE_PDF_SCALE,
+        useCORS: true,
+        width: 1920,
+        windowHeight: 1080,
+        windowWidth: 1920,
+      });
+      appendImagePage(printRoot, canvas.toDataURL('image/png'));
+      onProgress?.({
+        phase: 'processing',
+        current: i + 1,
+        total,
+        percent: 75 + ((i + 1) / total) * 24,
+      });
+    }
+
+    await waitForImages(printRoot);
+    await sleep(100);
+
+    onProgress?.({ phase: 'printing', current: total, total, percent: 99 });
+    const printDone = waitForAfterPrint();
+    window.print();
+    await printDone;
+  } finally {
+    onProgress?.({ phase: 'done', current: total, total, percent: 100 });
+    document.title = previousTitle;
+    for (const r of reactRoots) r.unmount();
+    sourceRoot.remove();
+    printRoot.remove();
+    style.remove();
+  }
+}
+
+function appendImagePage(root: HTMLElement, dataUrl: string): void {
+  const page = document.createElement('div');
+  page.className = 'os-image-pdf-frame';
+  const img = document.createElement('img');
+  img.className = 'os-image-pdf-page';
+  img.alt = '';
+  img.src = dataUrl;
+  page.appendChild(img);
+  root.appendChild(page);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function nextPaint(): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    requestAnimationFrame(settle);
+    setTimeout(settle, 50);
+  });
+}
+
+function waitForAfterPrint(timeoutMs = 60_000): Promise<void> {
+  return new Promise((resolve) => {
+    const cleanup = () => {
+      window.removeEventListener('afterprint', onAfter);
+      clearTimeout(timer);
+      resolve();
+    };
+    const onAfter = () => cleanup();
+    const timer = setTimeout(cleanup, timeoutMs);
+    window.addEventListener('afterprint', onAfter, { once: true });
+  });
+}
+
+function waitForImages(root: HTMLElement): Promise<void> {
+  const images = Array.from(root.querySelectorAll('img'));
+  return Promise.all(
+    images.map((img) => {
+      if (img.complete) return Promise.resolve();
+      return new Promise<void>((resolve, reject) => {
+        img.addEventListener('load', () => resolve(), { once: true });
+        img.addEventListener('error', () => reject(new Error('Failed to load image PDF page')), {
+          once: true,
+        });
+      });
+    }),
+  ).then(() => undefined);
+}

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -5,6 +5,7 @@ import {
   ChevronLeft,
   Download,
   FileCode2,
+  FileImage,
   FileText,
   Link2,
   Loader2,
@@ -51,6 +52,7 @@ import { SlideCanvas } from '../components/slide-canvas';
 import { SlideTransitionLayer } from '../components/slide-transition-layer';
 import { type ThumbnailActions, ThumbnailRail } from '../components/thumbnail-rail';
 import { exportSlideAsHtml } from '../lib/export-html';
+import { exportSlideAsImagePdf } from '../lib/export-image-pdf';
 import { exportSlideAsPdf, isSafari } from '../lib/export-pdf';
 import { remapNotesSessionCacheAfterReorder } from '../lib/inspector/use-notes';
 import type { SlideModule } from '../lib/sdk';
@@ -499,6 +501,48 @@ export function Slide() {
                     >
                       <FileText />
                       {t.slide.exportAsPdf}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      disabled={exporting}
+                      onSelect={async () => {
+                        if (!slide || exporting) return;
+                        if (isSafari()) {
+                          toast.error(t.slide.pdfExportSafariUnsupported, { duration: 5000 });
+                          return;
+                        }
+                        setExporting(true);
+                        const toastId = `image-pdf-export-${slideId}`;
+                        toast.custom(
+                          () => (
+                            <PdfProgressToast
+                              progress={{
+                                phase: 'processing',
+                                current: 0,
+                                total: pages.length,
+                                percent: 0,
+                              }}
+                            />
+                          ),
+                          { id: toastId, duration: Infinity },
+                        );
+                        try {
+                          await exportSlideAsImagePdf(slide, slideId, (p) => {
+                            toast.custom(() => <PdfProgressToast progress={p} />, {
+                              id: toastId,
+                              duration: Infinity,
+                            });
+                          });
+                        } catch (err) {
+                          console.error('[open-slide] image pdf export failed', err);
+                          toast.error(t.slide.pdfExportFailed, { id: toastId, duration: 4000 });
+                        } finally {
+                          setExporting(false);
+                          toast.dismiss(toastId);
+                        }
+                      }}
+                    >
+                      <FileImage />
+                      {t.slide.exportAsImagePdf}
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -105,6 +105,7 @@ export const en: Locale = {
     toastCopyLinkFailed: 'Failed to copy link',
     exportAsHtml: 'Export as HTML',
     exportAsPdf: 'Export as PDF',
+    exportAsImagePdf: 'Export as Image PDF',
     pdfExportFailed: 'PDF export failed',
     pdfExportSafariUnsupported:
       'Export as PDF is not supported on Safari. Please try a Chromium-based browser instead.',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -105,6 +105,7 @@ export const ja: Locale = {
     toastCopyLinkFailed: 'リンクのコピーに失敗しました',
     exportAsHtml: 'HTML として書き出し',
     exportAsPdf: 'PDF として書き出し',
+    exportAsImagePdf: '画像 PDF として書き出し',
     pdfExportFailed: 'PDF の書き出しに失敗しました',
     pdfExportSafariUnsupported:
       'PDF の書き出しは現在 Safari では対応していません。Chromium ベースのブラウザでお試しください。',

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -107,6 +107,7 @@ export type Locale = {
     toastCopyLinkFailed: string;
     exportAsHtml: string;
     exportAsPdf: string;
+    exportAsImagePdf: string;
     pdfExportFailed: string;
     pdfExportSafariUnsupported: string;
     present: string;

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -104,6 +104,7 @@ export const zhCN: Locale = {
     toastCopyLinkFailed: '复制链接失败',
     exportAsHtml: '导出为 HTML',
     exportAsPdf: '导出为 PDF',
+    exportAsImagePdf: '导出为图片 PDF',
     pdfExportFailed: 'PDF 导出失败',
     pdfExportSafariUnsupported:
       '导出 PDF 目前不支持 Safari 设备，请尝试使用基于 Chromium 的浏览器替代。',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -104,6 +104,7 @@ export const zhTW: Locale = {
     toastCopyLinkFailed: '複製連結失敗',
     exportAsHtml: '匯出為 HTML',
     exportAsPdf: '匯出為 PDF',
+    exportAsImagePdf: '匯出為圖片 PDF',
     pdfExportFailed: 'PDF 匯出失敗',
     pdfExportSafariUnsupported:
       '匯出 PDF 目前不支援 Safari 裝置，請嘗試用 Chromium 基底瀏覽器替代。',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       fflate:
         specifier: ^0.8.2
         version: 0.8.2
+      html2canvas-pro:
+        specifier: ^2.0.4
+        version: 2.0.4
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@18.3.1)
@@ -2836,6 +2839,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
@@ -3030,6 +3037,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -3626,6 +3636,10 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  html2canvas-pro@2.0.4:
+    resolution: {integrity: sha512-tfL8XNvuITvYQJKgAx4bvANauuLKc88C+ZSZt7HZJveqQBWjBDtkqs/It06UzlqbM+sSq7Cv45rFbuUxOFgmow==}
+    engines: {node: '>=16.0.0'}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -4892,6 +4906,9 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -5093,6 +5110,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   valibot@1.0.0:
     resolution: {integrity: sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==}
@@ -8080,6 +8100,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-arraybuffer@1.0.2: {}
+
   baseline-browser-mapping@2.10.20: {}
 
   better-path-resolve@1.0.0:
@@ -8247,6 +8269,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   cssesc@3.0.0: {}
 
@@ -8957,6 +8983,11 @@ snapshots:
   hookable@5.5.3: {}
 
   html-void-elements@3.0.0: {}
+
+  html2canvas-pro@2.0.4:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
 
   http-errors@2.0.1:
     dependencies:
@@ -10684,6 +10715,10 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -10908,6 +10943,10 @@ snapshots:
       react: 18.3.1
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   valibot@1.0.0(typescript@5.9.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Add a separate `Export as Image PDF` menu item without changing the existing PDF export path.
- Render slides off-screen, capture each page with `html2canvas-pro`, and print PNG-backed pages for a fully rasterized PDF fallback.
- Add locale strings and a patch changeset for `@open-slide/core`.

Related to #168.

## Test plan

- [x] `pnpm check` (passes with existing warnings in `apps/web/lib/layout.shared.tsx` and `packages/core/src/http/request-guard.ts`)
- [x] `pnpm test`
- [x] `pnpm --filter @open-slide/core build`
- [x] Browser smoke test: `image-placeholder-demo` generated 3 PNG-backed pages in `#os-image-pdf-print-root`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Export as Image PDF" option in the slide download menu. Converts slides to rasterized image-based PDF format for download (not supported on Safari).

* **Chores**
  * Added localization strings in English, Japanese, Simplified Chinese, and Traditional Chinese
  * Updated dependencies to support image-based PDF export

<!-- end of auto-generated comment: release notes by coderabbit.ai -->