### PR TITLE
feat(core): show version in home sidebar with update hint

### DIFF
--- a/.changeset/sidebar-version-footer.md
+++ b/.changeset/sidebar-version-footer.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Show the open-slide version at the bottom of the home sidebar, with a hover hint to update when a newer release is available.

--- a/packages/core/src/app/components/sidebar/sidebar-footer.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar-footer.tsx
@@ -1,0 +1,51 @@
+import config from 'virtual:open-slide/config';
+import { useEffect, useState } from 'react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { format, useLocale } from '@/lib/use-locale';
+
+type UpdateCheck = { current: string; latest: string | null; outdated: boolean };
+
+export function SidebarFooter() {
+  const t = useLocale();
+  const [update, setUpdate] = useState<UpdateCheck | null>(null);
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    let cancelled = false;
+    fetch('/__update-check')
+      .then((res) => (res.ok ? (res.json() as Promise<UpdateCheck>) : null))
+      .then((data) => {
+        if (!cancelled && data?.outdated) setUpdate(data);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const label = `v${config.version}`;
+
+  if (!update?.latest) {
+    return (
+      <div className="px-4 py-3 text-[11px] text-muted-foreground/70 tabular-nums">{label}</div>
+    );
+  }
+
+  return (
+    <div className="px-4 py-3">
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground/70 tabular-nums">
+              <span className="size-1.5 rounded-full bg-brand" aria-hidden />
+              {label}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={6} className="max-w-56">
+            {format(t.home.updateAvailable, { version: update.latest })}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+}

--- a/packages/core/src/app/components/sidebar/sidebar-footer.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar-footer.tsx
@@ -25,27 +25,27 @@ export function SidebarFooter() {
 
   const label = `v${config.version}`;
 
-  if (!update?.latest) {
-    return (
-      <div className="px-4 py-3 text-[11px] text-muted-foreground/70 tabular-nums">{label}</div>
-    );
-  }
+  const versionRow = (
+    <span className="inline-flex items-center gap-1.5">
+      {update?.latest && <span className="size-1.5 rounded-full bg-brand" aria-hidden />}
+      {label}
+    </span>
+  );
 
   return (
-    <div className="px-4 py-3">
-      <TooltipProvider delayDuration={200}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground/70 tabular-nums">
-              <span className="size-1.5 rounded-full bg-brand" aria-hidden />
-              {label}
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="top" sideOffset={6} className="max-w-56">
-            {format(t.home.updateAvailable, { version: update.latest })}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+    <div className="px-4 py-3 text-[11px] text-muted-foreground/70 tabular-nums">
+      {update?.latest ? (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>{versionRow}</TooltipTrigger>
+            <TooltipContent side="top" sideOffset={6} className="max-w-56">
+              {format(t.home.updateAvailable, { version: update.latest })}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        versionRow
+      )}
     </div>
   );
 }

--- a/packages/core/src/app/components/sidebar/sidebar.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar.tsx
@@ -9,6 +9,7 @@ import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import { FolderIconChip, FolderItem } from './folder-item';
 import { IconPicker, PRESET_COLORS } from './icon-picker';
+import { SidebarFooter } from './sidebar-footer';
 
 export const DRAFT_ID = 'draft';
 export const THEMES_ID = '__themes__';
@@ -272,6 +273,10 @@ export function Sidebar({
               <span>{t.home.newFolder}</span>
             </button>
           ))}
+      </div>
+
+      <div className="border-t border-hairline">
+        <SidebarFooter />
       </div>
     </aside>
   );

--- a/packages/core/src/app/virtual.d.ts
+++ b/packages/core/src/app/virtual.d.ts
@@ -13,6 +13,7 @@ declare module 'virtual:open-slide/config' {
     slidesDir?: string;
     port?: number;
     locale?: Locale;
+    version: string;
     build: {
       showSlideBrowser: boolean;
       showSlideUi: boolean;

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -44,6 +44,7 @@ export const en: Locale = {
     folders: 'Folders',
     newFolder: 'New folder',
     folderName: 'Folder name',
+    updateAvailable: 'open-slide {version} is available — update the package to get the latest.',
     changeIcon: 'Change icon',
     iconEmojiTab: 'Emoji',
     iconColorTab: 'Color',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -44,6 +44,8 @@ export const ja: Locale = {
     folders: 'フォルダ',
     newFolder: '新規フォルダ',
     folderName: 'フォルダ名',
+    updateAvailable:
+      'open-slide {version} が利用可能です — パッケージを更新して最新版を入手してください。',
     changeIcon: 'アイコンを変更',
     iconEmojiTab: '絵文字',
     iconColorTab: 'カラー',

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -44,6 +44,7 @@ export type Locale = {
     folders: string;
     newFolder: string;
     folderName: string;
+    updateAvailable: string;
     changeIcon: string;
     iconEmojiTab: string;
     iconColorTab: string;

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -44,7 +44,7 @@ export const zhCN: Locale = {
     folders: '文件夹',
     newFolder: '新建文件夹',
     folderName: '文件夹名称',
-    updateAvailable: 'open-slide {version} 已发布 —— 请更新软件包以获取最新版本。',
+    updateAvailable: 'open-slide {version} 已发布，请更新软件包以获取最新版本。',
     changeIcon: '更换图标',
     iconEmojiTab: 'Emoji',
     iconColorTab: '颜色',

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -44,6 +44,7 @@ export const zhCN: Locale = {
     folders: '文件夹',
     newFolder: '新建文件夹',
     folderName: '文件夹名称',
+    updateAvailable: 'open-slide {version} 已发布 —— 请更新软件包以获取最新版本。',
     changeIcon: '更换图标',
     iconEmojiTab: 'Emoji',
     iconColorTab: '颜色',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -44,7 +44,7 @@ export const zhTW: Locale = {
     folders: '資料夾',
     newFolder: '新增資料夾',
     folderName: '資料夾名稱',
-    updateAvailable: 'open-slide {version} 已發布 —— 請更新套件以取得最新版本。',
+    updateAvailable: 'open-slide {version} 已發布，請更新套件以取得最新版本。',
     changeIcon: '變更圖示',
     iconEmojiTab: 'Emoji',
     iconColorTab: '顏色',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -44,6 +44,7 @@ export const zhTW: Locale = {
     folders: '資料夾',
     newFolder: '新增資料夾',
     folderName: '資料夾名稱',
+    updateAvailable: 'open-slide {version} 已發布 —— 請更新套件以取得最新版本。',
     changeIcon: '變更圖示',
     iconEmojiTab: 'Emoji',
     iconColorTab: '顏色',

--- a/packages/core/src/vite/api-plugin.ts
+++ b/packages/core/src/vite/api-plugin.ts
@@ -6,6 +6,7 @@ import { registerEditRoutes } from './routes/edit.ts';
 import { registerFolderRoutes } from './routes/folders.ts';
 import { registerSlideRoutes } from './routes/slides.ts';
 import { registerSvglRoutes } from './routes/svgl.ts';
+import { registerUpdateRoutes } from './routes/update.ts';
 import { registerWatchers } from './routes/watchers.ts';
 
 export type { ApiPluginOptions };
@@ -26,6 +27,7 @@ export function apiPlugin(opts: ApiPluginOptions): Plugin {
       registerAssetRoutes(server, ctx);
       registerSvglRoutes(server);
       registerFolderRoutes(server, ctx);
+      registerUpdateRoutes(server, ctx.coreVersion);
     },
   };
 }

--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
@@ -24,6 +24,17 @@ function findPackageRoot(fromFile: string): string {
 const PKG_ROOT = findPackageRoot(fileURLToPath(import.meta.url));
 const APP_ROOT = path.join(PKG_ROOT, 'src', 'app');
 
+function readCoreVersion(): string {
+  try {
+    const raw = readFileSync(path.join(PKG_ROOT, 'package.json'), 'utf8');
+    return (JSON.parse(raw) as { version?: string }).version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+const CORE_VERSION = readCoreVersion();
+
 export type CreateViteConfigOptions = {
   userCwd: string;
   config?: OpenSlideConfig;
@@ -48,10 +59,10 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
       locTagsPlugin({ userCwd, slidesDir }),
       react(),
       tailwindcss(),
-      openSlidePlugin({ userCwd, config }),
+      openSlidePlugin({ userCwd, config, coreVersion: CORE_VERSION }),
       themesPlugin({ userCwd, config }),
       designPlugin({ userCwd }),
-      apiPlugin({ userCwd, slidesDir, assetsDir }),
+      apiPlugin({ userCwd, slidesDir, assetsDir, coreVersion: CORE_VERSION }),
       notesPlugin({ userCwd, slidesDir }),
       currentPlugin({ userCwd, slidesDir }),
     ],

--- a/packages/core/src/vite/open-slide-plugin.ts
+++ b/packages/core/src/vite/open-slide-plugin.ts
@@ -10,6 +10,7 @@ export type { OpenSlideConfig };
 export type OpenSlidePluginOptions = {
   userCwd: string;
   config: OpenSlideConfig;
+  coreVersion: string;
 };
 
 const CONFIG_FILE = 'open-slide.config.ts';
@@ -176,7 +177,7 @@ ${cases}
 }
 
 export function openSlidePlugin(opts: OpenSlidePluginOptions): Plugin {
-  const { userCwd, config } = opts;
+  const { userCwd, config, coreVersion } = opts;
   const slidesDir = config.slidesDir ?? 'slides';
   const slidesRoot = path.resolve(userCwd, slidesDir);
   const foldersManifestPath = path.join(slidesRoot, '.folders.json');
@@ -237,7 +238,7 @@ export function openSlidePlugin(opts: OpenSlidePluginOptions): Plugin {
               showSlideUi: userBuild.showSlideUi ?? true,
               allowHtmlDownload: userBuild.allowHtmlDownload ?? true,
             };
-        const resolvedConfig = { ...config, build: buildResolved };
+        const resolvedConfig = { ...config, build: buildResolved, version: coreVersion };
         return `export default ${JSON.stringify(resolvedConfig)};\n`;
       }
       if (id === resolved(FOLDERS_VMOD)) {

--- a/packages/core/src/vite/routes/context.ts
+++ b/packages/core/src/vite/routes/context.ts
@@ -9,12 +9,14 @@ export type ApiContext = {
   slidesRoot: string;
   globalAssetsRoot: string;
   manifestPath: string;
+  coreVersion: string;
 };
 
 export type ApiPluginOptions = {
   userCwd: string;
   slidesDir?: string;
   assetsDir?: string;
+  coreVersion: string;
 };
 
 export function makeContext(opts: ApiPluginOptions): ApiContext {
@@ -24,7 +26,14 @@ export function makeContext(opts: ApiPluginOptions): ApiContext {
   const slidesRoot = path.resolve(userCwd, slidesDir);
   const globalAssetsRoot = path.resolve(userCwd, assetsDir);
   const manifestPath = path.join(slidesRoot, '.folders.json');
-  return { userCwd, slidesDir, slidesRoot, globalAssetsRoot, manifestPath };
+  return {
+    userCwd,
+    slidesDir,
+    slidesRoot,
+    globalAssetsRoot,
+    manifestPath,
+    coreVersion: opts.coreVersion,
+  };
 }
 
 export async function readBody(req: Connect.IncomingMessage): Promise<unknown> {

--- a/packages/core/src/vite/routes/update.ts
+++ b/packages/core/src/vite/routes/update.ts
@@ -1,0 +1,61 @@
+import type { ViteDevServer } from 'vite';
+import { json } from './context.ts';
+
+// GET /__update-check  → { current, latest, outdated }
+//   Compares the running @open-slide/core version against the npm `latest`
+//   dist-tag. Network/parse failures degrade to { latest: null, outdated: false }.
+
+const PKG = '@open-slide/core';
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+type CheckResult = { current: string; latest: string | null; outdated: boolean };
+
+let cache: { at: number; latest: string | null } | null = null;
+
+function parseSemver(v: string): [number, number, number] | null {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)/.exec(v.trim());
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function isOutdated(current: string, latest: string): boolean {
+  const a = parseSemver(current);
+  const b = parseSemver(latest);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (b[i] > a[i]) return true;
+    if (b[i] < a[i]) return false;
+  }
+  return false;
+}
+
+async function fetchLatest(now: number): Promise<string | null> {
+  if (cache && now - cache.at < CACHE_TTL_MS) return cache.latest;
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${PKG}/latest`, {
+      signal: AbortSignal.timeout(3000),
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) throw new Error(`registry ${res.status}`);
+    const body = (await res.json()) as { version?: unknown };
+    const latest = typeof body.version === 'string' ? body.version : null;
+    cache = { at: now, latest };
+    return latest;
+  } catch {
+    return cache?.latest ?? null;
+  }
+}
+
+export function registerUpdateRoutes(server: ViteDevServer, current: string): void {
+  server.middlewares.use('/__update-check', async (req, res, next) => {
+    if ((req.method ?? 'GET') !== 'GET') return next();
+    const latest = await fetchLatest(Date.now());
+    const result: CheckResult = {
+      current,
+      latest,
+      outdated: latest ? isOutdated(current, latest) : false,
+    };
+    res.setHeader('cache-control', 'no-store');
+    json(res, 200, result);
+  });
+}


### PR DESCRIPTION
## What

Adds a footer to the home sidebar that shows the running `@open-slide/core` version. In dev mode, it checks npm for a newer release and — when one exists — renders an indicator dot plus a hover tooltip prompting the user to update the package.

## Why

When running `open-slide dev`, there was no way to see which version of the framework you were on, or whether a newer one was available to upgrade to.

## How

- **Version → client**: `config.ts` reads the core `package.json` version once and injects it through the `virtual:open-slide/config` module (`config.version`).
- **Update check (dev-only)**: new `GET /__update-check` route fetches `registry.npmjs.org/@open-slide/core/latest` server-side, returning `{ current, latest, outdated }`.
  - Lives in the `apiPlugin` (`apply: 'serve'`), so it never runs in a production build — telling a deployed deck's viewers to "update the package" makes no sense.
  - Dependency-free `major.minor.patch` comparison (no `semver` added), 3s timeout, 10-minute in-memory cache, and silent degradation to `outdated: false` on any network/parse error.
- **UI**: new `SidebarFooter` reads `config.version`, always shows `v<version>`, and only fetches the update check under `import.meta.env.DEV`. Tooltip text is localized.
- **i18n**: `home.updateAvailable` added to all four locales (en / zh-tw / zh-cn / ja).

## Reviewer notes

- Update detection and the tooltip are **dev-only by design** (confirmed with the maintainer). Production builds show the plain version number only.
- To see the dot + tooltip locally: temporarily lower the version in `packages/core/package.json` below the published one, run `pnpm dev`, and check `curl http://localhost:5173/__update-check`.

## Verification

- `pnpm core typecheck` ✅
- `pnpm check` (biome) ✅
- `pnpm test` ✅ (256 passed)

Changeset included (`@open-slide/core` minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version shown in the sidebar footer
  * Automatic update notification shows when a newer release is available, with a hover tooltip prompting an update
  * Localized update messages added for English, Japanese, Simplified Chinese and Traditional Chinese
<!-- end of auto-generated comment: release notes by coderabbit.ai -->