### PR TITLE
feat(core): show transition and step indicators in the overview grid

### DIFF
--- a/.changeset/tidy-grid-indicators.md
+++ b/.changeset/tidy-grid-indicators.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Show transition and step indicators in the slide overview grid.

--- a/packages/core/src/app/components/overview-grid.tsx
+++ b/packages/core/src/app/components/overview-grid.tsx
@@ -1,11 +1,13 @@
-import { X } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { ListOrdered, type LucideIcon, Sparkles, X } from 'lucide-react';
+import { type Ref, useEffect, useRef, useState } from 'react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import type { DesignSystem } from '../lib/design';
 import { SlidePageProvider } from '../lib/page-context';
 import type { Page } from '../lib/sdk';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
+import type { SlideTransition } from '../lib/transition';
 import { SlideCanvas } from './slide-canvas';
 
 const THUMB_W = 320;
@@ -21,6 +23,7 @@ type Props = {
   onClose: () => void;
   onSelect: (index: number) => void;
   variant?: OverviewVariant;
+  moduleTransition?: SlideTransition;
 };
 
 export function OverviewGrid({
@@ -31,6 +34,7 @@ export function OverviewGrid({
   onClose,
   onSelect,
   variant = 'present',
+  moduleTransition,
 }: Props) {
   const [focused, setFocused] = useState(current);
   const gridRef = useRef<HTMLDivElement>(null);
@@ -124,77 +128,192 @@ export function OverviewGrid({
         </div>
       </div>
       <div ref={gridRef} className="min-h-0 flex-1 overflow-auto px-8 pb-8">
-        <div
-          className="grid justify-center gap-5"
-          style={{
-            gridTemplateColumns: `repeat(auto-fill, ${THUMB_W}px)`,
-          }}
-        >
-          {pages.map((PageComp, i) => {
-            const isFocused = i === focused;
-            const isCurrent = i === current;
-            return (
-              <button
-                // biome-ignore lint/suspicious/noArrayIndexKey: pages list is render-stable
-                key={i}
-                ref={isFocused ? focusedRef : undefined}
-                type="button"
-                onClick={() => {
-                  onSelect(i);
-                  onClose();
-                }}
-                onMouseEnter={() => setFocused(i)}
-                aria-label={format(t.present.overviewGoToAria, { n: i + 1 })}
-                aria-current={isCurrent ? 'true' : undefined}
-                className={cn(
-                  'group/thumb flex flex-col items-start gap-2 rounded-[6px] p-1.5 outline-none transition-colors',
-                  isFocused ? styles.thumbFocused : styles.thumbHover,
-                )}
-              >
-                <div
-                  className={cn(
-                    'relative w-full overflow-hidden rounded-[4px] ring-1 transition-shadow',
-                    styles.thumbSurface,
-                    isFocused ? 'ring-2 ring-[var(--brand,#ef4444)]' : styles.thumbRing,
-                  )}
-                  style={{ height: THUMB_H }}
-                >
-                  <SlideCanvas
-                    scale={THUMB_W / CANVAS_WIDTH}
-                    center={false}
-                    flat
-                    freezeMotion
-                    design={design}
-                  >
-                    <SlidePageProvider index={i} total={pages.length}>
-                      <PageComp />
-                    </SlidePageProvider>
-                  </SlideCanvas>
-                  {isCurrent && (
-                    <span
-                      aria-hidden
-                      className="pointer-events-none absolute top-1.5 right-1.5 rounded-[3px] bg-[var(--brand,#ef4444)] px-1.5 py-0.5 font-mono text-[9.5px] tracking-[0.06em] uppercase text-white"
-                    >
-                      {t.present.nowBadge}
-                    </span>
-                  )}
-                </div>
-                <span
-                  className={cn(
-                    'font-mono text-[10.5px] tracking-[0.08em] tabular-nums uppercase',
-                    isFocused || isCurrent ? styles.labelActive : styles.labelMuted,
-                  )}
-                >
-                  {(i + 1).toString().padStart(2, '0')}
-                </span>
-              </button>
-            );
-          })}
-        </div>
+        <TooltipProvider delayDuration={200}>
+          <div
+            className="grid justify-center gap-5"
+            style={{
+              gridTemplateColumns: `repeat(auto-fill, ${THUMB_W}px)`,
+            }}
+          >
+            {pages.map((PageComp, i) => {
+              const isFocused = i === focused;
+              const isCurrent = i === current;
+              return (
+                <OverviewThumb
+                  // biome-ignore lint/suspicious/noArrayIndexKey: pages list is render-stable
+                  key={i}
+                  buttonRef={isFocused ? focusedRef : undefined}
+                  page={PageComp}
+                  index={i}
+                  total={pages.length}
+                  design={design}
+                  isFocused={isFocused}
+                  isCurrent={isCurrent}
+                  styles={styles}
+                  moduleTransition={moduleTransition}
+                  onFocus={() => setFocused(i)}
+                  onSelect={() => {
+                    onSelect(i);
+                    onClose();
+                  }}
+                />
+              );
+            })}
+          </div>
+        </TooltipProvider>
       </div>
     </div>
   );
 }
+
+function OverviewThumb({
+  page: PageComp,
+  index,
+  total,
+  design,
+  isFocused,
+  isCurrent,
+  styles,
+  moduleTransition,
+  onFocus,
+  onSelect,
+  buttonRef,
+}: {
+  page: Page;
+  index: number;
+  total: number;
+  design?: DesignSystem;
+  isFocused: boolean;
+  isCurrent: boolean;
+  styles: OverviewStyles;
+  moduleTransition?: SlideTransition;
+  onFocus: () => void;
+  onSelect: () => void;
+  buttonRef?: Ref<HTMLButtonElement>;
+}) {
+  const t = useLocale();
+  const boxRef = useRef<HTMLDivElement | null>(null);
+  const [hasSteps, setHasSteps] = useState(false);
+  const hasTransition = Boolean(PageComp.transition ?? moduleTransition);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-detect when the page at this slot changes
+  useEffect(() => {
+    setHasSteps(boxRef.current?.querySelector('[data-osd-step]') != null);
+  }, [PageComp]);
+
+  return (
+    <button
+      ref={buttonRef}
+      type="button"
+      onClick={onSelect}
+      onMouseEnter={onFocus}
+      aria-label={format(t.present.overviewGoToAria, { n: index + 1 })}
+      aria-current={isCurrent ? 'true' : undefined}
+      className={cn(
+        'group/thumb flex flex-col items-start gap-2 rounded-[6px] p-1.5 outline-none transition-colors',
+        isFocused ? styles.thumbFocused : styles.thumbHover,
+      )}
+    >
+      <div
+        ref={boxRef}
+        className={cn(
+          'relative w-full overflow-hidden rounded-[4px] ring-1 transition-shadow',
+          styles.thumbSurface,
+          isFocused ? 'ring-2 ring-[var(--brand,#ef4444)]' : styles.thumbRing,
+        )}
+        style={{ height: THUMB_H }}
+      >
+        <SlideCanvas
+          scale={THUMB_W / CANVAS_WIDTH}
+          center={false}
+          flat
+          freezeMotion
+          design={design}
+        >
+          <SlidePageProvider index={index} total={total}>
+            <PageComp />
+          </SlidePageProvider>
+        </SlideCanvas>
+        {isCurrent && (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute top-1.5 right-1.5 rounded-[3px] bg-[var(--brand,#ef4444)] px-1.5 py-0.5 font-mono text-[9.5px] tracking-[0.06em] uppercase text-white"
+          >
+            {t.present.nowBadge}
+          </span>
+        )}
+      </div>
+      <div className="flex h-4 w-full items-center justify-between gap-2">
+        <span
+          className={cn(
+            'font-mono text-[10.5px] tracking-[0.08em] tabular-nums uppercase',
+            isFocused || isCurrent ? styles.labelActive : styles.labelMuted,
+          )}
+        >
+          {(index + 1).toString().padStart(2, '0')}
+        </span>
+        {(hasTransition || hasSteps) && (
+          <span className="flex items-center gap-1">
+            {hasTransition && (
+              <OverviewIndicator
+                icon={Sparkles}
+                label={t.thumbnailRail.transitionIndicator}
+                className={styles.indicator}
+              />
+            )}
+            {hasSteps && (
+              <OverviewIndicator
+                icon={ListOrdered}
+                label={t.thumbnailRail.stepsIndicator}
+                className={styles.indicator}
+              />
+            )}
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}
+
+function OverviewIndicator({
+  icon: Icon,
+  label,
+  className,
+}: {
+  icon: LucideIcon;
+  label: string;
+  className: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          role="img"
+          aria-label={label}
+          className={cn('flex size-4 items-center justify-center', className)}
+        >
+          <Icon className="size-3.5" strokeWidth={1.9} />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={6}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+type OverviewStyles = {
+  surface: string;
+  eyebrow: string;
+  thumbFocused: string;
+  thumbHover: string;
+  thumbSurface: string;
+  thumbRing: string;
+  labelActive: string;
+  labelMuted: string;
+  indicator: string;
+  closeButton: string;
+};
 
 const presentStyles = {
   surface: 'bg-black/95',
@@ -205,6 +324,7 @@ const presentStyles = {
   thumbRing: 'ring-white/10',
   labelActive: 'text-white/85',
   labelMuted: 'text-white/45',
+  indicator: 'text-white/45 transition-colors group-hover/thumb:text-white/75',
   closeButton:
     'text-white/55 hover:bg-white/10 hover:text-white focus-visible:ring-2 focus-visible:ring-white/40',
 } as const;
@@ -218,6 +338,7 @@ const editorStyles = {
   thumbRing: 'ring-hairline',
   labelActive: 'text-foreground',
   labelMuted: 'text-muted-foreground/60',
+  indicator: 'text-muted-foreground/60 transition-colors group-hover/thumb:text-muted-foreground',
   closeButton:
     'text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring',
 } as const;

--- a/packages/core/src/app/components/overview-grid.tsx
+++ b/packages/core/src/app/components/overview-grid.tsx
@@ -24,6 +24,7 @@ type Props = {
   onSelect: (index: number) => void;
   variant?: OverviewVariant;
   moduleTransition?: SlideTransition;
+  tooltipContainer?: HTMLElement | null;
 };
 
 export function OverviewGrid({
@@ -35,6 +36,7 @@ export function OverviewGrid({
   onSelect,
   variant = 'present',
   moduleTransition,
+  tooltipContainer,
 }: Props) {
   const [focused, setFocused] = useState(current);
   const gridRef = useRef<HTMLDivElement>(null);
@@ -151,6 +153,7 @@ export function OverviewGrid({
                   isCurrent={isCurrent}
                   styles={styles}
                   moduleTransition={moduleTransition}
+                  tooltipContainer={tooltipContainer}
                   onFocus={() => setFocused(i)}
                   onSelect={() => {
                     onSelect(i);
@@ -175,6 +178,7 @@ function OverviewThumb({
   isCurrent,
   styles,
   moduleTransition,
+  tooltipContainer,
   onFocus,
   onSelect,
   buttonRef,
@@ -187,6 +191,7 @@ function OverviewThumb({
   isCurrent: boolean;
   styles: OverviewStyles;
   moduleTransition?: SlideTransition;
+  tooltipContainer?: HTMLElement | null;
   onFocus: () => void;
   onSelect: () => void;
   buttonRef?: Ref<HTMLButtonElement>;
@@ -207,6 +212,7 @@ function OverviewThumb({
       type="button"
       onClick={onSelect}
       onMouseEnter={onFocus}
+      onFocus={onFocus}
       aria-label={format(t.present.overviewGoToAria, { n: index + 1 })}
       aria-current={isCurrent ? 'true' : undefined}
       className={cn(
@@ -259,6 +265,7 @@ function OverviewThumb({
                 icon={Sparkles}
                 label={t.thumbnailRail.transitionIndicator}
                 className={styles.indicator}
+                tooltipContainer={tooltipContainer}
               />
             )}
             {hasSteps && (
@@ -266,6 +273,7 @@ function OverviewThumb({
                 icon={ListOrdered}
                 label={t.thumbnailRail.stepsIndicator}
                 className={styles.indicator}
+                tooltipContainer={tooltipContainer}
               />
             )}
           </span>
@@ -279,10 +287,12 @@ function OverviewIndicator({
   icon: Icon,
   label,
   className,
+  tooltipContainer,
 }: {
   icon: LucideIcon;
   label: string;
   className: string;
+  tooltipContainer?: HTMLElement | null;
 }) {
   return (
     <Tooltip>
@@ -295,7 +305,7 @@ function OverviewIndicator({
           <Icon className="size-3.5" strokeWidth={1.9} />
         </span>
       </TooltipTrigger>
-      <TooltipContent side="top" sideOffset={6}>
+      <TooltipContent side="top" sideOffset={6} container={tooltipContainer ?? undefined}>
         {label}
       </TooltipContent>
     </Tooltip>

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -389,6 +389,7 @@ export function Player({
             onSelect={handleIndexChange}
             variant="present"
             moduleTransition={transition}
+            tooltipContainer={rootEl}
           />
           <PresentHelpOverlay open={helpOpen} onOpenChange={setHelpOpen} container={rootEl} />
         </div>

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -388,6 +388,7 @@ export function Player({
             onClose={() => setOverviewOpen(false)}
             onSelect={handleIndexChange}
             variant="present"
+            moduleTransition={transition}
           />
           <PresentHelpOverlay open={helpOpen} onOpenChange={setHelpOpen} container={rootEl} />
         </div>

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -737,6 +737,7 @@ export function Slide() {
                   onClose={() => setOverviewOpen(false)}
                   onSelect={goTo}
                   variant="editor"
+                  moduleTransition={slide.transition}
                 />
               </div>
             </DesignProvider>


### PR DESCRIPTION
## Summary
- Add transition and step status indicators to slide overview thumbnails.
- Surface module-level transitions in both player and editor overview grids.
- Add tooltips and compact icon treatment to keep the grid readable.

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slide overview grid now shows visual indicators on each thumbnail to reveal whether slides include transitions and/or steps, improving at-a-glance navigation.
  * Updated thumbnail rendering to enhance behavior and tooltip support, with configurable tooltip container handling.
  
* **Chores**
  * Added a package release note entry for a patch update covering thumbnail transition/step indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->