### PR TITLE
fix(core): include speaker notes in PPTX export

### DIFF
--- a/.changeset/pptx-export-speaker-notes.md
+++ b/.changeset/pptx-export-speaker-notes.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Include speaker notes in the image PPTX export so they show up in PowerPoint's notes pane.

--- a/packages/core/src/app/lib/export-pptx.test.ts
+++ b/packages/core/src/app/lib/export-pptx.test.ts
@@ -1,0 +1,58 @@
+import { strToU8, unzipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { buildImagePptx } from './export-pptx';
+
+const fakePng = strToU8('not-a-real-png');
+
+function unzipText(zip: Uint8Array): Record<string, string> {
+  const out: Record<string, string> = {};
+  const dec = new TextDecoder();
+  for (const [name, bytes] of Object.entries(unzipSync(zip))) {
+    out[name] = dec.decode(bytes);
+  }
+  return out;
+}
+
+describe('buildImagePptx', () => {
+  it('omits all notes parts when there are no notes', async () => {
+    const files = unzipText(await buildImagePptx([fakePng, fakePng]));
+    expect(Object.keys(files).some((p) => p.startsWith('ppt/notesSlides/'))).toBe(false);
+    expect(files['ppt/notesMasters/notesMaster1.xml']).toBeUndefined();
+    expect(files['ppt/presentation.xml']).not.toContain('notesMasterIdLst');
+  });
+
+  it('emits a notes slide only for pages that have notes', async () => {
+    const files = unzipText(
+      await buildImagePptx([fakePng, fakePng, fakePng], ['first note', undefined, 'third note']),
+    );
+
+    expect(files['ppt/notesSlides/notesSlide1.xml']).toContain('first note');
+    expect(files['ppt/notesSlides/notesSlide2.xml']).toBeUndefined();
+    expect(files['ppt/notesSlides/notesSlide3.xml']).toContain('third note');
+
+    // The slide links to its notes slide; one without notes does not.
+    expect(files['ppt/slides/_rels/slide1.xml.rels']).toContain('notesSlide1.xml');
+    expect(files['ppt/slides/_rels/slide2.xml.rels']).not.toContain('notesSlide');
+
+    // Notes master + theme2 and content-type overrides are wired in.
+    expect(files['ppt/notesMasters/notesMaster1.xml']).toContain('notesStyle');
+    expect(files['ppt/theme/theme2.xml']).toBeDefined();
+    expect(files['ppt/presentation.xml']).toContain('notesMasterIdLst');
+    expect(files['[Content_Types].xml']).toContain('/ppt/notesSlides/notesSlide1.xml');
+    expect(files['[Content_Types].xml']).toContain('/ppt/notesMasters/notesMaster1.xml');
+  });
+
+  it('escapes XML-special characters and splits lines into paragraphs', async () => {
+    const files = unzipText(await buildImagePptx([fakePng], ['a < b & c\nsecond line']));
+    const xml = files['ppt/notesSlides/notesSlide1.xml'];
+    expect(xml).toContain('a &lt; b &amp; c');
+    expect(xml).not.toContain('a < b & c');
+    expect((xml.match(/<a:p>/g) ?? []).length).toBe(2);
+  });
+
+  it('treats whitespace-only notes as empty', async () => {
+    const files = unzipText(await buildImagePptx([fakePng], ['   \n  ']));
+    expect(files['ppt/notesSlides/notesSlide1.xml']).toBeUndefined();
+    expect(files['ppt/presentation.xml']).not.toContain('notesMasterIdLst');
+  });
+});

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -129,7 +129,7 @@ export async function exportSlideAsImagePptx(
     }
 
     onProgress?.({ phase: 'generating', current: total, total, percent: 98 });
-    const pptx = await buildImagePptx(images);
+    const pptx = await buildImagePptx(images, slide.notes);
     downloadBlob(
       new Blob([pptx as BlobPart], {
         type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
@@ -162,15 +162,25 @@ const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n';
 const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
 const OD_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
 
-async function buildImagePptx(images: Uint8Array[]): Promise<Uint8Array> {
+export async function buildImagePptx(
+  images: Uint8Array[],
+  notes?: (string | undefined)[],
+): Promise<Uint8Array> {
   const { zipSync, strToU8 } = await import('fflate');
   const n = images.length;
   const files: Record<string, Uint8Array> = {};
 
-  files['[Content_Types].xml'] = strToU8(contentTypesXml(n));
+  const noteFor = (i: number): string => {
+    const raw = notes?.[i];
+    return typeof raw === 'string' ? raw.trim() : '';
+  };
+  const slideHasNotes = images.map((_, i) => noteFor(i).length > 0);
+  const anyNotes = slideHasNotes.some(Boolean);
+
+  files['[Content_Types].xml'] = strToU8(contentTypesXml(n, slideHasNotes));
   files['_rels/.rels'] = strToU8(rootRelsXml());
-  files['ppt/presentation.xml'] = strToU8(presentationXml(n));
-  files['ppt/_rels/presentation.xml.rels'] = strToU8(presentationRelsXml(n));
+  files['ppt/presentation.xml'] = strToU8(presentationXml(n, anyNotes));
+  files['ppt/_rels/presentation.xml.rels'] = strToU8(presentationRelsXml(n, anyNotes));
   files['ppt/presProps.xml'] = strToU8(presPropsXml());
   files['ppt/theme/theme1.xml'] = strToU8(themeXml());
   files['ppt/slideMasters/slideMaster1.xml'] = strToU8(slideMasterXml());
@@ -178,38 +188,63 @@ async function buildImagePptx(images: Uint8Array[]): Promise<Uint8Array> {
   files['ppt/slideLayouts/slideLayout1.xml'] = strToU8(slideLayoutXml());
   files['ppt/slideLayouts/_rels/slideLayout1.xml.rels'] = strToU8(slideLayoutRelsXml());
 
+  if (anyNotes) {
+    files['ppt/notesMasters/notesMaster1.xml'] = strToU8(notesMasterXml());
+    files['ppt/notesMasters/_rels/notesMaster1.xml.rels'] = strToU8(notesMasterRelsXml());
+    files['ppt/theme/theme2.xml'] = strToU8(themeXml());
+  }
+
   for (let i = 0; i < n; i++) {
     const idx = i + 1;
     files[`ppt/slides/slide${idx}.xml`] = strToU8(slideXml());
-    files[`ppt/slides/_rels/slide${idx}.xml.rels`] = strToU8(slideRelsXml(idx));
+    files[`ppt/slides/_rels/slide${idx}.xml.rels`] = strToU8(slideRelsXml(idx, slideHasNotes[i]));
     files[`ppt/media/image${idx}.png`] = images[i];
+    if (slideHasNotes[i]) {
+      files[`ppt/notesSlides/notesSlide${idx}.xml`] = strToU8(notesSlideXml(noteFor(i)));
+      files[`ppt/notesSlides/_rels/notesSlide${idx}.xml.rels`] = strToU8(notesSlideRelsXml(idx));
+    }
   }
 
   return zipSync(files);
 }
 
-function contentTypesXml(n: number): string {
+function contentTypesXml(n: number, slideHasNotes: boolean[]): string {
   const slideOverrides = Array.from(
     { length: n },
     (_, i) =>
       `<Override PartName="/ppt/slides/slide${i + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>`,
   ).join('');
-  return `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/><Override PartName="/ppt/presProps.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presProps+xml"/><Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/><Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/><Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>${slideOverrides}</Types>`;
+  let notesOverrides = '';
+  if (slideHasNotes.some(Boolean)) {
+    notesOverrides += `<Override PartName="/ppt/notesMasters/notesMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.notesMaster+xml"/><Override PartName="/ppt/theme/theme2.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>`;
+    notesOverrides += slideHasNotes
+      .map((has, i) =>
+        has
+          ? `<Override PartName="/ppt/notesSlides/notesSlide${i + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.notesSlide+xml"/>`
+          : '',
+      )
+      .join('');
+  }
+  return `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/><Override PartName="/ppt/presProps.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presProps+xml"/><Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/><Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/><Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>${slideOverrides}${notesOverrides}</Types>`;
 }
 
 function rootRelsXml(): string {
   return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/officeDocument" Target="ppt/presentation.xml"/></Relationships>`;
 }
 
-function presentationXml(n: number): string {
+function presentationXml(n: number, anyNotes: boolean): string {
   const sldIds = Array.from(
     { length: n },
     (_, i) => `<p:sldId id="${256 + i}" r:id="rId${i + 3}"/>`,
   ).join('');
-  return `${XML_DECL}<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst><p:sldIdLst>${sldIds}</p:sldIdLst><p:sldSz cx="${EMU_W}" cy="${EMU_H}"/><p:notesSz cx="6858000" cy="9144000"/></p:presentation>`;
+  // Schema order: sldMasterIdLst, notesMasterIdLst, sldIdLst, sldSz, notesSz.
+  const notesMasterIdLst = anyNotes
+    ? `<p:notesMasterIdLst><p:notesMasterId r:id="rId${n + 3}"/></p:notesMasterIdLst>`
+    : '';
+  return `${XML_DECL}<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst>${notesMasterIdLst}<p:sldIdLst>${sldIds}</p:sldIdLst><p:sldSz cx="${EMU_W}" cy="${EMU_H}"/><p:notesSz cx="6858000" cy="9144000"/></p:presentation>`;
 }
 
-function presentationRelsXml(n: number): string {
+function presentationRelsXml(n: number, anyNotes: boolean): string {
   const rels = [
     `<Relationship Id="rId1" Type="${OD_REL}/slideMaster" Target="slideMasters/slideMaster1.xml"/>`,
     `<Relationship Id="rId2" Type="${OD_REL}/presProps" Target="presProps.xml"/>`,
@@ -217,6 +252,11 @@ function presentationRelsXml(n: number): string {
   for (let i = 0; i < n; i++) {
     rels.push(
       `<Relationship Id="rId${i + 3}" Type="${OD_REL}/slide" Target="slides/slide${i + 1}.xml"/>`,
+    );
+  }
+  if (anyNotes) {
+    rels.push(
+      `<Relationship Id="rId${n + 3}" Type="${OD_REL}/notesMaster" Target="notesMasters/notesMaster1.xml"/>`,
     );
   }
   return `${XML_DECL}<Relationships xmlns="${REL_NS}">${rels.join('')}</Relationships>`;
@@ -246,8 +286,45 @@ function slideXml(): string {
   return `${XML_DECL}<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:pic><p:nvPicPr><p:cNvPr id="2" name="Slide"/><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId2"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="${EMU_W}" cy="${EMU_H}"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic></p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>`;
 }
 
-function slideRelsXml(idx: number): string {
-  return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/slideLayout" Target="../slideLayouts/slideLayout1.xml"/><Relationship Id="rId2" Type="${OD_REL}/image" Target="../media/image${idx}.png"/></Relationships>`;
+function slideRelsXml(idx: number, hasNotes: boolean): string {
+  const notesRel = hasNotes
+    ? `<Relationship Id="rId3" Type="${OD_REL}/notesSlide" Target="../notesSlides/notesSlide${idx}.xml"/>`
+    : '';
+  return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/slideLayout" Target="../slideLayouts/slideLayout1.xml"/><Relationship Id="rId2" Type="${OD_REL}/image" Target="../media/image${idx}.png"/>${notesRel}</Relationships>`;
+}
+
+function notesSlideXml(note: string): string {
+  const paragraphs = note
+    .split('\n')
+    .map((line) =>
+      line.length === 0 ? '<a:p/>' : `<a:p><a:r><a:t>${escapeXml(line)}</a:t></a:r></a:p>`,
+    )
+    .join('');
+  return `${XML_DECL}<p:notes xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="2" name="Notes Placeholder 1"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr><p:spPr/><p:txBody><a:bodyPr/><a:lstStyle/>${paragraphs}</p:txBody></p:sp></p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:notes>`;
+}
+
+function notesSlideRelsXml(idx: number): string {
+  return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/slide" Target="../slides/slide${idx}.xml"/><Relationship Id="rId2" Type="${OD_REL}/notesMaster" Target="../notesMasters/notesMaster1.xml"/></Relationships>`;
+}
+
+function notesMasterXml(): string {
+  const notesStyle = Array.from(
+    { length: 9 },
+    (_, i) => `<a:lvl${i + 1}pPr><a:defRPr sz="1200"/></a:lvl${i + 1}pPr>`,
+  ).join('');
+  return `${XML_DECL}<p:notesMaster xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="2" name="Notes Placeholder 1"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="685800" y="1143000"/><a:ext cx="5486400" cy="6858000"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr lang="en-US"/></a:p></p:txBody></p:sp></p:spTree></p:cSld><p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/><p:notesStyle>${notesStyle}</p:notesStyle></p:notesMaster>`;
+}
+
+function notesMasterRelsXml(): string {
+  return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/theme" Target="../theme/theme2.xml"/></Relationships>`;
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
 }
 
 function themeXml(): string {


### PR DESCRIPTION
## Problem

Fixes #225. Exporting to PPTX silently drops speaker notes — the generated deck has no notes slides at all.

## Cause

`buildImagePptx` in `packages/core/src/app/lib/export-pptx.ts` wrote one image slide per page but never produced any `notesSlide` parts, nor the notes master / content-type / relationship wiring they require. `slide.notes` was never read.

## Fix

For each page that has a (non-whitespace) note:

- Emit `ppt/notesSlides/notesSlide{idx}.xml` with the note text, splitting on newlines into paragraphs and XML-escaping `& < > "`.
- Link the slide to it via a `notesSlide` relationship in `slide{idx}.xml.rels`.
- Add a notes master (`notesMaster1.xml` + its own `theme2.xml`), referenced from `presentation.xml` (`notesMasterIdLst`, in schema order) and `presentation.xml.rels`.
- Register every new part in `[Content_Types].xml`.

When no page has notes, nothing changes — no notes master or notes slides are added, so decks without notes are byte-for-byte the same as before.

## Tests

Added `export-pptx.test.ts` (unzips the generated package via fflate): notes slides appear only for pages with notes, the slide↔notes relationship is wired, the notes master / theme2 / content-type overrides / `notesMasterIdLst` are present, XML-special characters are escaped, multi-line notes split into paragraphs, and whitespace-only notes are treated as empty.

`pnpm test` (full suite, 265 tests), `pnpm core typecheck`, and `biome check` on the changed files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Speaker notes are now exported with PowerPoint PPTX files and visible in the presentation's notes pane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->