### PR TITLE
fix(core): keep speaker notes aligned when deleting/duplicating a page

### DIFF
--- a/.changeset/sync-notes-on-page-duplicate-delete.md
+++ b/.changeset/sync-notes-on-page-duplicate-delete.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Keep speaker notes aligned with pages when deleting or duplicating a page.

--- a/packages/core/src/editing/slide-ops.test.ts
+++ b/packages/core/src/editing/slide-ops.test.ts
@@ -3,8 +3,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
+  duplicateNotesElementInSource,
   duplicatePageInDefaultExportInSource,
   duplicateSlideDir,
+  removeNotesElementInSource,
   removePageFromDefaultExportInSource,
   reorderDefaultExportPagesInSource,
   reorderNotesArrayInSource,
@@ -410,5 +412,105 @@ export default [
 
   it('returns null when the default export is not an array', () => {
     expect(duplicatePageInDefaultExportInSource(`export default A;\n`, 0)).toBeNull();
+  });
+});
+
+describe('removeNotesElementInSource', () => {
+  it('returns the source unchanged when there is no notes export', () => {
+    const source = `export default [A, B];\n`;
+    expect(removeNotesElementInSource(source, 0)).toBe(source);
+  });
+
+  it('removes the note aligned with the deleted page', () => {
+    const source = [
+      'export const notes = [',
+      '  "first",',
+      '  "second",',
+      '  "third",',
+      '];',
+      'export default [A, B, C];',
+      '',
+    ].join('\n');
+    const out = removeNotesElementInSource(source, 1);
+    expect(out).not.toBeNull();
+    expect(out).toContain('export const notes = [\n  "first",\n  "third",\n];');
+  });
+
+  it('leaves notes untouched when the deleted page is past the recorded notes', () => {
+    const source = ['export const notes = ["only"];', 'export default [A, B, C];', ''].join('\n');
+    expect(removeNotesElementInSource(source, 2)).toBe(source);
+  });
+
+  it('collapses to [] when the last remaining note is removed', () => {
+    const source = ['export const notes = ["x"];', 'export default [A, B];', ''].join('\n');
+    const out = removeNotesElementInSource(source, 0);
+    expect(out).not.toBeNull();
+    expect(out).toContain('export const notes = [];');
+  });
+
+  it('returns null on a negative index', () => {
+    const source = `export const notes = ["a", "b"];\nexport default [A, B];\n`;
+    expect(removeNotesElementInSource(source, -1)).toBeNull();
+  });
+
+  it('returns null when notes is not an array literal', () => {
+    const source = `export const notes = "oops";\nexport default [A];\n`;
+    expect(removeNotesElementInSource(source, 0)).toBeNull();
+  });
+});
+
+describe('duplicateNotesElementInSource', () => {
+  it('returns the source unchanged when there is no notes export', () => {
+    const source = `export default [A, B];\n`;
+    expect(duplicateNotesElementInSource(source, 0)).toBe(source);
+  });
+
+  it('inserts a copy of the duplicated page note right after it', () => {
+    const source = [
+      'export const notes = [',
+      '  "first",',
+      '  "second",',
+      '  "third",',
+      '];',
+      'export default [A, B, C];',
+      '',
+    ].join('\n');
+    const out = duplicateNotesElementInSource(source, 1);
+    expect(out).not.toBeNull();
+    expect(out).toContain(
+      'export const notes = [\n  "first",\n  "second",\n  "second",\n  "third",\n];',
+    );
+  });
+
+  it('preserves template-literal notes verbatim when duplicating', () => {
+    const source = [
+      'export const notes = [',
+      '  `multi',
+      'line`,',
+      '  "second",',
+      '];',
+      'export default [A, B];',
+      '',
+    ].join('\n');
+    const out = duplicateNotesElementInSource(source, 0);
+    expect(out).not.toBeNull();
+    expect(out).toContain(
+      'export const notes = [\n  `multi\nline`,\n  `multi\nline`,\n  "second",\n];',
+    );
+  });
+
+  it('leaves notes untouched when the duplicated page is past the recorded notes', () => {
+    const source = ['export const notes = ["only"];', 'export default [A, B, C];', ''].join('\n');
+    expect(duplicateNotesElementInSource(source, 2)).toBe(source);
+  });
+
+  it('returns null on a negative index', () => {
+    const source = `export const notes = ["a", "b"];\nexport default [A, B];\n`;
+    expect(duplicateNotesElementInSource(source, -1)).toBeNull();
+  });
+
+  it('returns null when notes is not an array literal', () => {
+    const source = `export const notes = "oops";\nexport default [A];\n`;
+    expect(duplicateNotesElementInSource(source, 0)).toBeNull();
   });
 });

--- a/packages/core/src/editing/slide-ops.ts
+++ b/packages/core/src/editing/slide-ops.ts
@@ -417,15 +417,66 @@ export function reorderNotesArrayInSource(source: string, order: number[]): stri
   const { arrayStart, arrayEnd, elementTexts } = found;
   const pick = (i: number): string =>
     i >= 0 && i < elementTexts.length ? elementTexts[i] : 'undefined';
-  const reordered = order.map(pick);
-  while (reordered.length > 0 && reordered[reordered.length - 1] === 'undefined') {
-    reordered.pop();
+  return rebuildNotesArray(source, arrayStart, arrayEnd, order.map(pick));
+}
+
+/**
+ * Remove the note aligned with the page at `index` so the `notes` export stays
+ * index-aligned with `export default [...]` after a page deletion. Mirrors
+ * {@link removePageFromDefaultExportInSource}.
+ *
+ * Returns the rewritten source, the original source if no `notes` export exists
+ * or the index falls past the recorded notes, or `null` if the `notes` export's
+ * shape is too surprising to touch safely.
+ */
+export function removeNotesElementInSource(source: string, index: number): string | null {
+  if (!Number.isInteger(index) || index < 0) return null;
+  const found = findNotesArray(source);
+  if (found === 'invalid') return null;
+  if (found === null) return source;
+
+  const { arrayStart, arrayEnd, elementTexts } = found;
+  if (index >= elementTexts.length) return source;
+  const next = elementTexts.slice();
+  next.splice(index, 1);
+  return rebuildNotesArray(source, arrayStart, arrayEnd, next);
+}
+
+/**
+ * Duplicate the note aligned with the page at `index`, inserting the copy right
+ * after it so the `notes` export stays index-aligned with `export default [...]`
+ * after a page duplication. Mirrors {@link duplicatePageInDefaultExportInSource}.
+ *
+ * Returns the rewritten source, the original source if no `notes` export exists
+ * or the index falls past the recorded notes (the new slot and everything after
+ * it are absent, so nothing shifts), or `null` if the shape is too surprising.
+ */
+export function duplicateNotesElementInSource(source: string, index: number): string | null {
+  if (!Number.isInteger(index) || index < 0) return null;
+  const found = findNotesArray(source);
+  if (found === 'invalid') return null;
+  if (found === null) return source;
+
+  const { arrayStart, arrayEnd, elementTexts } = found;
+  if (index >= elementTexts.length) return source;
+  const next = elementTexts.slice();
+  next.splice(index + 1, 0, next[index]);
+  return rebuildNotesArray(source, arrayStart, arrayEnd, next);
+}
+
+function rebuildNotesArray(
+  source: string,
+  arrayStart: number,
+  arrayEnd: number,
+  elements: string[],
+): string {
+  const trimmed = elements.slice();
+  while (trimmed.length > 0 && trimmed[trimmed.length - 1] === 'undefined') {
+    trimmed.pop();
   }
-
   const replacement =
-    reordered.length === 0 ? '[]' : `[\n${reordered.map((s) => `  ${s},`).join('\n')}\n]`;
+    trimmed.length === 0 ? '[]' : `[\n${trimmed.map((s) => `  ${s},`).join('\n')}\n]`;
   if (replacement === source.slice(arrayStart, arrayEnd)) return source;
-
   return source.slice(0, arrayStart) + replacement + source.slice(arrayEnd);
 }
 

--- a/packages/core/src/vite/routes/slides.ts
+++ b/packages/core/src/vite/routes/slides.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs/promises';
 import type { ViteDevServer } from 'vite';
 import {
+  duplicateNotesElementInSource,
   duplicatePageInDefaultExportInSource,
   duplicateSlideDir,
+  removeNotesElementInSource,
   removePageFromDefaultExportInSource,
   reorderDefaultExportPagesInSource,
   reorderNotesArrayInSource,
@@ -114,8 +116,18 @@ export function registerSlideRoutes(server: ViteDevServer, ctx: ApiContext): voi
               : 'could not duplicate page — index out of range or default export is not an array',
           });
         }
-        if (updated !== source) {
-          await fs.writeFile(entry, updated, 'utf8');
+        const withNotes = isDelete
+          ? removeNotesElementInSource(updated, pageIndex)
+          : duplicateNotesElementInSource(updated, pageIndex);
+        if (withNotes === null) {
+          return json(res, 422, {
+            error: isDelete
+              ? 'could not delete page — `notes` export has an unexpected shape'
+              : 'could not duplicate page — `notes` export has an unexpected shape',
+          });
+        }
+        if (withNotes !== source) {
+          await fs.writeFile(entry, withNotes, 'utf8');
         }
         return json(res, 200, { ok: true, slideId, index: pageIndex });
       }


### PR DESCRIPTION
## Problem

Fixes #222. Speaker notes get misaligned or lost after a page is duplicated or deleted. Reordering pages handled notes correctly, but delete/duplicate did not.

## Cause

In `packages/core/src/vite/routes/slides.ts`, the reorder handler keeps the `notes` export in sync via `reorderNotesArrayInSource`, but the delete/duplicate handler only edited the default page array (`removePageFromDefaultExportInSource` / `duplicatePageInDefaultExportInSource`). The index-aligned `notes` array was left untouched, so every note after the affected index shifted by one.

## Fix

- Add `removeNotesElementInSource` and `duplicateNotesElementInSource` in `slide-ops.ts`, mirroring the existing `reorderNotesArrayInSource` (shared rebuild helper, same trailing-`undefined` trimming and shape guards).
- Apply them in the slides route delete/duplicate handler, returning a 422 if the `notes` export has an unexpected shape (matching the reorder path).

Both helpers no-op when the affected index falls past the recorded notes, and preserve template-literal notes verbatim.

## Tests

Added unit tests for both helpers (alignment after delete/duplicate, template-literal preservation, out-of-range no-ops, collapse to `[]`, and null on bad shapes). `pnpm test` (157 editing tests), `pnpm core typecheck`, and `biome check` on the changed files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Speaker notes now remain synchronized with pages when pages are deleted or duplicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->