### PR TITLE
fix(core): remove force-load loop in waitForFonts to prevent CJK hang

### DIFF
--- a/.changeset/waitforfonts-cjk-hang.md
+++ b/.changeset/waitforfonts-cjk-hang.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Stop force-loading every registered font face before PDF export, which hung or crashed the tab on subsetted CJK webfonts.

--- a/packages/core/src/app/lib/print-ready.test.ts
+++ b/packages/core/src/app/lib/print-ready.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { waitForFonts } from './print-ready';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('waitForFonts', () => {
+  it('awaits document.fonts.ready without force-loading any face', async () => {
+    const load = vi.fn();
+    const faces = [
+      { status: 'loaded', load },
+      { status: 'unloaded', load },
+      { status: 'unloaded', load },
+    ];
+    const fonts = {
+      ready: Promise.resolve(),
+      [Symbol.iterator]: () => faces[Symbol.iterator](),
+    };
+    vi.stubGlobal('document', { fonts });
+
+    await waitForFonts();
+
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it('resolves when the FontFaceSet API is unavailable', async () => {
+    vi.stubGlobal('document', {});
+
+    await expect(waitForFonts()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/app/lib/print-ready.ts
+++ b/packages/core/src/app/lib/print-ready.ts
@@ -1,15 +1,12 @@
 const DEFAULT_WAITFOR_TIMEOUT_MS = 10_000;
 
+// `document.fonts.ready` already waits for every in-flight face. Never call
+// `face.load()` on the rest: unloaded faces were never requested by CSS, and
+// `load()` ignores `unicode-range`, so a subsetted CJK family (hundreds of
+// faces) would be force-downloaded in full and hang or crash the tab.
 export async function waitForFonts(): Promise<void> {
   if (!('fonts' in document)) return;
   await document.fonts.ready;
-  const pending: Promise<unknown>[] = [];
-  for (const face of document.fonts) {
-    if (face.status !== 'loaded') pending.push(face.load());
-  }
-  if (pending.length) {
-    await Promise.all(pending.map((p) => p.catch(() => undefined)));
-  }
 }
 
 export async function waitForDataWaitfor(


### PR DESCRIPTION
## Problem
PDF export calls `face.load()` on every registered `FontFace` that is not yet `loaded`. `FontFace.load()` ignores `unicode-range`, so a subsetted CJK Google Font (e.g. Noto Sans TC: 5 weights × ~105 subsets = 525 faces) is force-downloaded and decoded in full, saturating the CPU and crashing the tab before the print dialog opens. Repro: load a CJK webfont via `@import`, add ~12 pages of Chinese content, trigger Export → PDF.

## Change
Remove the force-load loop. `await document.fonts.ready` already waits for every face the page actually requested (status `loading`) to settle; faces still `unloaded` afterwards were never referenced by rendered text and must not be fetched. The `'fonts' in document` guard stays.

## Testing
Added `print-ready.test.ts`: mocks `document.fonts` with unloaded faces and asserts `face.load()` is never called, plus a no-FontFaceSet fallback case. `pnpm check`, `pnpm typecheck`, `pnpm test` all pass (258 tests).

## Related
Fixes #215


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tab hangs and crashes occurring during PDF export with subsetted CJK webfonts. PDF export now handles font loading more efficiently for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->