### PR TITLE
fix(core): prevent slide toolbar title overlap on mobile

### DIFF
--- a/.changeset/fix-mobile-title-overlap.md
+++ b/.changeset/fix-mobile-title-overlap.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Fix the slide toolbar on narrow screens: keep the title from overlapping the icons, and collapse the copy-link and download actions into a single overflow menu.

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   Maximize,
   MonitorSpeaker,
+  MoreHorizontal,
   Play,
   Presentation,
 } from 'lucide-react';
@@ -376,6 +377,127 @@ export function Slide() {
 
   const title = slide.meta?.title ?? slideId;
 
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      toast.success(t.slide.toastCopyLinkSuccess);
+      setLinkCopied(true);
+      if (linkCopiedTimerRef.current) clearTimeout(linkCopiedTimerRef.current);
+      linkCopiedTimerRef.current = setTimeout(() => setLinkCopied(false), 1200);
+    } catch (err) {
+      console.error('[open-slide] copy link failed', err);
+      toast.error(t.slide.toastCopyLinkFailed);
+    }
+  };
+
+  const exportHtml = async () => {
+    if (!slide || exporting) return;
+    setExporting(true);
+    try {
+      await exportSlideAsHtml(slide, slideId);
+    } catch (err) {
+      console.error('[open-slide] export failed', err);
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const exportPdf = async () => {
+    if (!slide || exporting) return;
+    if (isSafari()) {
+      toast.error(t.slide.pdfExportSafariUnsupported, { duration: 5000 });
+      return;
+    }
+    setExporting(true);
+    const toastId = `pdf-export-${slideId}`;
+    toast.custom(
+      () => (
+        <PdfProgressToast
+          progress={{ phase: 'processing', current: 0, total: pages.length, percent: 0 }}
+        />
+      ),
+      { id: toastId, duration: Infinity },
+    );
+    try {
+      await exportSlideAsPdf(slide, slideId, (p) => {
+        toast.custom(() => <PdfProgressToast progress={p} />, { id: toastId, duration: Infinity });
+      });
+    } catch (err) {
+      console.error('[open-slide] pdf export failed', err);
+      toast.error(t.slide.pdfExportFailed, { id: toastId, duration: 4000 });
+    } finally {
+      setExporting(false);
+      toast.dismiss(toastId);
+    }
+  };
+
+  const exportImagePptx = async () => {
+    if (!slide || exporting) return;
+    setExporting(true);
+    const toastId = `pptx-export-${slideId}`;
+    toast.custom(
+      () => (
+        <PptxProgressToast
+          progress={{ phase: 'processing', current: 0, total: pages.length, percent: 0 }}
+        />
+      ),
+      { id: toastId, duration: Infinity },
+    );
+    try {
+      await exportSlideAsImagePptx(slide, slideId, (p) => {
+        toast.custom(() => <PptxProgressToast progress={p} />, { id: toastId, duration: Infinity });
+      });
+    } catch (err) {
+      console.error('[open-slide] image pptx export failed', err);
+      toast.error(t.slide.imagePptxExportFailed, { id: toastId, duration: 4000 });
+    } finally {
+      setExporting(false);
+      toast.dismiss(toastId);
+    }
+  };
+
+  const exportMenuItems = (
+    <>
+      <DropdownMenuItem disabled={exporting} onSelect={exportHtml}>
+        <FileCode2 />
+        {t.slide.exportAsHtml}
+      </DropdownMenuItem>
+      <DropdownMenuItem disabled={exporting} onSelect={exportPdf}>
+        <FileText />
+        {t.slide.exportAsPdf}
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem disabled={exporting} onSelect={exportImagePptx}>
+        <FileImage />
+        {t.slide.exportAsImagePptx}
+      </DropdownMenuItem>
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              aria-disabled
+              className="relative flex cursor-help items-center justify-between gap-2 rounded-[5px] px-2 py-1.5 text-[12.5px] opacity-45 select-none [&_svg]:size-3.5 [&_svg]:shrink-0 [&_svg]:opacity-80"
+            >
+              <span className="flex items-center gap-2">
+                <Presentation />
+                {t.slide.exportAsPptx}
+              </span>
+              <span className="rounded-[3px] bg-muted px-1.5 py-0.5 font-mono text-[9.5px] tracking-[0.04em] text-muted-foreground">
+                {t.slide.comingSoon}
+              </span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent
+            side="left"
+            className="w-max max-w-[min(520px,calc(100vw-2rem))] text-center leading-relaxed"
+          >
+            {t.slide.pptxComingSoonTooltip}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </>
+  );
+
   return (
     <HistoryProvider>
       <InspectorProvider slideId={slideId} pageIndex={index}>
@@ -383,7 +505,7 @@ export function Slide() {
         <div className="flex h-dvh flex-col overflow-hidden bg-background text-foreground">
           {/* Editorial toolbar — three zones, hairline separators, mono-folio center */}
           <header className="relative flex h-12 shrink-0 items-center gap-2 border-b border-hairline bg-sidebar/85 px-2 backdrop-blur-md md:px-3">
-            <div className="flex shrink-0 items-center gap-1.5 md:gap-2">
+            <div className="flex flex-1 items-center gap-1.5 md:flex-none md:gap-2">
               {showSlideBrowser && (
                 <Button asChild variant="ghost" size="icon-sm" title={t.slide.home}>
                   <Link to="/" aria-label={t.slide.backToHome}>
@@ -416,32 +538,26 @@ export function Slide() {
               {import.meta.env.DEV && <AgentConnectedBadge />}
             </div>
 
-            {/* Title centered to the viewport, not the leftover space between the side groups. */}
-            <div className="pointer-events-none absolute inset-x-0 flex justify-center px-2">
+            {/* On md+ the title centers to the viewport via absolute positioning. On mobile the
+                two side groups each flex-1, so the in-flow title lands at the viewport center too —
+                and min-w-0 lets it truncate instead of overlapping the icons on narrow widths. */}
+            <div className="pointer-events-none relative flex min-w-0 justify-center px-2 md:absolute md:inset-x-0">
               <div className="pointer-events-auto min-w-0 max-w-[34rem]">
                 <InlineTitleEditor title={title} onSubmit={(next) => renameSlide(slideId, next)} />
               </div>
             </div>
 
-            <div className="ml-auto flex shrink-0 items-center gap-1">
+            <div className="flex flex-1 items-center justify-end gap-1 md:ml-auto md:flex-none">
               {view === 'slides' && (
                 <button
                   type="button"
                   aria-label={t.slide.copyLink}
                   title={t.slide.copyLink}
-                  className={cn(buttonVariants({ variant: 'ghost', size: 'icon-sm' }))}
-                  onClick={async () => {
-                    try {
-                      await navigator.clipboard.writeText(window.location.href);
-                      toast.success(t.slide.toastCopyLinkSuccess);
-                      setLinkCopied(true);
-                      if (linkCopiedTimerRef.current) clearTimeout(linkCopiedTimerRef.current);
-                      linkCopiedTimerRef.current = setTimeout(() => setLinkCopied(false), 1200);
-                    } catch (err) {
-                      console.error('[open-slide] copy link failed', err);
-                      toast.error(t.slide.toastCopyLinkFailed);
-                    }
-                  }}
+                  className={cn(
+                    buttonVariants({ variant: 'ghost', size: 'icon-sm' }),
+                    'hidden md:inline-flex',
+                  )}
+                  onClick={copyLink}
                 >
                   <span className="relative grid size-4 place-items-center">
                     <Link2
@@ -466,7 +582,10 @@ export function Slide() {
                     disabled={exporting}
                     aria-label={t.slide.download}
                     title={t.slide.download}
-                    className={cn(buttonVariants({ variant: 'ghost', size: 'icon-sm' }))}
+                    className={cn(
+                      buttonVariants({ variant: 'ghost', size: 'icon-sm' }),
+                      'hidden md:inline-flex',
+                    )}
                   >
                     {exporting ? (
                       <Loader2 className="size-4 animate-spin" />
@@ -475,131 +594,35 @@ export function Slide() {
                     )}
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="min-w-[200px]">
-                    <DropdownMenuItem
-                      disabled={exporting}
-                      onSelect={async () => {
-                        if (!slide || exporting) return;
-                        setExporting(true);
-                        try {
-                          await exportSlideAsHtml(slide, slideId);
-                        } catch (err) {
-                          console.error('[open-slide] export failed', err);
-                        } finally {
-                          setExporting(false);
-                        }
-                      }}
-                    >
-                      <FileCode2 />
-                      {t.slide.exportAsHtml}
+                    {exportMenuItems}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+              {view === 'slides' && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    type="button"
+                    disabled={exporting}
+                    aria-label={t.slide.moreActions}
+                    title={t.slide.moreActions}
+                    className={cn(
+                      buttonVariants({ variant: 'ghost', size: 'icon-sm' }),
+                      'inline-flex md:hidden',
+                    )}
+                  >
+                    {exporting ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <MoreHorizontal className="size-4" />
+                    )}
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="min-w-[200px]">
+                    <DropdownMenuItem onSelect={copyLink}>
+                      <Link2 />
+                      {t.slide.copyLink}
                     </DropdownMenuItem>
-                    <DropdownMenuItem
-                      disabled={exporting}
-                      onSelect={async () => {
-                        if (!slide || exporting) return;
-                        if (isSafari()) {
-                          toast.error(t.slide.pdfExportSafariUnsupported, { duration: 5000 });
-                          return;
-                        }
-                        setExporting(true);
-                        const toastId = `pdf-export-${slideId}`;
-                        toast.custom(
-                          () => (
-                            <PdfProgressToast
-                              progress={{
-                                phase: 'processing',
-                                current: 0,
-                                total: pages.length,
-                                percent: 0,
-                              }}
-                            />
-                          ),
-                          { id: toastId, duration: Infinity },
-                        );
-                        try {
-                          await exportSlideAsPdf(slide, slideId, (p) => {
-                            toast.custom(() => <PdfProgressToast progress={p} />, {
-                              id: toastId,
-                              duration: Infinity,
-                            });
-                          });
-                        } catch (err) {
-                          console.error('[open-slide] pdf export failed', err);
-                          toast.error(t.slide.pdfExportFailed, { id: toastId, duration: 4000 });
-                        } finally {
-                          setExporting(false);
-                          toast.dismiss(toastId);
-                        }
-                      }}
-                    >
-                      <FileText />
-                      {t.slide.exportAsPdf}
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      disabled={exporting}
-                      onSelect={async () => {
-                        if (!slide || exporting) return;
-                        setExporting(true);
-                        const toastId = `pptx-export-${slideId}`;
-                        toast.custom(
-                          () => (
-                            <PptxProgressToast
-                              progress={{
-                                phase: 'processing',
-                                current: 0,
-                                total: pages.length,
-                                percent: 0,
-                              }}
-                            />
-                          ),
-                          { id: toastId, duration: Infinity },
-                        );
-                        try {
-                          await exportSlideAsImagePptx(slide, slideId, (p) => {
-                            toast.custom(() => <PptxProgressToast progress={p} />, {
-                              id: toastId,
-                              duration: Infinity,
-                            });
-                          });
-                        } catch (err) {
-                          console.error('[open-slide] image pptx export failed', err);
-                          toast.error(t.slide.imagePptxExportFailed, {
-                            id: toastId,
-                            duration: 4000,
-                          });
-                        } finally {
-                          setExporting(false);
-                          toast.dismiss(toastId);
-                        }
-                      }}
-                    >
-                      <FileImage />
-                      {t.slide.exportAsImagePptx}
-                    </DropdownMenuItem>
-                    <TooltipProvider delayDuration={200}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <div
-                            aria-disabled
-                            className="relative flex cursor-help items-center justify-between gap-2 rounded-[5px] px-2 py-1.5 text-[12.5px] opacity-45 select-none [&_svg]:size-3.5 [&_svg]:shrink-0 [&_svg]:opacity-80"
-                          >
-                            <span className="flex items-center gap-2">
-                              <Presentation />
-                              {t.slide.exportAsPptx}
-                            </span>
-                            <span className="rounded-[3px] bg-muted px-1.5 py-0.5 font-mono text-[9.5px] tracking-[0.04em] text-muted-foreground">
-                              {t.slide.comingSoon}
-                            </span>
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent
-                          side="left"
-                          className="w-max max-w-[min(520px,calc(100vw-2rem))] text-center leading-relaxed"
-                        >
-                          {t.slide.pptxComingSoonTooltip}
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
+                    {allowHtmlDownload && <DropdownMenuSeparator />}
+                    {allowHtmlDownload && exportMenuItems}
                   </DropdownMenuContent>
                 </DropdownMenu>
               )}

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -106,6 +106,7 @@ export const en: Locale = {
       'Lost connection to the dev server, so your agent can no longer see the current slide or inspector selection. Restart the dev server to restore the connection.',
     download: 'Download',
     copyLink: 'Copy link',
+    moreActions: 'More actions',
     toastCopyLinkSuccess: 'Link copied to clipboard',
     toastCopyLinkFailed: 'Failed to copy link',
     exportAsHtml: 'Export as HTML',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -107,6 +107,7 @@ export const ja: Locale = {
     backToHome: 'ホームへ戻る',
     download: 'ダウンロード',
     copyLink: 'リンクをコピー',
+    moreActions: 'その他の操作',
     toastCopyLinkSuccess: 'リンクをクリップボードにコピーしました',
     toastCopyLinkFailed: 'リンクのコピーに失敗しました',
     exportAsHtml: 'HTML として書き出し',

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -108,6 +108,7 @@ export type Locale = {
     agentDisconnectedTooltip: string;
     download: string;
     copyLink: string;
+    moreActions: string;
     toastCopyLinkSuccess: string;
     toastCopyLinkFailed: string;
     exportAsHtml: string;

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -105,6 +105,7 @@ export const zhCN: Locale = {
     backToHome: '返回首页',
     download: '下载',
     copyLink: '复制链接',
+    moreActions: '更多操作',
     toastCopyLinkSuccess: '已复制链接到剪贴板',
     toastCopyLinkFailed: '复制链接失败',
     exportAsHtml: '导出为 HTML',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -105,6 +105,7 @@ export const zhTW: Locale = {
     backToHome: '返回首頁',
     download: '下載',
     copyLink: '複製連結',
+    moreActions: '更多動作',
     toastCopyLinkSuccess: '已複製連結到剪貼簿',
     toastCopyLinkFailed: '複製連結失敗',
     exportAsHtml: '匯出為 HTML',


### PR DESCRIPTION
## What

Fixes the slide toolbar on narrow screens:

- **Title no longer overlaps the toolbar icons.** On mobile the two side groups each take `flex-1`, so the in-flow title lands at the viewport center, and `min-w-0` lets it truncate instead of overlapping. On `md+` the title keeps its original absolute centering.
- **Copy-link and download actions collapse into a single overflow menu** (`MoreHorizontal`) on mobile. On `md+` the standalone copy-link button and download dropdown render as before.

The export menu items were extracted into a shared `exportMenuItems` fragment reused by both the desktop download dropdown and the mobile overflow menu, removing duplicated handler code.

**Before:**
<img width="380" height="809" alt="Dia 2026-06-15 20 59 02" src="https://github.com/user-attachments/assets/4e70ab8c-33b5-4389-b736-651e498af0b2" />

**After:**
<img width="380" height="809" alt="Dia 2026-06-15 20 58 57" src="https://github.com/user-attachments/assets/796906d7-c07d-4fbd-9316-65bd4322ba7c" />
<img width="380" height="809" alt="Dia 2026-06-15 20 59 11" src="https://github.com/user-attachments/assets/e62d1ce2-341b-4f15-8051-2029381c68b4" />

## Notes

- Adds a `moreActions` locale string across en / ja / zh-cn / zh-tw and the `Locale` type.
- Changeset included (`@open-slide/core` patch).
- `tsc` and Biome pass clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)