### PR TITLE
feat(core): add Tailscale live preview sharing

### DIFF
--- a/.changeset/tall-shoes-serve.md
+++ b/.changeset/tall-shoes-serve.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Add Tailscale IP sharing for live dev previews.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -22,9 +22,13 @@ Once installed, the `open-slide` bin is available in the workspace:
 
 | Command | Description |
 | --- | --- |
-| `open-slide dev` | Start the dev server. Flags: `-p, --port <port>`, `--host [host]`, `--open`. |
+| `open-slide dev` | Start the dev server. Flags: `-p, --port <port>`, `--host [host]`, `--share tailscale`, `--open`. |
 | `open-slide build` | Build a static site. Flags: `--out-dir <dir>` (defaults to `dist`). |
 | `open-slide preview` | Preview the production build. Flags: `-p, --port <port>`, `--host [host]`, `--open`. |
+
+### Tailscale live preview
+
+Use `open-slide dev --share tailscale` to start the dev server on `0.0.0.0` and print this device's Tailscale URL. Open the printed `http://<tailscale-ip>:<port>/` URL from another Tailscale-connected device to view live updates during development.
 
 ## Config
 

--- a/packages/core/src/cli/dev.ts
+++ b/packages/core/src/cli/dev.ts
@@ -1,23 +1,57 @@
 import { createServer, mergeConfig } from 'vite';
 import { createViteConfig } from '../vite/config.ts';
+import { createTailscaleShare, type ShareProvider } from './share.ts';
 
 export interface DevOptions {
   port?: number;
   host?: string | boolean;
   open?: boolean;
+  share?: ShareProvider;
 }
 
 export async function dev(opts: DevOptions = {}): Promise<void> {
   const base = await createViteConfig({ userCwd: process.cwd() });
+  const host = opts.host ?? (opts.share === 'tailscale' ? '0.0.0.0' : undefined);
   const config = mergeConfig(base, {
     server: {
       ...(opts.port !== undefined ? { port: opts.port } : {}),
-      ...(opts.host !== undefined ? { host: opts.host } : {}),
+      ...(host !== undefined ? { host } : {}),
       ...(opts.open !== undefined ? { open: opts.open } : {}),
     },
   });
   const server = await createServer(config);
   await server.listen();
   server.printUrls();
+  if (opts.share) {
+    const address = server.httpServer?.address();
+    const port = typeof address === 'object' && address ? address.port : opts.port;
+    if (!port) {
+      await server.close();
+      throw new Error('Could not determine dev server port for sharing.');
+    }
+    try {
+      if (opts.share === 'tailscale') {
+        process.stdout.write('\n');
+        process.stdout.write('  Tailscale Preview\n');
+        const share = await createTailscaleShare(port);
+        if (share.url) {
+          process.stdout.write(`  ${share.url}\n`);
+        } else {
+          process.stdout.write(
+            `  Run \`${share.statusCommand}\` to find this device's Tailscale IP.\n`,
+          );
+          process.stdout.write(
+            `  Then open http://<tailscale-ip>:${port}/ from another tailnet device.\n`,
+          );
+        }
+        if (share.stopCommand) {
+          process.stdout.write(`  Stop sharing with \`${share.stopCommand}\`.\n`);
+        }
+      }
+    } catch (err) {
+      await server.close();
+      throw err;
+    }
+  }
   server.bindCLIShortcuts({ print: true });
 }

--- a/packages/core/src/cli/run.test.ts
+++ b/packages/core/src/cli/run.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parsePort } from './run.ts';
+import { parsePort, parseShareProvider } from './run.ts';
 
 describe('parsePort', () => {
   it('accepts valid integer ports', () => {
@@ -22,5 +22,15 @@ describe('parsePort', () => {
 
   it('rejects non-integer numbers', () => {
     expect(() => parsePort('80.5')).toThrow(/Invalid port/);
+  });
+});
+
+describe('parseShareProvider', () => {
+  it('accepts tailscale', () => {
+    expect(parseShareProvider('tailscale')).toBe('tailscale');
+  });
+
+  it('rejects unknown share providers', () => {
+    expect(() => parseShareProvider('ngrok')).toThrow(/Invalid share provider/);
   });
 });

--- a/packages/core/src/cli/run.ts
+++ b/packages/core/src/cli/run.ts
@@ -4,6 +4,7 @@ import * as readline from 'node:readline/promises';
 import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { Command, Option } from 'commander';
+import type { ShareProvider } from './share.ts';
 import { detectSkillsDrift, syncSkills } from './sync.ts';
 
 async function readVersion(): Promise<string> {
@@ -22,6 +23,11 @@ export function parsePort(value: string): number {
   return n;
 }
 
+export function parseShareProvider(value: string): ShareProvider {
+  if (value === 'tailscale') return value;
+  throw new Error(`Invalid share provider: ${value}`);
+}
+
 interface ServerFlags {
   port?: number;
   host?: string | boolean;
@@ -30,6 +36,7 @@ interface ServerFlags {
 
 interface DevFlags extends ServerFlags {
   skillsCheck?: boolean;
+  share?: ShareProvider;
 }
 
 async function runSkillsDriftCheck(skillsDir: string): Promise<void> {
@@ -103,6 +110,11 @@ export async function run(argv: string[]): Promise<void> {
     .description('Start the dev server')
     .addOption(new Option('-p, --port <port>', 'port to listen on').argParser(parsePort))
     .addOption(new Option('--host [host]', 'expose on the network (optional host)'))
+    .addOption(
+      new Option('--share <provider>', 'share the dev server with a provider')
+        .choices(['tailscale'])
+        .argParser(parseShareProvider),
+    )
     .option('--open', 'open the browser on start')
     .option('--no-skills-check', 'skip the built-in skills drift check')
     .action(async (flags: DevFlags) => {

--- a/packages/core/src/cli/share.test.ts
+++ b/packages/core/src/cli/share.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createTailscaleShare, TAILSCALE_IP_TIMEOUT_MS } from './share.ts';
+
+describe('createTailscaleShare', () => {
+  it('uses the local Tailscale IPv4 address for a tailnet URL', async () => {
+    const commands: string[][] = [];
+    const timeoutMs: Array<number | undefined> = [];
+    expect(TAILSCALE_IP_TIMEOUT_MS).toBeGreaterThanOrEqual(2_000);
+    expect(TAILSCALE_IP_TIMEOUT_MS).toBeLessThanOrEqual(5_000);
+    const share = await createTailscaleShare(5173, {
+      run: async (command, args, opts) => {
+        commands.push([command, ...args]);
+        timeoutMs.push(opts?.timeoutMs);
+        return '100.124.194.22\n';
+      },
+    });
+
+    expect(commands).toEqual([['tailscale', 'ip', '-4']]);
+    expect(timeoutMs).toEqual([TAILSCALE_IP_TIMEOUT_MS]);
+    expect(share.url).toBe('http://100.124.194.22:5173/');
+    expect(share.stopCommand).toBeNull();
+  });
+
+  it('falls back to status guidance when Tailscale does not report an IPv4 address', async () => {
+    const share = await createTailscaleShare(5173, {
+      run: async () => '',
+    });
+
+    expect(share.url).toBeNull();
+    expect(share.statusCommand).toBe('tailscale status');
+  });
+
+  it('falls back to status guidance when Tailscale IP lookup fails', async () => {
+    const share = await createTailscaleShare(5173, {
+      run: async () => {
+        throw new Error('ip lookup failed');
+      },
+    });
+
+    expect(share.url).toBeNull();
+    expect(share.statusCommand).toBe('tailscale status');
+  });
+});

--- a/packages/core/src/cli/share.ts
+++ b/packages/core/src/cli/share.ts
@@ -1,0 +1,60 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+export const TAILSCALE_IP_TIMEOUT_MS = 3_000;
+
+export type ShareProvider = 'tailscale';
+
+export type ShareResult = {
+  provider: ShareProvider;
+  url: string | null;
+  statusCommand: string;
+  stopCommand: string | null;
+};
+
+export type TailscaleRunner = {
+  run(command: string, args: string[], opts?: { timeoutMs?: number }): Promise<string>;
+};
+
+const defaultRunner: TailscaleRunner = {
+  async run(command, args, opts) {
+    try {
+      const { stdout } = await execFileAsync(command, args, {
+        ...(opts?.timeoutMs !== undefined ? { timeout: opts.timeoutMs } : {}),
+      });
+      return stdout;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(
+          'tailscale CLI not found. Install Tailscale and make sure `tailscale` is on PATH.',
+        );
+      }
+      throw err;
+    }
+  },
+};
+
+function parseTailscaleIpv4(rawIp: string): string | null {
+  const [first] = rawIp.trim().split(/\s+/);
+  return first && /^\d{1,3}(?:\.\d{1,3}){3}$/.test(first) ? first : null;
+}
+
+export async function createTailscaleShare(
+  port: number,
+  runner: TailscaleRunner = defaultRunner,
+): Promise<ShareResult> {
+  let rawIp = '';
+  try {
+    rawIp = await runner.run('tailscale', ['ip', '-4'], { timeoutMs: TAILSCALE_IP_TIMEOUT_MS });
+  } catch {
+    rawIp = '';
+  }
+  const ip = parseTailscaleIpv4(rawIp);
+  return {
+    provider: 'tailscale',
+    url: ip ? `http://${ip}:${port}/` : null,
+    statusCommand: 'tailscale status',
+    stopCommand: null,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `open-slide dev --share tailscale` for mobile-friendly live previews over a tailnet.
- Default the dev server host to `0.0.0.0` when Tailscale sharing is requested.
- Print a direct `http://<tailscale-ip>:<port>/` URL using `tailscale ip -4`.
- Document the new flag and add a changeset for `@open-slide/core`.

## Validation

- `corepack pnpm vitest run packages/core/src/cli/run.test.ts packages/core/src/cli/share.test.ts`
- `corepack pnpm --filter @open-slide/core typecheck`
- `corepack pnpm exec biome check packages/core/src/cli/dev.ts packages/core/src/cli/run.ts packages/core/src/cli/run.test.ts packages/core/src/cli/share.ts packages/core/src/cli/share.test.ts packages/core/README.md .changeset/tall-shoes-serve.md`
- `git diff --check upstream/main..HEAD`
- `corepack pnpm --filter @open-slide/core build`

`corepack pnpm check` still fails on existing unrelated Biome issues in the demo/web files, so I validated the touched files directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --share tailscale option to the dev command to expose live development previews via a Tailscale-accessible URL; dev server will bind appropriately and prints preview URL plus an optional stop-sharing command.

* **Documentation**
  * Updated CLI docs with Tailscale live preview setup and usage instructions.

* **Tests**
  * Added tests for share provider parsing and Tailscale share behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->