### PR TITLE
fix(core): guard rename and folder inputs against IME composition keydowns

### DIFF
--- a/.changeset/ime-guard-rename-inputs.md
+++ b/.changeset/ime-guard-rename-inputs.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Ignore Enter/Escape during IME composition in slide title, slide rename, asset rename, and folder name inputs.

--- a/packages/core/src/app/components/asset-view.tsx
+++ b/packages/core/src/app/components/asset-view.tsx
@@ -510,6 +510,7 @@ function RenameCard({
             if (!saving) commit();
           }}
           onKeyDown={(e) => {
+            if (e.nativeEvent.isComposing) return;
             if (e.key === 'Enter') {
               e.preventDefault();
               commit();

--- a/packages/core/src/app/components/sidebar/folder-item.tsx
+++ b/packages/core/src/app/components/sidebar/folder-item.tsx
@@ -197,6 +197,7 @@ export function FolderItem({
           onChange={(e) => setDraftName(e.target.value)}
           onBlur={commitRename}
           onKeyDown={(e) => {
+            if (e.nativeEvent.isComposing) return;
             if (e.key === 'Enter') commitRename();
             if (e.key === 'Escape') {
               setDraftName(row.folder.name);

--- a/packages/core/src/app/components/sidebar/sidebar.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar.tsx
@@ -255,6 +255,7 @@ export function Sidebar({
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
                 onKeyDown={(e) => {
+                  if (e.nativeEvent.isComposing) return;
                   if (e.key === 'Enter') commitCreate();
                   if (e.key === 'Escape') exitCreate();
                 }}

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -616,6 +616,7 @@ function RenameDialog({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => {
+            if (e.nativeEvent.isComposing) return;
             if (e.key === 'Enter') {
               e.preventDefault();
               submit();

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -1006,6 +1006,7 @@ function InlineTitleEditor({
               if (!saving) commit();
             }}
             onKeyDown={(e) => {
+              if (e.nativeEvent.isComposing) return;
               if (e.key === 'Enter') {
                 e.preventDefault();
                 commit();


### PR DESCRIPTION
## Problem
Five text inputs commit or cancel on Enter/Escape without checking IME composition state: the slide title inline editor (`routes/slide.tsx`), the slide rename dialog (`routes/home.tsx`), the asset rename card (`asset-view.tsx`), the new-folder input (`sidebar/sidebar.tsx`), and the folder rename input (`sidebar/folder-item.tsx`). With a CJK IME, pressing Enter to select a candidate submits the rename mid-composition, and Escape cancels editing instead of dismissing the candidate list. Same bug class as #214 / 7e00047, which fixed only the inspector and notes textareas.

## Change
Add `if (e.nativeEvent.isComposing) return;` at the top of each input's `onKeyDown`, so composition keydowns are left to the IME and the commit/cancel behavior is unchanged outside composition.

## Testing
- `pnpm check`, `pnpm typecheck`, `pnpm test` all pass.
- Verified in `apps/demo` against the running dev server by dispatching `keydown` events with `isComposing: true/false` on the slide title editor and the new-folder input: composition Enter/Escape are ignored, plain Enter/Escape keep their commit/cancel behavior. The remaining three inputs use the identical one-line guard.

## Related
Same class as #214. Found during an audit of `packages/core/src` keyboard handlers.
