### PR TITLE
fix(core): show assets stored in nested folders in the asset library

### DIFF
--- a/.changeset/asset-library-nested-folders.md
+++ b/.changeset/asset-library-nested-folders.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Show and serve assets stored in nested folders inside the asset library.

--- a/packages/core/src/files/assets.test.ts
+++ b/packages/core/src/files/assets.test.ts
@@ -1,5 +1,13 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { mimeForFilename, validateAssetName } from './assets.ts';
+import {
+  listAssetFilesRecursive,
+  mimeForFilename,
+  validateAssetName,
+  validateAssetPath,
+} from './assets.ts';
 
 describe('validateAssetName', () => {
   it('accepts simple filenames with extensions', () => {
@@ -38,6 +46,63 @@ describe('validateAssetName', () => {
     expect(validateAssetName(null)).toBeNull();
     expect(validateAssetName(42)).toBeNull();
     expect(validateAssetName(`${'x'.repeat(120)}.png`)).toBeNull();
+  });
+});
+
+describe('validateAssetPath', () => {
+  it('accepts simple filenames and nested paths', () => {
+    expect(validateAssetPath('logo.svg')).toBe('logo.svg');
+    expect(validateAssetPath('logos/brand.svg')).toBe('logos/brand.svg');
+    expect(validateAssetPath('a/b/c/photo.png')).toBe('a/b/c/photo.png');
+  });
+
+  it('only requires an extension on the final segment', () => {
+    expect(validateAssetPath('2024/q1/chart.png')).toBe('2024/q1/chart.png');
+    expect(validateAssetPath('dir/noext')).toBeNull();
+  });
+
+  it('rejects traversal, absolute, and backslash paths', () => {
+    expect(validateAssetPath('../foo.png')).toBeNull();
+    expect(validateAssetPath('a/../b.png')).toBeNull();
+    expect(validateAssetPath('/abs.png')).toBeNull();
+    expect(validateAssetPath('a/.png')).toBeNull();
+    expect(validateAssetPath('dir/')).toBeNull();
+    expect(validateAssetPath('a//b.png')).toBeNull();
+    expect(validateAssetPath('a\\b.png')).toBeNull();
+  });
+
+  it('rejects hidden segments and shell-unsafe characters', () => {
+    expect(validateAssetPath('.git/config.json')).toBeNull();
+    expect(validateAssetPath('dir/.hidden.png')).toBeNull();
+    expect(validateAssetPath('dir/foo\x00.png')).toBeNull();
+  });
+
+  it('rejects empty / non-string input', () => {
+    expect(validateAssetPath('')).toBeNull();
+    expect(validateAssetPath(null)).toBeNull();
+    expect(validateAssetPath(42)).toBeNull();
+  });
+});
+
+describe('listAssetFilesRecursive', () => {
+  it('returns forward-slash paths for files in nested folders', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'open-slide-assets-'));
+    try {
+      await fs.mkdir(path.join(dir, 'logos', 'brand'), { recursive: true });
+      await fs.writeFile(path.join(dir, 'top.png'), 'x');
+      await fs.writeFile(path.join(dir, 'logos', 'a.svg'), 'x');
+      await fs.writeFile(path.join(dir, 'logos', 'brand', 'b.svg'), 'x');
+
+      const out = await listAssetFilesRecursive(dir);
+      expect(out).not.toBeNull();
+      expect(new Set(out)).toEqual(new Set(['top.png', 'logos/a.svg', 'logos/brand/b.svg']));
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when the directory does not exist', async () => {
+    expect(await listAssetFilesRecursive('/no/such/dir/open-slide')).toBeNull();
   });
 });
 

--- a/packages/core/src/files/assets.ts
+++ b/packages/core/src/files/assets.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { SLIDE_ID_RE } from '../editing/slide-ops.ts';
 
@@ -35,19 +36,67 @@ export function mimeForFilename(name: string): string {
   return MIME_BY_EXT[ext] ?? 'application/octet-stream';
 }
 
+// A single path segment: no separators / control chars / characters
+// Windows/macOS can't store, no leading dot or tilde (hidden files, home
+// expansion), no `..`. `requireExt` enforces a sensible MIME / dev-server
+// extension on the final filename segment.
+function isValidAssetSegment(seg: string, requireExt: boolean): boolean {
+  if (seg.length < 1 || seg.length > 120) return false;
+  if (ASSET_FORBIDDEN_RE.test(seg)) return false;
+  if (seg.startsWith('.') || seg.startsWith('~')) return false;
+  if (seg === '..') return false;
+  if (requireExt) {
+    const dot = seg.lastIndexOf('.');
+    if (dot <= 0 || dot === seg.length - 1) return false;
+  }
+  return true;
+}
+
 export function validateAssetName(v: unknown): string | null {
   if (typeof v !== 'string') return null;
   const trimmed = v.trim();
-  if (trimmed.length < 1 || trimmed.length > 120) return null;
-  // No path separators, control chars, or characters Windows/macOS can't store.
-  if (ASSET_FORBIDDEN_RE.test(trimmed)) return null;
-  // Block leading dots / tildes (hidden files, home expansion) and any `..` segment.
-  if (trimmed.startsWith('.') || trimmed.startsWith('~')) return null;
-  if (trimmed === '..' || trimmed.split(/[/\\]/).includes('..')) return null;
-  // Require an extension so authors get sensible MIME / dev-server behavior.
-  const dot = trimmed.lastIndexOf('.');
-  if (dot <= 0 || dot === trimmed.length - 1) return null;
+  return isValidAssetSegment(trimmed, true) ? trimmed : null;
+}
+
+// Like validateAssetName but accepts forward-slash-separated nested paths (e.g.
+// `logos/brand.svg`). Every segment is validated and only the final one needs
+// an extension. Path traversal is still blocked at resolution time by the
+// `startsWith(dir + sep)` containment check.
+export function validateAssetPath(v: unknown): string | null {
+  if (typeof v !== 'string') return null;
+  const trimmed = v.trim();
+  if (trimmed.length < 1 || trimmed.length > 255) return null;
+  if (trimmed.includes('\\')) return null;
+  if (trimmed.startsWith('/') || trimmed.endsWith('/')) return null;
+  const segments = trimmed.split('/');
+  for (let i = 0; i < segments.length; i++) {
+    if (!isValidAssetSegment(segments[i], i === segments.length - 1)) return null;
+  }
   return trimmed;
+}
+
+// Forward-slash-relative paths of every file under `dir`, recursing into
+// subdirectories. Returns `null` when `dir` does not exist.
+export async function listAssetFilesRecursive(dir: string): Promise<string[] | null> {
+  const out: string[] = [];
+  const walk = async (current: string, prefix: string): Promise<void> => {
+    const entries = await fs.readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(path.join(current, entry.name), rel);
+      } else if (entry.isFile()) {
+        out.push(rel);
+      }
+    }
+  };
+  try {
+    await walk(dir, '');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+  return out;
 }
 
 export function resolveAssetsDir(slidesRoot: string, slideId: string): string | null {
@@ -62,7 +111,7 @@ export function resolveAssetsDir(slidesRoot: string, slideId: string): string | 
 function resolveAssetFile(slidesRoot: string, slideId: string, filename: string): string | null {
   const assetsDir = resolveAssetsDir(slidesRoot, slideId);
   if (!assetsDir) return null;
-  if (!validateAssetName(filename)) return null;
+  if (!validateAssetPath(filename)) return null;
   const file = path.resolve(assetsDir, filename);
   if (!file.startsWith(assetsDir + path.sep)) return null;
   return file;
@@ -84,7 +133,7 @@ export function resolveScopedAssetFile(
   filename: string,
 ): string | null {
   if (scope === GLOBAL_SCOPE) {
-    if (!validateAssetName(filename)) return null;
+    if (!validateAssetPath(filename)) return null;
     const file = path.resolve(globalAssetsRoot, filename);
     if (!file.startsWith(globalAssetsRoot + path.sep)) return null;
     return file;

--- a/packages/core/src/vite/routes/assets.ts
+++ b/packages/core/src/vite/routes/assets.ts
@@ -6,10 +6,12 @@ import { resolveSlideEntry, SLIDE_ID_RE } from '../../editing/slide-ops.ts';
 import {
   ASSET_MAX_BYTES,
   GLOBAL_SCOPE,
+  listAssetFilesRecursive,
   mimeForFilename,
   resolveScopedAssetFile,
   resolveScopedAssetsDir,
   validateAssetName,
+  validateAssetPath,
 } from '../../files/assets.ts';
 import { validateMutationRequest } from '../../http/request-guard.ts';
 import { type ApiContext, json, readBody } from './context.ts';
@@ -34,7 +36,7 @@ export function registerAssetRoutes(server: ViteDevServer, ctx: ApiContext): voi
       if (usagesMatch && method === 'GET') {
         const scope = usagesMatch[1];
         const filename = decodeURIComponent(usagesMatch[2]);
-        if (!validateAssetName(filename)) return json(res, 400, { error: 'invalid path' });
+        if (!validateAssetPath(filename)) return json(res, 400, { error: 'invalid path' });
 
         const isGlobal = scope === GLOBAL_SCOPE;
         const assetPath = isGlobal ? `@assets/${filename}` : `./assets/${filename}`;
@@ -79,15 +81,8 @@ export function registerAssetRoutes(server: ViteDevServer, ctx: ApiContext): voi
         const scopedDir = resolveScopedAssetsDir(ctx.slidesRoot, ctx.globalAssetsRoot, slideId);
         if (!scopedDir) return json(res, 400, { error: 'invalid slideId' });
 
-        let entries: string[];
-        try {
-          entries = await fs.readdir(scopedDir);
-        } catch (err) {
-          if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-            return json(res, 200, { assets: [] });
-          }
-          throw err;
-        }
+        const entries = await listAssetFilesRecursive(scopedDir);
+        if (entries === null) return json(res, 200, { assets: [] });
 
         const assets: Array<{
           name: string;
@@ -98,7 +93,7 @@ export function registerAssetRoutes(server: ViteDevServer, ctx: ApiContext): voi
           unused: boolean;
         }> = [];
         for (const name of entries) {
-          if (!validateAssetName(name)) continue;
+          if (!validateAssetPath(name)) continue;
           const stat = await fs.stat(path.join(scopedDir, name));
           if (!stat.isFile()) continue;
           assets.push({
@@ -198,7 +193,7 @@ export function registerAssetRoutes(server: ViteDevServer, ctx: ApiContext): voi
 
           const scopedDir = resolveScopedAssetsDir(ctx.slidesRoot, ctx.globalAssetsRoot, slideId);
           if (!scopedDir) return json(res, 400, { error: 'invalid slideId' });
-          await fs.mkdir(scopedDir, { recursive: true });
+          await fs.mkdir(path.dirname(file), { recursive: true });
 
           const chunks: Buffer[] = [];
           let total = 0;
@@ -236,13 +231,16 @@ export function registerAssetRoutes(server: ViteDevServer, ctx: ApiContext): voi
           const body = (await readBody(req)) as { name?: unknown };
           const target = validateAssetName(body.name);
           if (!target) return json(res, 400, { error: 'invalid name' });
-          if (target === filename) return json(res, 200, { ok: true, name: filename });
+          // Rename in place: a nested asset keeps its directory.
+          const slash = filename.lastIndexOf('/');
+          const targetPath = slash >= 0 ? `${filename.slice(0, slash + 1)}${target}` : target;
+          if (targetPath === filename) return json(res, 200, { ok: true, name: filename });
 
           const dest = resolveScopedAssetFile(
             ctx.slidesRoot,
             ctx.globalAssetsRoot,
             slideId,
-            target,
+            targetPath,
           );
           if (!dest) return json(res, 400, { error: 'invalid name' });
 
@@ -261,7 +259,7 @@ export function registerAssetRoutes(server: ViteDevServer, ctx: ApiContext): voi
             }
             throw err;
           }
-          return json(res, 200, { ok: true, name: target });
+          return json(res, 200, { ok: true, name: targetPath });
         }
 
         if (method === 'DELETE') {


### PR DESCRIPTION
## Problem

Fixes #224. Files placed in subfolders of a slide's `assets/` (or the global assets dir) never appear in the asset library — only top-level files are listed.

## Cause

In `packages/core/src/vite/routes/assets.ts`, the list handler read the scoped assets directory with a single non-recursive `fs.readdir`, and `validateAssetName` rejected any name containing a path separator. Nested files were therefore never enumerated, never served, and never matched for usage detection.

## Fix

- Add `listAssetFilesRecursive`, which walks the scoped directory and returns forward-slash relative paths.
- Add `validateAssetPath` (nested-aware sibling of `validateAssetName`): validates every segment, requires an extension only on the final segment, and rejects `..`, absolute, and backslash paths. The existing `path.resolve(...) + startsWith(dir + sep)` containment check remains the traversal boundary.
- Support nested paths end to end: list, serve, usages, upload (creates parent dirs), rename (keeps the asset in its directory), and delete. URLs keep the nested name in a single path segment via `encodeURIComponent` (`/` → `%2F`), so routing is unchanged.

## Tests

Added unit tests for `validateAssetPath` (nested accept, traversal/absolute/backslash/hidden-segment reject) and `listAssetFilesRecursive` (nested enumeration, missing dir). `pnpm test`, `pnpm core typecheck`, and `biome check` on the changed files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The asset library now supports and displays assets organized in nested folders. Assets can be accessed using paths like `logos/brand.svg`. Upload and rename operations preserve nested folder structures, enabling improved asset organization and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->