### PR TITLE
fix(core): block pointer input on frozen slide previews

### DIFF
--- a/.changeset/thumbnail-pointer-shield.md
+++ b/.changeset/thumbnail-pointer-shield.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Block pointer input on frozen slide previews so interactive content no longer hijacks thumbnail and overview clicks.

--- a/packages/core/src/app/components/slide-canvas.tsx
+++ b/packages/core/src/app/components/slide-canvas.tsx
@@ -87,6 +87,7 @@ export function SlideCanvas({
           {children}
         </div>
       </div>
+      {freezeMotion && <div aria-hidden className="absolute inset-0 z-10" />}
     </div>
   );
 }


### PR DESCRIPTION
## What

Adds a pointer-blocking overlay to `SlideCanvas` when `freezeMotion` is set, so interactive slide content can no longer hijack clicks meant for the thumbnail and overview surfaces.

## Why

In frozen previews (thumbnails, overview), interactive content inside a slide could capture pointer events, swallowing clicks that should select/navigate the slide.

## Change

- Render an `aria-hidden` absolutely-positioned overlay (`z-10`) over the canvas only when `freezeMotion` is true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Pointer input is now blocked on frozen slide previews, preventing interactive content from hijacking thumbnail and overview clicks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->