### PR TITLE
fix(core): pin export frame with flex-shrink to preserve 16:9 aspect ratio

### DIFF
--- a/.changeset/fix-export-frame-aspect-ratio.md
+++ b/.changeset/fix-export-frame-aspect-ratio.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Fix HTML export distorting the slide aspect ratio on narrow viewports.

--- a/packages/core/src/app/lib/export-html.ts
+++ b/packages/core/src/app/lib/export-html.ts
@@ -260,7 +260,7 @@ ${opts.externalLinks}
 <style>
 html, body { margin: 0; height: 100%; background: #000; overflow: hidden; font-family: system-ui, sans-serif; }
 .os-stage { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; }
-.os-frame { width: 1920px; height: 1080px; background: #fff; color: #000; transform-origin: center center; overflow: hidden; position: relative; }
+.os-frame { width: 1920px; height: 1080px; flex-shrink: 0; background: #fff; color: #000; transform-origin: center center; overflow: hidden; position: relative; }
 .os-page { position: absolute; inset: 0; }
 .os-page[hidden] { display: none !important; }
 .os-counter { position: fixed; bottom: 12px; left: 50%; transform: translateX(-50%); color: #fff; background: rgba(0,0,0,.5); padding: 2px 10px; border-radius: 999px; font-size: 12px; z-index: 10; font-variant-numeric: tabular-nums; }


### PR DESCRIPTION
## Summary

The HTML export renders the slide canvas **narrower than 16:9** whenever the browser window is narrower than 1920px — i.e. most laptops and monitors. The deck looks correct in the OpenSlide editor / present mode but the exported `.html`, opened in a normal-width window, shows a too-narrow canvas: content laid out for a 1920px-wide canvas gets crammed into a narrower one (and anything anchored past the shrunk width is clipped by the frame's `overflow: hidden`). At window widths ≥ 1920px it renders correctly, which is why the bug is easy to miss.

Note: individual elements are **not** distorted — the `transform: scale()` is uniform, so a circle stays a circle. What changes is the **canvas proportion** and the **spacing** between elements. It's also easy to miss on dark-themed decks, where the narrowed canvas blends into the black letterbox (`body { background: #000 }`).

## Root cause

The export shell centers the canvas with flexbox:

```css
.os-stage { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; }
.os-frame { width: 1920px; height: 1080px; transform-origin: center center; /* ... */ }
```

`.os-frame` is a flex item, so it carries the default `flex-shrink: 1`. When `.os-stage` (the viewport) is narrower than the frame's `1920px`, flexbox shrinks the frame's **width** down to the container width while its **height** stays `1080px`. `fit()` then applies `transform: scale()` on top of that already-narrowed box, so the rendered canvas is no longer 16:9.

The dev viewer (`slide-canvas.tsx`) does **not** hit this: it sizes the wrapper to `1920·s × 1080·s` and scales the inner canvas with `transform-origin: top left`, never relying on a shrinkable flex child. That's why a deck looks correct in the editor but wrong in the exported HTML.

## Fix

Pin the frame so flexbox cannot shrink it:

```css
.os-frame { /* ... */ flex-shrink: 0; }
```

One line in `packages/core/src/app/lib/export-html.ts`. A changeset (`@open-slide/core` patch) is included.

## Evidence — measured `.os-frame` bounding rect

| Window | frame computed width | rendered ratio |
| --- | --- | --- |
| 1280×800, **before** | 1280px (shrunk from 1920) | **1.1852 ❌** |
| 1440×900, **before** | 1440px (shrunk from 1920) | **1.3333 ❌** |
| 1280 / 1440, with `flex-shrink:0` | 1920px | **1.7778 ✅** |
| 2200×900 (≥1920 wide), before | 1920px (no shrink) | 1.7778 ✅ |
| real exported deck (16 pages), 1440×900, before | 1440px | **1.3333 ❌** |

## Demonstration

The probe page below is a real exported deck: a centred circle, two squares pinned near the left/right edges, an edge outline, and a `1920px`-wide ruler.

**In the OpenSlide editor — correct 16:9** (circle centred, squares near the edges with room to breathe, ruler reaches `1920px`):

<img width="1440" height="900" alt="probe-frontend" src="https://github.com/user-attachments/assets/a2f7e556-bc8d-4ca9-9581-bfeda0ecc1f0" />

**Genuine export of this deck** (Export → HTML on `@open-slide/core` 1.12.0), opened in a 1280px-wide window — **before this fix.** The canvas is no longer 16:9; the side squares are pulled inward and overlap the circle; the `1920px` ruler mark is clipped off the right. The shapes keep their form — they're just crammed into a narrower canvas:

<img width="1280" height="800" alt="probe-real-export-bug" src="https://github.com/user-attachments/assets/fb81dade-c085-4f18-bc78-e90e271f213b" />

**Same exported file, same window — with `flex-shrink: 0`.** 16:9 restored; matches the editor:

<img width="1280" height="800" alt="probe-real-export-fixed" src="https://github.com/user-attachments/assets/ea9b460f-d6c9-4c3c-afed-e9631340e794" />

## Reproduction

<details>
<summary>repro.html — shell CSS copied verbatim from <code>buildHtml()</code></summary>

```html
<!doctype html>
<html lang="en">
<head>
<meta charset="utf-8">
<meta name="viewport" content="width=device-width, initial-scale=1">
<title>open-slide export aspect-ratio repro</title>
<style>
/* ---- copied verbatim from export-html.ts buildHtml() ---- */
html, body { margin: 0; height: 100%; background: #000; overflow: hidden; font-family: system-ui, sans-serif; }
.os-stage { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; }
.os-frame { width: 1920px; height: 1080px; background: #fff; color: #000; transform-origin: center center; overflow: hidden; position: relative; }
.os-page { position: absolute; inset: 0; }
/* ---- end verbatim ---- */
.demo { width: 100%; height: 100%; position: relative; overflow: hidden; background: #f4f1ea; }
.circle { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
  width: 600px; height: 600px; border-radius: 50%; border: 14px solid #c0392b; box-sizing: border-box; }
.sq { position: absolute; top: 50%; transform: translateY(-50%); width: 300px; height: 300px;
  border: 10px solid #2c3e50; box-sizing: border-box; }
.left { left: 150px; } .right { right: 150px; border-style: dashed; }
.ruler { position: absolute; left: 0; bottom: 120px; width: 1920px; height: 6px; background: #2c3e50; }
.end { position: absolute; left: 1660px; bottom: 138px; font: 700 24px system-ui; color: #2c3e50; }
</style>
</head>
<body>
<div class="os-stage"><div class="os-frame" id="os-frame">
  <div class="os-page" data-idx="0">
    <div class="demo">
      <div class="sq left"></div><div class="sq right"></div><div class="circle"></div>
      <div class="ruler"></div><div class="end">1920px →</div>
    </div>
  </div>
</div></div>
<script>
(function () {
  var frame = document.getElementById('os-frame');
  function fit() { frame.style.transform = 'scale(' + Math.min(innerWidth/1920, innerHeight/1080) + ')'; }
  addEventListener('resize', fit); fit();
})();
</script>
</body>
</html>
```
</details>

1. Save as `repro.html` and open it in a window **narrower than 1920px**.
2. The canvas renders narrower than 16:9 — the squares are pulled inward over the circle and the `1920px` ruler mark is clipped off the right edge.
3. Add `flex-shrink: 0` to `.os-frame` → the canvas is 16:9 again, squares back at the edges, ruler complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML export aspect ratio distortion on narrow viewports by adjusting the exported frame layout to prevent shrinking and preserve the intended 16:9 canvas proportions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->