### PR TITLE
feat(core): open slide overview grid from the pages editor

### DIFF
--- a/.changeset/overview-grid-in-pages.md
+++ b/.changeset/overview-grid-in-pages.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': minor
+---
+
+Open the slide overview grid from the pages editor — press O or click the grid button next to the page count. The overlay adopts the editor theme instead of the present-mode black.

--- a/packages/core/src/app/components/overview-grid.tsx
+++ b/packages/core/src/app/components/overview-grid.tsx
@@ -1,3 +1,4 @@
+import { X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
@@ -103,11 +104,24 @@ export function OverviewGrid({
       aria-label={t.present.overviewDialogAria}
       className={cn('absolute inset-0 z-50 flex flex-col backdrop-blur-sm', styles.surface)}
     >
-      <div className="flex shrink-0 items-baseline justify-between px-8 pt-6 pb-3">
+      <div className="flex shrink-0 items-center justify-between px-8 pt-6 pb-3">
         <span className={cn('eyebrow', styles.eyebrow)}>{t.present.overviewEyebrow}</span>
-        <span className={cn('font-mono text-[11px] tabular-nums', styles.eyebrow)}>
-          {(focused + 1).toString().padStart(2, '0')} · {pages.length.toString().padStart(2, '0')}
-        </span>
+        <div className="flex items-center gap-3">
+          <span className={cn('font-mono text-[11px] tabular-nums', styles.eyebrow)}>
+            {(focused + 1).toString().padStart(2, '0')} · {pages.length.toString().padStart(2, '0')}
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t.common.close}
+            className={cn(
+              'flex size-6 items-center justify-center rounded-[4px] outline-none transition-colors',
+              styles.closeButton,
+            )}
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
       </div>
       <div ref={gridRef} className="min-h-0 flex-1 overflow-auto px-8 pb-8">
         <div
@@ -191,6 +205,8 @@ const presentStyles = {
   thumbRing: 'ring-white/10',
   labelActive: 'text-white/85',
   labelMuted: 'text-white/45',
+  closeButton:
+    'text-white/55 hover:bg-white/10 hover:text-white focus-visible:ring-2 focus-visible:ring-white/40',
 } as const;
 
 const editorStyles = {
@@ -202,6 +218,8 @@ const editorStyles = {
   thumbRing: 'ring-hairline',
   labelActive: 'text-foreground',
   labelMuted: 'text-muted-foreground/60',
+  closeButton:
+    'text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring',
 } as const;
 
 function computeCols(grid: HTMLDivElement | null) {

--- a/packages/core/src/app/components/overview-grid.tsx
+++ b/packages/core/src/app/components/overview-grid.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useRef, useState } from 'react';
 import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
-import type { DesignSystem } from '../../lib/design';
-import { SlidePageProvider } from '../../lib/page-context';
-import type { Page } from '../../lib/sdk';
-import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../../lib/sdk';
-import { SlideCanvas } from '../slide-canvas';
+import type { DesignSystem } from '../lib/design';
+import { SlidePageProvider } from '../lib/page-context';
+import type { Page } from '../lib/sdk';
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
+import { SlideCanvas } from './slide-canvas';
 
 const THUMB_W = 320;
 const THUMB_H = (THUMB_W * CANVAS_HEIGHT) / CANVAS_WIDTH;
+
+export type OverviewVariant = 'present' | 'editor';
 
 type Props = {
   pages: Page[];
@@ -17,9 +19,18 @@ type Props = {
   current: number;
   onClose: () => void;
   onSelect: (index: number) => void;
+  variant?: OverviewVariant;
 };
 
-export function PresentOverviewGrid({ pages, design, open, current, onClose, onSelect }: Props) {
+export function OverviewGrid({
+  pages,
+  design,
+  open,
+  current,
+  onClose,
+  onSelect,
+  variant = 'present',
+}: Props) {
   const [focused, setFocused] = useState(current);
   const gridRef = useRef<HTMLDivElement>(null);
   const focusedRef = useRef<HTMLButtonElement | null>(null);
@@ -82,16 +93,19 @@ export function PresentOverviewGrid({ pages, design, open, current, onClose, onS
   }, [open, pages.length, focused, onClose, onSelect]);
 
   if (!open) return null;
+
+  const styles = variant === 'present' ? presentStyles : editorStyles;
+
   return (
     <div
       role="dialog"
       aria-modal="true"
       aria-label={t.present.overviewDialogAria}
-      className="absolute inset-0 z-50 flex flex-col bg-black/95 backdrop-blur-sm"
+      className={cn('absolute inset-0 z-50 flex flex-col backdrop-blur-sm', styles.surface)}
     >
       <div className="flex shrink-0 items-baseline justify-between px-8 pt-6 pb-3">
-        <span className="eyebrow text-white/55">{t.present.overviewEyebrow}</span>
-        <span className="font-mono text-[11px] text-white/55 tabular-nums">
+        <span className={cn('eyebrow', styles.eyebrow)}>{t.present.overviewEyebrow}</span>
+        <span className={cn('font-mono text-[11px] tabular-nums', styles.eyebrow)}>
           {(focused + 1).toString().padStart(2, '0')} · {pages.length.toString().padStart(2, '0')}
         </span>
       </div>
@@ -120,13 +134,14 @@ export function PresentOverviewGrid({ pages, design, open, current, onClose, onS
                 aria-current={isCurrent ? 'true' : undefined}
                 className={cn(
                   'group/thumb flex flex-col items-start gap-2 rounded-[6px] p-1.5 outline-none transition-colors',
-                  isFocused ? 'bg-white/10' : 'hover:bg-white/5',
+                  isFocused ? styles.thumbFocused : styles.thumbHover,
                 )}
               >
                 <div
                   className={cn(
-                    'relative w-full overflow-hidden rounded-[4px] bg-black ring-1 ring-white/10 transition-shadow',
-                    isFocused && 'ring-2 ring-[var(--brand,#ef4444)]',
+                    'relative w-full overflow-hidden rounded-[4px] ring-1 transition-shadow',
+                    styles.thumbSurface,
+                    isFocused ? 'ring-2 ring-[var(--brand,#ef4444)]' : styles.thumbRing,
                   )}
                   style={{ height: THUMB_H }}
                 >
@@ -153,7 +168,7 @@ export function PresentOverviewGrid({ pages, design, open, current, onClose, onS
                 <span
                   className={cn(
                     'font-mono text-[10.5px] tracking-[0.08em] tabular-nums uppercase',
-                    isFocused || isCurrent ? 'text-white/85' : 'text-white/45',
+                    isFocused || isCurrent ? styles.labelActive : styles.labelMuted,
                   )}
                 >
                   {(i + 1).toString().padStart(2, '0')}
@@ -166,6 +181,28 @@ export function PresentOverviewGrid({ pages, design, open, current, onClose, onS
     </div>
   );
 }
+
+const presentStyles = {
+  surface: 'bg-black/95',
+  eyebrow: 'text-white/55',
+  thumbFocused: 'bg-white/10',
+  thumbHover: 'hover:bg-white/5',
+  thumbSurface: 'bg-black',
+  thumbRing: 'ring-white/10',
+  labelActive: 'text-white/85',
+  labelMuted: 'text-white/45',
+} as const;
+
+const editorStyles = {
+  surface: 'bg-background/95',
+  eyebrow: 'text-muted-foreground',
+  thumbFocused: 'bg-muted',
+  thumbHover: 'hover:bg-muted/60',
+  thumbSurface: 'bg-card',
+  thumbRing: 'ring-hairline',
+  labelActive: 'text-foreground',
+  labelMuted: 'text-muted-foreground/60',
+} as const;
 
 function computeCols(grid: HTMLDivElement | null) {
   if (!grid) return 4;

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -7,12 +7,12 @@ import type { Page } from '../lib/sdk';
 import type { EntryDirection, StepAggregate, StepController } from '../lib/step-context';
 import type { SlideTransition } from '../lib/transition';
 import { usePrefersReducedMotion } from '../lib/use-prefers-reduced-motion';
+import { OverviewGrid } from './overview-grid';
 import { PresentBlackoutOverlay } from './present/blackout-overlay';
 import { PresentControlBar } from './present/control-bar';
 import { PresentHelpOverlay } from './present/help-overlay';
 import { PresentJumpInput } from './present/jump-input';
 import { PresentLaserPointer } from './present/laser-pointer';
-import { PresentOverviewGrid } from './present/overview-grid';
 import { PresentProgressBar } from './present/progress-bar';
 import { useIdle } from './present/use-idle';
 import { usePointerNearBottom } from './present/use-pointer-near-bottom';
@@ -380,13 +380,14 @@ export function Player({
             onHelp={() => setHelpOpen(true)}
             onExit={onExit}
           />
-          <PresentOverviewGrid
+          <OverviewGrid
             pages={pages}
             design={design}
             open={overviewOpen}
             current={index}
             onClose={() => setOverviewOpen(false)}
             onSelect={handleIndexChange}
+            variant="present"
           />
           <PresentHelpOverlay open={helpOpen} onOpenChange={setHelpOpen} container={rootEl} />
         </div>

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -15,7 +15,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Copy, ListOrdered, type LucideIcon, Sparkles, Trash2 } from 'lucide-react';
+import { Copy, Grid2x2, ListOrdered, type LucideIcon, Sparkles, Trash2 } from 'lucide-react';
 import { Fragment, useEffect, useRef, useState } from 'react';
 import {
   ContextMenu,
@@ -54,6 +54,8 @@ type Props = {
   width?: number;
   /** Deck-level transition default; used to flag pages that inherit a transition. */
   moduleTransition?: SlideTransition;
+  /** When provided, the vertical rail header renders a button that opens the overview grid. */
+  onOverview?: () => void;
 };
 
 const DEFAULT_VERTICAL_THUMB_WIDTH = 184;
@@ -71,6 +73,7 @@ export function ThumbnailRail({
   orientation = 'vertical',
   width,
   moduleTransition,
+  onOverview,
 }: Props) {
   const activeRef = useRef<HTMLButtonElement | null>(null);
   const t = useLocale();
@@ -214,10 +217,35 @@ export function ThumbnailRail({
   };
 
   const list = (
-    <aside className="flex flex-col gap-2 px-3 py-3">
-      <div className="flex items-baseline justify-between px-1 pb-1">
-        <span className="eyebrow">{t.thumbnailRail.pages}</span>
-        <span className="folio">{pages.length.toString().padStart(2, '0')}</span>
+    <aside className="flex flex-col gap-2 px-3 pb-3">
+      <div className="-mx-3 sticky top-0 z-10 bg-sidebar px-4 pt-3 pb-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className="eyebrow">{t.thumbnailRail.pages}</span>
+          <div className="flex items-center gap-1.5">
+            <span className="folio">{pages.length.toString().padStart(2, '0')}</span>
+            {onOverview && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={onOverview}
+                    aria-label={t.thumbnailRail.overviewAria}
+                    className={cn(
+                      'flex size-5 items-center justify-center rounded-[3px] text-muted-foreground/70 outline-none',
+                      'motion-safe:transition-colors hover:bg-muted hover:text-foreground',
+                      'focus-visible:ring-1 focus-visible:ring-brand',
+                    )}
+                  >
+                    <Grid2x2 className="size-3.5" strokeWidth={1.75} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6}>
+                  {t.thumbnailRail.overviewAria}
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        </div>
       </div>
       {pages.map(renderThumb)}
     </aside>
@@ -226,14 +254,16 @@ export function ThumbnailRail({
   if (!onReorder) {
     return (
       <TooltipProvider delayDuration={200}>
-        <ScrollArea className="h-full border-r border-hairline bg-sidebar">{list}</ScrollArea>
+        <ScrollArea className="h-full border-r border-hairline bg-sidebar [&_[data-slot=scroll-area-scrollbar]]:z-20">
+          {list}
+        </ScrollArea>
       </TooltipProvider>
     );
   }
 
   return (
     <TooltipProvider delayDuration={200}>
-      <ScrollArea className="h-full border-r border-hairline bg-sidebar">
+      <ScrollArea className="h-full border-r border-hairline bg-sidebar [&_[data-slot=scroll-area-scrollbar]]:z-20">
         <SortableRail pages={pages} onReorder={onReorder} onSelect={onSelect}>
           {list}
         </SortableRail>

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -49,6 +49,7 @@ import { format, useLocale } from '@/lib/use-locale';
 import { useWheelPageNavigation } from '@/lib/use-wheel-page-navigation';
 import { cn } from '@/lib/utils';
 import { NotesDrawer } from '../components/notes-drawer';
+import { OverviewGrid } from '../components/overview-grid';
 import { PdfProgressToast } from '../components/pdf-progress-toast';
 import { openPresenterWindow, Player } from '../components/player';
 import { PptxProgressToast } from '../components/pptx-progress-toast';
@@ -74,6 +75,7 @@ export function Slide() {
   const [linkCopied, setLinkCopied] = useState(false);
   const linkCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [designOpen, setDesignOpen] = useState(false);
+  const [overviewOpen, setOverviewOpen] = useState(false);
 
   useEffect(() => {
     return () => {
@@ -237,6 +239,18 @@ export function Slide() {
     if (playMode) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.target instanceof HTMLElement && e.target.matches('input, textarea')) return;
+      // Letter shortcuts only fire bare so browser combos (Cmd/Ctrl-P, ⌘F…) stay intact.
+      if (e.altKey || e.ctrlKey || e.metaKey) return;
+      // Toggle overview from either state — the overview's own capture-phase
+      // handler doesn't consume O, so this stays consistent open ↔ closed.
+      if (e.key === 'o' || e.key === 'O') {
+        e.preventDefault();
+        setOverviewOpen((v) => !v);
+        return;
+      }
+      // Once overview owns focus, swallow everything else here — its
+      // capture-phase listener drives the focused thumbnail.
+      if (overviewOpen) return;
       if (
         e.key === 'ArrowRight' ||
         e.key === 'ArrowDown' ||
@@ -252,8 +266,6 @@ export function Slide() {
         goTo(index - 1);
         return;
       }
-      // Letter shortcuts only fire bare so browser combos (Cmd/Ctrl-P, ⌘F…) stay intact.
-      if (e.altKey || e.ctrlKey || e.metaKey) return;
       if (e.key === 'f' || e.key === 'F') {
         setPlayMode('fullscreen');
       } else if (e.key === 'Enter') {
@@ -267,7 +279,7 @@ export function Slide() {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [index, goTo, playMode, slideId]);
+  }, [index, goTo, playMode, slideId, overviewOpen]);
 
   if (error) {
     return (
@@ -653,7 +665,7 @@ export function Slide() {
             </div>
           ) : (
             <DesignProvider slideId={slideId}>
-              <div className="flex min-h-0 flex-1 flex-col">
+              <div className="relative flex min-h-0 flex-1 flex-col">
                 <div className="flex min-h-0 flex-1 flex-col md:flex-row">
                   <ResizableRail
                     pages={pages}
@@ -663,6 +675,7 @@ export function Slide() {
                     onReorder={import.meta.env.DEV ? reorderPage : undefined}
                     actions={thumbnailActions}
                     moduleTransition={slide.transition}
+                    onOverview={() => setOverviewOpen(true)}
                   />
                   <main
                     ref={slideViewportRef}
@@ -716,6 +729,15 @@ export function Slide() {
                     initial={slide.notes?.[index]}
                   />
                 )}
+                <OverviewGrid
+                  pages={pages}
+                  design={slide.design}
+                  open={overviewOpen}
+                  current={index}
+                  onClose={() => setOverviewOpen(false)}
+                  onSelect={goTo}
+                  variant="editor"
+                />
               </div>
             </DesignProvider>
           )}
@@ -746,6 +768,7 @@ function ResizableRail(props: {
   onReorder?: (from: number, to: number) => void;
   actions?: ThumbnailActions;
   moduleTransition?: SlideModule['transition'];
+  onOverview?: () => void;
 }) {
   const t = useLocale();
   const [width, setWidth] = useState<number>(readStoredRailWidth);

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -345,6 +345,7 @@ export const en: Locale = {
     resizeRail: 'Resize thumbnail rail',
     transitionIndicator: 'Has slide transition',
     stepsIndicator: 'Has step-by-step reveals',
+    overviewAria: 'Slide overview (O)',
   },
 
   pdfToast: {

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -350,6 +350,7 @@ export const ja: Locale = {
     resizeRail: 'サムネイル幅を調整',
     transitionIndicator: 'スライドトランジションあり',
     stepsIndicator: 'ステップ表示あり',
+    overviewAria: 'スライド一覧 (O)',
   },
 
   pdfToast: {

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -366,6 +366,7 @@ export type Locale = {
     resizeRail: string;
     transitionIndicator: string;
     stepsIndicator: string;
+    overviewAria: string;
   };
 
   pdfToast: {

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -343,6 +343,7 @@ export const zhCN: Locale = {
     resizeRail: '调整缩略图栏宽度',
     transitionIndicator: '有换页转场',
     stepsIndicator: '有逐步揭示',
+    overviewAria: '幻灯片总览 (O)',
   },
 
   pdfToast: {

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -343,6 +343,7 @@ export const zhTW: Locale = {
     resizeRail: '調整縮圖欄寬度',
     transitionIndicator: '有換頁轉場',
     stepsIndicator: '有逐步揭示',
+    overviewAria: '投影片總覽 (O)',
   },
 
   pdfToast: {


### PR DESCRIPTION
## Summary

Bring the slide overview grid — previously only reachable in present mode — into the pages editor.

- Press **O** or click the new **grid button** next to the page count in the thumbnail rail to open the overview.
- Promote `PresentOverviewGrid` → shared `OverviewGrid` with a `variant` prop (`'present' | 'editor'`). The editor variant uses design tokens (`bg-background`, `muted`, `card`, `hairline`) so the overlay adopts the editor theme instead of the present-mode black.
- The thumbnail rail header is now sticky with the page count; the grid button only renders when an `onOverview` handler is passed.
- `overviewAria` string added across all locales (en / ja / zh-cn / zh-tw) + `Locale` type.
<img width="3812" height="1774" alt="Dia 2026-06-07 11 44 22" src="https://github.com/user-attachments/assets/f1209133-5471-41cb-9590-c721347e0231" />

## Notes / behavior changes

- In the editor key handler, the modifier-key guard (`Alt/Ctrl/Meta → return`) moved above the arrow-navigation block, so `Cmd/Ctrl/Alt + Arrow` no longer changes pages and is left to the browser/OS. Intentional, to keep native combos intact.
- The overview reuses present mode's capture-phase keyboard listener: arrows/Home/End/Enter/Escape are consumed inside the overview, while `O` intentionally bubbles so the editor handler can toggle it closed.

## Verification

- `pnpm typecheck` — passes
- `pnpm check` (biome) — clean on changed files
- Changeset included (`minor`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Open slide overview grid from the pages editor with keyboard shortcut O or the toolbar/grid button.
  * Overview grid now matches the editor theme when opened from the editor.
  * Thumbnail rail (vertical) includes a grid button to open the overview.

* **Accessibility / Localization**
  * Added aria label and translations for the overview control (en, ja, zh-CN, zh-TW).

* **Behavior**
  * Keyboard handling updated so overview toggling takes precedence when open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->