### PR TITLE
fix(web): mobile logo marquee spacing

### DIFF
--- a/apps/web/app/(home)/landing.css
+++ b/apps/web/app/(home)/landing.css
@@ -133,9 +133,21 @@ html.light .os-landing {
 }
 .os-landing .marquee-track {
   display: inline-flex;
-  gap: 160px;
+  gap: 56px;
   animation: os-marquee 45s linear infinite;
   white-space: nowrap;
+}
+
+@media (min-width: 640px) {
+  .os-landing .marquee-track {
+    gap: 96px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .os-landing .marquee-track {
+    gap: 160px;
+  }
 }
 
 @keyframes os-rise {


### PR DESCRIPTION
## Summary

Fix the homepage logo marquee spacing on mobile by using smaller responsive gaps for the marquee track while preserving the existing desktop spacing.

## Root cause

The logo marquee used a fixed `160px` gap at every viewport size, which left oversized empty space between logos on narrow mobile screens.

## Changes

- Set the mobile marquee gap to `56px`.
- Add a tablet breakpoint with a `96px` gap.
- Keep the existing `160px` gap at `1024px` and above.

## Validation

- Verified in a `393x852` mobile viewport that `.marquee-track` computes to `56px` and multiple logos are visible at once.
- Verified in a `1280x800` desktop viewport that `.marquee-track` still computes to `160px`.
- Ran `pnpm check`; it exits 0 with one existing warning in `packages/core/src/http/request-guard.ts`, unrelated to this CSS change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized marquee spacing with responsive adjustments to improve visual balance across mobile, tablet, and desktop screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->