### PR TITLE
fix(core): center slide tooltip copy

### DIFF
--- a/.changeset/center-slide-tooltips.md
+++ b/.changeset/center-slide-tooltips.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Center longer slide UI tooltip messages.

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -862,7 +862,11 @@ function AgentWatchingBadge() {
             {connected ? t.inspector.agentWatching : t.inspector.agentNotWatching}
           </button>
         </TooltipTrigger>
-        <TooltipContent side="bottom" align="end" className="max-w-[260px] leading-relaxed">
+        <TooltipContent
+          side="bottom"
+          align="end"
+          className="w-max max-w-[min(520px,calc(100vw-2rem))] text-center leading-relaxed"
+        >
           {connected ? t.inspector.agentWatchingTooltip : t.inspector.agentNotWatchingTooltip}
         </TooltipContent>
       </Tooltip>

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -592,7 +592,10 @@ export function Slide() {
                             </span>
                           </div>
                         </TooltipTrigger>
-                        <TooltipContent side="left" className="max-w-[240px] leading-relaxed">
+                        <TooltipContent
+                          side="left"
+                          className="w-max max-w-[min(520px,calc(100vw-2rem))] text-center leading-relaxed"
+                        >
                           {t.slide.pptxComingSoonTooltip}
                         </TooltipContent>
                       </Tooltip>
@@ -896,7 +899,11 @@ function AgentConnectedBadge() {
             {connected ? t.slide.agentConnected : t.slide.agentDisconnected}
           </button>
         </TooltipTrigger>
-        <TooltipContent side="bottom" align="start" className="max-w-[280px] leading-relaxed">
+        <TooltipContent
+          side="bottom"
+          align="start"
+          className="w-max max-w-[min(520px,calc(100vw-2rem))] text-center leading-relaxed"
+        >
           {connected ? t.slide.agentConnectedTooltip : t.slide.agentDisconnectedTooltip}
         </TooltipContent>
       </Tooltip>


### PR DESCRIPTION
## Summary

- Center longer slide UI tooltip messages.
- Let slide and inspector agent tooltips size to their content while respecting the viewport.
- Add a patch changeset for `@open-slide/core`.

## Validation

- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved tooltip display with responsive sizing and centered text alignment for better readability of longer messages across tooltips throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->