### PR TITLE
Preserve raster (url) backgrounds in PDF export while still stripping gradients

### DIFF
--- a/.changeset/preserve-raster-pdf-backgrounds.md
+++ b/.changeset/preserve-raster-pdf-backgrounds.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Preserve raster backgrounds in PDF exports while stripping gradient layers.

--- a/packages/core/src/app/lib/export-pdf.ts
+++ b/packages/core/src/app/lib/export-pdf.ts
@@ -195,11 +195,75 @@ export async function exportSlideAsPdf(
 function neutralizeGradientBackgrounds(root: HTMLElement): void {
   const elements = root.querySelectorAll<HTMLElement>('*');
   for (const el of elements) {
-    const bg = getComputedStyle(el).backgroundImage;
-    if (bg?.includes('gradient(')) {
-      el.style.backgroundImage = 'none';
+    const styles = getComputedStyle(el);
+    const bg = styles.backgroundImage;
+    if (!bg?.includes('gradient(')) continue;
+
+    const result = removeGradientBackgroundLayers(bg);
+    const size = styles.backgroundSize;
+    const position = styles.backgroundPosition;
+    const repeat = styles.backgroundRepeat;
+
+    el.style.backgroundImage = result.backgroundImage;
+    if (result.keptIndices.length === 0 || result.keptIndices.length === result.layerCount)
+      continue;
+
+    el.style.backgroundSize = reindexBackgroundLayerValues(size, result.keptIndices);
+    el.style.backgroundPosition = reindexBackgroundLayerValues(position, result.keptIndices);
+    el.style.backgroundRepeat = reindexBackgroundLayerValues(repeat, result.keptIndices);
+  }
+}
+
+function removeGradientBackgroundLayers(backgroundImage: string): {
+  backgroundImage: string;
+  keptIndices: number[];
+  layerCount: number;
+} {
+  const layers = splitBackgroundImageLayers(backgroundImage);
+  const keptLayers: string[] = [];
+  const keptIndices: number[] = [];
+
+  for (let i = 0; i < layers.length; i++) {
+    const layer = layers[i];
+    if (!layer) continue;
+    const value = layer.trim();
+    if (value.startsWith('url(') && !value.includes('gradient(')) {
+      keptLayers.push(value);
+      keptIndices.push(i);
     }
   }
+
+  return {
+    backgroundImage: keptLayers.length > 0 ? keptLayers.join(', ') : 'none',
+    keptIndices,
+    layerCount: layers.length,
+  };
+}
+
+function reindexBackgroundLayerValues(value: string, keptIndices: number[]): string {
+  const layers = splitBackgroundImageLayers(value);
+  if (layers.length === 0) return value;
+
+  return keptIndices.map((index) => layers[index % layers.length]).join(', ');
+}
+
+function splitBackgroundImageLayers(backgroundImage: string): string[] {
+  const layers: string[] = [];
+  let depth = 0;
+  let layerStart = 0;
+
+  for (let i = 0; i < backgroundImage.length; i++) {
+    const char = backgroundImage[i];
+    if (char === '(') depth++;
+    if (char === ')') depth = Math.max(0, depth - 1);
+    if (char === ',' && depth === 0) {
+      layers.push(backgroundImage.slice(layerStart, i).trim());
+      layerStart = i + 1;
+    }
+  }
+
+  layers.push(backgroundImage.slice(layerStart).trim());
+  return layers;
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

Slides with a raster background image (`background-image: url(...)`) now keep that image when exported to PDF. Previously the export wiped the entire `background-image` shorthand on any element whose computed background contained a gradient, so a full-slide background image disappeared and white-on-image text rendered as invisible white-on-white.

The neutralization is now surgical: gradient layers are dropped (so the macOS Preview slowdown stays fixed) while `url(...)` image layers are preserved. The per-layer `background-size`, `background-position`, and `background-repeat` lists are reindexed to match the surviving layers, so a `cover`/`center`/`no-repeat` image keeps its sizing instead of inheriting the removed gradient layer's defaults.

## Why this matters

Fixes the white-on-white slide reported in #168. Root cause: `neutralizeGradientBackgrounds()` set `el.style.backgroundImage = 'none'` for any element whose computed `backgroundImage` contained `gradient(`. For a layered value like `linear-gradient(...), url(...)` this discarded the raster layer too, not just the gradient.

This keeps the constraint from the closed #169: CSS gradients must still be stripped, because Chromium serializes them as PDF transparency groups / soft masks that make macOS Preview lag on every page turn. Only the gradient layers are removed; raster layers survive.

## Testing

- `pnpm core typecheck` (tsc) - clean
- `pnpm core build` (tsdown) - clean
- `pnpm test` (vitest) - 256 passing
- `biome check` on the changed file - clean
- Verified layer behavior in headless Chrome: `linear-gradient(...), url(...)` resolves to the `url(...)` layer with correct `background-size`/`position`/`repeat`; a pure gradient still resolves to `none`; comma-bearing values (`rgba(...)`, `url(data:...)`) split into the correct layers via paren-depth-aware parsing.

Fixes #168


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PDF export functionality to better handle background styling: raster backgrounds are now preserved during export while gradient backgrounds are removed, with CSS background properties properly realigned for remaining layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->