### PR TITLE
fix(core): include inline background-image assets in HTML export

### DIFF
--- a/.changeset/html-export-inline-background-image.md
+++ b/.changeset/html-export-inline-background-image.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Include inline `style` background-image assets in HTML export so they are bundled instead of dropped.

--- a/packages/core/src/app/lib/export-html.test.ts
+++ b/packages/core/src/app/lib/export-html.test.ts
@@ -1,0 +1,47 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const originalWindow = (globalThis as { window?: unknown }).window;
+
+beforeAll(() => {
+  (globalThis as { window?: unknown }).window = {
+    location: { href: 'http://localhost:5173/', origin: 'http://localhost:5173' },
+  };
+});
+
+afterAll(() => {
+  if (originalWindow === undefined) {
+    delete (globalThis as { window?: unknown }).window;
+  } else {
+    (globalThis as { window?: unknown }).window = originalWindow;
+  }
+});
+
+const { findHtmlAssetUrls } = await import('./export-html');
+
+describe('findHtmlAssetUrls', () => {
+  it('collects src and srcset assets', () => {
+    const html = '<img src="/assets/a.png" srcset="/assets/b.png 1x, /assets/c.png 2x">';
+    expect(findHtmlAssetUrls(html)).toEqual(
+      expect.arrayContaining(['/assets/a.png', '/assets/b.png', '/assets/c.png']),
+    );
+  });
+
+  it('collects inline background-image with entity-encoded quotes', () => {
+    const html = '<div style="background-image:url(&quot;/assets/bg.png&quot;)"></div>';
+    expect(findHtmlAssetUrls(html)).toContain('/assets/bg.png');
+  });
+
+  it('collects inline background-image with plain quotes and without quotes', () => {
+    const html =
+      '<div style="background:url(\'/assets/x.jpg\')"></div><div style="background-image:url(/assets/y.webp)"></div>';
+    expect(findHtmlAssetUrls(html)).toEqual(
+      expect.arrayContaining(['/assets/x.jpg', '/assets/y.webp']),
+    );
+  });
+
+  it('ignores data URIs and non-asset urls', () => {
+    const html =
+      '<div style="background-image:url(data:image/png;base64,AAAA)"></div><a href="/page">x</a>';
+    expect(findHtmlAssetUrls(html)).toEqual([]);
+  });
+});

--- a/packages/core/src/app/lib/export-html.ts
+++ b/packages/core/src/app/lib/export-html.ts
@@ -141,7 +141,7 @@ function collectExternalStylesheetLinks(): string {
   return links.join('\n');
 }
 
-function findHtmlAssetUrls(html: string): string[] {
+export function findHtmlAssetUrls(html: string): string[] {
   const out: string[] = [];
   const attrRe = /\s(?:src|href)="([^"]+)"/g;
   for (const m of html.matchAll(attrRe)) {
@@ -154,7 +154,27 @@ function findHtmlAssetUrls(html: string): string[] {
       if (url && looksLikeAsset(url)) out.push(url);
     }
   }
+  out.push(...findInlineStyleAssetUrls(html));
   return out;
+}
+
+// Inline `style="background-image:url(...)"` survives DOM serialization with its
+// quotes encoded as HTML entities (e.g. url(&quot;/assets/x.png&quot;)), so the
+// plain CSS scanner misses them.
+function findInlineStyleAssetUrls(html: string): string[] {
+  const out: string[] = [];
+  const re = /url\(([^)]*)\)/gi;
+  for (const m of html.matchAll(re)) {
+    const url = stripCssUrlQuotes(m[1]);
+    if (url && looksLikeAsset(url)) out.push(url);
+  }
+  return out;
+}
+
+function stripCssUrlQuotes(raw: string): string {
+  const quote =
+    /^(?:&quot;|&#34;|&#039;|&#39;|&apos;|['"])|(?:&quot;|&#34;|&#039;|&#39;|&apos;|['"])$/g;
+  return raw.trim().replace(quote, '').trim();
 }
 
 function findCssAssetUrls(css: string): string[] {


### PR DESCRIPTION
## Problem

Fixes #223. HTML export drops assets referenced through inline `style="background-image:url(...)"`. Only `src`/`href`/`srcset` attributes were scanned, so inline-style background images vanished from the exported file.

## Cause

`findHtmlAssetUrls` in `packages/core/src/app/lib/export-html.ts` matched only `src`/`href`/`srcset`. The CSS `url(...)` scanner ran exclusively over the bundled stylesheet, never over the rendered page HTML, so inline-style backgrounds were never collected and therefore never bundled or rewritten.

## Fix

- Scan inline `url(...)` references in the rendered page HTML.
- Tolerate the HTML-entity-encoded quotes the DOM serializer emits (e.g. `url(&quot;/assets/x.png&quot;)`), as well as plain and unquoted forms.
- Existing `rewriteUrls` (string replace on the bare URL) already rewrites these once collected, so no change was needed there.

## Tests

Added `export-html.test.ts` covering src/srcset collection, inline background-image with entity-encoded / plain / unquoted forms, and rejection of data URIs and non-asset URLs.

`pnpm test`, `pnpm core typecheck`, and `biome check` on the changed files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed HTML export to properly bundle inline CSS `background-image` assets instead of dropping them during export.

* **Tests**
  * Added comprehensive test coverage for asset URL discovery in HTML exports, including inline styles and multiple URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->