### PR TITLE
feat(core): make presenter previews step-aware

### DIFF
--- a/.changeset/presenter-step-aware-preview.md
+++ b/.changeset/presenter-step-aware-preview.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Presenter window now reflects in-slide `<Steps>` state: Now Showing mirrors the projection's revealed count, and Up Next previews the next step until the current slide's steps are exhausted before rolling over to the next slide.

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -4,7 +4,7 @@ import { useWheelPageNavigation } from '@/lib/use-wheel-page-navigation';
 import { cn } from '@/lib/utils';
 import type { DesignSystem } from '../lib/design';
 import type { Page } from '../lib/sdk';
-import type { EntryDirection, StepController } from '../lib/step-context';
+import type { EntryDirection, StepAggregate, StepController } from '../lib/step-context';
 import type { SlideTransition } from '../lib/transition';
 import { usePrefersReducedMotion } from '../lib/use-prefers-reduced-motion';
 import { PresentBlackoutOverlay } from './present/blackout-overlay';
@@ -87,6 +87,15 @@ export function Player({
 
   const stepControllerRef = useRef<StepController | null>(null);
   const [entryDirection, setEntryDirection] = useState<EntryDirection>('jump');
+  const [stepAggregate, setStepAggregate] = useState<StepAggregate>({
+    revealed: 0,
+    stepCount: 0,
+  });
+  const handleAggregateChange = useCallback((a: StepAggregate) => {
+    setStepAggregate((cur) =>
+      cur.revealed === a.revealed && cur.stepCount === a.stepCount ? cur : a,
+    );
+  }, []);
 
   // Every navigation funnels through here so entryDirection is settled
   // synchronously, before the incoming page's <Steps> reads it on mount.
@@ -164,8 +173,15 @@ export function Player({
   // and answers `request-state` pings so newly opened presenter windows
   // hydrate immediately.
   const presenterState = useMemo<PresenterState>(
-    () => ({ index, pageCount: pages.length, blackout, startedAt }),
-    [index, pages.length, blackout, startedAt],
+    () => ({
+      index,
+      pageCount: pages.length,
+      blackout,
+      startedAt,
+      stepIndex: stepAggregate.revealed,
+      stepCount: stepAggregate.stepCount,
+    }),
+    [index, pages.length, blackout, startedAt, stepAggregate],
   );
   const presenterStateRef = useRef(presenterState);
   presenterStateRef.current = presenterState;
@@ -334,6 +350,7 @@ export function Player({
           disabled={prefersReducedMotion}
           stepControllerRef={stepControllerRef}
           entryDirection={entryDirection}
+          onStepAggregateChange={handleAggregateChange}
         />
       </SlideCanvas>
 

--- a/packages/core/src/app/components/present/use-presenter-channel.ts
+++ b/packages/core/src/app/components/present/use-presenter-channel.ts
@@ -5,6 +5,8 @@ export type PresenterState = {
   pageCount: number;
   blackout: 'black' | 'white' | null;
   startedAt: number; // epoch ms when present mode began
+  stepIndex: number;
+  stepCount: number;
 };
 
 export type PresenterCommand =

--- a/packages/core/src/app/components/slide-transition-layer.tsx
+++ b/packages/core/src/app/components/slide-transition-layer.tsx
@@ -1,7 +1,12 @@
 import { type MutableRefObject, useEffect, useRef, useState } from 'react';
 import { SlidePageProvider } from '../lib/page-context';
 import type { Page } from '../lib/sdk';
-import { type EntryDirection, type StepController, StepHost } from '../lib/step-context';
+import {
+  type EntryDirection,
+  type StepAggregate,
+  type StepController,
+  StepHost,
+} from '../lib/step-context';
 import { resolveTransition, type SlideTransition, type TransitionPhase } from '../lib/transition';
 
 type Props = {
@@ -12,6 +17,7 @@ type Props = {
   disabled?: boolean;
   stepControllerRef?: MutableRefObject<StepController | null>;
   entryDirection?: EntryDirection;
+  onStepAggregateChange?: (aggregate: StepAggregate) => void;
 };
 
 type Direction = 'forward' | 'backward';
@@ -41,6 +47,7 @@ export function SlideTransitionLayer({
   disabled,
   stepControllerRef,
   entryDirection = 'jump',
+  onStepAggregateChange,
 }: Props) {
   const [current, setCurrent] = useState(index);
   const [outgoing, setOutgoing] = useState<number | null>(null);
@@ -175,6 +182,7 @@ export function SlideTransitionLayer({
               isActivePage
               entryDirection={entryDirection}
               controllerRef={activeControllerRef}
+              onAggregateChange={onStepAggregateChange}
             >
               <CurrentPage />
             </StepHost>

--- a/packages/core/src/app/lib/step-context.tsx
+++ b/packages/core/src/app/lib/step-context.tsx
@@ -7,8 +7,8 @@ import {
   type MutableRefObject,
   type PropsWithChildren,
   type ReactElement,
+  useCallback,
   useContext,
-  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -23,9 +23,24 @@ export type StepController = {
   retreat: () => boolean;
 };
 
+export type StepAggregate = {
+  revealed: number;
+  stepCount: number;
+};
+
+type Registration = {
+  id: object;
+  stepCount: number;
+  initialRevealed: number;
+  controller: StepController;
+  setRevealed: (n: number) => void;
+};
+
 type StepHostContextValue = {
-  register: (ctrl: StepController) => () => void;
+  register: (reg: Registration) => () => void;
+  reportRevealed: (id: object, revealed: number) => void;
   entryDirection: EntryDirection;
+  controlled: boolean;
 };
 
 const GLOBAL_KEY = '__open_slide_step_host_context__';
@@ -42,22 +57,39 @@ type StepHostProps = PropsWithChildren<{
   isActivePage: boolean;
   entryDirection: EntryDirection;
   controllerRef: MutableRefObject<StepController | null>;
+  // When set, the host distributes this count across <Steps> children in
+  // mount order — first fills to its stepCount, next takes the remainder.
+  controlledRevealed?: number;
+  onAggregateChange?: (aggregate: StepAggregate) => void;
 }>;
 
-export function StepHost({ isActivePage, entryDirection, controllerRef, children }: StepHostProps) {
-  const controllersRef = useRef<StepController[]>([]);
+export function StepHost({
+  isActivePage,
+  entryDirection,
+  controllerRef,
+  controlledRevealed,
+  onAggregateChange,
+  children,
+}: StepHostProps) {
+  type Tracked = Registration & { revealed: number };
+  const registrationsRef = useRef<Tracked[]>([]);
+
+  const onAggregateChangeRef = useRef(onAggregateChange);
+  onAggregateChangeRef.current = onAggregateChange;
+  const controlledRevealedRef = useRef(controlledRevealed);
+  controlledRevealedRef.current = controlledRevealed;
 
   const composite = useMemo<StepController>(
     () => ({
       advance: () => {
-        for (const c of controllersRef.current) {
-          if (c.advance()) return true;
+        for (const r of registrationsRef.current) {
+          if (r.controller.advance()) return true;
         }
         return false;
       },
       retreat: () => {
-        for (let i = controllersRef.current.length - 1; i >= 0; i--) {
-          if (controllersRef.current[i].retreat()) return true;
+        for (let i = registrationsRef.current.length - 1; i >= 0; i--) {
+          if (registrationsRef.current[i].controller.retreat()) return true;
         }
         return false;
       },
@@ -76,19 +108,63 @@ export function StepHost({ isActivePage, entryDirection, controllerRef, children
     };
   }, [isActivePage, composite, controllerRef]);
 
+  const notifyAggregate = useCallback(() => {
+    const cb = onAggregateChangeRef.current;
+    if (!cb) return;
+    let revealed = 0;
+    let stepCount = 0;
+    for (const r of registrationsRef.current) {
+      revealed += r.revealed;
+      stepCount += r.stepCount;
+    }
+    cb({ revealed, stepCount });
+  }, []);
+
+  const distributeControlled = useCallback(() => {
+    const target = controlledRevealedRef.current;
+    if (target == null) return;
+    let remaining = target;
+    for (const r of registrationsRef.current) {
+      const share = Math.max(0, Math.min(r.stepCount, remaining));
+      remaining -= share;
+      if (r.revealed !== share) {
+        r.revealed = share;
+        r.setRevealed(share);
+      }
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    if (controlledRevealed == null) return;
+    distributeControlled();
+    notifyAggregate();
+  }, [controlledRevealed, distributeControlled, notifyAggregate]);
+
   const value = useMemo<StepHostContextValue>(
     () => ({
-      register: (ctrl) => {
-        if (!isActivePage) return () => {};
-        controllersRef.current.push(ctrl);
+      register: (reg) => {
+        const tracked: Tracked = { ...reg, revealed: reg.initialRevealed };
+        registrationsRef.current.push(tracked);
+        if (controlledRevealedRef.current != null) {
+          distributeControlled();
+        }
+        notifyAggregate();
         return () => {
-          const i = controllersRef.current.indexOf(ctrl);
-          if (i !== -1) controllersRef.current.splice(i, 1);
+          const i = registrationsRef.current.indexOf(tracked);
+          if (i !== -1) registrationsRef.current.splice(i, 1);
+          notifyAggregate();
         };
       },
+      reportRevealed: (id, revealed) => {
+        const r = registrationsRef.current.find((x) => x.id === id);
+        if (!r) return;
+        r.revealed = revealed;
+        notifyAggregate();
+      },
       entryDirection,
+      controlled: controlledRevealed != null,
     }),
-    [isActivePage, entryDirection],
+    [entryDirection, controlledRevealed, distributeControlled, notifyAggregate],
   );
 
   return <StepHostContext.Provider value={value}>{children}</StepHostContext.Provider>;
@@ -101,28 +177,44 @@ export function Steps({ children }: StepsProps) {
   const flat = Children.toArray(children);
   const stepCount = flat.filter((c) => isValidElement(c) && c.type === Step).length;
 
-  const initial = host?.entryDirection === 'forward' ? 0 : stepCount;
+  // Controlled mode waits for the host to assign a slice in the registration
+  // layout-effect; otherwise the entry direction picks the initial reveal.
+  const initial = host?.controlled ? 0 : host?.entryDirection === 'forward' ? 0 : stepCount;
   const revealedRef = useRef(initial);
   const [revealed, setRevealed] = useState(initial);
 
-  useEffect(() => {
+  const idRef = useRef<object>({});
+
+  const applyRevealed = useCallback((n: number) => {
+    revealedRef.current = n;
+    setRevealed(n);
+  }, []);
+
+  useLayoutEffect(() => {
     if (!host) return;
+    const id = idRef.current;
     const ctrl: StepController = {
       advance: () => {
         if (revealedRef.current >= stepCount) return false;
-        revealedRef.current += 1;
-        setRevealed(revealedRef.current);
+        applyRevealed(revealedRef.current + 1);
+        host.reportRevealed(id, revealedRef.current);
         return true;
       },
       retreat: () => {
         if (revealedRef.current <= 0) return false;
-        revealedRef.current -= 1;
-        setRevealed(revealedRef.current);
+        applyRevealed(revealedRef.current - 1);
+        host.reportRevealed(id, revealedRef.current);
         return true;
       },
     };
-    return host.register(ctrl);
-  }, [host, stepCount]);
+    return host.register({
+      id,
+      stepCount,
+      initialRevealed: revealedRef.current,
+      controller: ctrl,
+      setRevealed: applyRevealed,
+    });
+  }, [host, stepCount, applyRevealed]);
 
   const effectiveRevealed = host ? revealed : stepCount;
 

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, ChevronRight, RotateCcw, Square, Sun } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { format, useLocale } from '@/lib/use-locale';
@@ -11,6 +11,7 @@ import {
 import { SlideCanvas } from '../components/slide-canvas';
 import { SlidePageProvider } from '../lib/page-context';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
+import { type StepController, StepHost } from '../lib/step-context';
 import { useSlideModule } from '../lib/use-slide-module';
 
 export function Presenter() {
@@ -114,14 +115,20 @@ export function Presenter() {
   const pages = slide.default;
   const total = pages.length;
   const index = Math.max(0, Math.min(total - 1, state?.index ?? 0));
-  const nextIndex = Math.min(total - 1, index + 1);
-  const hasNext = index < total - 1;
   const note = slide.notes?.[index];
   const blackout = state?.blackout ?? null;
   const startedAt = state?.startedAt ?? localStart;
+  const stepIndex = Math.max(0, state?.stepIndex ?? 0);
+  const stepCount = Math.max(0, state?.stepCount ?? 0);
+
+  const stepsRemaining = stepIndex < stepCount;
+  const hasNextSlide = index < total - 1;
+  const hasNext = stepsRemaining || hasNextSlide;
+  const nextPageIndex = stepsRemaining ? index : Math.min(total - 1, index + 1);
+  const nextRevealed = stepsRemaining ? stepIndex + 1 : 0;
 
   const CurrentPage = pages[index];
-  const NextPage = hasNext ? pages[nextIndex] : null;
+  const NextPage = hasNext ? pages[nextPageIndex] : null;
 
   return (
     <div className="dark flex h-dvh w-screen flex-col overflow-hidden bg-background text-foreground">
@@ -140,7 +147,9 @@ export function Presenter() {
           <div className="relative min-h-0 flex-1 overflow-hidden rounded-[8px] bg-black ring-1 ring-border">
             <SlideCanvas flat design={slide.design}>
               <SlidePageProvider index={index} total={total}>
-                <CurrentPage />
+                <PreviewStepHost revealed={stepIndex}>
+                  <CurrentPage />
+                </PreviewStepHost>
               </SlidePageProvider>
             </SlideCanvas>
             {blackout && (
@@ -167,8 +176,10 @@ export function Presenter() {
             >
               {NextPage ? (
                 <SlideCanvas flat freezeMotion design={slide.design}>
-                  <SlidePageProvider index={nextIndex} total={total}>
-                    <NextPage />
+                  <SlidePageProvider index={nextPageIndex} total={total}>
+                    <PreviewStepHost revealed={nextRevealed}>
+                      <NextPage />
+                    </PreviewStepHost>
                   </SlidePageProvider>
                 </SlideCanvas>
               ) : (
@@ -348,6 +359,20 @@ function PresenterJumpControl({
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return <span className="eyebrow">{children}</span>;
+}
+
+function PreviewStepHost({ revealed, children }: { revealed: number; children: ReactNode }) {
+  const noopControllerRef = useRef<StepController | null>(null);
+  return (
+    <StepHost
+      isActivePage={false}
+      entryDirection="jump"
+      controllerRef={noopControllerRef}
+      controlledRevealed={revealed}
+    >
+      {children}
+    </StepHost>
+  );
 }
 
 function Clock() {


### PR DESCRIPTION
## Summary

- Presenter window now mirrors the projection's `<Steps>` state — Now Showing reveals the same step count the audience sees, and Up Next previews the next step on the current slide until all steps are revealed before rolling over to the next slide.
- `Steps` reports per-slide aggregate `(revealed, stepCount)` up through `StepHost` → `SlideTransitionLayer` → `Player`, which broadcasts it on the existing presenter channel.
- New `controlledRevealed` prop on `StepHost` lets the presenter window render a slide at a specific reveal count without affecting the projection's actual step state.

## Test plan

- [ ] `pnpm dev`, open a slide with `<Steps>` (e.g. `/s/build-on-reveal` or `/s/steps-in-motion`).
- [ ] Press `P` to open the presenter window.
- [ ] Confirm Now Showing tracks the projection step-for-step as you press →.
- [ ] Confirm Up Next previews the same slide with one more step revealed until the slide's steps are exhausted, then switches to the next slide with reveals reset to 0.
- [ ] Confirm slides without `<Steps>` still behave as before (Up Next jumps straight to the next slide).
- [ ] Confirm backward navigation (←) — pressing prev on a fully-revealed slide steps back through reveals before moving to the previous slide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The presenter window now displays step-by-step progression information, showing which steps are currently revealed ("Now Showing") and previewing upcoming steps ("Up Next") before advancing to the next slide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->