### PR TITLE
feat(core): add webfont loading guidance to slide-authoring skill

### DIFF
--- a/.changeset/webfont-skill-guidance.md
+++ b/.changeset/webfont-skill-guidance.md
@@ -1,0 +1,6 @@
+---
+"@open-slide/core": patch
+"@open-slide/cli": patch
+---
+
+Add webfont guidance to the slide-authoring skill: load the stylesheet once in `<head>`, list only the weights used, and subset CJK with `&text=`.

--- a/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
@@ -121,6 +121,26 @@ Pick a coherent look and hold it across every page:
 
 Consult the `frontend-design` skill for deeper aesthetic guidance if the user wants something bold.
 
+## Webfonts
+
+The default is a system font stack — prefer it. When a deck genuinely needs a webfont (a brand font, or CJK / Thai / Arabic where system coverage is poor):
+
+- **Load the stylesheet once, in `<head>` — never inside a per-page component.** Every page is mounted live at the same time (thumbnail rail, overview grid, and the PDF print root), so a `<style>@import>` / `<link>` rendered inside a `Page` registers the whole `@font-face` set once *per page*. Inject it once, idempotently:
+
+  ```tsx
+  const FONT_HREF = 'https://fonts.googleapis.com/css2?family=...&display=swap';
+  if (typeof document !== 'undefined' && !document.getElementById('osd-webfont')) {
+    const link = document.createElement('link');
+    link.id = 'osd-webfont';
+    link.rel = 'stylesheet';
+    link.href = FONT_HREF;
+    document.head.appendChild(link);
+  }
+  ```
+
+- **List only the weights you actually use.** Each extra weight multiplies the number of `@font-face` rules.
+- **CJK fonts are large.** A Google Fonts CJK family registers hundreds of `unicode-range` subset faces (Noto Sans TC ≈ 105 subsets × each weight), and PDF export waits on fonts before printing. If the deck's text is fixed, add `&text=<unique chars>` to the URL to request a tiny single-face subset instead of the full set.
+
 ## Themes
 
 If `themes/<id>.md` exists at the project root and the slide is meant to follow it, **the theme file overrides the defaults in this skill** — its palette, typography, layout padding, and Title/Footer components are authoritative. Read the theme file before applying anything else in this section.

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -121,6 +121,26 @@ Pick a coherent look and hold it across every page:
 
 Consult the `frontend-design` skill for deeper aesthetic guidance if the user wants something bold.
 
+## Webfonts
+
+The default is a system font stack — prefer it. When a deck genuinely needs a webfont (a brand font, or CJK / Thai / Arabic where system coverage is poor):
+
+- **Load the stylesheet once, in `<head>` — never inside a per-page component.** Every page is mounted live at the same time (thumbnail rail, overview grid, and the PDF print root), so a `<style>@import>` / `<link>` rendered inside a `Page` registers the whole `@font-face` set once *per page*. Inject it once, idempotently:
+
+  ```tsx
+  const FONT_HREF = 'https://fonts.googleapis.com/css2?family=...&display=swap';
+  if (typeof document !== 'undefined' && !document.getElementById('osd-webfont')) {
+    const link = document.createElement('link');
+    link.id = 'osd-webfont';
+    link.rel = 'stylesheet';
+    link.href = FONT_HREF;
+    document.head.appendChild(link);
+  }
+  ```
+
+- **List only the weights you actually use.** Each extra weight multiplies the number of `@font-face` rules.
+- **CJK fonts are large.** A Google Fonts CJK family registers hundreds of `unicode-range` subset faces (Noto Sans TC ≈ 105 subsets × each weight), and PDF export waits on fonts before printing. If the deck's text is fixed, add `&text=<unique chars>` to the URL to request a tiny single-face subset instead of the full set.
+
 ## Themes
 
 If `themes/<id>.md` exists at the project root and the slide is meant to follow it, **the theme file overrides the defaults in this skill** — its palette, typography, layout padding, and Title/Footer components are authoritative. Read the theme file before applying anything else in this section.


### PR DESCRIPTION
Adds a **Webfonts** subsection to the `slide-authoring` skill.

The skill currently says "System stack unless the user specifies" but gives no guidance on *how* to load a webfont when one is actually needed. This documents the safe pattern:

- Load the stylesheet **once in `<head>`**, not inside a per-page component — every page mounts live at the same time (thumbnail rail, overview grid, PDF print root), so a per-page `@import` / `<link>` registers the whole `@font-face` set once *per page*.
- List only the weights actually used.
- Subset CJK families with `&text=` when the deck's text is fixed.

Authoring hygiene only — keeps the existing system-font-first default, no behaviour change. The second changed file is the CLI template copy, regenerated via `sync:template-skills`.

Pairs with #215, which reports the underlying `waitForFonts()` over-fetch that turns this per-page pattern into a tab crash on PDF export with CJK webfonts.

Note: `apps/web/content/docs/skills/slide-authoring.mdx` is a curated mirror of this skill — I left it untouched here, but happy to reflect the same guidance on the docs site if you'd like.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added webfonts guidance to slide-authoring: prefer system fonts when possible, load webfont stylesheets once in the page head with deduplication safeguards, only request needed font weights, and use CJK subsetting (e.g., Google Fonts text parameter) to reduce font sizes and speed up PDF/export times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->