### PR TITLE
fix(core): remove touchcancel listener on cleanup in useTouchSwipe

### DIFF
--- a/.changeset/touch-swipe-cancel-listener-leak.md
+++ b/.changeset/touch-swipe-cancel-listener-leak.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Remove the touchcancel listener on cleanup in the present-mode swipe handler so listeners no longer accumulate while navigating.

--- a/packages/core/src/app/components/present/use-touch-swipe.ts
+++ b/packages/core/src/app/components/present/use-touch-swipe.ts
@@ -50,14 +50,17 @@ export function useTouchSwipe<T extends HTMLElement>({
       else onPrev();
     };
 
+    const onCancel = () => {
+      start.current = null;
+    };
+
     el.addEventListener('touchstart', onStart, { passive: true });
     el.addEventListener('touchend', onEnd);
-    el.addEventListener('touchcancel', () => {
-      start.current = null;
-    });
+    el.addEventListener('touchcancel', onCancel);
     return () => {
       el.removeEventListener('touchstart', onStart);
       el.removeEventListener('touchend', onEnd);
+      el.removeEventListener('touchcancel', onCancel);
     };
   }, [ref, enabled, onPrev, onNext]);
 }


### PR DESCRIPTION
## Problem
`useTouchSwipe` registers a `touchcancel` listener with an inline anonymous function, but the effect cleanup only removes `touchstart` and `touchend`. The effect's dependencies include `onPrev`/`onNext`, which are recreated on every page navigation in the Player, so each navigation re-runs the effect and stacks one more permanent `touchcancel` listener on the root element for the lifetime of the presentation.

## Change
Name the handler, register it, and remove it in the cleanup alongside the other two listeners.

## Testing
`pnpm check`, `pnpm typecheck`, and `pnpm test` all pass. No unit test added — the fix is listener bookkeeping inside a DOM-bound hook.

## Related
Found during an audit of `packages/core/src` event-listener cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where touch event listeners were accumulating in presentation mode, improving performance during slide navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->