### PR TITLE
feat(core): add configurable base path for subpath hosting

### DIFF
--- a/.changeset/configurable-base-path.md
+++ b/.changeset/configurable-base-path.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Add `base` to `OpenSlideConfig` for hosting under a subpath (e.g. GitHub Pages, Nginx subdirectory). Wires through to Vite's `base` and React Router's `basename`.

--- a/apps/web/content/docs/cli/build.mdx
+++ b/apps/web/content/docs/cli/build.mdx
@@ -44,3 +44,18 @@ const config: OpenSlideConfig = {
 ```
 
 See [Export](/docs/core-feature/export) for the full set of build knobs.
+
+## Deploying under a subpath
+
+If the build won't sit at the domain root (GitHub Pages project sites,
+a reverse-proxy folder, an intranet path), set `base` in
+`open-slide.config.ts` so asset URLs and client-side navigation resolve
+against the deployed path:
+
+```ts
+const config: OpenSlideConfig = {
+  base: '/my-slides/',
+};
+```
+
+See [Config](/docs/reference/config) for details.

--- a/apps/web/content/docs/reference/config.mdx
+++ b/apps/web/content/docs/reference/config.mdx
@@ -27,6 +27,8 @@ type OpenSlideBuildConfig = {
 };
 
 type OpenSlideConfig = {
+  /** Base public path for subpath hosting (leading + trailing slash). Default: '/'. */
+  base?: string;
   /** Folder that contains your decks. Default: 'slides'. */
   slidesDir?: string;
   /** Folder that holds theme markdown + demo files. Default: 'themes'. */
@@ -55,6 +57,21 @@ const config: OpenSlideConfig = {
   },
 };
 ```
+
+### Host under a subpath
+
+Set `base` to deploy the build under a sub-directory instead of the domain
+root — GitHub Pages project sites, a reverse-proxy folder, an intranet path.
+Use a leading and trailing slash:
+
+```ts
+const config: OpenSlideConfig = {
+  base: '/my-slides/',
+};
+```
+
+The value is passed straight to Vite's `base` and to React Router's
+`basename`, so client-side navigation matches the deployed path.
 
 ### Multiple deck folders
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -41,6 +41,18 @@ const openSlideConfig: OpenSlideConfig = {
 export default openSlideConfig;
 ```
 
+### Hosting under a subpath
+
+Set `base` to deploy the built site under a sub-directory (intranet folders, GitHub Pages project sites, reverse proxies). Use a leading and trailing slash:
+
+```ts
+const openSlideConfig: OpenSlideConfig = {
+  base: '/my-slides/',
+};
+```
+
+The value is passed straight to Vite's `base` and to React Router's `basename`, so client-side navigation matches the deployed path.
+
 ## Authoring slides
 
 Slides live under `slides/<kebab-case-id>/index.tsx` and default-export an array of `Page` components:

--- a/packages/core/src/app/app.tsx
+++ b/packages/core/src/app/app.tsx
@@ -11,7 +11,7 @@ import { ThemeDetailPage, ThemesGalleryPage } from './routes/themes';
 
 export function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <Routes>
         {config.build.showSlideBrowser ? (
           <Route element={<HomeShell />}>

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -380,6 +380,6 @@ export function Player({
 
 export function openPresenterWindow(slideId: string) {
   if (typeof window === 'undefined') return;
-  const url = `/s/${encodeURIComponent(slideId)}/presenter`;
+  const url = `${import.meta.env.BASE_URL}s/${encodeURIComponent(slideId)}/presenter`;
   window.open(url, `open-slide-presenter-${slideId}`, 'popup,width=1280,height=800');
 }

--- a/packages/core/src/app/virtual.d.ts
+++ b/packages/core/src/app/virtual.d.ts
@@ -10,6 +10,7 @@ declare module 'virtual:open-slide/config' {
   import type { Locale } from '../locale/types';
 
   const config: {
+    base?: string;
     slidesDir?: string;
     port?: number;
     locale?: Locale;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -7,6 +7,7 @@ export type OpenSlideBuildConfig = {
 };
 
 export type OpenSlideConfig = {
+  base?: string;
   slidesDir?: string;
   themesDir?: string;
   assetsDir?: string;

--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -52,6 +52,7 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
   const assetsAbs = path.resolve(userCwd, assetsDir);
 
   return {
+    base: config.base ?? '/',
     root: APP_ROOT,
     configFile: false,
     envDir: userCwd,

--- a/packages/core/src/vite/open-slide-plugin.ts
+++ b/packages/core/src/vite/open-slide-plugin.ts
@@ -122,7 +122,7 @@ async function generateSlidesModule(
   const entries = await Promise.all(
     files.map(async (abs) => {
       const id = toId(abs, slidesRoot);
-      const importPath = isDev ? `/@fs/${abs.replace(/^\/+/, '')}` : abs;
+      const importPath = isDev ? `@fs/${abs.replace(/^\/+/, '')}` : abs;
       const meta = await readSlideMeta(abs);
       return { id, importPath, theme: meta.theme, createdAt: parseCreatedAtMs(meta.createdAt) };
     }),
@@ -155,7 +155,7 @@ if (import.meta.hot) {
   const cases = entries
     .map((e) => {
       const importExpr = isDev
-        ? `import(/* @vite-ignore */ ${JSON.stringify(`${e.importPath}?t=`)} + slideImportTokens[${JSON.stringify(e.id)}])`
+        ? `import(/* @vite-ignore */ import.meta.env.BASE_URL + ${JSON.stringify(`${e.importPath}?t=`)} + slideImportTokens[${JSON.stringify(e.id)}])`
         : `import(${JSON.stringify(e.importPath)})`;
       return `    case ${JSON.stringify(e.id)}: return ${importExpr};`;
     })

--- a/packages/core/src/vite/open-slide-plugin.ts
+++ b/packages/core/src/vite/open-slide-plugin.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import fg from 'fast-glob';
-import { loadConfigFromFile, type Plugin, type ViteDevServer } from 'vite';
+import { loadConfigFromFile, normalizePath, type Plugin, type ViteDevServer } from 'vite';
 import type { OpenSlideConfig } from '../config.ts';
 
 export type { OpenSlideConfig };
@@ -122,7 +122,7 @@ async function generateSlidesModule(
   const entries = await Promise.all(
     files.map(async (abs) => {
       const id = toId(abs, slidesRoot);
-      const importPath = isDev ? `@fs/${abs.replace(/^\/+/, '')}` : abs;
+      const importPath = isDev ? `@fs/${normalizePath(abs).replace(/^\/+/, '')}` : abs;
       const meta = await readSlideMeta(abs);
       return { id, importPath, theme: meta.theme, createdAt: parseCreatedAtMs(meta.createdAt) };
     }),

--- a/packages/core/src/vite/themes-plugin.ts
+++ b/packages/core/src/vite/themes-plugin.ts
@@ -94,8 +94,11 @@ function generateThemesModule(themes: ParsedTheme[], isDev: boolean): string {
     .flatMap((t) => {
       const abs = t.demoAbs;
       if (!abs) return [];
-      const importPath = isDev ? `/@fs/${normalizePath(abs).replace(/^\/+/, '')}` : abs;
-      return [`    case ${JSON.stringify(t.id)}: return import(${JSON.stringify(importPath)});`];
+      const importPath = isDev ? `@fs/${normalizePath(abs).replace(/^\/+/, '')}` : abs;
+      const importExpr = isDev
+        ? `import(/* @vite-ignore */ import.meta.env.BASE_URL + ${JSON.stringify(importPath)})`
+        : `import(${JSON.stringify(importPath)})`;
+      return [`    case ${JSON.stringify(t.id)}: return ${importExpr};`];
     })
     .join('\n');
 


### PR DESCRIPTION
## Summary
- Add `base` field to `OpenSlideConfig` so the built site can be hosted under a sub-directory (GitHub Pages project sites, Nginx subdirectories, intranet folders).
- Forward the value to Vite's `base` and React Router's `basename`, and rewrite dev-time virtual imports for slides and themes through `import.meta.env.BASE_URL` so HMR keeps working under any base.
- Document the new option in `packages/core/README.md`.
- Close #173.

## Test plan
- [ ] `pnpm dev` from `apps/demo` with no `base` set — slides/themes load and HMR works (default `/`).
- [ ] Set `base: '/my-slides/'` in `apps/demo/open-slide.config.ts`, run `pnpm dev` — pages render at the new path and HMR still applies.
- [ ] `pnpm build` from `apps/demo` with `base: '/my-slides/'` — assets reference the subpath and `openPresenterWindow` opens at the correct URL.
- [ ] `pnpm check` and `pnpm typecheck` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for hosting the app under a configurable base path so routes and presenter view work from a subpath (deployed subdirectory).
* **Documentation**
  * Added guidance and examples for configuring deployment under a subpath, and notes on how client-side navigation and presenter links align with the deployed base path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->