### PR TITLE
feat(core): toggle slide canvas between 16:9 and 4:3

### DIFF
--- a/.changeset/aspect-toggle.md
+++ b/.changeset/aspect-toggle.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Add a toolbar button to toggle a slide's canvas between 16:9 and 4:3. Stored as `meta.aspect`; honored in the editor, presenter, present mode, and HTML/PDF exports.

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -3,7 +3,7 @@ import { useClickPageNavigation } from '@/lib/use-click-page-navigation';
 import { useWheelPageNavigation } from '@/lib/use-wheel-page-navigation';
 import { cn } from '@/lib/utils';
 import type { DesignSystem } from '../lib/design';
-import type { Page } from '../lib/sdk';
+import type { Page, SlideAspect } from '../lib/sdk';
 import type { SlideTransition } from '../lib/transition';
 import { usePrefersReducedMotion } from '../lib/use-prefers-reduced-motion';
 import { PresentBlackoutOverlay } from './present/blackout-overlay';
@@ -31,6 +31,7 @@ type Props = {
   pages: Page[];
   design?: DesignSystem;
   transition?: SlideTransition;
+  aspect?: SlideAspect;
   index: number;
   onIndexChange: (index: number) => void;
   onExit: () => void;
@@ -49,6 +50,7 @@ export function Player({
   pages,
   design,
   transition,
+  aspect,
   index,
   onIndexChange,
   onExit,
@@ -308,7 +310,7 @@ export function Player({
         controls && (hideCursor ? 'cursor-none' : 'cursor-default'),
       )}
     >
-      <SlideCanvas flat design={design}>
+      <SlideCanvas flat design={design} aspect={aspect}>
         <SlideTransitionLayer
           pages={pages}
           index={index}
@@ -347,6 +349,7 @@ export function Player({
           <PresentOverviewGrid
             pages={pages}
             design={design}
+            aspect={aspect}
             open={overviewOpen}
             current={index}
             onClose={() => setOverviewOpen(false)}

--- a/packages/core/src/app/components/present/overview-grid.tsx
+++ b/packages/core/src/app/components/present/overview-grid.tsx
@@ -3,23 +3,33 @@ import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import type { DesignSystem } from '../../lib/design';
 import { SlidePageProvider } from '../../lib/page-context';
-import type { Page } from '../../lib/sdk';
-import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../../lib/sdk';
+import type { Page, SlideAspect } from '../../lib/sdk';
+import { getCanvasDims } from '../../lib/sdk';
 import { SlideCanvas } from '../slide-canvas';
 
 const THUMB_W = 320;
-const THUMB_H = (THUMB_W * CANVAS_HEIGHT) / CANVAS_WIDTH;
 
 type Props = {
   pages: Page[];
   design?: DesignSystem;
+  aspect?: SlideAspect;
   open: boolean;
   current: number;
   onClose: () => void;
   onSelect: (index: number) => void;
 };
 
-export function PresentOverviewGrid({ pages, design, open, current, onClose, onSelect }: Props) {
+export function PresentOverviewGrid({
+  pages,
+  design,
+  aspect,
+  open,
+  current,
+  onClose,
+  onSelect,
+}: Props) {
+  const { width: canvasW, height: canvasH } = getCanvasDims(aspect);
+  const thumbH = (THUMB_W * canvasH) / canvasW;
   const [focused, setFocused] = useState(current);
   const gridRef = useRef<HTMLDivElement>(null);
   const focusedRef = useRef<HTMLButtonElement | null>(null);
@@ -128,14 +138,15 @@ export function PresentOverviewGrid({ pages, design, open, current, onClose, onS
                     'relative w-full overflow-hidden rounded-[4px] bg-black ring-1 ring-white/10 transition-shadow',
                     isFocused && 'ring-2 ring-[var(--brand,#ef4444)]',
                   )}
-                  style={{ height: THUMB_H }}
+                  style={{ height: thumbH }}
                 >
                   <SlideCanvas
-                    scale={THUMB_W / CANVAS_WIDTH}
+                    scale={THUMB_W / canvasW}
                     center={false}
                     flat
                     freezeMotion
                     design={design}
+                    aspect={aspect}
                   >
                     <SlidePageProvider index={i} total={pages.length}>
                       <PageComp />

--- a/packages/core/src/app/components/slide-canvas.tsx
+++ b/packages/core/src/app/components/slide-canvas.tsx
@@ -1,7 +1,7 @@
 import { type CSSProperties, type ReactNode, useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { type DesignSystem, designToCssVars } from '../lib/design';
-import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
+import { getCanvasDims, type SlideAspect } from '../lib/sdk';
 
 type Props = {
   children: ReactNode;
@@ -12,6 +12,7 @@ type Props = {
   freezeMotion?: boolean;
   className?: string;
   design?: DesignSystem;
+  aspect?: SlideAspect;
 };
 
 export function SlideCanvas({
@@ -22,9 +23,11 @@ export function SlideCanvas({
   freezeMotion = false,
   className,
   design,
+  aspect,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [fitScale, setFitScale] = useState(1);
+  const { width: canvasW, height: canvasH } = getCanvasDims(aspect);
 
   useEffect(() => {
     if (scale !== undefined) return;
@@ -33,15 +36,15 @@ export function SlideCanvas({
     const ro = new ResizeObserver(() => {
       const { width, height } = el.getBoundingClientRect();
       if (width === 0 || height === 0) return;
-      setFitScale(Math.min(width / CANVAS_WIDTH, height / CANVAS_HEIGHT));
+      setFitScale(Math.min(width / canvasW, height / canvasH));
     });
     ro.observe(el);
     return () => ro.disconnect();
-  }, [scale]);
+  }, [scale, canvasW, canvasH]);
 
   const s = scale ?? fitScale;
-  const scaledW = CANVAS_WIDTH * s;
-  const scaledH = CANVAS_HEIGHT * s;
+  const scaledW = canvasW * s;
+  const scaledH = canvasH * s;
 
   return (
     <div ref={containerRef} className={cn('relative h-full w-full overflow-hidden', className)}>
@@ -70,8 +73,8 @@ export function SlideCanvas({
           data-osd-freeze-motion={freezeMotion ? '' : undefined}
           style={
             {
-              width: CANVAS_WIDTH,
-              height: CANVAS_HEIGHT,
+              width: canvasW,
+              height: canvasH,
               transform: `scale(${s})`,
               transformOrigin: 'top left',
               ...(design ? designToCssVars(design) : {}),

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -29,8 +29,8 @@ import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import type { DesignSystem } from '../lib/design';
 import { SlidePageProvider } from '../lib/page-context';
-import type { Page } from '../lib/sdk';
-import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
+import type { Page, SlideAspect } from '../lib/sdk';
+import { getCanvasDims } from '../lib/sdk';
 import { SlideCanvas } from './slide-canvas';
 
 type Orientation = 'vertical' | 'horizontal';
@@ -50,6 +50,7 @@ type Props = {
   orientation?: Orientation;
   /** Vertical-only: total rail width in px. Thumbnails scale to fit. */
   width?: number;
+  aspect?: SlideAspect;
 };
 
 const DEFAULT_VERTICAL_THUMB_WIDTH = 184;
@@ -66,7 +67,9 @@ export function ThumbnailRail({
   actions,
   orientation = 'vertical',
   width,
+  aspect,
 }: Props) {
+  const { width: canvasW, height: canvasH } = getCanvasDims(aspect);
   const activeRef = useRef<HTMLButtonElement | null>(null);
   const t = useLocale();
 
@@ -82,8 +85,8 @@ export function ThumbnailRail({
   }, [current]);
 
   if (orientation === 'horizontal') {
-    const scale = HORIZONTAL_THUMB_HEIGHT / CANVAS_HEIGHT;
-    const width = CANVAS_WIDTH * scale;
+    const scale = HORIZONTAL_THUMB_HEIGHT / canvasH;
+    const width = canvasW * scale;
     return (
       <div className="bg-sidebar">
         <div className="overflow-x-auto overflow-y-hidden">
@@ -118,7 +121,14 @@ export function ThumbnailRail({
                     )}
                     style={{ width, height: HORIZONTAL_THUMB_HEIGHT }}
                   >
-                    <SlideCanvas scale={scale} center={false} flat freezeMotion design={design}>
+                    <SlideCanvas
+                      scale={scale}
+                      center={false}
+                      flat
+                      freezeMotion
+                      design={design}
+                      aspect={aspect}
+                    >
                       <SlidePageProvider index={i} total={pages.length}>
                         <PageComp />
                       </SlidePageProvider>
@@ -150,8 +160,8 @@ export function ThumbnailRail({
     width != null
       ? Math.max(MIN_VERTICAL_THUMB_WIDTH, width - VERTICAL_RAIL_CHROME)
       : DEFAULT_VERTICAL_THUMB_WIDTH;
-  const scale = thumbWidth / CANVAS_WIDTH;
-  const height = CANVAS_HEIGHT * scale;
+  const scale = thumbWidth / canvasW;
+  const height = canvasH * scale;
 
   const renderThumb = (PageComp: Page, i: number) => {
     const active = i === current;
@@ -165,6 +175,7 @@ export function ThumbnailRail({
         scale={scale}
         thumbWidth={thumbWidth}
         height={height}
+        aspect={aspect}
       />
     );
 
@@ -247,6 +258,7 @@ function ThumbContents({
   scale,
   thumbWidth,
   height,
+  aspect,
 }: {
   index: number;
   total: number;
@@ -256,6 +268,7 @@ function ThumbContents({
   scale: number;
   thumbWidth: number;
   height: number;
+  aspect?: SlideAspect;
 }) {
   return (
     <>
@@ -276,7 +289,7 @@ function ThumbContents({
         )}
         style={{ width: thumbWidth, height }}
       >
-        <SlideCanvas scale={scale} center={false} flat freezeMotion design={design}>
+        <SlideCanvas scale={scale} center={false} flat freezeMotion design={design} aspect={aspect}>
           <SlidePageProvider index={index} total={total}>
             <PageComp />
           </SlidePageProvider>

--- a/packages/core/src/app/lib/export-html.ts
+++ b/packages/core/src/app/lib/export-html.ts
@@ -2,7 +2,7 @@ import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { designToCssVars } from './design';
 import { SlidePageProvider } from './page-context';
-import type { SlideModule } from './sdk';
+import { getCanvasDims, type SlideModule } from './sdk';
 
 type AssetEntry = { name: string; bytes: Uint8Array };
 
@@ -13,8 +13,9 @@ export async function exportSlideAsHtml(slide: SlideModule, slideId: string): Pr
   const pages = slide.default ?? [];
   if (pages.length === 0) return;
   const title = slide.meta?.title ?? slideId;
+  const { width: canvasW, height: canvasH } = getCanvasDims(slide.meta?.aspect);
 
-  const pagesHtml = await renderPagesToHtml(pages);
+  const pagesHtml = await renderPagesToHtml(pages, canvasW, canvasH);
   const bundledCss = collectCss();
   const externalLinks = collectExternalStylesheetLinks();
 
@@ -47,6 +48,8 @@ export async function exportSlideAsHtml(slide: SlideModule, slideId: string): Pr
     bundledCss: rewrittenCss,
     externalLinks,
     design: slide.design,
+    canvasW,
+    canvasH,
   });
 
   const htmlBytes = new TextEncoder().encode(html);
@@ -68,15 +71,19 @@ export async function exportSlideAsHtml(slide: SlideModule, slideId: string): Pr
   downloadBlob(new Blob([zipped as BlobPart], { type: 'application/zip' }), `${slideId}.zip`);
 }
 
-async function renderPagesToHtml(pages: NonNullable<SlideModule['default']>): Promise<string[]> {
+async function renderPagesToHtml(
+  pages: NonNullable<SlideModule['default']>,
+  canvasW: number,
+  canvasH: number,
+): Promise<string[]> {
   const container = document.createElement('div');
   container.setAttribute('aria-hidden', 'true');
   Object.assign(container.style, {
     position: 'fixed',
     left: '-99999px',
     top: '0',
-    width: '1920px',
-    height: '1080px',
+    width: `${canvasW}px`,
+    height: `${canvasH}px`,
     pointerEvents: 'none',
   });
   document.body.appendChild(container);
@@ -87,8 +94,8 @@ async function renderPagesToHtml(pages: NonNullable<SlideModule['default']>): Pr
       const Page = pages[i];
       if (!Page) continue;
       const host = document.createElement('div');
-      host.style.width = '1920px';
-      host.style.height = '1080px';
+      host.style.width = `${canvasW}px`;
+      host.style.height = `${canvasH}px`;
       container.appendChild(host);
       const root = createRoot(host);
       root.render(
@@ -237,6 +244,8 @@ function buildHtml(opts: {
   bundledCss: string;
   externalLinks: string;
   design: SlideModule['design'];
+  canvasW: number;
+  canvasH: number;
 }): string {
   const pagesMarkup = opts.pagesHtml
     .map(
@@ -260,7 +269,7 @@ ${opts.externalLinks}
 <style>
 html, body { margin: 0; height: 100%; background: #000; overflow: hidden; font-family: system-ui, sans-serif; }
 .os-stage { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; }
-.os-frame { width: 1920px; height: 1080px; background: #fff; color: #000; transform-origin: center center; overflow: hidden; position: relative; }
+.os-frame { width: ${opts.canvasW}px; height: ${opts.canvasH}px; background: #fff; color: #000; transform-origin: center center; overflow: hidden; position: relative; }
 .os-page { position: absolute; inset: 0; }
 .os-page[hidden] { display: none !important; }
 .os-counter { position: fixed; bottom: 12px; left: 50%; transform: translateX(-50%); color: #fff; background: rgba(0,0,0,.5); padding: 2px 10px; border-radius: 999px; font-size: 12px; z-index: 10; font-variant-numeric: tabular-nums; }
@@ -277,7 +286,7 @@ html, body { margin: 0; height: 100%; background: #000; overflow: hidden; font-f
   var frame = document.getElementById('os-frame');
   var cur = document.getElementById('os-cur');
   function fit() {
-    var s = Math.min(window.innerWidth / 1920, window.innerHeight / 1080);
+    var s = Math.min(window.innerWidth / ${opts.canvasW}, window.innerHeight / ${opts.canvasH});
     frame.style.transform = 'scale(' + s + ')';
   }
   function go(i) {

--- a/packages/core/src/app/lib/export-pdf.ts
+++ b/packages/core/src/app/lib/export-pdf.ts
@@ -3,13 +3,14 @@ import { createRoot, type Root } from 'react-dom/client';
 import { designToCssVars } from './design';
 import { SlidePageProvider } from './page-context';
 import { isFrameAnimationSettled, waitForDataWaitfor, waitForFonts } from './print-ready';
-import type { SlideModule } from './sdk';
+import { getCanvasDims, type SlideModule } from './sdk';
 
 const PRINT_ROOT_ID = 'os-print-root';
 const PRINT_STYLE_ID = 'os-print-style';
 
-const PRINT_STYLES = `
-@page { size: 1920px 1080px; margin: 0; }
+function buildPrintStyles(width: number, height: number): string {
+  return `
+@page { size: ${width}px ${height}px; margin: 0; }
 
 @media screen {
   #${PRINT_ROOT_ID} {
@@ -36,8 +37,8 @@ const PRINT_STYLES = `
     background: #fff !important;
   }
   #${PRINT_ROOT_ID} .os-print-frame {
-    width: 1920px !important;
-    height: 1080px !important;
+    width: ${width}px !important;
+    height: ${height}px !important;
     background: #fff;
     color: #000;
     overflow: hidden;
@@ -52,13 +53,13 @@ const PRINT_STYLES = `
   }
   /* Supersample: Chrome rasterizes filtered/composited layers (e.g. filter:
      blur, mix-blend-mode) at the layer's CSS-pixel size, so a blurred
-     gradient on a 1920×1080 page bakes in at ~1× DPI and bands when the PDF
+     gradient on a page bakes in at ~1× DPI and bands when the PDF
      is viewed scaled up. zoom:2 doubles the layer raster size; scale(0.5)
-     composites it back to 1920×1080. Vector content (text, plain CSS
-     gradients, SVG) stays vector through both transforms. */
+     composites it back. Vector content (text, plain CSS gradients, SVG)
+     stays vector through both transforms. */
   #${PRINT_ROOT_ID} .os-print-supersample {
-    width: 1920px !important;
-    height: 1080px !important;
+    width: ${width}px !important;
+    height: ${height}px !important;
     zoom: 2;
     transform: scale(0.5);
     transform-origin: top left;
@@ -79,6 +80,7 @@ const PRINT_STYLES = `
   }
 }
 `;
+}
 
 export function isSafari(): boolean {
   if (typeof navigator === 'undefined') return false;
@@ -107,10 +109,11 @@ export async function exportSlideAsPdf(
   if (pages.length === 0) return;
 
   const total = pages.length;
+  const { width: canvasW, height: canvasH } = getCanvasDims(slide.meta?.aspect);
 
   const style = document.createElement('style');
   style.id = PRINT_STYLE_ID;
-  style.textContent = PRINT_STYLES;
+  style.textContent = buildPrintStyles(canvasW, canvasH);
   document.head.appendChild(style);
 
   const root = document.createElement('div');
@@ -130,15 +133,15 @@ export async function exportSlideAsPdf(
     const host = document.createElement('div');
     host.className = 'os-print-frame';
     host.setAttribute('data-osd-canvas', '');
-    host.style.width = '1920px';
-    host.style.height = '1080px';
+    host.style.width = `${canvasW}px`;
+    host.style.height = `${canvasH}px`;
     if (designVars) {
       for (const [k, v] of Object.entries(designVars)) host.style.setProperty(k, v);
     }
     const inner = document.createElement('div');
     inner.className = 'os-print-supersample';
-    inner.style.width = '1920px';
-    inner.style.height = '1080px';
+    inner.style.width = `${canvasW}px`;
+    inner.style.height = `${canvasH}px`;
     host.appendChild(inner);
     root.appendChild(host);
     frames.push(host);

--- a/packages/core/src/app/lib/sdk.test.ts
+++ b/packages/core/src/app/lib/sdk.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { CANVAS_HEIGHT, CANVAS_WIDTH } from './sdk.ts';
+import { CANVAS_HEIGHT, CANVAS_WIDTH, getCanvasDims } from './sdk.ts';
 
 describe('canvas constants', () => {
   it('targets a 1920x1080 canvas', () => {
@@ -9,5 +9,19 @@ describe('canvas constants', () => {
 
   it('preserves a 16:9 aspect ratio', () => {
     expect(CANVAS_WIDTH / CANVAS_HEIGHT).toBeCloseTo(16 / 9);
+  });
+});
+
+describe('getCanvasDims', () => {
+  it('returns 16:9 dims by default', () => {
+    expect(getCanvasDims(undefined)).toEqual({ width: 1920, height: 1080 });
+    expect(getCanvasDims('16:9')).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it('returns 4:3 dims when requested', () => {
+    const { width, height } = getCanvasDims('4:3');
+    expect(width).toBe(1440);
+    expect(height).toBe(1080);
+    expect(width / height).toBeCloseTo(4 / 3);
   });
 });

--- a/packages/core/src/app/lib/sdk.ts
+++ b/packages/core/src/app/lib/sdk.ts
@@ -41,8 +41,6 @@ export const CANVAS_WIDTH = 1920;
 export const CANVAS_HEIGHT = 1080;
 export const CANVAS_WIDTH_4_3 = 1440;
 
-export const DEFAULT_ASPECT: SlideAspect = '16:9';
-
 export function getCanvasDims(aspect: SlideAspect | undefined): { width: number; height: number } {
   return aspect === '4:3'
     ? { width: CANVAS_WIDTH_4_3, height: CANVAS_HEIGHT }

--- a/packages/core/src/app/lib/sdk.ts
+++ b/packages/core/src/app/lib/sdk.ts
@@ -4,11 +4,15 @@ import type { SlideTransition } from './transition.ts';
 
 export type Page = ComponentType & { transition?: SlideTransition };
 
+export type SlideAspect = '16:9' | '4:3';
+
 export type SlideMeta = {
   title?: string;
   theme?: string;
   /** ISO 8601 timestamp. Set once at scaffold time; used to sort the slide list. */
   createdAt?: string;
+  /** Canvas aspect ratio. Defaults to '16:9' when omitted. */
+  aspect?: SlideAspect;
 };
 
 export type SlideModule = {
@@ -35,3 +39,12 @@ export type FoldersManifest = {
 
 export const CANVAS_WIDTH = 1920;
 export const CANVAS_HEIGHT = 1080;
+export const CANVAS_WIDTH_4_3 = 1440;
+
+export const DEFAULT_ASPECT: SlideAspect = '16:9';
+
+export function getCanvasDims(aspect: SlideAspect | undefined): { width: number; height: number } {
+  return aspect === '4:3'
+    ? { width: CANVAS_WIDTH_4_3, height: CANVAS_HEIGHT }
+    : { width: CANVAS_WIDTH, height: CANVAS_HEIGHT };
+}

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -460,7 +460,7 @@ function SlideCard({
           <div className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] group-hover:shadow-floating group-hover:ring-foreground/20 motion-safe:transition-[box-shadow,--tw-ring-color] motion-safe:duration-200">
             {FirstPage ? (
               <div className="h-full w-full motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]">
-                <SlideCanvas flat freezeMotion design={slide?.design}>
+                <SlideCanvas flat freezeMotion design={slide?.design} aspect={slide?.meta?.aspect}>
                   <SlidePageProvider index={0} total={slide?.default.length ?? 1}>
                     <FirstPage />
                   </SlidePageProvider>

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -457,7 +457,10 @@ function SlideCard({
       >
         <Link to={`/s/${id}`} className="block focus-visible:outline-none">
           {/* Slide thumb — tight border, grey baseboard, no shadcn rounded-xl */}
-          <div className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] group-hover:shadow-floating group-hover:ring-foreground/20 motion-safe:transition-[box-shadow,--tw-ring-color] motion-safe:duration-200">
+          <div
+            className="relative overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] group-hover:shadow-floating group-hover:ring-foreground/20 motion-safe:transition-[box-shadow,--tw-ring-color] motion-safe:duration-200"
+            style={{ aspectRatio: slide?.meta?.aspect === '4:3' ? '4 / 3' : '16 / 9' }}
+          >
             {FirstPage ? (
               <div className="h-full w-full motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]">
                 <SlideCanvas flat freezeMotion design={slide?.design} aspect={slide?.meta?.aspect}>

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -10,7 +10,7 @@ import {
 } from '../components/present/use-presenter-channel';
 import { SlideCanvas } from '../components/slide-canvas';
 import { SlidePageProvider } from '../lib/page-context';
-import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
+import { getCanvasDims } from '../lib/sdk';
 import { useSlideModule } from '../lib/use-slide-module';
 
 export function Presenter() {
@@ -122,6 +122,8 @@ export function Presenter() {
 
   const CurrentPage = pages[index];
   const NextPage = hasNext ? pages[nextIndex] : null;
+  const aspect = slide.meta?.aspect;
+  const { width: canvasW, height: canvasH } = getCanvasDims(aspect);
 
   return (
     <div className="dark flex h-dvh w-screen flex-col overflow-hidden bg-background text-foreground">
@@ -138,7 +140,7 @@ export function Presenter() {
         <section className="flex min-h-0 flex-col gap-3">
           <SectionLabel>{t.presenter.nowShowing}</SectionLabel>
           <div className="relative min-h-0 flex-1 overflow-hidden rounded-[8px] bg-black ring-1 ring-border">
-            <SlideCanvas flat design={slide.design}>
+            <SlideCanvas flat design={slide.design} aspect={aspect}>
               <SlidePageProvider index={index} total={total}>
                 <CurrentPage />
               </SlidePageProvider>
@@ -163,10 +165,10 @@ export function Presenter() {
             <SectionLabel>{hasNext ? t.presenter.upNext : t.presenter.lastSlide}</SectionLabel>
             <div
               className="relative w-full overflow-hidden rounded-[8px] bg-black ring-1 ring-border"
-              style={{ aspectRatio: `${CANVAS_WIDTH}/${CANVAS_HEIGHT}` }}
+              style={{ aspectRatio: `${canvasW}/${canvasH}` }}
             >
               {NextPage ? (
-                <SlideCanvas flat freezeMotion design={slide.design}>
+                <SlideCanvas flat freezeMotion design={slide.design} aspect={aspect}>
                   <SlidePageProvider index={nextIndex} total={total}>
                     <NextPage />
                   </SlidePageProvider>

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -53,7 +53,7 @@ import { type ThumbnailActions, ThumbnailRail } from '../components/thumbnail-ra
 import { exportSlideAsHtml } from '../lib/export-html';
 import { exportSlideAsPdf, isSafari } from '../lib/export-pdf';
 import { remapNotesSessionCacheAfterReorder } from '../lib/inspector/use-notes';
-import type { SlideModule } from '../lib/sdk';
+import type { SlideAspect, SlideModule } from '../lib/sdk';
 import { usePrefersReducedMotion } from '../lib/use-prefers-reduced-motion';
 import { useSlideModule } from '../lib/use-slide-module';
 
@@ -227,6 +227,25 @@ export function Slide() {
     [duplicatePage, deletePage],
   );
 
+  const updateAspect = useCallback(
+    async (next: SlideAspect) => {
+      try {
+        const res = await fetch(`/__slides/${encodeURIComponent(slideId)}/aspect`, {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ aspect: next }),
+        });
+        if (!res.ok) {
+          const detail = await res.json().catch(() => ({ error: res.statusText }));
+          throw new Error(detail.error ?? `HTTP ${res.status}`);
+        }
+      } catch (err) {
+        toast.error(`Failed to set aspect: ${String((err as Error).message ?? err)}`);
+      }
+    },
+    [slideId],
+  );
+
   useEffect(() => {
     if (playMode) return;
     const onKey = (e: KeyboardEvent) => {
@@ -316,6 +335,7 @@ export function Slide() {
       <Player
         pages={pages}
         design={slide.design}
+        aspect={slide.meta?.aspect}
         index={index}
         onIndexChange={goTo}
         onExit={() => {}}
@@ -330,6 +350,7 @@ export function Slide() {
         pages={pages}
         design={slide.design}
         transition={slide.transition}
+        aspect={slide.meta?.aspect}
         index={index}
         onIndexChange={goTo}
         onExit={() => setPlayMode(null)}
@@ -341,6 +362,7 @@ export function Slide() {
   }
 
   const title = slide.meta?.title ?? slideId;
+  const aspect = slide.meta?.aspect;
 
   return (
     <HistoryProvider>
@@ -506,6 +528,18 @@ export function Slide() {
               {view === 'slides' && (
                 <DesignToggleButton active={designOpen} onToggle={() => setDesignOpen((v) => !v)} />
               )}
+              {view === 'slides' && import.meta.env.DEV && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => updateAspect(aspect === '4:3' ? '16:9' : '4:3')}
+                  title={t.slide.aspectToggleTitle}
+                  aria-label={t.slide.aspectToggleAria}
+                  className="font-mono text-[11px] tabular-nums"
+                >
+                  {aspect === '4:3' ? '4:3' : '16:9'}
+                </Button>
+              )}
               {view === 'slides' && <InspectToggleButton />}
               <span aria-hidden className="mx-0.5 hidden h-5 w-px bg-hairline md:block" />
               {view === 'slides' && (
@@ -574,6 +608,7 @@ export function Slide() {
                     onSelect={goTo}
                     onReorder={import.meta.env.DEV ? reorderPage : undefined}
                     actions={thumbnailActions}
+                    aspect={aspect}
                   />
                   <main
                     ref={slideViewportRef}
@@ -588,7 +623,7 @@ export function Slide() {
                       canPrev={index > 0}
                       canNext={index < pageCount - 1}
                     />
-                    <SlideCanvas design={slide.design}>
+                    <SlideCanvas design={slide.design} aspect={aspect}>
                       <SlideTransitionLayer
                         pages={pages}
                         index={index}
@@ -614,6 +649,7 @@ export function Slide() {
                       onSelect={goTo}
                       orientation="horizontal"
                       actions={thumbnailActions}
+                      aspect={aspect}
                     />
                   </div>
                   <InspectorPanel />
@@ -656,6 +692,7 @@ function ResizableRail(props: {
   onSelect: (i: number) => void;
   onReorder?: (from: number, to: number) => void;
   actions?: ThumbnailActions;
+  aspect?: SlideAspect;
 }) {
   const t = useLocale();
   const [width, setWidth] = useState<number>(readStoredRailWidth);

--- a/packages/core/src/editing/slide-ops.test.ts
+++ b/packages/core/src/editing/slide-ops.test.ts
@@ -442,10 +442,20 @@ describe('updateMetaAspectInSource', () => {
     expect(updateMetaAspectInSource(baseMultiline, '16:9')).toBe(baseMultiline);
   });
 
-  it('creates a meta block when none exists and aspect is not the default', () => {
+  it('eats a same-line trailing comment when removing aspect', () => {
+    const source = `export const meta: SlideMeta = {\n  aspect: '4:3', // widescreen off\n  title: 'Hi',\n};\nexport default [];\n`;
+    const out = updateMetaAspectInSource(source, '16:9');
+    expect(out).not.toContain('aspect');
+    expect(out).not.toContain('widescreen off');
+    expect(out).not.toMatch(/\{\n[ \t]+\n/);
+    expect(out).toContain("title: 'Hi'");
+  });
+
+  it('creates an untyped meta block when none exists (no dangling SlideMeta import)', () => {
     const source = `export default [];\n`;
     const out = updateMetaAspectInSource(source, '4:3');
     expect(out).toContain("aspect: '4:3'");
-    expect(out).toContain('export const meta: SlideMeta');
+    expect(out).toContain('export const meta = {');
+    expect(out).not.toContain('SlideMeta');
   });
 });

--- a/packages/core/src/editing/slide-ops.test.ts
+++ b/packages/core/src/editing/slide-ops.test.ts
@@ -8,6 +8,7 @@ import {
   removePageFromDefaultExportInSource,
   reorderDefaultExportPagesInSource,
   reorderNotesArrayInSource,
+  updateMetaAspectInSource,
   updateMetaTitleInSource,
   validateSlideName,
 } from './slide-ops.ts';
@@ -410,5 +411,41 @@ export default [
 
   it('returns null when the default export is not an array', () => {
     expect(duplicatePageInDefaultExportInSource(`export default A;\n`, 0)).toBeNull();
+  });
+});
+
+describe('updateMetaAspectInSource', () => {
+  const baseMultiline = `export const meta: SlideMeta = {\n  title: 'Hello',\n};\nexport default [];\n`;
+
+  it('inserts aspect when meta exists without one', () => {
+    const out = updateMetaAspectInSource(baseMultiline, '4:3');
+    expect(out).toContain("aspect: '4:3'");
+    expect(out).toContain("title: 'Hello'");
+  });
+
+  it('rewrites an existing aspect literal', () => {
+    const source = `export const meta: SlideMeta = {\n  aspect: '4:3',\n  title: 'Hi',\n};\nexport default [];\n`;
+    const out = updateMetaAspectInSource(source, '4:3');
+    expect(out).toContain("aspect: '4:3'");
+  });
+
+  it('removes the aspect line entirely when switching back to 16:9', () => {
+    const source = `export const meta: SlideMeta = {\n  aspect: '4:3',\n  title: 'Hi',\n};\nexport default [];\n`;
+    const out = updateMetaAspectInSource(source, '16:9');
+    expect(out).not.toContain('aspect');
+    // No stray indented blank line where the property used to live.
+    expect(out).not.toMatch(/\{\n[ \t]+\n/);
+    expect(out).toContain("title: 'Hi'");
+  });
+
+  it('returns the source unchanged when removing an aspect that does not exist', () => {
+    expect(updateMetaAspectInSource(baseMultiline, '16:9')).toBe(baseMultiline);
+  });
+
+  it('creates a meta block when none exists and aspect is not the default', () => {
+    const source = `export default [];\n`;
+    const out = updateMetaAspectInSource(source, '4:3');
+    expect(out).toContain("aspect: '4:3'");
+    expect(out).toContain('export const meta: SlideMeta');
   });
 });

--- a/packages/core/src/editing/slide-ops.ts
+++ b/packages/core/src/editing/slide-ops.ts
@@ -254,6 +254,8 @@ export function updateMetaTitleInSource(source: string, title: string): string |
   return source.slice(0, exportDefaultIdx) + insertion + source.slice(exportDefaultIdx);
 }
 
+// Mirror of SlideAspect in app/lib/sdk.ts; kept separate so this editor-side
+// module doesn't import the client runtime.
 export type SlideAspectValue = '16:9' | '4:3';
 
 export function validateSlideAspect(v: unknown): SlideAspectValue | null {

--- a/packages/core/src/editing/slide-ops.ts
+++ b/packages/core/src/editing/slide-ops.ts
@@ -254,6 +254,102 @@ export function updateMetaTitleInSource(source: string, title: string): string |
   return source.slice(0, exportDefaultIdx) + insertion + source.slice(exportDefaultIdx);
 }
 
+export type SlideAspectValue = '16:9' | '4:3';
+
+export function validateSlideAspect(v: unknown): SlideAspectValue | null {
+  return v === '16:9' || v === '4:3' ? v : null;
+}
+
+/**
+ * Rewrite (or insert) the `aspect` field in the slide module's `export const meta`.
+ * Mirrors updateMetaTitleInSource but writes the `aspect` key. Setting to '16:9'
+ * removes the field instead (since it's the default).
+ */
+export function updateMetaAspectInSource(source: string, aspect: SlideAspectValue): string | null {
+  const remove = aspect === '16:9';
+  const newLiteral = `'${aspect}'`;
+
+  const metaStart = source.search(/export\s+const\s+meta\b/);
+  if (metaStart !== -1) {
+    const eqIdx = source.indexOf('=', metaStart);
+    if (eqIdx === -1) return null;
+    const openBrace = source.indexOf('{', eqIdx);
+    if (openBrace === -1) return null;
+
+    let depth = 0;
+    let closeBrace = -1;
+    for (let i = openBrace; i < source.length; i++) {
+      const ch = source[i];
+      if (ch === '{') depth++;
+      else if (ch === '}') {
+        depth--;
+        if (depth === 0) {
+          closeBrace = i;
+          break;
+        }
+      }
+    }
+    if (closeBrace === -1) return null;
+
+    const body = source.slice(openBrace + 1, closeBrace);
+    const aspectRe = /(^|[\s,{])(aspect\s*:\s*)(['"`])((?:\\.|(?!\3).)*)\3(\s*,?)/;
+    const match = body.match(aspectRe);
+    if (match) {
+      if (remove) {
+        const idx = body.indexOf(match[0]);
+        const before = body.slice(0, idx);
+        const after = body.slice(idx + match[0].length);
+        const stripped = (before + after).replace(/,(\s*[},])/, '$1');
+        return source.slice(0, openBrace + 1) + stripped + source.slice(closeBrace);
+      }
+      const newBody = body.replace(aspectRe, `${match[1]}${match[2]}${newLiteral}${match[5]}`);
+      return source.slice(0, openBrace + 1) + newBody + source.slice(closeBrace);
+    }
+
+    if (remove) return source;
+
+    const firstIndentMatch = body.match(/\n([ \t]+)\S/);
+    const indent = firstIndentMatch ? firstIndentMatch[1] : '  ';
+    const trimmedBody = body.replace(/^\s*\n?/, '');
+    const needsSeparator = trimmedBody.trim().length > 0;
+    const insertion = `\n${indent}aspect: ${newLiteral}${needsSeparator ? ',' : ''}`;
+    return source.slice(0, openBrace + 1) + insertion + body + source.slice(closeBrace);
+  }
+
+  if (remove) return source;
+
+  const exportDefaultIdx = source.search(/export\s+default\b/);
+  if (exportDefaultIdx === -1) return null;
+  const insertion = `export const meta: SlideMeta = { aspect: ${newLiteral} };\n\n`;
+  return source.slice(0, exportDefaultIdx) + insertion + source.slice(exportDefaultIdx);
+}
+
+export async function setSlideAspect(
+  slidesRoot: string,
+  slideId: string,
+  aspect: SlideAspectValue,
+): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
+  const entry = resolveSlideEntry(slidesRoot, slideId);
+  if (!entry) return { ok: false, status: 400, error: 'invalid slideId' };
+  let source: string;
+  try {
+    source = await fs.readFile(entry, 'utf8');
+  } catch {
+    return { ok: false, status: 404, error: 'slide not found' };
+  }
+  const updated = updateMetaAspectInSource(source, aspect);
+  if (updated === null) {
+    return { ok: false, status: 422, error: 'could not update slide aspect' };
+  }
+  if (updated === source) return { ok: true };
+  try {
+    await fs.writeFile(entry, updated, 'utf8');
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, status: 500, error: String((err as Error).message ?? err) };
+  }
+}
+
 type ArrayElementRange = { start: number; end: number };
 
 function findDefaultExportArray(

--- a/packages/core/src/editing/slide-ops.ts
+++ b/packages/core/src/editing/slide-ops.ts
@@ -297,8 +297,17 @@ export function updateMetaAspectInSource(source: string, aspect: SlideAspectValu
     if (match) {
       if (remove) {
         const idx = body.indexOf(match[0]);
-        const before = body.slice(0, idx);
-        const after = body.slice(idx + match[0].length);
+        const matchLen = match[0].length;
+        // Eat the indentation + newline of the line we're deleting so we don't
+        // leave a blank, indented line behind in the object literal.
+        let lineStart = idx;
+        while (lineStart > 0 && (body[lineStart - 1] === ' ' || body[lineStart - 1] === '\t')) {
+          lineStart--;
+        }
+        let lineEnd = idx + matchLen;
+        if (body[lineEnd] === '\n') lineEnd++;
+        const before = body.slice(0, lineStart);
+        const after = body.slice(lineEnd);
         const stripped = (before + after).replace(/,(\s*[},])/, '$1');
         return source.slice(0, openBrace + 1) + stripped + source.slice(closeBrace);
       }

--- a/packages/core/src/editing/slide-ops.ts
+++ b/packages/core/src/editing/slide-ops.ts
@@ -307,6 +307,11 @@ export function updateMetaAspectInSource(source: string, aspect: SlideAspectValu
           lineStart--;
         }
         let lineEnd = idx + matchLen;
+        // Also eat a same-line trailing comment so it isn't orphaned inside meta.
+        while (body[lineEnd] === ' ' || body[lineEnd] === '\t') lineEnd++;
+        if (body.startsWith('//', lineEnd)) {
+          while (lineEnd < body.length && body[lineEnd] !== '\n') lineEnd++;
+        }
         if (body[lineEnd] === '\n') lineEnd++;
         const before = body.slice(0, lineStart);
         const after = body.slice(lineEnd);
@@ -331,7 +336,9 @@ export function updateMetaAspectInSource(source: string, aspect: SlideAspectValu
 
   const exportDefaultIdx = source.search(/export\s+default\b/);
   if (exportDefaultIdx === -1) return null;
-  const insertion = `export const meta: SlideMeta = { aspect: ${newLiteral} };\n\n`;
+  // Untyped: a slide that had no meta block won't import SlideMeta, and the
+  // annotation would dangle. Inference against SlideModule.meta still checks it.
+  const insertion = `export const meta = { aspect: ${newLiteral} };\n\n`;
   return source.slice(0, exportDefaultIdx) + insertion + source.slice(exportDefaultIdx);
 }
 

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -116,6 +116,8 @@ export const en: Locale = {
     slidesTab: 'Slides',
     assetsTab: 'Assets',
     renameSlide: 'Rename slide',
+    aspectToggleTitle: 'Toggle aspect ratio (16:9 / 4:3)',
+    aspectToggleAria: 'Toggle slide aspect ratio',
     loadingEyebrow: 'Loading',
     emptyEyebrow: 'Empty',
     nothingToShow: 'Nothing to show.',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -116,6 +116,8 @@ export const ja: Locale = {
     slidesTab: 'スライド',
     assetsTab: 'アセット',
     renameSlide: 'スライドの名前を変更',
+    aspectToggleTitle: 'アスペクト比を切替 (16:9 / 4:3)',
+    aspectToggleAria: 'スライドのアスペクト比を切替',
     loadingEyebrow: '読み込み中',
     emptyEyebrow: '空',
     nothingToShow: '表示する内容がありません。',

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -117,6 +117,8 @@ export type Locale = {
     slidesTab: string;
     assetsTab: string;
     renameSlide: string;
+    aspectToggleTitle: string;
+    aspectToggleAria: string;
     loadingEyebrow: string;
     emptyEyebrow: string;
     nothingToShow: string;

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -115,6 +115,8 @@ export const zhCN: Locale = {
     slidesTab: '幻灯片',
     assetsTab: '素材',
     renameSlide: '重命名幻灯片',
+    aspectToggleTitle: '切换比例（16:9 / 4:3）',
+    aspectToggleAria: '切换幻灯片比例',
     loadingEyebrow: '加载中',
     emptyEyebrow: '空白',
     nothingToShow: '没有可显示的内容。',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -115,6 +115,8 @@ export const zhTW: Locale = {
     slidesTab: '投影片',
     assetsTab: '素材',
     renameSlide: '重新命名投影片',
+    aspectToggleTitle: '切換比例（16:9 / 4:3）',
+    aspectToggleAria: '切換投影片比例',
     loadingEyebrow: '載入中',
     emptyEyebrow: '空白',
     nothingToShow: '沒有可顯示的內容。',

--- a/packages/core/src/vite/routes/slides.ts
+++ b/packages/core/src/vite/routes/slides.ts
@@ -9,7 +9,9 @@ import {
   resolveSlideEntry,
   rmSlideDir,
   SLIDE_ID_RE,
+  setSlideAspect,
   updateMetaTitleInSource,
+  validateSlideAspect,
   validateSlideName,
 } from '../../editing/slide-ops.ts';
 import { readManifest, writeManifest } from '../../files/folders.ts';
@@ -20,6 +22,7 @@ import { type ApiContext, json, readBody } from './context.ts';
 // DELETE /__slides/:id/pages/:i           remove page
 // POST   /__slides/:id/pages/:i/duplicate duplicate page
 // POST   /__slides/:id/duplicate          duplicate slide directory { newId? }
+// PUT    /__slides/:id/aspect             set meta.aspect { aspect: '16:9' | '4:3' }
 // PATCH  /__slides/:id                    rename slide (writes meta.title)
 // DELETE /__slides/:id                    delete slide directory + folder assignment
 
@@ -144,6 +147,25 @@ export function registerSlideRoutes(server: ViteDevServer, ctx: ApiContext): voi
           await writeManifest(ctx.manifestPath, manifest);
         }
         return json(res, 200, { ok: true, slideId: duplicated.slideId });
+      }
+
+      const aspectMatch = url.pathname.match(/^\/([^/]+)\/aspect$/);
+      if (aspectMatch && method === 'PUT') {
+        const requestCheck = validateMutationRequest(req, { requireJsonBody: true });
+        if (!requestCheck.ok) {
+          return json(res, requestCheck.status, { error: requestCheck.error });
+        }
+        const slideId = aspectMatch[1];
+        if (!SLIDE_ID_RE.test(slideId)) return json(res, 400, { error: 'invalid slideId' });
+
+        const body = (await readBody(req)) as { aspect?: unknown };
+        const aspect = validateSlideAspect(body.aspect);
+        if (!aspect) return json(res, 400, { error: 'invalid aspect' });
+
+        const result = await setSlideAspect(ctx.slidesRoot, slideId, aspect);
+        if (!result.ok) return json(res, result.status, { error: result.error });
+        server.ws.send({ type: 'full-reload' });
+        return json(res, 200, { ok: true, slideId, aspect });
       }
 
       const idMatch = url.pathname.match(/^\/([^/]+)$/);


### PR DESCRIPTION
## What

Adds a per-slide aspect-ratio toggle so a deck can mix 16:9 and 4:3 slides. A `meta.aspect` field (`'16:9'` default, `'4:3'` opt-in) drives the canvas dimensions everywhere a slide is rendered, and a DEV-only toolbar button flips it.

## How

- **`meta.aspect`** — new optional `SlideAspect` field on `SlideMeta`. `getCanvasDims()` in `sdk.ts` maps it to dimensions (16:9 → 1920×1080, 4:3 → 1440×1080; height stays fixed so existing 1080-tall content isn't rescaled, the 4:3 frame just narrows).
- **Rendering** — `SlideCanvas` takes an `aspect` prop; threaded through the editor canvas, thumbnail rails (vertical + horizontal), presenter, present mode + overview grid, and home-page card previews.
- **Exports** — `export-pdf` (`@page size`, frame + supersample dims) and `export-html` (`.os-frame` size, fit script) read the slide's aspect.
- **Writer** — `setSlideAspect` / `updateMetaAspectInSource` edit `meta.aspect` in `index.tsx` via a new `PUT /__slides/:id/aspect` dev endpoint. Resetting to 16:9 removes the field (it's the default) and cleans up the line so the file doesn't accrete blank lines.
- **Toolbar button** — DEV-only segmented `16:9` / `4:3` control next to the Inspect toggle.
- **i18n** — added strings for en / ja / zh-cn / zh-tw.

## Tests

- New `getCanvasDims` unit tests (default / 16:9 / 4:3).
- New `updateMetaAspectInSource` tests covering insert / replace / remove / no-op / fresh-meta, including the no-stray-blank-line invariant.
- Full suite: 263 passing. `typecheck` + `biome check` clean.

A changeset (`minor`) is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an aspect ratio toggle to switch slides between 16:9 and 4:3; choice is stored with the slide and honored across editor, thumbnails, presenter, present mode, and HTML/PDF exports
  * Slide aspect can be updated programmatically via a new slide metadata update route

* **Localization**
  * Added toggle UI text in English, Japanese, Simplified Chinese, and Traditional Chinese
<!-- end of auto-generated comment: release notes by coderabbit.ai -->