### PR TITLE
fix(core): prevent homepage thumbnail scale flicker

### DIFF
--- a/.changeset/fix-thumbnail-scale-flicker.md
+++ b/.changeset/fix-thumbnail-scale-flicker.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Fix homepage thumbnails flashing at full size before scaling down by measuring the fit scale before first paint.

--- a/packages/core/src/app/components/slide-canvas.tsx
+++ b/packages/core/src/app/components/slide-canvas.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type ReactNode, useEffect, useRef, useState } from 'react';
+import { type CSSProperties, type ReactNode, useLayoutEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { type DesignSystem, designToCssVars } from '../lib/design';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
@@ -24,22 +24,27 @@ export function SlideCanvas({
   design,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [fitScale, setFitScale] = useState(1);
+  const [fitScale, setFitScale] = useState<number | null>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (scale !== undefined) return;
     const el = containerRef.current;
     if (!el) return;
-    const ro = new ResizeObserver(() => {
+    const measure = () => {
       const { width, height } = el.getBoundingClientRect();
       if (width === 0 || height === 0) return;
       setFitScale(Math.min(width / CANVAS_WIDTH, height / CANVAS_HEIGHT));
-    });
+    };
+    // Measure synchronously before paint so the fitted scale is applied on the
+    // first visible frame — otherwise the canvas flashes at full size.
+    measure();
+    const ro = new ResizeObserver(measure);
     ro.observe(el);
     return () => ro.disconnect();
   }, [scale]);
 
-  const s = scale ?? fitScale;
+  const measured = scale ?? fitScale;
+  const s = measured ?? 1;
   const scaledW = CANVAS_WIDTH * s;
   const scaledH = CANVAS_HEIGHT * s;
 
@@ -55,6 +60,7 @@ export function SlideCanvas({
         style={{
           width: scaledW,
           height: scaledH,
+          visibility: measured === null ? 'hidden' : undefined,
           ...(center
             ? {
                 position: 'absolute',


### PR DESCRIPTION
## What

Fixes the flicker on the homepage thumbnail grid where each thumbnail briefly renders at full size (content zoomed in / cropped) before snapping to the correctly-scaled-down preview.

## Why

In `SlideCanvas`, when no explicit `scale` prop is passed (auto-fit mode — how the homepage thumbnails use it), the fit scale was computed by a `ResizeObserver` inside a `useEffect`. The observer callback only fires **after** the browser paints, so:

1. **Frame 1:** `fitScale` defaults to `1` → inner canvas renders at full 1280×720, overflowing and cropping → the zoomed/cropped flash.
2. **Frame 2:** observer fires, measures the container, applies the fitted scale → correct thumbnail.

The gap between the two frames is the visible flicker.

## How

`packages/core/src/app/components/slide-canvas.tsx`:

- Switch `useEffect` → `useLayoutEffect` and measure the container **synchronously** once before paint, so the fitted scale lands on the first visible frame. The `ResizeObserver` is kept for subsequent resizes.
- Initialize `fitScale` to `null` (meaning "not yet measured") and set the canvas to `visibility: hidden` until a real scale is known — guards against a 0-size synchronous measurement (container not yet laid out) ever exposing a full-size frame.

Only affects auto-fit mode; callers passing an explicit `scale` are unchanged.

## Notes for reviewer

- `pnpm check` and `pnpm typecheck` pass (the one biome warning is pre-existing in an unrelated request-validation file).
- Changeset added (`patch` for `@open-slide/core`).
- Worth a quick visual check of thumbnail load on the homepage to confirm the flash is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed homepage thumbnails flickering by ensuring proper scaling is applied before the initial render, eliminating the visual flash of thumbnails at full size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->