### PR TITLE
fix(core): guard Escape blur against IME composition in notes-drawer

### DIFF
--- a/.changeset/ime-escape-notes-drawer.md
+++ b/.changeset/ime-escape-notes-drawer.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Keep the notes textarea focused when Escape is pressed during IME composition.

--- a/packages/core/src/app/components/notes-drawer.tsx
+++ b/packages/core/src/app/components/notes-drawer.tsx
@@ -97,6 +97,9 @@ export function NotesDrawer({ slideId, index, total, initial }: Props) {
               }}
               onKeyDown={(e) => {
                 if (e.key === 'Escape') {
+                  // Escape during IME composition dismisses the candidate
+                  // list; it must not blur the textarea.
+                  if (e.nativeEvent.isComposing) return;
                   e.preventDefault();
                   textareaRef.current?.blur();
                 } else if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {


### PR DESCRIPTION
## Problem
When editing speaker notes with a CJK IME (Bopomofo, Pinyin, etc.), pressing Escape to dismiss the candidate list also blurs the notes textarea, interrupting long-form typing. The Escape branch in the notes drawer's `onKeyDown` runs unconditionally during composition.

## Change
Add an early return in the Escape branch when `e.nativeEvent.isComposing` is true, so Escape is left to the IME during composition and keeps its blur behavior otherwise. Same pattern as the inspector content textarea fix in 7e00047.

## Testing
- `pnpm check`, `pnpm typecheck`, `pnpm test` all pass.
- Verified in `apps/demo` against the running dev server by dispatching `keydown` events on the notes textarea: Escape with `isComposing: true` keeps focus; Escape with `isComposing: false` still blurs.

## Related
Fixes #214
