### PR TITLE
feat(core): resizable design/inspector panels with responsive layout

### DIFF
--- a/.changeset/resizable-panels.md
+++ b/.changeset/resizable-panels.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Drag to resize the design and inspector panels, and keep the slide preview beside them on narrow viewports instead of being pushed off-screen.

--- a/packages/core/src/app/components/panel/panel-shell.tsx
+++ b/packages/core/src/app/components/panel/panel-shell.tsx
@@ -1,8 +1,24 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
 
 export const PANEL_W = 320;
+const MIN_PANEL_W = 280;
+const MAX_PANEL_W = 560;
 export const PANEL_TRANSITION_MS = 240;
+
+function panelWidthStorageKey(uiAttr: 'inspector' | 'design'): string {
+  return `open-slide:panel-width:${uiAttr}`;
+}
+
+function readStoredPanelWidth(uiAttr: 'inspector' | 'design'): number {
+  if (typeof window === 'undefined') return PANEL_W;
+  const raw = window.localStorage.getItem(panelWidthStorageKey(uiAttr));
+  const parsed = raw == null ? Number.NaN : Number(raw);
+  if (!Number.isFinite(parsed)) return PANEL_W;
+  return Math.min(MAX_PANEL_W, Math.max(MIN_PANEL_W, parsed));
+}
 
 // Defer the width expansion to the next frame so the browser paints once
 // at width=0 first; otherwise the transition has no starting frame.
@@ -51,19 +67,113 @@ export function PanelShell({
   footer,
   children,
 }: PanelShellProps) {
+  const t = useLocale();
   const dataAttrs = uiAttr === 'inspector' ? { 'data-inspector-ui': '' } : { 'data-design-ui': '' };
+
+  const [width, setWidth] = useState(() => readStoredPanelWidth(uiAttr));
+  const [resizing, setResizing] = useState(false);
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(panelWidthStorageKey(uiAttr), String(width));
+  }, [uiAttr, width]);
+
+  useEffect(() => {
+    if (!resizing) return;
+    const prev = {
+      cursor: document.body.style.cursor,
+      userSelect: document.body.style.userSelect,
+    };
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    return () => {
+      document.body.style.cursor = prev.cursor;
+      document.body.style.userSelect = prev.userSelect;
+    };
+  }, [resizing]);
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    dragRef.current = { startX: e.clientX, startWidth: width };
+    setResizing(true);
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    // Panel is docked to the right edge, so dragging the left handle leftward widens it.
+    const delta = dragRef.current.startX - e.clientX;
+    const next = Math.min(MAX_PANEL_W, Math.max(MIN_PANEL_W, dragRef.current.startWidth + delta));
+    setWidth(next);
+  };
+
+  const onPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    dragRef.current = null;
+    setResizing(false);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const step = e.shiftKey ? 32 : 8;
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      e.stopPropagation();
+      setWidth((w) => Math.min(MAX_PANEL_W, w + step));
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      e.stopPropagation();
+      setWidth((w) => Math.max(MIN_PANEL_W, w - step));
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      e.stopPropagation();
+      setWidth(PANEL_W);
+    }
+  };
+
   return (
     <aside
       {...dataAttrs}
       className="flex h-full shrink-0 justify-end overflow-hidden bg-sidebar transition-[width,border-left-width] ease-out"
       style={{
-        width: animVisible ? PANEL_W : 0,
+        width: animVisible ? width : 0,
         borderLeftWidth: animVisible ? 1 : 0,
         borderLeftColor: 'var(--hairline)',
-        transitionDuration: `${PANEL_TRANSITION_MS}ms`,
+        transitionDuration: resizing ? '0ms' : `${PANEL_TRANSITION_MS}ms`,
       }}
     >
-      <div style={{ width: PANEL_W }} className="flex h-full shrink-0 flex-col">
+      <div style={{ width }} className="relative flex h-full shrink-0 flex-col">
+        {/* biome-ignore lint/a11y/useSemanticElements: focusable resize handle (splitter pattern), not a static <hr> */}
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={t.common.resizePanel}
+          aria-valuenow={width}
+          aria-valuemin={MIN_PANEL_W}
+          aria-valuemax={MAX_PANEL_W}
+          tabIndex={0}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onKeyDown={onKeyDown}
+          onDoubleClick={() => setWidth(PANEL_W)}
+          className={cn(
+            'group/resize absolute inset-y-0 left-0 z-20 w-1.5 cursor-col-resize touch-none outline-none',
+            'focus-visible:bg-brand/20',
+          )}
+        >
+          <span
+            aria-hidden
+            className={cn(
+              'pointer-events-none absolute inset-y-0 left-0 w-px bg-brand opacity-0 transition-opacity',
+              'group-hover/resize:opacity-100 group-focus-visible/resize:opacity-100',
+              resizing && 'opacity-100',
+            )}
+          />
+        </div>
         <header className="flex h-9 shrink-0 items-center justify-between gap-2 border-b border-hairline px-3">
           {header}
         </header>

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -566,7 +566,7 @@ export function Slide() {
           ) : (
             <DesignProvider slideId={slideId}>
               <div className="flex min-h-0 flex-1 flex-col">
-                <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+                <div className="flex min-h-0 flex-1 flex-row">
                   <ResizableRail
                     pages={pages}
                     design={slide.design}
@@ -575,49 +575,51 @@ export function Slide() {
                     onReorder={import.meta.env.DEV ? reorderPage : undefined}
                     actions={thumbnailActions}
                   />
-                  <main
-                    ref={slideViewportRef}
-                    data-inspector-root
-                    data-slide-id={slideId}
-                    className="paper relative min-h-0 min-w-0 flex-1 bg-canvas p-2 md:p-10"
-                  >
-                    <SlideViewportNavigation
-                      targetRef={slideViewportRef}
-                      onPrev={() => goTo(index - 1)}
-                      onNext={() => goTo(index + 1)}
-                      canPrev={index > 0}
-                      canNext={index < pageCount - 1}
-                    />
-                    <SlideCanvas design={slide.design}>
-                      <SlideTransitionLayer
-                        pages={pages}
-                        index={index}
-                        total={pageCount}
-                        moduleTransition={slide.transition}
-                        disabled={prefersReducedMotion}
+                  <div className="flex min-h-0 min-w-0 flex-1 flex-row">
+                    <main
+                      ref={slideViewportRef}
+                      data-inspector-root
+                      data-slide-id={slideId}
+                      className="paper relative min-h-0 min-w-0 flex-1 bg-canvas p-2 md:p-10"
+                    >
+                      <SlideViewportNavigation
+                        targetRef={slideViewportRef}
+                        onPrev={() => goTo(index - 1)}
+                        onNext={() => goTo(index + 1)}
+                        canPrev={index > 0}
+                        canNext={index < pageCount - 1}
                       />
-                    </SlideCanvas>
-                    <InspectOverlay />
-                    <SaveBar />
-                    {import.meta.env.DEV && <CommentWidget />}
-                  </main>
-                  {/* Mobile-only horizontal rail. Sits below the canvas and
-                    pads its bottom for the iOS home indicator / Safari URL bar. */}
-                  <div
-                    className="shrink-0 border-t border-hairline md:hidden"
-                    style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
-                  >
-                    <ThumbnailRail
-                      pages={pages}
-                      design={slide.design}
-                      current={index}
-                      onSelect={goTo}
-                      orientation="horizontal"
-                      actions={thumbnailActions}
-                    />
+                      <SlideCanvas design={slide.design}>
+                        <SlideTransitionLayer
+                          pages={pages}
+                          index={index}
+                          total={pageCount}
+                          moduleTransition={slide.transition}
+                          disabled={prefersReducedMotion}
+                        />
+                      </SlideCanvas>
+                      <InspectOverlay />
+                      <SaveBar />
+                      {import.meta.env.DEV && <CommentWidget />}
+                    </main>
+                    <InspectorPanel />
+                    <DesignPanel open={designOpen} onClose={() => setDesignOpen(false)} />
                   </div>
-                  <InspectorPanel />
-                  <DesignPanel open={designOpen} onClose={() => setDesignOpen(false)} />
+                </div>
+                {/* Mobile-only horizontal rail. Sits below the canvas and
+                  pads its bottom for the iOS home indicator / Safari URL bar. */}
+                <div
+                  className="shrink-0 border-t border-hairline md:hidden"
+                  style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+                >
+                  <ThumbnailRail
+                    pages={pages}
+                    design={slide.design}
+                    current={index}
+                    onSelect={goTo}
+                    orientation="horizontal"
+                    actions={thumbnailActions}
+                  />
                 </div>
                 {import.meta.env.DEV && (
                   <NotesDrawer

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -28,6 +28,7 @@ export const en: Locale = {
     dark: 'Dark',
     system: 'System',
     selected: 'Selected',
+    resizePanel: 'Resize panel',
   },
 
   notFound: {

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -28,6 +28,7 @@ export const ja: Locale = {
     dark: 'ダーク',
     system: 'システム',
     selected: '選択中',
+    resizePanel: 'パネル幅を調整',
   },
 
   notFound: {

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -28,6 +28,7 @@ export type Locale = {
     dark: string;
     system: string;
     selected: string;
+    resizePanel: string;
   };
 
   notFound: {

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -28,6 +28,7 @@ export const zhCN: Locale = {
     dark: '深色',
     system: '系统',
     selected: '已选中',
+    resizePanel: '调整面板宽度',
   },
 
   notFound: {

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -28,6 +28,7 @@ export const zhTW: Locale = {
     dark: '深色',
     system: '系統',
     selected: '已選取',
+    resizePanel: '調整面板寬度',
   },
 
   notFound: {


### PR DESCRIPTION
## What

At narrow viewports (e.g. ~767×827, just under the \`md\` breakpoint), opening the Design or Inspector panel pushed the slide viewer off-screen because the panel was a fixed-width, in-flow column with no responsive handling.

This reworks the slide content area so the **preview always sits beside the panel**, and makes the panels **resizable**.

## Changes

- **Resizable panels** — the Design and Inspector panels now have a drag handle on their inner edge (the seam with the canvas), mirroring the existing thumbnail-rail splitter. Min 280px / max 560px / default 320px, persisted per panel in \`localStorage\`. Keyboard accessible (\`←/→\`, \`Shift\` for larger steps, \`Home\`/double-click to reset) with \`role="separator"\` + aria-value attributes.
- **Responsive layout** — \`<main>\` (preview) and the panels are wrapped in an always-row flex container with \`flex-1 min-w-0\`, so the canvas shrinks to make room for the panel instead of being covered or shoved off-screen. The slide auto-scales, so a narrower preview just renders smaller. The mobile horizontal deck rail moved below this row.
- **i18n** — new \`common.resizePanel\` key across en / ja / zh-cn / zh-tw for the handle's aria-label.

## Notes

- A changeset is included (\`minor\` — adds the resizable-panel interaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resizable design and inspector panels with drag, keyboard arrow keys, and double-click reset controls.
  * Panel widths automatically persist across sessions per UI mode.
  * Improved responsive layout ensures slide preview stays visible when resizing panels on narrow viewports.
  * Added localization support for panel resize functionality across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->