### PR TITLE
Add editable PPTX export (native PowerPoint objects)

### DIFF
--- a/.changeset/editable-pptx-export.md
+++ b/.changeset/editable-pptx-export.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Add "Export as PPTX" — an editable PowerPoint export where each block (text, image, shape, table) becomes an independent native object rather than one flattened image per slide. This enables the download menu's reserved "Export as PPTX" item, alongside the existing "Export as image PPTX" option.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,6 +82,7 @@
     "html-to-image": "^1.11.13",
     "lucide-react": "^1.8.0",
     "next-themes": "^0.4.6",
+    "pptxgenjs": "^4.0.1",
     "radix-ui": "^1.4.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/core/src/app/lib/export-editable-pptx.ts
+++ b/packages/core/src/app/lib/export-editable-pptx.ts
@@ -1,0 +1,558 @@
+import { createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { designToCssVars } from './design';
+import { isSafari } from './export-pdf';
+import type { PptxExportProgress } from './export-pptx';
+import { SlidePageProvider } from './page-context';
+import { classifyNode, type NodeView } from './pptx/classify';
+import { buildGradFillXml, parseGradient, patchSlideXmlGradients } from './pptx/gradient';
+import {
+  alphaToTransparency,
+  isBold,
+  lineSpacingMultiple,
+  mapTextAlign,
+  parseBoxShadow,
+  parseCssColor,
+  pxToIn,
+  pxToPt,
+  rotationDeg,
+} from './pptx/units';
+import { isFrameAnimationSettled, waitForDataWaitfor, waitForFonts } from './print-ready';
+import type { SlideModule } from './sdk';
+
+const ROOT_ID = 'os-editable-pptx-root';
+const ANIMATION_TIMEOUT_MS = 15_000;
+const POLL_INTERVAL_MS = 100;
+const MAX_RASTER_EDGE_PX = 1600;
+
+const INLINE_PHRASING = new Set([
+  'a',
+  'abbr',
+  'b',
+  'big',
+  'br',
+  'cite',
+  'code',
+  'del',
+  'em',
+  'i',
+  'ins',
+  'kbd',
+  'label',
+  'mark',
+  'q',
+  's',
+  'samp',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'time',
+  'tt',
+  'u',
+  'var',
+  'wbr',
+]);
+
+type Box = { x: number; y: number; w: number; h: number; rotate: number };
+
+type EmitContext = {
+  // biome-ignore lint/suspicious/noExplicitAny: PptxGenJS slide type is loaded dynamically.
+  pptxSlide: any;
+  frameRect: DOMRect;
+  imageCache: Map<string, string>;
+  gradients: Map<string, string>;
+  seq: { n: number };
+};
+
+export async function exportSlideAsPptx(
+  slide: SlideModule,
+  slideId: string,
+  onProgress?: (progress: PptxExportProgress) => void,
+): Promise<void> {
+  const pages = slide.default ?? [];
+  if (pages.length === 0) return;
+  const total = pages.length;
+
+  const root = document.createElement('div');
+  root.id = ROOT_ID;
+  root.setAttribute('aria-hidden', 'true');
+  Object.assign(root.style, {
+    position: 'fixed',
+    left: '-99999px',
+    top: '0',
+    pointerEvents: 'none',
+  });
+  document.body.appendChild(root);
+
+  onProgress?.({ phase: 'processing', current: 0, total, percent: 0 });
+
+  const designVars = slide.design ? designToCssVars(slide.design) : null;
+  const reactRoots: Root[] = [];
+  const frames: HTMLElement[] = [];
+
+  for (let i = 0; i < pages.length; i++) {
+    const Page = pages[i];
+    if (!Page) continue;
+    const host = document.createElement('div');
+    host.setAttribute('data-osd-canvas', '');
+    Object.assign(host.style, {
+      width: '1920px',
+      height: '1080px',
+      position: 'relative',
+      overflow: 'hidden',
+      background: '#fff',
+    });
+    if (designVars) {
+      for (const [k, v] of Object.entries(designVars)) host.style.setProperty(k, v);
+    }
+    root.appendChild(host);
+    frames.push(host);
+    const r = createRoot(host);
+    r.render(
+      createElement(SlidePageProvider, { index: i, total: pages.length }, createElement(Page)),
+    );
+    reactRoots.push(r);
+  }
+
+  await nextPaint();
+
+  try {
+    await waitForFonts();
+
+    const deadline = performance.now() + ANIMATION_TIMEOUT_MS;
+    while (performance.now() < deadline) {
+      const settled = frames.reduce((n, f) => (isFrameAnimationSettled(f) ? n + 1 : n), 0);
+      onProgress?.({
+        phase: 'processing',
+        current: settled,
+        total,
+        percent: Math.min(90, (settled / frames.length) * 90),
+      });
+      if (settled === frames.length) break;
+      await sleep(POLL_INTERVAL_MS);
+    }
+    await waitForDataWaitfor(root);
+    await sleep(100);
+
+    const PptxGenJS = (await import('pptxgenjs')).default;
+    const pptx = new PptxGenJS();
+    pptx.defineLayout({ name: 'OSD', width: 20, height: 11.25 });
+    pptx.layout = 'OSD';
+
+    const imageCache = new Map<string, string>();
+    const gradients = new Map<string, string>();
+    const seq = { n: 0 };
+    for (let i = 0; i < frames.length; i++) {
+      const frame = frames[i];
+      const pptxSlide = pptx.addSlide();
+      const frameRect = frame.getBoundingClientRect();
+      const ctx: EmitContext = { pptxSlide, frameRect, imageCache, gradients, seq };
+      for (const child of Array.from(frame.children)) {
+        await walk(child as HTMLElement, ctx);
+      }
+      onProgress?.({
+        phase: 'processing',
+        current: total,
+        total,
+        percent: 90 + ((i + 1) / frames.length) * 9,
+      });
+    }
+
+    onProgress?.({ phase: 'generating', current: total, total, percent: 98 });
+    const raw = (await pptx.write({ outputType: 'arraybuffer' })) as ArrayBuffer;
+    const blob = await applyGradients(new Uint8Array(raw), gradients);
+    downloadBlob(blob, `${slideId}.pptx`);
+  } finally {
+    onProgress?.({ phase: 'done', current: total, total, percent: 100 });
+    for (const r of reactRoots) r.unmount();
+    root.remove();
+  }
+}
+
+async function walk(el: HTMLElement, ctx: EmitContext): Promise<void> {
+  const cs = getComputedStyle(el);
+  const node = toNodeView(el, cs);
+  const { kind, recurse } = classifyNode(node);
+
+  switch (kind) {
+    case 'skip':
+      return;
+    case 'text':
+      emitText(el, cs, ctx);
+      return;
+    case 'image':
+      await emitImage(el as HTMLImageElement, ctx);
+      return;
+    case 'table':
+      emitTable(el as HTMLTableElement, cs, ctx);
+      return;
+    case 'raster':
+      await emitRaster(el, ctx);
+      return;
+    case 'shape':
+      emitShape(el, cs, ctx);
+      break;
+    case 'container':
+      break;
+  }
+
+  if (recurse) {
+    for (const child of Array.from(el.children)) {
+      await walk(child as HTMLElement, ctx);
+    }
+  }
+}
+
+function toNodeView(el: HTMLElement, cs: CSSStyleDeclaration): NodeView {
+  return {
+    tag: el.tagName.toLowerCase(),
+    isSvg: el.namespaceURI === 'http://www.w3.org/2000/svg',
+    hasTextContent: (el.textContent ?? '').trim().length > 0,
+    childElementTags: Array.from(el.children).map((c) => c.tagName.toLowerCase()),
+    style: {
+      display: cs.display,
+      visibility: cs.visibility,
+      filter: cs.filter,
+      backdropFilter:
+        cs.backdropFilter ||
+        (cs as unknown as Record<string, string>).webkitBackdropFilter ||
+        'none',
+      mixBlendMode: cs.mixBlendMode,
+      clipPath: cs.clipPath,
+      transform: cs.transform,
+      backgroundColor: cs.backgroundColor,
+      backgroundImage: cs.backgroundImage,
+      borderStyle: cs.borderTopStyle,
+      borderTopWidth: cs.borderTopWidth,
+    },
+  };
+}
+
+function measureBox(el: HTMLElement, cs: CSSStyleDeclaration, frameRect: DOMRect): Box {
+  const rotate = rotationDeg(cs.transform);
+  let rect: DOMRect;
+  if (rotate !== 0) {
+    const prev = el.style.transform;
+    el.style.transform = 'none';
+    rect = el.getBoundingClientRect();
+    el.style.transform = prev;
+  } else {
+    rect = el.getBoundingClientRect();
+  }
+  return {
+    x: pxToIn(rect.left - frameRect.left),
+    y: pxToIn(rect.top - frameRect.top),
+    w: pxToIn(rect.width),
+    h: pxToIn(rect.height),
+    rotate,
+  };
+}
+
+function box(b: Box) {
+  const out: Record<string, number> = { x: b.x, y: b.y, w: b.w, h: b.h };
+  if (b.rotate !== 0) out.rotate = b.rotate;
+  return out;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: PptxGenJS run/option types are loaded dynamically.
+type Run = { text: string; options: Record<string, any> };
+
+function emitText(el: HTMLElement, cs: CSSStyleDeclaration, ctx: EmitContext): void {
+  const runs = buildRuns(el);
+  if (runs.length === 0) return;
+  const b = measureBox(el, cs, ctx.frameRect);
+  const lh = lineSpacingMultiple(parseFloat(cs.lineHeight), parseFloat(cs.fontSize));
+  // biome-ignore lint/suspicious/noExplicitAny: PptxGenJS option bag.
+  const opts: Record<string, any> = {
+    ...box(b),
+    margin: 0,
+    fit: 'none',
+    valign: 'top',
+    align: mapTextAlign(cs.textAlign),
+  };
+  if (lh && Number.isFinite(lh)) opts.lineSpacingMultiple = Math.min(9.99, Math.max(0.1, lh));
+  const paint = paintFromStyle(cs);
+  if (paint.fill) opts.fill = paint.fill;
+  if (paint.line) opts.line = paint.line;
+  ctx.pptxSlide.addText(runs, opts);
+}
+
+function buildRuns(el: HTMLElement): Run[] {
+  const runs: Run[] = [];
+  const visit = (n: Node, styleSource: HTMLElement, href: string | undefined) => {
+    for (const child of Array.from(n.childNodes)) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        const text = (child.textContent ?? '').replace(/\s+/g, ' ');
+        if (text.trim().length === 0 && text !== ' ') continue;
+        const options = runOptions(styleSource);
+        if (href) options.hyperlink = { url: href };
+        runs.push({ text, options });
+      } else if (child.nodeType === Node.ELEMENT_NODE) {
+        const ce = child as HTMLElement;
+        const tag = ce.tagName.toLowerCase();
+        if (tag === 'br') {
+          if (runs.length > 0) runs[runs.length - 1].options.breakLine = true;
+          else runs.push({ text: '', options: { breakLine: true } });
+          continue;
+        }
+        if (INLINE_PHRASING.has(tag)) {
+          visit(ce, ce, tag === 'a' ? (linkHref(ce) ?? href) : href);
+        }
+      }
+    }
+  };
+  visit(el, el, linkHref(el));
+  return runs;
+}
+
+// Only real navigable links become PPTX hyperlinks; in-page anchors are dropped.
+function linkHref(el: HTMLElement): string | undefined {
+  if (el.tagName.toLowerCase() !== 'a') return undefined;
+  const href = el.getAttribute('href')?.trim();
+  if (!href) return undefined;
+  return /^(https?:|mailto:)/i.test(href) ? href : undefined;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: PptxGenJS run options.
+function runOptions(el: HTMLElement): Record<string, any> {
+  const cs = getComputedStyle(el);
+  // biome-ignore lint/suspicious/noExplicitAny: PptxGenJS run options.
+  const opts: Record<string, any> = {
+    fontFace: substituteFont(cs.fontFamily),
+    fontSize: round(pxToPt(parseFloat(cs.fontSize)), 1),
+    bold: isBold(cs.fontWeight),
+  };
+  if (cs.fontStyle === 'italic' || cs.fontStyle === 'oblique') opts.italic = true;
+  const color = parseCssColor(cs.color);
+  if (color) {
+    opts.color = color.hex;
+    if (color.alpha < 1) opts.transparency = alphaToTransparency(color.alpha);
+  }
+  if (cs.textDecorationLine.includes('underline')) opts.underline = { style: 'sng' };
+  if (cs.textDecorationLine.includes('line-through')) opts.strike = 'sngStrike';
+  if (cs.letterSpacing && cs.letterSpacing !== 'normal') {
+    const ls = parseFloat(cs.letterSpacing);
+    if (Number.isFinite(ls) && ls !== 0) opts.charSpacing = round(pxToPt(ls), 1);
+  }
+  return opts;
+}
+
+function emitShape(el: HTMLElement, cs: CSSStyleDeclaration, ctx: EmitContext): void {
+  const b = measureBox(el, cs, ctx.frameRect);
+  if (b.w <= 0 || b.h <= 0) return;
+  const radius = parseFloat(cs.borderTopLeftRadius);
+  const shapeType = Number.isFinite(radius) && radius > 0 ? 'roundRect' : 'rect';
+  const paint = paintFromStyle(cs);
+  // biome-ignore lint/suspicious/noExplicitAny: PptxGenJS shape options.
+  const opts: Record<string, any> = { ...box(b), fill: paint.fill ?? { type: 'none' } };
+  if (paint.line) opts.line = paint.line;
+  const shadow = shadowFromStyle(cs);
+  if (shadow) opts.shadow = shadow;
+
+  // Gradient backgrounds: PptxGenJS can't emit a:gradFill, so set a solid
+  // placeholder (also the safe fallback) and register the real gradient to be
+  // patched into the XML after packaging. linear + radial map to native OOXML
+  // fills; conic has no OOXML equivalent, so it keeps the solid first-stop fallback.
+  const grad = parseGradient(cs.backgroundImage);
+  if (grad && grad.stops.length > 0) {
+    opts.fill = { color: grad.stops[0].hex };
+    if (grad.kind === 'linear' || grad.kind === 'radial') {
+      const name = `osd-grad-${ctx.seq.n++}`;
+      opts.objectName = name;
+      ctx.gradients.set(name, buildGradFillXml(grad));
+    }
+  }
+
+  ctx.pptxSlide.addShape(shapeType, opts);
+}
+
+async function applyGradients(bytes: Uint8Array, gradients: Map<string, string>): Promise<Blob> {
+  const type = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+  if (gradients.size === 0) return new Blob([bytes as BlobPart], { type });
+  const { unzipSync, zipSync, strToU8, strFromU8 } = await import('fflate');
+  const files = unzipSync(bytes);
+  for (const path of Object.keys(files)) {
+    if (!/^ppt\/slides\/slide\d+\.xml$/.test(path)) continue;
+    const patched = patchSlideXmlGradients(strFromU8(files[path]), gradients);
+    files[path] = strToU8(patched);
+  }
+  return new Blob([zipSync(files) as BlobPart], { type });
+}
+
+function paintFromStyle(cs: CSSStyleDeclaration): {
+  // biome-ignore lint/suspicious/noExplicitAny: PptxGenJS fill option bag.
+  fill?: Record<string, any>;
+  // biome-ignore lint/suspicious/noExplicitAny: PptxGenJS line option bag.
+  line?: Record<string, any>;
+} {
+  // biome-ignore lint/suspicious/noExplicitAny: PptxGenJS option bags.
+  const out: { fill?: Record<string, any>; line?: Record<string, any> } = {};
+  const bg = parseCssColor(cs.backgroundColor);
+  if (bg && bg.alpha > 0) {
+    out.fill = { color: bg.hex };
+    if (bg.alpha < 1) out.fill.transparency = alphaToTransparency(bg.alpha);
+  }
+  const borderColor = parseCssColor(cs.borderTopColor);
+  const borderWidth = parseFloat(cs.borderTopWidth);
+  if (cs.borderTopStyle !== 'none' && borderWidth > 0 && borderColor) {
+    out.line = {
+      color: borderColor.hex,
+      width: round(pxToPt(borderWidth), 2),
+      dashType:
+        cs.borderTopStyle === 'dashed'
+          ? 'dash'
+          : cs.borderTopStyle === 'dotted'
+            ? 'sysDot'
+            : 'solid',
+    };
+  }
+  return out;
+}
+
+async function emitImage(el: HTMLImageElement, ctx: EmitContext): Promise<void> {
+  const src = el.currentSrc || el.src;
+  if (!src) return;
+  const cs = getComputedStyle(el);
+  const b = measureBox(el, cs, ctx.frameRect);
+  if (b.w <= 0 || b.h <= 0) return;
+  const data = await toDataUri(src, ctx.imageCache);
+  if (!data) return;
+  // biome-ignore lint/suspicious/noExplicitAny: PptxGenJS image options.
+  const opts: Record<string, any> = { ...box(b), data };
+  if (cs.objectFit === 'cover' || cs.objectFit === 'contain') {
+    opts.sizing = { type: cs.objectFit, w: b.w, h: b.h };
+  }
+  const shadow = shadowFromStyle(cs);
+  if (shadow) opts.shadow = shadow;
+  ctx.pptxSlide.addImage(opts);
+}
+
+// Maps a CSS box-shadow to a PptxGenJS outer shadow (offset/angle in pt/deg).
+// biome-ignore lint/suspicious/noExplicitAny: PptxGenJS shadow option bag.
+function shadowFromStyle(cs: CSSStyleDeclaration): Record<string, any> | undefined {
+  const s = parseBoxShadow(cs.boxShadow);
+  if (!s) return undefined;
+  const offset = round(pxToPt(Math.hypot(s.offX, s.offY)), 1);
+  const blur = round(pxToPt(s.blur), 1);
+  if (offset === 0 && blur === 0) return undefined;
+  const angle = Math.round(((((Math.atan2(s.offY, s.offX) * 180) / Math.PI) % 360) + 360) % 360);
+  return {
+    type: 'outer',
+    color: s.hex,
+    opacity: Math.round(s.alpha * 100) / 100,
+    blur,
+    offset,
+    angle,
+  };
+}
+
+function emitTable(el: HTMLTableElement, _cs: CSSStyleDeclaration, ctx: EmitContext): void {
+  const b = measureBox(el, getComputedStyle(el), ctx.frameRect);
+  const rows: { text: string }[][] = [];
+  for (const tr of Array.from(el.rows)) {
+    const cells: { text: string }[] = [];
+    for (const cell of Array.from(tr.cells)) {
+      cells.push({ text: (cell.textContent ?? '').trim() });
+    }
+    if (cells.length > 0) rows.push(cells);
+  }
+  if (rows.length === 0) return;
+  ctx.pptxSlide.addTable(rows, { ...box(b) });
+}
+
+async function emitRaster(el: HTMLElement, ctx: EmitContext): Promise<void> {
+  if (isSafari()) return;
+  const cs = getComputedStyle(el);
+  const b = measureBox(el, cs, ctx.frameRect);
+  if (b.w <= 0 || b.h <= 0) return;
+  // Cap the bitmap's longest edge so a full-bleed decorative subtree (e.g. a
+  // 1920px noise overlay) can't balloon the deck into hundreds of MB.
+  const longestPx = Math.max(b.w, b.h) * 96;
+  const pixelRatio = Math.min(2, Math.max(0.5, MAX_RASTER_EDGE_PX / longestPx));
+  try {
+    const { toPng } = await import('html-to-image');
+    const dataUrl = await toPng(el, { pixelRatio, cacheBust: true });
+    ctx.pptxSlide.addImage({ ...box(b), data: dataUrl });
+  } catch (err) {
+    console.warn('[open-slide] raster fallback failed for element', el, err);
+  }
+}
+
+async function toDataUri(src: string, cache: Map<string, string>): Promise<string | null> {
+  if (src.startsWith('data:')) return src;
+  const cached = cache.get(src);
+  if (cached) return cached;
+  try {
+    const res = await fetch(src);
+    if (!res.ok) return null;
+    const blob = await res.blob();
+    const data = await blobToDataUri(blob);
+    cache.set(src, data);
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+function blobToDataUri(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+const FONT_SUBSTITUTIONS: { test: RegExp; face: string }[] = [
+  { test: /mono|consol|courier|jetbrains/i, face: 'Consolas' },
+  { test: /georgia|times|serif|iowan|charter/i, face: 'Georgia' },
+  { test: /inter|geist|aptos|helvetica|arial|system-ui|sans/i, face: 'Aptos' },
+];
+
+function substituteFont(fontFamily: string): string {
+  const first =
+    fontFamily
+      .split(',')[0]
+      ?.trim()
+      .replace(/^["']|["']$/g, '') ?? '';
+  for (const { test, face } of FONT_SUBSTITUTIONS) {
+    if (test.test(fontFamily)) return face;
+  }
+  return first || 'Aptos';
+}
+
+function round(n: number, decimals: number): number {
+  const f = 10 ** decimals;
+  return Math.round(n * f) / f;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function nextPaint(): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    requestAnimationFrame(settle);
+    setTimeout(settle, 50);
+  });
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.rel = 'noopener';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/packages/core/src/app/lib/export-editable-pptx.ts
+++ b/packages/core/src/app/lib/export-editable-pptx.ts
@@ -505,10 +505,12 @@ function blobToDataUri(blob: Blob): Promise<string> {
   });
 }
 
+// Order matters: sans is tested before serif so a "sans-serif" token isn't
+// captured by the serif rule (which would map every sans stack to Georgia).
 const FONT_SUBSTITUTIONS: { test: RegExp; face: string }[] = [
   { test: /mono|consol|courier|jetbrains/i, face: 'Consolas' },
-  { test: /georgia|times|serif|iowan|charter/i, face: 'Georgia' },
   { test: /inter|geist|aptos|helvetica|arial|system-ui|sans/i, face: 'Aptos' },
+  { test: /georgia|times|serif|iowan|charter/i, face: 'Georgia' },
 ];
 
 function substituteFont(fontFamily: string): string {
@@ -517,8 +519,10 @@ function substituteFont(fontFamily: string): string {
       .split(',')[0]
       ?.trim()
       .replace(/^["']|["']$/g, '') ?? '';
+  // Match the first declared family, not the whole stack — otherwise the
+  // trailing generic (e.g. `sans-serif`) drives the substitution.
   for (const { test, face } of FONT_SUBSTITUTIONS) {
-    if (test.test(fontFamily)) return face;
+    if (test.test(first)) return face;
   }
   return first || 'Aptos';
 }

--- a/packages/core/src/app/lib/pptx/classify.test.ts
+++ b/packages/core/src/app/lib/pptx/classify.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import { classifyNode, type NodeStyleView, type NodeView } from './classify';
+
+function view(
+  partial: Partial<Omit<NodeView, 'style'>> & { tag: string; style?: Partial<NodeStyleView> },
+): NodeView {
+  return {
+    isSvg: false,
+    hasTextContent: false,
+    childElementTags: [],
+    ...partial,
+    style: {
+      display: 'block',
+      visibility: 'visible',
+      filter: 'none',
+      backdropFilter: 'none',
+      mixBlendMode: 'normal',
+      clipPath: 'none',
+      transform: 'none',
+      backgroundColor: 'rgba(0, 0, 0, 0)',
+      backgroundImage: 'none',
+      borderStyle: 'none',
+      borderTopWidth: '0px',
+      ...partial.style,
+    },
+  };
+}
+
+describe('classifyNode', () => {
+  it('classifies a heading with inline children as a single text box (no recurse)', () => {
+    const c = classifyNode(
+      view({ tag: 'h2', hasTextContent: true, childElementTags: ['em', 'br'] }),
+    );
+    expect(c).toEqual({ kind: 'text', recurse: false });
+  });
+
+  it('classifies a plain paragraph as text', () => {
+    expect(classifyNode(view({ tag: 'p', hasTextContent: true })).kind).toBe('text');
+  });
+
+  it('classifies a layout wrapper with block children as a container (recurse, emit nothing)', () => {
+    const c = classifyNode(view({ tag: 'div', childElementTags: ['div', 'div'] }));
+    expect(c).toEqual({ kind: 'container', recurse: true });
+  });
+
+  it('emits a backing shape but still recurses when a box has a visible solid background', () => {
+    const c = classifyNode(
+      view({
+        tag: 'div',
+        childElementTags: ['h2', 'p'],
+        style: { backgroundColor: 'rgb(20, 20, 20)' },
+      }),
+    );
+    expect(c).toEqual({ kind: 'shape', recurse: true });
+  });
+
+  it('emits a backing shape for a visible border with no background', () => {
+    const c = classifyNode(
+      view({
+        tag: 'div',
+        childElementTags: ['p'],
+        style: { borderStyle: 'solid', borderTopWidth: '2px' },
+      }),
+    );
+    expect(c.kind).toBe('shape');
+    expect(c.recurse).toBe(true);
+  });
+
+  it('treats a fully transparent background as no paint (container)', () => {
+    const c = classifyNode(
+      view({ tag: 'div', childElementTags: ['div'], style: { backgroundColor: 'rgba(0,0,0,0)' } }),
+    );
+    expect(c.kind).toBe('container');
+  });
+
+  it('classifies an <img> as an image leaf', () => {
+    expect(classifyNode(view({ tag: 'img' }))).toEqual({ kind: 'image', recurse: false });
+  });
+
+  it('classifies a <table> as a table leaf', () => {
+    expect(classifyNode(view({ tag: 'table', hasTextContent: true }))).toEqual({
+      kind: 'table',
+      recurse: false,
+    });
+  });
+
+  it('rasterizes any SVG subtree', () => {
+    expect(classifyNode(view({ tag: 'svg' })).kind).toBe('raster');
+  });
+
+  it('keeps a text element editable when it has a filter (drops the effect, no raster)', () => {
+    expect(
+      classifyNode(
+        view({ tag: 'h2', hasTextContent: true, style: { filter: 'drop-shadow(0 2px 4px #000)' } }),
+      ).kind,
+    ).toBe('text');
+  });
+
+  it('recurses (does not rasterize) a container with text descendants and a blend mode', () => {
+    expect(
+      classifyNode(
+        view({
+          tag: 'div',
+          hasTextContent: true,
+          childElementTags: ['h2', 'p'],
+          style: { mixBlendMode: 'multiply' },
+        }),
+      ).kind,
+    ).toBe('container');
+  });
+
+  it('rasterizes a text-free decorative element with a filter', () => {
+    expect(
+      classifyNode(view({ tag: 'div', hasTextContent: false, style: { filter: 'blur(40px)' } }))
+        .kind,
+    ).toBe('raster');
+  });
+
+  it('rasterizes a text-free decorative element with a non-normal blend mode', () => {
+    expect(
+      classifyNode(view({ tag: 'div', hasTextContent: false, style: { mixBlendMode: 'multiply' } }))
+        .kind,
+    ).toBe('raster');
+  });
+
+  it('rasterizes a text-free element clipped by clip-path', () => {
+    expect(
+      classifyNode(view({ tag: 'div', hasTextContent: false, style: { clipPath: 'inset(10px)' } }))
+        .kind,
+    ).toBe('raster');
+  });
+
+  it('rasterizes a skewed subtree but not a rotated one', () => {
+    expect(
+      classifyNode(
+        view({ tag: 'div', hasTextContent: true, style: { transform: 'matrix(1,0,0.36,1,0,0)' } }),
+      ).kind,
+    ).toBe('raster');
+    expect(
+      classifyNode(
+        view({ tag: 'p', hasTextContent: true, style: { transform: 'matrix(0,1,-1,0,0,0)' } }),
+      ).kind,
+    ).toBe('text');
+  });
+
+  it('skips display:none and hidden elements', () => {
+    expect(classifyNode(view({ tag: 'div', style: { display: 'none' } })).kind).toBe('skip');
+    expect(classifyNode(view({ tag: 'div', style: { visibility: 'hidden' } })).kind).toBe('skip');
+  });
+
+  it('skips non-visual tags', () => {
+    expect(classifyNode(view({ tag: 'script' })).kind).toBe('skip');
+    expect(classifyNode(view({ tag: 'style' })).kind).toBe('skip');
+  });
+});

--- a/packages/core/src/app/lib/pptx/classify.ts
+++ b/packages/core/src/app/lib/pptx/classify.ts
@@ -1,0 +1,112 @@
+import { parseCssColor, transformNeedsRaster } from './units';
+
+export type NodeKind = 'text' | 'image' | 'table' | 'shape' | 'raster' | 'container' | 'skip';
+
+export interface NodeStyleView {
+  display: string;
+  visibility: string;
+  filter: string;
+  backdropFilter: string;
+  mixBlendMode: string;
+  clipPath: string;
+  transform: string;
+  backgroundColor: string;
+  backgroundImage: string;
+  borderStyle: string;
+  borderTopWidth: string;
+}
+
+export interface NodeView {
+  tag: string;
+  isSvg: boolean;
+  hasTextContent: boolean;
+  childElementTags: string[];
+  style: NodeStyleView;
+}
+
+export interface Classification {
+  kind: NodeKind;
+  recurse: boolean;
+}
+
+const NON_VISUAL = new Set(['script', 'style', 'noscript', 'template', 'head', 'meta', 'link']);
+
+const INLINE_PHRASING = new Set([
+  'a',
+  'abbr',
+  'b',
+  'big',
+  'br',
+  'cite',
+  'code',
+  'del',
+  'em',
+  'i',
+  'ins',
+  'kbd',
+  'label',
+  'mark',
+  'q',
+  's',
+  'samp',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'time',
+  'tt',
+  'u',
+  'var',
+  'wbr',
+]);
+
+export function classifyNode(node: NodeView): Classification {
+  const { tag, style } = node;
+
+  if (NON_VISUAL.has(tag)) return leaf('skip');
+  if (style.display === 'none' || style.visibility === 'hidden') return leaf('skip');
+
+  if (needsRaster(node)) return leaf('raster');
+
+  if (tag === 'table') return leaf('table');
+  if (tag === 'img' || tag === 'video') return leaf('image');
+
+  if (isTextLeaf(node)) return leaf('text');
+
+  return { kind: hasVisiblePaint(style) ? 'shape' : 'container', recurse: true };
+}
+
+function leaf(kind: NodeKind): Classification {
+  return { kind, recurse: false };
+}
+
+function needsRaster(node: NodeView): boolean {
+  const s = node.style;
+  // Graphics and un-representable geometry always rasterize.
+  if (node.isSvg || node.tag === 'svg') return true;
+  if (transformNeedsRaster(s.transform)) return true;
+  // CSS effects with no DrawingML equivalent (filter/blur/blend/clip) only
+  // rasterize when the element is a decorative graphic with no text anywhere in
+  // its subtree. If it carries text, keep that text editable and drop the
+  // effect rather than baking the whole subtree into an image.
+  const hasUnmappableEffect =
+    s.filter !== 'none' ||
+    (s.backdropFilter !== 'none' && s.backdropFilter !== '') ||
+    s.mixBlendMode !== 'normal' ||
+    s.clipPath !== 'none';
+  return hasUnmappableEffect && !node.hasTextContent;
+}
+
+function isTextLeaf(node: NodeView): boolean {
+  if (!node.hasTextContent) return false;
+  return node.childElementTags.every((t) => INLINE_PHRASING.has(t));
+}
+
+function hasVisiblePaint(style: NodeStyleView): boolean {
+  const bg = parseCssColor(style.backgroundColor);
+  if (bg && bg.alpha > 0) return true;
+  if (style.backgroundImage !== 'none' && style.backgroundImage !== '') return true;
+  if (style.borderStyle !== 'none' && Number.parseFloat(style.borderTopWidth) > 0) return true;
+  return false;
+}

--- a/packages/core/src/app/lib/pptx/gradient.test.ts
+++ b/packages/core/src/app/lib/pptx/gradient.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildGradFillXml,
+  cssAngleToOoxml,
+  parseGradient,
+  patchSlideXmlGradients,
+} from './gradient';
+
+describe('cssAngleToOoxml', () => {
+  it('maps CSS gradient angles to OOXML 60000ths-of-a-degree (clockwise from +x)', () => {
+    expect(cssAngleToOoxml(90)).toBe(0); // to right
+    expect(cssAngleToOoxml(180)).toBe(90 * 60000); // to bottom
+    expect(cssAngleToOoxml(0)).toBe(270 * 60000); // to top
+    expect(cssAngleToOoxml(45)).toBe(315 * 60000);
+  });
+});
+
+describe('parseGradient', () => {
+  it('parses a linear-gradient with explicit angle and stops', () => {
+    const g = parseGradient('linear-gradient(90deg, rgb(255, 0, 0) 0%, rgb(0, 0, 255) 100%)');
+    expect(g).toEqual({
+      kind: 'linear',
+      angleDeg: 90,
+      stops: [
+        { hex: 'FF0000', alpha: 1, pos: 0 },
+        { hex: '0000FF', alpha: 1, pos: 100 },
+      ],
+    });
+  });
+
+  it('resolves the "to <side>" keyword to an angle', () => {
+    const g = parseGradient('linear-gradient(to right, rgb(0, 0, 0), rgb(255, 255, 255))');
+    expect(g?.kind).toBe('linear');
+    expect(g?.angleDeg).toBe(90);
+  });
+
+  it('defaults to 180deg (to bottom) when no direction is given', () => {
+    const g = parseGradient('linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255))');
+    expect(g?.angleDeg).toBe(180);
+  });
+
+  it('distributes positions evenly when stops omit them', () => {
+    const g = parseGradient(
+      'linear-gradient(0deg, rgb(0,0,0), rgb(128,128,128), rgb(255,255,255))',
+    );
+    expect(g?.stops.map((s) => s.pos)).toEqual([0, 50, 100]);
+  });
+
+  it('keeps the alpha channel of rgba stops', () => {
+    const g = parseGradient('linear-gradient(90deg, rgba(255, 0, 0, 0.5) 0%, rgb(0, 0, 255) 100%)');
+    expect(g?.stops[0]).toEqual({ hex: 'FF0000', alpha: 0.5, pos: 0 });
+  });
+
+  it('classifies radial gradients as "radial" and drops the shape/position head', () => {
+    const g = parseGradient('radial-gradient(circle at center, rgb(255, 0, 0), rgb(0, 0, 255))');
+    expect(g?.kind).toBe('radial');
+    expect(g?.stops).toEqual([
+      { hex: 'FF0000', alpha: 1, pos: 0 },
+      { hex: '0000FF', alpha: 1, pos: 100 },
+    ]);
+  });
+
+  it('classifies conic gradients as "conic" (no native OOXML fill; solid fallback only)', () => {
+    const g = parseGradient('conic-gradient(from 0deg, rgb(255, 0, 0), rgb(0, 0, 255))');
+    expect(g?.kind).toBe('conic');
+    expect(g?.stops[0].hex).toBe('FF0000');
+  });
+
+  it('parses a modern-color stop that carries an explicit position', () => {
+    // getComputedStyle can hand back a gradient whose stops keep their oklch()
+    // notation plus a position; the color and the position must be split before
+    // the color is normalised. A fake normaliser stands in for the canvas.
+    const normalize = (css: string) =>
+      css.startsWith('oklch') ? 'rgb(10, 20, 30)' : css.startsWith('rgb') ? css : null;
+    const g = parseGradient(
+      'linear-gradient(90deg, oklch(0.7 0.15 30) 40%, rgb(0, 0, 255) 100%)',
+      normalize,
+    );
+    expect(g?.stops).toEqual([
+      { hex: '0A141E', alpha: 1, pos: 40 },
+      { hex: '0000FF', alpha: 1, pos: 100 },
+    ]);
+  });
+
+  it('returns null for non-gradient values', () => {
+    expect(parseGradient('none')).toBeNull();
+    expect(parseGradient('url(foo.png)')).toBeNull();
+  });
+});
+
+describe('buildGradFillXml', () => {
+  it('builds an a:gradFill with gsLst stops and a linear angle', () => {
+    const xml = buildGradFillXml({
+      kind: 'linear',
+      angleDeg: 90,
+      stops: [
+        { hex: 'FF0000', alpha: 1, pos: 0 },
+        { hex: '0000FF', alpha: 1, pos: 100 },
+      ],
+    });
+    expect(xml).toContain('<a:gradFill>');
+    expect(xml).toContain('<a:gsLst>');
+    expect(xml).toContain('<a:gs pos="0"><a:srgbClr val="FF0000"/></a:gs>');
+    expect(xml).toContain('<a:gs pos="100000"><a:srgbClr val="0000FF"/></a:gs>');
+    expect(xml).toContain('<a:lin ang="0" scaled="1"/>');
+  });
+
+  it('encodes stop alpha as an a:alpha child', () => {
+    const xml = buildGradFillXml({
+      kind: 'linear',
+      angleDeg: 180,
+      stops: [
+        { hex: 'FF0000', alpha: 0.5, pos: 0 },
+        { hex: '0000FF', alpha: 1, pos: 100 },
+      ],
+    });
+    expect(xml).toContain('<a:srgbClr val="FF0000"><a:alpha val="50000"/></a:srgbClr>');
+    expect(xml).toContain('<a:lin ang="5400000" scaled="1"/>');
+  });
+
+  it('builds a centered circle path fill for radial gradients (no a:lin)', () => {
+    const xml = buildGradFillXml({
+      kind: 'radial',
+      angleDeg: 0,
+      stops: [
+        { hex: 'FF0000', alpha: 1, pos: 0 },
+        { hex: '0000FF', alpha: 1, pos: 100 },
+      ],
+    });
+    expect(xml).toContain('<a:gs pos="0"><a:srgbClr val="FF0000"/></a:gs>');
+    expect(xml).toContain('<a:gs pos="100000"><a:srgbClr val="0000FF"/></a:gs>');
+    expect(xml).toContain(
+      '<a:path path="circle"><a:fillToRect l="50000" t="50000" r="50000" b="50000"/></a:path>',
+    );
+    expect(xml).not.toContain('<a:lin');
+  });
+});
+
+describe('patchSlideXmlGradients', () => {
+  const shape = (name: string) =>
+    `<p:sp><p:nvSpPr><p:cNvPr id="2" name="${name}"/></p:nvSpPr><p:spPr><a:prstGeom prst="rect"/><a:solidFill><a:srgbClr val="112233"/></a:solidFill><a:ln><a:solidFill><a:srgbClr val="445566"/></a:solidFill></a:ln></p:spPr></p:sp>`;
+
+  it('replaces the fill solidFill of a marked shape with its gradFill, leaving the border fill intact', () => {
+    const gradients = new Map([['osd-grad-0', '<a:gradFill>GRAD</a:gradFill>']]);
+    const out = patchSlideXmlGradients(shape('osd-grad-0'), gradients);
+    expect(out).toContain('<a:gradFill>GRAD</a:gradFill>');
+    expect(out).toContain('<a:ln><a:solidFill><a:srgbClr val="445566"/></a:solidFill></a:ln>');
+    expect(out).not.toContain('<a:srgbClr val="112233"/>');
+  });
+
+  it('leaves shapes without a matching marker untouched', () => {
+    const gradients = new Map([['osd-grad-9', '<a:gradFill>GRAD</a:gradFill>']]);
+    const input = shape('osd-grad-0');
+    expect(patchSlideXmlGradients(input, gradients)).toBe(input);
+  });
+
+  it('is a no-op when there are no gradients', () => {
+    const input = shape('osd-grad-0');
+    expect(patchSlideXmlGradients(input, new Map())).toBe(input);
+  });
+});

--- a/packages/core/src/app/lib/pptx/gradient.ts
+++ b/packages/core/src/app/lib/pptx/gradient.ts
@@ -1,0 +1,184 @@
+import { parseCssColor } from './units';
+
+export interface GradientStop {
+  hex: string;
+  alpha: number;
+  pos: number;
+}
+
+export interface ParsedGradient {
+  // `linear` and `radial` map to native OOXML gradient fills; `conic` has no
+  // native OOXML equivalent (PowerPoint only supports linear/path fills) and is
+  // kept only so callers can fall back to a solid first stop; `other` is any
+  // gradient we couldn't classify.
+  kind: 'linear' | 'radial' | 'conic' | 'other';
+  angleDeg: number;
+  stops: GradientStop[];
+}
+
+/** Injectable resolver for modern color syntaxes; defaults to the canvas round-trip in units. */
+export type ColorNormalizer = (css: string) => string | null;
+
+const SIDE_ANGLES: Record<string, number> = {
+  top: 0,
+  right: 90,
+  bottom: 180,
+  left: 270,
+  'top right': 45,
+  'right top': 45,
+  'bottom right': 135,
+  'right bottom': 135,
+  'bottom left': 225,
+  'left bottom': 225,
+  'top left': 315,
+  'left top': 315,
+};
+
+export function cssAngleToOoxml(cssDeg: number): number {
+  const norm = (((cssDeg - 90) % 360) + 360) % 360;
+  return Math.round(norm * 60000);
+}
+
+export function parseGradient(css: string, normalize?: ColorNormalizer): ParsedGradient | null {
+  if (!css || css === 'none') return null;
+  const linear = css.match(/(repeating-)?linear-gradient\(([\s\S]*)\)/i);
+  const radial = css.match(/(repeating-)?(radial|conic)-gradient\(([\s\S]*)\)/i);
+  if (!linear && !radial) return null;
+
+  const inner = linear ? linear[2] : (radial as RegExpMatchArray)[3];
+  const parts = splitTopLevel(inner);
+
+  let angleDeg = 180;
+  let stopParts = parts;
+  if (linear && parts.length > 0) {
+    const head = parts[0].trim();
+    const deg = head.match(/^(-?[\d.]+)deg$/i);
+    if (deg) {
+      angleDeg = Number.parseFloat(deg[1]);
+      stopParts = parts.slice(1);
+    } else if (/^to\s/i.test(head)) {
+      const side = head
+        .replace(/^to\s+/i, '')
+        .trim()
+        .toLowerCase();
+      angleDeg = SIDE_ANGLES[side] ?? 180;
+      stopParts = parts.slice(1);
+    } else if (/^[\d.]+(turn|rad|grad)$/i.test(head)) {
+      angleDeg = toDeg(head);
+      stopParts = parts.slice(1);
+    }
+  } else if (radial) {
+    // Drop the shape/position head (e.g. "circle at center") if it carries no color.
+    if (parts.length > 0 && !hasColor(parts[0], normalize)) stopParts = parts.slice(1);
+  }
+
+  const stops = parseStops(stopParts, normalize);
+  if (stops.length === 0) return null;
+
+  let kind: ParsedGradient['kind'] = 'other';
+  if (linear) kind = 'linear';
+  else if (radial) kind = radial[2].toLowerCase() === 'conic' ? 'conic' : 'radial';
+  return { kind, angleDeg, stops };
+}
+
+/** Splits a "color [position]" gradient stop into its color expression and %-position. */
+function splitColorAndPos(part: string): { color: string; pos: number | null } {
+  const p = part.trim();
+  let color = p;
+  let rest = '';
+  // A modern color function (oklch(), rgb(), color(), …) is wrapped in parens, so
+  // anything after the final ')' is the position. Otherwise (named/hex color) the
+  // position is whatever follows the first whitespace.
+  const lastParen = p.lastIndexOf(')');
+  if (lastParen >= 0) {
+    color = p.slice(0, lastParen + 1).trim();
+    rest = p.slice(lastParen + 1).trim();
+  } else {
+    const sp = p.search(/\s/);
+    if (sp >= 0) {
+      color = p.slice(0, sp).trim();
+      rest = p.slice(sp).trim();
+    }
+  }
+  const posMatch = rest.match(/(-?[\d.]+)%/);
+  return { color, pos: posMatch ? Number.parseFloat(posMatch[1]) : null };
+}
+
+function hasColor(part: string, normalize?: ColorNormalizer): boolean {
+  const { color } = splitColorAndPos(part);
+  return parseCssColor(color, normalize) !== null;
+}
+
+function parseStops(parts: string[], normalize?: ColorNormalizer): GradientStop[] {
+  const raw = parts
+    .map((p) => {
+      const { color: colorExpr, pos } = splitColorAndPos(p);
+      const color = parseCssColor(colorExpr, normalize);
+      if (!color) return null;
+      return { hex: color.hex, alpha: color.alpha, pos };
+    })
+    .filter((s): s is { hex: string; alpha: number; pos: number | null } => s !== null);
+
+  const n = raw.length;
+  return raw.map((s, i) => ({
+    hex: s.hex,
+    alpha: s.alpha,
+    pos: s.pos ?? (n <= 1 ? 0 : (i / (n - 1)) * 100),
+  }));
+}
+
+export function buildGradFillXml(grad: ParsedGradient): string {
+  const gs = grad.stops
+    .map((s) => {
+      const pos = Math.round(Math.max(0, Math.min(100, s.pos)) * 1000);
+      const clr =
+        s.alpha < 1
+          ? `<a:srgbClr val="${s.hex}"><a:alpha val="${Math.round(s.alpha * 100000)}"/></a:srgbClr>`
+          : `<a:srgbClr val="${s.hex}"/>`;
+      return `<a:gs pos="${pos}">${clr}</a:gs>`;
+    })
+    .join('');
+  // Radial gradients use a centered "circle" path fill; everything else is linear.
+  const shade =
+    grad.kind === 'radial'
+      ? '<a:path path="circle"><a:fillToRect l="50000" t="50000" r="50000" b="50000"/></a:path>'
+      : `<a:lin ang="${cssAngleToOoxml(grad.angleDeg)}" scaled="1"/>`;
+  return `<a:gradFill><a:gsLst>${gs}</a:gsLst>${shade}</a:gradFill>`;
+}
+
+export function patchSlideXmlGradients(xml: string, gradients: Map<string, string>): string {
+  if (gradients.size === 0) return xml;
+  return xml.replace(/<p:sp>[\s\S]*?<\/p:sp>/g, (shape) => {
+    const name = shape.match(/<p:cNvPr[^>]*\bname="([^"]+)"/);
+    if (!name) return shape;
+    const gradFill = gradients.get(name[1]);
+    if (!gradFill) return shape;
+    return shape.replace(/<a:solidFill>[\s\S]*?<\/a:solidFill>/, gradFill);
+  });
+}
+
+function splitTopLevel(input: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of input) {
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    if (ch === ',' && depth === 0) {
+      out.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) out.push(current);
+  return out;
+}
+
+function toDeg(value: string): number {
+  const num = Number.parseFloat(value);
+  if (/turn$/i.test(value)) return num * 360;
+  if (/rad$/i.test(value)) return (num * 180) / Math.PI;
+  if (/grad$/i.test(value)) return num * 0.9;
+  return num;
+}

--- a/packages/core/src/app/lib/pptx/units.test.ts
+++ b/packages/core/src/app/lib/pptx/units.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import {
+  alphaToTransparency,
+  isBold,
+  lineSpacingMultiple,
+  mapTextAlign,
+  parseBoxShadow,
+  parseCssColor,
+  pxToIn,
+  pxToPt,
+  rotationDeg,
+  transformNeedsRaster,
+} from './units';
+
+describe('pxToIn', () => {
+  it('converts px to inches at the CSS 96dpi reference', () => {
+    expect(pxToIn(96)).toBe(1);
+    expect(pxToIn(1920)).toBe(20);
+    expect(pxToIn(0)).toBe(0);
+  });
+});
+
+describe('pxToPt', () => {
+  it('converts px to points (1px = 0.75pt at 96dpi)', () => {
+    expect(pxToPt(16)).toBe(12);
+    expect(pxToPt(40)).toBe(30);
+  });
+});
+
+describe('parseCssColor', () => {
+  it('parses an rgb() string into uppercase hex with full alpha', () => {
+    expect(parseCssColor('rgb(255, 0, 0)')).toEqual({ hex: 'FF0000', alpha: 1 });
+  });
+
+  it('parses an rgba() string and keeps the alpha channel', () => {
+    expect(parseCssColor('rgba(0, 128, 255, 0.5)')).toEqual({ hex: '0080FF', alpha: 0.5 });
+  });
+
+  it('treats a fully transparent color as alpha 0', () => {
+    expect(parseCssColor('rgba(0, 0, 0, 0)')).toEqual({ hex: '000000', alpha: 0 });
+  });
+
+  it('returns null for a non-color value', () => {
+    expect(parseCssColor('none')).toBeNull();
+    expect(parseCssColor('')).toBeNull();
+  });
+
+  it('parses rgb directly without invoking the normalizer', () => {
+    let called = false;
+    const normalize = () => {
+      called = true;
+      return null;
+    };
+    expect(parseCssColor('rgb(10, 20, 30)', normalize)).toEqual({ hex: '0A141E', alpha: 1 });
+    expect(called).toBe(false);
+  });
+
+  it('falls back to the normalizer for modern color syntax (e.g. oklch)', () => {
+    // Browser getComputedStyle preserves oklch()/lab()/color() — the normalizer
+    // (canvas round-trip in the browser) turns it back into rgb.
+    const normalize = (css: string) => (css.startsWith('oklch') ? 'rgb(37, 99, 235)' : null);
+    expect(parseCssColor('oklch(0.55 0.2 264)', normalize)).toEqual({ hex: '2563EB', alpha: 1 });
+  });
+
+  it('returns null for modern color syntax when no normalizer can resolve it', () => {
+    expect(parseCssColor('oklch(0.55 0.2 264)', () => null)).toBeNull();
+  });
+});
+
+describe('isBold', () => {
+  it('treats numeric weight >= 600 as bold', () => {
+    expect(isBold('600')).toBe(true);
+    expect(isBold('700')).toBe(true);
+    expect(isBold('400')).toBe(false);
+    expect(isBold('100')).toBe(false);
+  });
+
+  it('handles keyword weights', () => {
+    expect(isBold('bold')).toBe(true);
+    expect(isBold('normal')).toBe(false);
+  });
+});
+
+describe('mapTextAlign', () => {
+  it('maps CSS text-align to PptxGenJS alignment', () => {
+    expect(mapTextAlign('left')).toBe('left');
+    expect(mapTextAlign('center')).toBe('center');
+    expect(mapTextAlign('right')).toBe('right');
+    expect(mapTextAlign('justify')).toBe('justify');
+  });
+
+  it('falls back to left for start/unknown values', () => {
+    expect(mapTextAlign('start')).toBe('left');
+    expect(mapTextAlign('-webkit-auto')).toBe('left');
+  });
+});
+
+describe('lineSpacingMultiple', () => {
+  it('returns the ratio of line-height to font-size', () => {
+    expect(lineSpacingMultiple(60, 40)).toBeCloseTo(1.5);
+  });
+
+  it('returns null when font-size is zero', () => {
+    expect(lineSpacingMultiple(60, 0)).toBeNull();
+  });
+});
+
+describe('rotationDeg', () => {
+  it('returns 0 for no transform', () => {
+    expect(rotationDeg('none')).toBe(0);
+  });
+
+  it('recovers the rotation angle from a 2D matrix', () => {
+    // rotate(90deg) => matrix(0, 1, -1, 0, 0, 0)
+    expect(rotationDeg('matrix(0, 1, -1, 0, 0, 0)')).toBeCloseTo(90);
+    // rotate(45deg)
+    const c = Math.SQRT1_2;
+    expect(rotationDeg(`matrix(${c}, ${c}, ${-c}, ${c}, 0, 0)`)).toBeCloseTo(45);
+  });
+
+  it('normalizes negative rotations into 0..360', () => {
+    // rotate(-90deg) => matrix(0, -1, 1, 0, 0, 0)
+    expect(rotationDeg('matrix(0, -1, 1, 0, 0, 0)')).toBeCloseTo(270);
+  });
+});
+
+describe('transformNeedsRaster', () => {
+  it('is false for none, pure translation, and pure rotation', () => {
+    expect(transformNeedsRaster('none')).toBe(false);
+    expect(transformNeedsRaster('matrix(1, 0, 0, 1, 30, 50)')).toBe(false);
+    expect(transformNeedsRaster('matrix(0, 1, -1, 0, 0, 0)')).toBe(false);
+  });
+
+  it('is true for 3D transforms', () => {
+    expect(transformNeedsRaster('matrix3d(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1)')).toBe(true);
+  });
+
+  it('is true for skew (non-orthogonal axes)', () => {
+    // skewX(20deg) => matrix(1, 0, tan20, 1, 0, 0)
+    expect(transformNeedsRaster('matrix(1, 0, 0.364, 1, 0, 0)')).toBe(true);
+  });
+
+  it('is true for non-uniform scale', () => {
+    expect(transformNeedsRaster('matrix(2, 0, 0, 3, 0, 0)')).toBe(true);
+  });
+});
+
+describe('alphaToTransparency', () => {
+  it('converts an alpha channel to a PptxGenJS transparency percent', () => {
+    expect(alphaToTransparency(1)).toBe(0);
+    expect(alphaToTransparency(0)).toBe(100);
+    expect(alphaToTransparency(0.5)).toBe(50);
+  });
+});
+
+describe('parseBoxShadow', () => {
+  it('returns null for none / empty', () => {
+    expect(parseBoxShadow('none')).toBeNull();
+    expect(parseBoxShadow('')).toBeNull();
+  });
+
+  it('parses color + offset + blur (spread ignored)', () => {
+    expect(parseBoxShadow('rgba(0, 0, 0, 0.25) 0px 8px 24px 0px')).toEqual({
+      hex: '000000',
+      alpha: 0.25,
+      offX: 0,
+      offY: 8,
+      blur: 24,
+    });
+  });
+
+  it('defaults blur to 0 when only two lengths are given', () => {
+    expect(parseBoxShadow('rgb(10, 20, 30) 4px 6px')).toEqual({
+      hex: '0A141E',
+      alpha: 1,
+      offX: 4,
+      offY: 6,
+      blur: 0,
+    });
+  });
+
+  it('skips inset shadows and takes the first outer one', () => {
+    const v = 'rgba(0,0,0,0.3) 0px 2px 4px 0px inset, rgba(0,0,0,0.5) 0px 10px 30px 0px';
+    expect(parseBoxShadow(v)).toEqual({ hex: '000000', alpha: 0.5, offX: 0, offY: 10, blur: 30 });
+  });
+
+  it('returns null when every shadow is inset', () => {
+    expect(parseBoxShadow('rgba(0,0,0,0.3) 0px 2px 4px inset')).toBeNull();
+  });
+});

--- a/packages/core/src/app/lib/pptx/units.ts
+++ b/packages/core/src/app/lib/pptx/units.ts
@@ -1,0 +1,163 @@
+export function pxToIn(px: number): number {
+  return px / 96;
+}
+
+export function pxToPt(px: number): number {
+  return px * 0.75;
+}
+
+export function parseCssColor(
+  css: string,
+  normalize: (css: string) => string | null = normalizeColorViaCanvas,
+): { hex: string; alpha: number } | null {
+  const direct = parseRgb(css);
+  if (direct) return direct;
+  // Modern color syntaxes (oklch/lab/lch/color) are preserved verbatim by
+  // getComputedStyle (e.g. Tailwind v4 palettes). Round-trip them through the
+  // normalizer to get an rgb() string we can parse.
+  const normalized = normalize(css);
+  return normalized ? parseRgb(normalized) : null;
+}
+
+function parseRgb(css: string): { hex: string; alpha: number } | null {
+  const m = css.match(/rgba?\(([^)]+)\)/i);
+  if (!m) return null;
+  const parts = m[1].split(/[,/\s]+/).filter(Boolean);
+  if (parts.length < 3) return null;
+  const [r, g, b] = parts.map((p) => Number.parseFloat(p));
+  if (![r, g, b].every((n) => Number.isFinite(n))) return null;
+  const alpha = parts.length >= 4 ? Number.parseFloat(parts[3]) : 1;
+  return { hex: toHex(r) + toHex(g) + toHex(b), alpha: Number.isFinite(alpha) ? alpha : 1 };
+}
+
+let canvasCtx: CanvasRenderingContext2D | null | undefined;
+
+function normalizeColorViaCanvas(css: string): string | null {
+  if (typeof document === 'undefined') return null;
+  if (canvasCtx === undefined) {
+    canvasCtx = document.createElement('canvas').getContext('2d');
+  }
+  if (!canvasCtx) return null;
+  // The canvas paints in sRGB and reports fillStyle back as rgb()/rgba(),
+  // converting any in-/out-of-gamut modern color the browser understands.
+  canvasCtx.fillStyle = '#000';
+  canvasCtx.fillStyle = css;
+  const resolved = canvasCtx.fillStyle;
+  return typeof resolved === 'string' && resolved.startsWith('rgb') ? resolved : null;
+}
+
+function toHex(channel: number): string {
+  const v = Math.max(0, Math.min(255, Math.round(channel)));
+  return v.toString(16).padStart(2, '0').toUpperCase();
+}
+
+export function isBold(fontWeight: string): boolean {
+  if (fontWeight === 'bold' || fontWeight === 'bolder') return true;
+  const n = Number.parseInt(fontWeight, 10);
+  return Number.isFinite(n) && n >= 600;
+}
+
+export function mapTextAlign(align: string): 'left' | 'center' | 'right' | 'justify' {
+  switch (align) {
+    case 'center':
+      return 'center';
+    case 'right':
+    case 'end':
+      return 'right';
+    case 'justify':
+      return 'justify';
+    default:
+      return 'left';
+  }
+}
+
+export function lineSpacingMultiple(lineHeightPx: number, fontSizePx: number): number | null {
+  if (!Number.isFinite(fontSizePx) || fontSizePx <= 0) return null;
+  return lineHeightPx / fontSizePx;
+}
+
+export function rotationDeg(transform: string): number {
+  const m = parseMatrix(transform);
+  if (!m) return 0;
+  const deg = (Math.atan2(m.b, m.a) * 180) / Math.PI;
+  return ((deg % 360) + 360) % 360;
+}
+
+export function transformNeedsRaster(transform: string): boolean {
+  if (!transform || transform === 'none') return false;
+  if (/matrix3d|perspective/i.test(transform)) return true;
+  const m = parseMatrix(transform);
+  if (!m) return false;
+  const { a, b, c, d } = m;
+  const sx = Math.hypot(a, b);
+  const sy = Math.hypot(c, d);
+  if (sx === 0 || sy === 0) return true;
+  const dot = a * c + b * d; // 0 when axes are orthogonal (pure rotation/scale)
+  if (Math.abs(dot) / (sx * sy) > 1e-3) return true; // skew
+  if (Math.abs(sx - sy) > 1e-3) return true; // non-uniform scale
+  return false;
+}
+
+export function alphaToTransparency(alpha: number): number {
+  return Math.round((1 - alpha) * 100);
+}
+
+export interface BoxShadow {
+  hex: string;
+  alpha: number;
+  /** offset in px */
+  offX: number;
+  offY: number;
+  /** blur radius in px */
+  blur: number;
+}
+
+/**
+ * Parses a computed `box-shadow` value into the first outer (non-inset) shadow.
+ * Returns null for `none`, inset-only shadows, or unparseable input. Spread and
+ * any shadows past the first are ignored (PowerPoint shapes take one shadow).
+ */
+export function parseBoxShadow(value: string): BoxShadow | null {
+  if (!value || value === 'none') return null;
+  for (const seg of splitTopLevelCommas(value)) {
+    const s = seg.trim();
+    if (!s || /(^|\s)inset(\s|$)/i.test(s)) continue;
+    const colorMatch = s.match(/rgba?\([^)]*\)/i);
+    if (!colorMatch) continue;
+    const color = parseCssColor(colorMatch[0]);
+    if (!color || color.alpha <= 0) continue;
+    const nums = (s.replace(colorMatch[0], '').match(/-?[\d.]+px/g) ?? []).map((n) =>
+      Number.parseFloat(n),
+    );
+    if (nums.length < 2) continue;
+    const [offX, offY, blur = 0] = nums;
+    return { hex: color.hex, alpha: color.alpha, offX, offY, blur };
+  }
+  return null;
+}
+
+function splitTopLevelCommas(input: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of input) {
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    if (ch === ',' && depth === 0) {
+      out.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) out.push(current);
+  return out;
+}
+
+function parseMatrix(transform: string): { a: number; b: number; c: number; d: number } | null {
+  const m = transform.match(/matrix\(([^)]+)\)/);
+  if (!m) return null;
+  const n = m[1].split(',').map((p) => Number.parseFloat(p.trim()));
+  if (n.length < 4 || n.some((v) => !Number.isFinite(v))) return null;
+  return { a: n[0], b: n[1], c: n[2], d: n[3] };
+}

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -57,6 +57,7 @@ import { PptxProgressToast } from '../components/pptx-progress-toast';
 import { SlideCanvas } from '../components/slide-canvas';
 import { SlideTransitionLayer } from '../components/slide-transition-layer';
 import { type ThumbnailActions, ThumbnailRail } from '../components/thumbnail-rail';
+import { exportSlideAsPptx } from '../lib/export-editable-pptx';
 import { exportSlideAsHtml } from '../lib/export-html';
 import { exportSlideAsPdf, isSafari } from '../lib/export-pdf';
 import { exportSlideAsImagePptx } from '../lib/export-pptx';
@@ -457,6 +458,31 @@ export function Slide() {
     }
   };
 
+  const exportPptx = async () => {
+    if (!slide || exporting) return;
+    setExporting(true);
+    const toastId = `pptx-editable-export-${slideId}`;
+    toast.custom(
+      () => (
+        <PptxProgressToast
+          progress={{ phase: 'processing', current: 0, total: pages.length, percent: 0 }}
+        />
+      ),
+      { id: toastId, duration: Infinity },
+    );
+    try {
+      await exportSlideAsPptx(slide, slideId, (p) => {
+        toast.custom(() => <PptxProgressToast progress={p} />, { id: toastId, duration: Infinity });
+      });
+    } catch (err) {
+      console.error('[open-slide] editable pptx export failed', err);
+      toast.error(t.slide.pptxExportFailed, { id: toastId, duration: 4000 });
+    } finally {
+      setExporting(false);
+      toast.dismiss(toastId);
+    }
+  };
+
   const exportMenuItems = (
     <>
       <DropdownMenuItem disabled={exporting} onSelect={exportHtml}>
@@ -472,30 +498,10 @@ export function Slide() {
         <FileImage />
         {t.slide.exportAsImagePptx}
       </DropdownMenuItem>
-      <TooltipProvider delayDuration={200}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div
-              aria-disabled
-              className="relative flex cursor-help items-center justify-between gap-2 rounded-[5px] px-2 py-1.5 text-[12.5px] opacity-45 select-none [&_svg]:size-3.5 [&_svg]:shrink-0 [&_svg]:opacity-80"
-            >
-              <span className="flex items-center gap-2">
-                <Presentation />
-                {t.slide.exportAsPptx}
-              </span>
-              <span className="rounded-[3px] bg-muted px-1.5 py-0.5 font-mono text-[9.5px] tracking-[0.04em] text-muted-foreground">
-                {t.slide.comingSoon}
-              </span>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent
-            side="left"
-            className="w-max max-w-[min(520px,calc(100vw-2rem))] text-center leading-relaxed"
-          >
-            {t.slide.pptxComingSoonTooltip}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <DropdownMenuItem disabled={exporting} onSelect={exportPptx}>
+        <Presentation />
+        {t.slide.exportAsPptx}
+      </DropdownMenuItem>
     </>
   );
 

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -113,11 +113,9 @@ export const en: Locale = {
     exportAsPdf: 'Export as PDF',
     exportAsImagePptx: 'Export as image PPTX',
     exportAsPptx: 'Export as PPTX',
-    comingSoon: 'Coming soon',
-    pptxComingSoonTooltip:
-      'Editable PPTX export isn’t ready yet. For now, use “Export as image PPTX” instead.',
     pdfExportFailed: 'PDF export failed',
     imagePptxExportFailed: 'PPTX export failed',
+    pptxExportFailed: 'PPTX export failed',
     pdfExportSafariUnsupported:
       'Export as PDF is not supported on Safari. Please try a Chromium-based browser instead.',
     present: 'Present',

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -115,7 +115,7 @@ export const en: Locale = {
     exportAsPptx: 'Export as PPTX',
     pdfExportFailed: 'PDF export failed',
     imagePptxExportFailed: 'PPTX export failed',
-    pptxExportFailed: 'PPTX export failed',
+    pptxExportFailed: 'Editable PPTX export failed',
     pdfExportSafariUnsupported:
       'Export as PDF is not supported on Safari. Please try a Chromium-based browser instead.',
     present: 'Present',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -114,11 +114,9 @@ export const ja: Locale = {
     exportAsPdf: 'PDF として書き出し',
     exportAsImagePptx: '画像 PPTX として書き出し',
     exportAsPptx: 'PPTX として書き出し',
-    comingSoon: '近日公開',
-    pptxComingSoonTooltip:
-      '編集可能な PPTX の書き出しはまだ対応していません。それまでは「画像 PPTX として書き出し」をご利用ください。',
     pdfExportFailed: 'PDF の書き出しに失敗しました',
     imagePptxExportFailed: 'PPTX の書き出しに失敗しました',
+    pptxExportFailed: 'PPTX の書き出しに失敗しました',
     pdfExportSafariUnsupported:
       'PDF の書き出しは現在 Safari では対応していません。Chromium ベースのブラウザでお試しください。',
     present: '発表',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -116,7 +116,7 @@ export const ja: Locale = {
     exportAsPptx: 'PPTX として書き出し',
     pdfExportFailed: 'PDF の書き出しに失敗しました',
     imagePptxExportFailed: 'PPTX の書き出しに失敗しました',
-    pptxExportFailed: 'PPTX の書き出しに失敗しました',
+    pptxExportFailed: '編集可能な PPTX の書き出しに失敗しました',
     pdfExportSafariUnsupported:
       'PDF の書き出しは現在 Safari では対応していません。Chromium ベースのブラウザでお試しください。',
     present: '発表',

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -115,10 +115,9 @@ export type Locale = {
     exportAsPdf: string;
     exportAsImagePptx: string;
     exportAsPptx: string;
-    comingSoon: string;
-    pptxComingSoonTooltip: string;
     pdfExportFailed: string;
     imagePptxExportFailed: string;
+    pptxExportFailed: string;
     pdfExportSafariUnsupported: string;
     present: string;
     presentMenuAria: string;

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -114,7 +114,7 @@ export const zhCN: Locale = {
     exportAsPptx: '导出 PPTX',
     pdfExportFailed: 'PDF 导出失败',
     imagePptxExportFailed: 'PPTX 导出失败',
-    pptxExportFailed: 'PPTX 导出失败',
+    pptxExportFailed: '可编辑 PPTX 导出失败',
     pdfExportSafariUnsupported:
       '导出 PDF 目前不支持 Safari 设备，请尝试使用基于 Chromium 的浏览器替代。',
     present: '演示',

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -112,10 +112,9 @@ export const zhCN: Locale = {
     exportAsPdf: '导出为 PDF',
     exportAsImagePptx: '导出图片 PPTX',
     exportAsPptx: '导出 PPTX',
-    comingSoon: '即将推出',
-    pptxComingSoonTooltip: '可编辑的 PPTX 导出尚未支持，在此之前可以先使用“导出图片 PPTX”。',
     pdfExportFailed: 'PDF 导出失败',
     imagePptxExportFailed: 'PPTX 导出失败',
+    pptxExportFailed: 'PPTX 导出失败',
     pdfExportSafariUnsupported:
       '导出 PDF 目前不支持 Safari 设备，请尝试使用基于 Chromium 的浏览器替代。',
     present: '演示',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -114,7 +114,7 @@ export const zhTW: Locale = {
     exportAsPptx: '匯出 PPTX',
     pdfExportFailed: 'PDF 匯出失敗',
     imagePptxExportFailed: 'PPTX 匯出失敗',
-    pptxExportFailed: 'PPTX 匯出失敗',
+    pptxExportFailed: '可編輯 PPTX 匯出失敗',
     pdfExportSafariUnsupported:
       '匯出 PDF 目前不支援 Safari 裝置，請嘗試用 Chromium 基底瀏覽器替代。',
     present: '簡報',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -112,10 +112,9 @@ export const zhTW: Locale = {
     exportAsPdf: '匯出為 PDF',
     exportAsImagePptx: '匯出圖片 PPTX',
     exportAsPptx: '匯出 PPTX',
-    comingSoon: '即將推出',
-    pptxComingSoonTooltip: '可編輯的 PPTX 匯出尚未支援，在此之前可以先使用「匯出圖片 PPTX」。',
     pdfExportFailed: 'PDF 匯出失敗',
     imagePptxExportFailed: 'PPTX 匯出失敗',
+    pptxExportFailed: 'PPTX 匯出失敗',
     pdfExportSafariUnsupported:
       '匯出 PDF 目前不支援 Safari 裝置，請嘗試用 Chromium 基底瀏覽器替代。',
     present: '簡報',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      pptxgenjs:
+        specifier: ^4.0.1
+        version: 4.0.1
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3112,6 +3115,9 @@ packages:
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -3752,6 +3758,9 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  https@1.0.0:
+    resolution: {integrity: sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==}
+
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
@@ -3771,6 +3780,14 @@ packages:
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  image-size@1.2.1:
+    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
+    engines: {node: '>=16.x'}
+    hasBin: true
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -3898,6 +3915,9 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -3955,6 +3975,9 @@ packages:
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -3962,6 +3985,9 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -4487,6 +4513,9 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4594,6 +4623,9 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  pptxgenjs@4.0.1:
+    resolution: {integrity: sha512-TeJISr8wouAuXw4C1F/mC33xbZs/FuEG6nH9FG1Zj+nuPcGMP5YRHl6X+j3HSUnS1f3at6k75ZZXPMZlA5Lj9A==}
+
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
@@ -4605,6 +4637,9 @@ packages:
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -4636,6 +4671,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
@@ -4735,6 +4773,9 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -4860,6 +4901,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -4899,6 +4943,9 @@ packages:
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -5007,6 +5054,9 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -8543,6 +8593,8 @@ snapshots:
 
   core-js@3.49.0: {}
 
+  core-util-is@1.0.3: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -9312,6 +9364,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https@1.0.0: {}
+
   human-id@4.1.3: {}
 
   human-signals@2.1.0: {}
@@ -9323,6 +9377,12 @@ snapshots:
       safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
+
+  image-size@1.2.1:
+    dependencies:
+      queue: 6.0.2
+
+  immediate@3.0.6: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -9408,6 +9468,8 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isarray@1.0.0: {}
+
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
@@ -9453,9 +9515,20 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -10240,6 +10313,8 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -10347,6 +10422,13 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  pptxgenjs@4.0.1:
+    dependencies:
+      '@types/node': 22.19.17
+      https: 1.0.0
+      image-size: 1.2.1
+      jszip: 3.10.1
+
   preact@10.29.1: {}
 
   prettier@2.8.8: {}
@@ -10354,6 +10436,8 @@ snapshots:
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
+
+  process-nextick-args@2.0.1: {}
 
   prompts@2.4.2:
     dependencies:
@@ -10393,6 +10477,10 @@ snapshots:
   query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
+
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
 
   radix-ui@1.4.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -10572,6 +10660,16 @@ snapshots:
       js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -10794,6 +10892,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.1.2: {}
+
   safer-buffer@2.1.2: {}
 
   scheduler@0.23.2:
@@ -10841,6 +10941,8 @@ snapshots:
 
   set-cookie-parser@3.1.0:
     optional: true
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -11015,6 +11117,10 @@ snapshots:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   stringify-entities@4.0.4:
     dependencies:


### PR DESCRIPTION
Closes #194

<img width="960" height="540" alt="editable-pptx-full-demo" src="https://github.com/user-attachments/assets/4e29e65f-2dd5-44c4-8986-3a01ca749169" />

*End-to-end: pick a deck in open-slide → **Download ▸ Export as PPTX** → open the file → every block is an independent, editable object (⌘A selects 31 separate objects). The "opened file" panel is a reconstruction rendered from the **real exported `.pptx`** — object outlines and the select-all count are read straight from its OOXML.*

## What

Adds an **"Export as PPTX"** option that turns a deck into an **editable** PowerPoint file: every block — text, image, shape, table — becomes an **independent native object**, not a flattened image per slide.

This fills the **reserved, disabled "Export as PPTX" slot** that already exists in the Download menu (the "coming soon" placeholder next to *Export as image PPTX*). It sits **alongside** the image exporter — image PPTX for pixel-perfect fidelity, editable PPTX for hand-off/co-editing.

## Proof it's really editable (not a flat image)

Parsed from the OOXML of a **real** `Export as PPTX` run over the `vercel-labs-2026` demo deck — no manual editing:

| | Text boxes | Shapes | Pictures | Gradient fills | Text runs |
|---|--:|--:|--:|--:|--:|
| **10 slides, total** | **205** | 45 | **40** | **13** vector | **314** |

- **245 independent native objects** across 10 slides (avg ~24/slide) — a flat-image export would have exactly **10** (one picture per slide).
- **314 native `<a:t>` text runs** — every word stays live, editable text.
- **13 vector `<a:gradFill>` gradients** — recolourable, not rasterised.
- Object-level edit round-trip (change one text run, move one shape, recolour one fill) touches **only those 3 XML elements** — proving each object is independently mutable.
- *Note:* this deck has no `<table>`, so it exercises 4 of the 5 native types; the table path is covered by unit tests + `emitTable` → native `<a:tbl>`.

## How it works

- New `packages/core/src/app/lib/export-editable-pptx.ts` mirrors the existing PDF/image-PPTX lifecycle (mount offscreen at 1920×1080 → wait for fonts/animations to settle → walk the DOM → download), reusing the shared helpers in `print-ready.ts`.
- Per node: `getBoundingClientRect` + `getComputedStyle` → a classifier picks **text box / picture / autoshape / table / rasterize / container**, emitting one PptxGenJS object each. 1920px @ 96dpi → exact 20″×11.25″ geometry.
- Pure, unit-tested helpers under `pptx/`: `units.ts` (px→EMU/pt, colour, box-shadow, rotation), `classify.ts`, `gradient.ts` (CSS gradient → `a:gradFill`).
- **Gradients:** PptxGenJS can't emit gradient fills, so **linear** (`a:lin`) and **radial** (`a:path path="circle"`) gradients are post-patched into the OOXML with the already-bundled `fflate`. Conic has no native OOXML fill → safe solid-first-stop fallback.
- **Rasterization is a last resort:** only text-free decorative subtrees (inline SVG, blur/blend overlays) rasterize, via lazy `html-to-image`, at a capped resolution. Anything containing text stays editable.
- Wired into the `slide.tsx` Download dropdown, reusing the existing `PptxProgressToast` + `pptxToast` locale + `PptxExportProgress` type; locale strings for en/ja/zh-tw/zh-cn.

## Fidelity improvements included

- **radial gradients** vectorised to a native circle path fill (only linear was vectorised before)
- **oklch / modern-colour gradient stops** parsed correctly (colour split from position, then normalised)
- **box-shadow** → native PowerPoint outer shadow on shapes/pictures
- **`<a href>`** (http/https/mailto) → native hyperlink runs

## Dependencies

Adds **only `pptxgenjs`** (its sole dep is JSZip), lazy-imported via dynamic `import()`. `html-to-image` and `fflate` are already direct deps, and gradient patching reuses the existing `fflate`.

## How tested

- `pnpm check`, `pnpm typecheck`, `pnpm test` all pass — **334 unit tests** (units / classify / gradient helpers).
- Exercised end-to-end via the real Download ▸ Export as PPTX button across `apps/demo` decks; opened the output and verified native objects by unzipping the OOXML (opens without a repair prompt).

## Known limitations

- Web fonts can't be embedded by PptxGenJS → substituted to system fonts; text may re-wrap slightly.
- flex/grid is baked to absolute coordinates (editable, not reflow-aware).
- conic gradients fall back to a solid first stop (linear + radial are vectorised).
- inline SVG / blur / mix-blend decorative graphics are rasterized (minimal subtree, resolution-capped).
- transitions/animations are not exported — final settled state is captured (same as PDF/image export).

## Checklist
- [x] `pnpm check` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (334 tests)
- [x] Changeset added (`@open-slide/core`, minor)
- [x] Rebased onto current `main`; coexists with the image PPTX exporter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an editable **Export as PPTX** option in the slide download menu.
  * PPTX export now preserves slide content as separate editable native objects (e.g., text, shapes, images, tables) instead of flattening slides into a single image.
  * Added PPTX export progress feedback (start, processing, generating, and completion).

* **Bug Fixes**
  * Improved PPTX export handling for styled content such as gradients, shadows, and images, with safer fallbacks where needed.
  * Added clearer PPTX export failure messaging in supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->