### PR TITLE
fix: reject unsafe Windows asset names

### DIFF
--- a/.changeset/tidy-kids-march.md
+++ b/.changeset/tidy-kids-march.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Tighten asset filename validation for Windows reserved names.

--- a/packages/core/src/files/assets.test.ts
+++ b/packages/core/src/files/assets.test.ts
@@ -37,9 +37,12 @@ describe('validateAssetName', () => {
     expect(validateAssetName('CON.png')).toBeNull();
     expect(validateAssetName('aux.txt')).toBeNull();
     expect(validateAssetName('COM1.svg')).toBeNull();
+    expect(validateAssetName('COM¹.svg')).toBeNull();
+    expect(validateAssetName('LPT².txt')).toBeNull();
     expect(validateAssetName('LPT9.jpg')).toBeNull();
     expect(validateAssetName('image. .png')).toBe('image. .png');
     expect(validateAssetName('image.png.')).toBeNull();
+    expect(validateAssetName(' image.png')).toBeNull();
     expect(validateAssetName('image.png ')).toBeNull();
   });
 

--- a/packages/core/src/files/assets.test.ts
+++ b/packages/core/src/files/assets.test.ts
@@ -33,6 +33,16 @@ describe('validateAssetName', () => {
     expect(validateAssetName('foo?.png')).toBeNull();
   });
 
+  it('rejects names Windows cannot create safely', () => {
+    expect(validateAssetName('CON.png')).toBeNull();
+    expect(validateAssetName('aux.txt')).toBeNull();
+    expect(validateAssetName('COM1.svg')).toBeNull();
+    expect(validateAssetName('LPT9.jpg')).toBeNull();
+    expect(validateAssetName('image. .png')).toBe('image. .png');
+    expect(validateAssetName('image.png.')).toBeNull();
+    expect(validateAssetName('image.png ')).toBeNull();
+  });
+
   it('rejects empty / non-string / overlong names', () => {
     expect(validateAssetName('')).toBeNull();
     expect(validateAssetName(null)).toBeNull();

--- a/packages/core/src/files/assets.ts
+++ b/packages/core/src/files/assets.ts
@@ -6,7 +6,8 @@ export const ASSET_MAX_BYTES = 25 * 1024 * 1024;
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: explicit control-char block list for filename safety
 const ASSET_FORBIDDEN_RE = /[\x00-\x1F\x7F/\\:*?"<>|]/;
-const WINDOWS_RESERVED_BASENAME_RE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|$)/i;
+const WINDOWS_RESERVED_BASENAME_RE =
+  /^(con|prn|aux|nul|com(?:[1-9]|[\u00B9\u00B2\u00B3\u2074-\u2079])|lpt(?:[1-9]|[\u00B9\u00B2\u00B3\u2074-\u2079]))(\.|$)/i;
 
 const MIME_BY_EXT: Record<string, string> = {
   png: 'image/png',

--- a/packages/core/src/files/assets.ts
+++ b/packages/core/src/files/assets.ts
@@ -6,6 +6,7 @@ export const ASSET_MAX_BYTES = 25 * 1024 * 1024;
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: explicit control-char block list for filename safety
 const ASSET_FORBIDDEN_RE = /[\x00-\x1F\x7F/\\:*?"<>|]/;
+const WINDOWS_RESERVED_BASENAME_RE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|$)/i;
 
 const MIME_BY_EXT: Record<string, string> = {
   png: 'image/png',
@@ -38,9 +39,11 @@ export function mimeForFilename(name: string): string {
 export function validateAssetName(v: unknown): string | null {
   if (typeof v !== 'string') return null;
   const trimmed = v.trim();
+  if (trimmed !== v) return null;
   if (trimmed.length < 1 || trimmed.length > 120) return null;
   // No path separators, control chars, or characters Windows/macOS can't store.
   if (ASSET_FORBIDDEN_RE.test(trimmed)) return null;
+  if (trimmed.endsWith('.') || WINDOWS_RESERVED_BASENAME_RE.test(trimmed)) return null;
   // Block leading dots / tildes (hidden files, home expansion) and any `..` segment.
   if (trimmed.startsWith('.') || trimmed.startsWith('~')) return null;
   if (trimmed === '..' || trimmed.split(/[/\\]/).includes('..')) return null;


### PR DESCRIPTION
## Summary
- reject Windows reserved device names such as `CON.png`, `AUX.txt`, and `COM1.svg` during asset filename validation
- reject filenames with leading/trailing whitespace so unsafe Windows trailing dots/spaces are not silently normalized
- add regression coverage for cross-platform asset name validation

## Verification
- RED: `corepack pnpm test -- --run packages/core/src/files/assets.test.ts` failed with `expected 'CON.png' to be null`
- GREEN: `corepack pnpm exec vitest run packages/core/src/files/assets.test.ts` passed, 9 tests
- `corepack pnpm test` passed, 16 files / 257 tests
- `corepack pnpm check` passed with one existing warning in `packages/core/src/http/request-guard.ts`
- `corepack pnpm --filter @open-slide/core typecheck` passed
- `corepack pnpm --filter @open-slide/core build` passed
- `git diff --check` passed

Note: root `corepack pnpm typecheck` failed in this local environment because Turbo could not find the package manager binary (`cannot find binary path`), so I ran the affected package typecheck directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened asset filename validation to reject Windows reserved device basenames (including common COM/LPT variants) and names with leading/trailing whitespace.
  * Also disallows improperly formatted filenames such as those ending with a trailing dot, reducing Windows-specific file creation issues.
* **Tests**
  * Added coverage for the updated Windows reserved name and whitespace/trailing-dot validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->