### PR TITLE
feat(core): add freeform image cropping to inspector

### DIFF
--- a/.changeset/add-freeform-crop.md
+++ b/.changeset/add-freeform-crop.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': minor
+---
+
+Add "Freeform" image cropping fit option to the inspector.

--- a/packages/core/src/app/components/inspector/image-crop-dialog.tsx
+++ b/packages/core/src/app/components/inspector/image-crop-dialog.tsx
@@ -37,14 +37,32 @@ export function ImageCropDialog({
   onApply: (result: ImageCropResult) => void;
 }) {
   const t = useLocale();
-  const [fit, setFit] = useState<'cover' | 'contain'>(initialFit);
+  const [fit, setFit] = useState<'cover' | 'contain' | 'freeform'>(initialFit);
   const aspect = targetWidth > 0 && targetHeight > 0 ? targetWidth / targetHeight : 1;
   const [crop, setCrop] = useState<Crop | undefined>(undefined);
   const imgRef = useRef<HTMLImageElement>(null);
 
   const onImageLoad = (e: SyntheticEvent<HTMLImageElement>) => {
     const im = e.currentTarget;
-    setCrop(initialCrop(im.naturalWidth, im.naturalHeight, aspect, initialRect, initialPosition));
+    if (initialRect && fit === 'cover') {
+      const rectAspect =
+        (initialRect.width * im.naturalWidth) / (initialRect.height * im.naturalHeight);
+      if (Math.abs(rectAspect - aspect) > 0.05) {
+        setFit('freeform');
+        setCrop({ unit: '%', ...initialRect });
+        return;
+      }
+    }
+    setCrop(
+      initialCrop(
+        im.naturalWidth,
+        im.naturalHeight,
+        aspect,
+        initialRect,
+        initialPosition,
+        fit === 'freeform',
+      ),
+    );
   };
 
   useEffect(() => {
@@ -52,11 +70,19 @@ export function ImageCropDialog({
     if (!im?.complete || !im.naturalWidth || !im.naturalHeight) return;
     setCrop((prev) => {
       if (prev && prev.unit === '%') {
+        if (fit === 'freeform') return prev;
         return clampToAspect(prev as PercentCrop, aspect, im.naturalWidth, im.naturalHeight);
       }
-      return initialCrop(im.naturalWidth, im.naturalHeight, aspect, initialRect, initialPosition);
+      return initialCrop(
+        im.naturalWidth,
+        im.naturalHeight,
+        aspect,
+        initialRect,
+        initialPosition,
+        fit === 'freeform',
+      );
     });
-  }, [aspect, initialPosition, initialRect]);
+  }, [aspect, initialPosition, initialRect, fit]);
 
   const onApplyClick = () => {
     if (fit === 'contain') {
@@ -67,7 +93,7 @@ export function ImageCropDialog({
       crop && crop.unit === '%'
         ? roundRect(crop as PercentCrop)
         : { x: 0, y: 0, width: 100, height: 100 };
-    onApply({ fit, rect });
+    onApply({ fit: fit === 'freeform' ? 'cover' : fit, rect });
   };
 
   return (
@@ -82,7 +108,7 @@ export function ImageCropDialog({
             type="single"
             value={fit}
             onValueChange={(v) => {
-              if (v === 'cover' || v === 'contain') setFit(v);
+              if (v === 'cover' || v === 'contain' || v === 'freeform') setFit(v);
             }}
             variant="outline"
             size="sm"
@@ -90,17 +116,20 @@ export function ImageCropDialog({
             <ToggleGroupItem value="cover" className="text-xs">
               {t.inspector.cropFitCover}
             </ToggleGroupItem>
+            <ToggleGroupItem value="freeform" className="text-xs">
+              {t.inspector.cropFitFreeform}
+            </ToggleGroupItem>
             <ToggleGroupItem value="contain" className="text-xs">
               {t.inspector.cropFitContain}
             </ToggleGroupItem>
           </ToggleGroup>
         </div>
         <div className="flex h-[420px] w-full items-center justify-center overflow-hidden rounded-md border bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:12px_12px]">
-          {fit === 'cover' ? (
+          {fit === 'cover' || fit === 'freeform' ? (
             <ReactCrop
               crop={crop}
               onChange={(_, percentCrop) => setCrop(percentCrop)}
-              aspect={aspect}
+              aspect={fit === 'freeform' ? undefined : aspect}
               keepSelection
               className="max-h-full"
             >
@@ -133,11 +162,13 @@ function initialCrop(
   aspect: number,
   rect: ImageCropRect | null,
   position: { x: number; y: number },
+  isFreeform: boolean,
 ): PercentCrop {
   if (rect) {
+    if (isFreeform) return { unit: '%', ...rect };
     return clampToAspect({ unit: '%', ...rect }, aspect, naturalW, naturalH);
   }
-  return makeMaxSizeCrop(naturalW, naturalH, aspect, position);
+  return makeMaxSizeCrop(naturalW, naturalH, aspect, position, isFreeform);
 }
 
 function makeMaxSizeCrop(
@@ -145,8 +176,9 @@ function makeMaxSizeCrop(
   naturalH: number,
   aspect: number,
   position: { x: number; y: number },
+  isFreeform: boolean,
 ): PercentCrop {
-  if (naturalW <= 0 || naturalH <= 0) {
+  if (naturalW <= 0 || naturalH <= 0 || isFreeform) {
     return { unit: '%', x: 0, y: 0, width: 100, height: 100 };
   }
   const sourceAspect = naturalW / naturalH;

--- a/packages/core/src/app/components/inspector/image-crop-dialog.tsx
+++ b/packages/core/src/app/components/inspector/image-crop-dialog.tsx
@@ -45,6 +45,11 @@ export function ImageCropDialog({
   const onImageLoad = (e: SyntheticEvent<HTMLImageElement>) => {
     const im = e.currentTarget;
     if (initialRect && fit === 'cover') {
+      if (!initialRect.height || !im.naturalHeight || !Number.isFinite(im.naturalWidth)) {
+        setFit('freeform');
+        setCrop({ unit: '%', ...initialRect });
+        return;
+      }
       const rectAspect =
         (initialRect.width * im.naturalWidth) / (initialRect.height * im.naturalHeight);
       if (Math.abs(rectAspect - aspect) > 0.05) {

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -228,6 +228,7 @@ export const en: Locale = {
     cropDialogTitle: 'Crop image',
     cropDialogDescription: 'Drag the frame to choose what stays visible.',
     cropFitCover: 'Fill',
+    cropFitFreeform: 'Freeform',
     cropFitContain: 'Fit',
     cropApply: 'Apply',
     cropResetAria: 'Reset crop',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -225,6 +225,7 @@ export const ja: Locale = {
     cropDialogTitle: '画像をトリミング',
     cropDialogDescription: '枠をドラッグして表示する範囲を選択します。',
     cropFitCover: '塗りつぶす',
+    cropFitFreeform: '自由',
     cropFitContain: '全体表示',
     cropApply: '適用',
     cropResetAria: 'トリミングをリセット',

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -230,6 +230,7 @@ export type Locale = {
     cropDialogTitle: string;
     cropDialogDescription: string;
     cropFitCover: string;
+    cropFitFreeform: string;
     cropFitContain: string;
     cropApply: string;
     cropResetAria: string;

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -221,6 +221,7 @@ export const zhCN: Locale = {
     cropDialogTitle: '裁剪图片',
     cropDialogDescription: '拖动框线决定要保留的可见区域。',
     cropFitCover: '填满',
+    cropFitFreeform: '自由裁剪',
     cropFitContain: '完整显示',
     cropApply: '应用',
     cropResetAria: '重置裁剪',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -221,6 +221,7 @@ export const zhTW: Locale = {
     cropDialogTitle: '裁切圖片',
     cropDialogDescription: '拖曳框線決定要保留的可見範圍。',
     cropFitCover: '填滿',
+    cropFitFreeform: '自由裁剪',
     cropFitContain: '完整顯示',
     cropApply: '套用',
     cropResetAria: '重設裁切',


### PR DESCRIPTION
### What does this PR do?
  
As an open-slide user, I found the crop feature a bit inconvenient during my workflow, so I created this PR.
This PR adds a new "Freeform" crop mode to the inspector's image crop dialog. Users can now freely crop images on their slides without having the crop box forced to match the aspect ratio of the underlying image element.

This allows users to have more flexibility when adjusting image compositions on slides.

<img width="1242" height="711" alt="image" src="https://github.com/user-attachments/assets/25eba67e-8dfb-48bb-865a-e002ed1d35d8" />

  
  ### Key Changes
  
  - Freeform Cropping: Added a  freeform  fit option in  ImageCropDialog  that disables the aspect ratio constraint in  <ReactCrop /> .             
  - Smart Detection: When re-opening the crop dialog on an already cropped image, the component now automatically calculates the aspect ratio of the existing  object-view-box . If it differs from the element's layout aspect ratio, it defaults to the "Freeform" mode, preventing destructive auto-snapping of the user's previous crop.
  - Localization: Added translations for the new "Freeform" toggle ( cropFitFreeform ) in English, Japanese, Simplified Chinese, and Traditional Chinese.
  - Changeset: Included a minor changeset for  @open-slide/core .
  
  ### How to test
  
  1. Run  pnpm dev  in the root directory.
  2. Open the demo app and press  i  to enter inspector mode.
  3. Click an image and select the Crop tool.
  4. Verify the new "Freeform" option works, allowing for unrestricted crop dimensions.
  5. Apply the crop, close the dialog, and re-open it to ensure your freeform crop bounds and toggle state are correctly restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Freeform" image cropping mode to the crop inspector dialog, allowing unrestricted aspect-ratio adjustments when editing images.
  * Applying a freeform edit produces a normalized rectangular crop for consistent output.
  * Included localization support for the new freeform crop option across English, Japanese, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->