### PR TITLE
feat(core): dual-window presenter mode

### DIFF
--- a/.changeset/presenter-mode-audience-window.md
+++ b/.changeset/presenter-mode-audience-window.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Presenter Mode now turns the current window into the speaker console and opens the slides in a separate audience window, which can be moved to a second screen and clicked to go fullscreen.

--- a/packages/core/src/app/app.tsx
+++ b/packages/core/src/app/app.tsx
@@ -6,6 +6,7 @@ import { AssetsPage } from './routes/assets';
 import { Home } from './routes/home';
 import { HomeShell } from './routes/home-shell';
 import { Presenter } from './routes/presenter';
+import { Screen } from './routes/screen';
 import { Slide } from './routes/slide';
 import { ThemeDetailPage, ThemesGalleryPage } from './routes/themes';
 
@@ -25,6 +26,7 @@ export function App() {
         )}
         <Route path="/s/:slideId" element={<Slide />} />
         <Route path="/s/:slideId/presenter" element={<Presenter />} />
+        <Route path="/s/:slideId/screen" element={<Screen />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
       <Toaster />

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -402,8 +402,11 @@ export function openPresenterWindow(slideId: string) {
   window.open(url, `open-slide-presenter-${slideId}`, 'popup,width=1280,height=800');
 }
 
-// Opens the audience slide window. Kept synchronous so the click still counts
-// as user activation — otherwise some browsers open a tab instead of a window.
+/**
+ * Opens the audience slide window. Kept synchronous (not behind an async
+ * function) so the click still counts as user activation — otherwise some
+ * browsers open a tab instead of a window.
+ */
 export function openAudienceWindow(slideId: string, startIndex = 0): Window | null {
   if (typeof window === 'undefined') return null;
   const url = `${import.meta.env.BASE_URL}s/${encodeURIComponent(slideId)}/screen?p=${startIndex + 1}`;

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -401,3 +401,11 @@ export function openPresenterWindow(slideId: string) {
   const url = `${import.meta.env.BASE_URL}s/${encodeURIComponent(slideId)}/presenter`;
   window.open(url, `open-slide-presenter-${slideId}`, 'popup,width=1280,height=800');
 }
+
+// Opens the audience slide window. Kept synchronous so the click still counts
+// as user activation — otherwise some browsers open a tab instead of a window.
+export function openAudienceWindow(slideId: string, startIndex = 0): Window | null {
+  if (typeof window === 'undefined') return null;
+  const url = `${import.meta.env.BASE_URL}s/${encodeURIComponent(slideId)}/screen?p=${startIndex + 1}`;
+  return window.open(url, `open-slide-screen-${slideId}`, 'popup,width=1280,height=800');
+}

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -14,6 +14,11 @@ import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
 import { type StepController, StepHost } from '../lib/step-context';
 import { useSlideModule } from '../lib/use-slide-module';
 
+/**
+ * The presenter console — a passive mirror of the audience window. Used both as
+ * the `/presenter` route and inline in the editor; pass `onExit` for the inline
+ * case so `Esc` returns to the editor.
+ */
 export function Presenter({
   slideId: slideIdProp,
   onExit,

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -14,8 +14,15 @@ import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
 import { type StepController, StepHost } from '../lib/step-context';
 import { useSlideModule } from '../lib/use-slide-module';
 
-export function Presenter() {
-  const { slideId = '' } = useParams();
+export function Presenter({
+  slideId: slideIdProp,
+  onExit,
+}: {
+  slideId?: string;
+  onExit?: () => void;
+} = {}) {
+  const params = useParams();
+  const slideId = slideIdProp ?? params.slideId ?? '';
   const { slide, error } = useSlideModule(slideId);
 
   // Presenter view is a passive mirror of the projection window. It only
@@ -76,11 +83,14 @@ export function Presenter() {
       } else if (e.key === 'w' || e.key === 'W') {
         e.preventDefault();
         toggleWhite();
+      } else if (e.key === 'Escape' && onExit) {
+        e.preventDefault();
+        onExit();
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [goNext, goPrev, toggleBlack, toggleWhite]);
+  }, [goNext, goPrev, toggleBlack, toggleWhite, onExit]);
 
   if (error) {
     return (

--- a/packages/core/src/app/routes/screen.tsx
+++ b/packages/core/src/app/routes/screen.tsx
@@ -4,8 +4,10 @@ import { format, useLocale } from '@/lib/use-locale';
 import { Player } from '../components/player';
 import { useSlideModule } from '../lib/use-slide-module';
 
-// The audience slide window. It hosts the Player with controls, so it is the
-// source of truth that broadcasts state and answers the presenter's commands.
+/**
+ * The audience slide window. It hosts the Player with controls, so it is the
+ * source of truth that broadcasts state and answers the presenter's commands.
+ */
 export function Screen() {
   const { slideId = '' } = useParams();
   const { slide, error } = useSlideModule(slideId);

--- a/packages/core/src/app/routes/screen.tsx
+++ b/packages/core/src/app/routes/screen.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { format, useLocale } from '@/lib/use-locale';
+import { Player } from '../components/player';
+import { useSlideModule } from '../lib/use-slide-module';
+
+// The audience slide window. It hosts the Player with controls, so it is the
+// source of truth that broadcasts state and answers the presenter's commands.
+export function Screen() {
+  const { slideId = '' } = useParams();
+  const { slide, error } = useSlideModule(slideId);
+  const [searchParams] = useSearchParams();
+  const [index, setIndex] = useState(() => {
+    const p = Number(searchParams.get('p') ?? '1') - 1;
+    return Number.isFinite(p) && p > 0 ? p : 0;
+  });
+  // Fullscreen needs a user gesture in this window; window.open doesn't carry
+  // one across, so the audience starts behind a one-click overlay.
+  const [showFullscreenPrompt, setShowFullscreenPrompt] = useState(true);
+  const t = useLocale();
+
+  if (error) {
+    return (
+      <div className="dark grid h-dvh place-items-center bg-background p-8 text-foreground">
+        <div className="max-w-md text-center">
+          <span className="eyebrow text-destructive/80">{t.common.loadFailed}</span>
+          <h2 className="mt-2 font-heading text-xl font-semibold">{t.common.failedToLoadSlide}</h2>
+          <pre className="mt-4 overflow-auto rounded-[6px] border border-border bg-card p-4 text-left text-[11.5px] whitespace-pre-wrap shadow-edge">
+            {error}
+          </pre>
+        </div>
+      </div>
+    );
+  }
+
+  if (!slide) {
+    return (
+      <div className="dark grid h-dvh place-items-center bg-background text-muted-foreground">
+        <div className="flex flex-col items-center gap-4">
+          <div className="relative h-px w-56 overflow-hidden bg-border">
+            <span
+              aria-hidden
+              className="line-loader-bar absolute inset-y-[-0.5px] left-0 w-1/4 bg-foreground"
+            />
+          </div>
+          <div className="text-[11.5px]">{format(t.presenter.loadingSlide, { slideId })}</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Player
+        pages={slide.default}
+        design={slide.design}
+        transition={slide.transition}
+        index={Math.max(0, Math.min(slide.default.length - 1, index))}
+        onIndexChange={setIndex}
+        onExit={() => window.close()}
+        controls
+        slideId={slideId}
+        fullscreen={false}
+      />
+      {showFullscreenPrompt && (
+        <button
+          type="button"
+          onClick={() => {
+            document.documentElement
+              .requestFullscreen?.()
+              .then(() => setShowFullscreenPrompt(false))
+              .catch(() => {});
+          }}
+          className="dark fixed inset-0 z-[9999] grid place-items-center bg-black/80 text-foreground"
+        >
+          <span className="font-heading text-2xl font-semibold tracking-tight">
+            {t.present.enterFullscreenAria}
+          </span>
+        </button>
+      )}
+    </>
+  );
+}

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -125,9 +125,11 @@ export function Slide() {
     [pageCount, setSearchParams],
   );
 
-  // Open the slides in a second window (audience) and turn this window into the
-  // presenter console. The audience window is the source of truth; this console
-  // mirrors it and drives navigation over the channel.
+  /**
+   * Open the slides in a second window (audience) and turn this window into the
+   * presenter console. The audience window is the source of truth; this console
+   * mirrors it and drives navigation over the channel.
+   */
   const startPresenterMode = useCallback(() => {
     if (!slideId) return;
     openAudienceWindow(slideId, index);

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -51,7 +51,7 @@ import { cn } from '@/lib/utils';
 import { NotesDrawer } from '../components/notes-drawer';
 import { OverviewGrid } from '../components/overview-grid';
 import { PdfProgressToast } from '../components/pdf-progress-toast';
-import { openPresenterWindow, Player } from '../components/player';
+import { openAudienceWindow, Player } from '../components/player';
 import { PptxProgressToast } from '../components/pptx-progress-toast';
 import { SlideCanvas } from '../components/slide-canvas';
 import { SlideTransitionLayer } from '../components/slide-transition-layer';
@@ -63,6 +63,7 @@ import { remapNotesSessionCacheAfterReorder } from '../lib/inspector/use-notes';
 import type { SlideModule } from '../lib/sdk';
 import { usePrefersReducedMotion } from '../lib/use-prefers-reduced-motion';
 import { useSlideModule } from '../lib/use-slide-module';
+import { Presenter } from './presenter';
 
 const { showSlideUi, showSlideBrowser, allowHtmlDownload } = config.build;
 
@@ -70,7 +71,7 @@ export function Slide() {
   const { slideId = '' } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const { slide, error } = useSlideModule(slideId);
-  const [playMode, setPlayMode] = useState<'window' | 'fullscreen' | null>(null);
+  const [playMode, setPlayMode] = useState<'window' | 'fullscreen' | 'presenter' | null>(null);
   const [exporting, setExporting] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
   const linkCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -123,6 +124,15 @@ export function Slide() {
     },
     [pageCount, setSearchParams],
   );
+
+  // Open the slides in a second window (audience) and turn this window into the
+  // presenter console. The audience window is the source of truth; this console
+  // mirrors it and drives navigation over the channel.
+  const startPresenterMode = useCallback(() => {
+    if (!slideId) return;
+    openAudienceWindow(slideId, index);
+    setPlayMode('presenter');
+  }, [slideId, index]);
 
   const reorderPage = useCallback(
     async (from: number, to: number) => {
@@ -271,15 +281,14 @@ export function Slide() {
       } else if (e.key === 'Enter') {
         setPlayMode('window');
       } else if (e.key === 'p' || e.key === 'P') {
-        if (slideId) openPresenterWindow(slideId);
-        setPlayMode('window');
+        startPresenterMode();
       } else if (import.meta.env.DEV && (e.key === 'd' || e.key === 'D')) {
         setDesignOpen((v) => !v);
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [index, goTo, playMode, slideId, overviewOpen]);
+  }, [index, goTo, playMode, overviewOpen, startPresenterMode]);
 
   if (error) {
     return (
@@ -356,6 +365,10 @@ export function Slide() {
         allowExit={false}
       />
     );
+  }
+
+  if (playMode === 'presenter') {
+    return <Presenter slideId={slideId} onExit={() => setPlayMode(null)} />;
   }
 
   if (playMode) {
@@ -645,12 +658,7 @@ export function Slide() {
                         {t.slide.presentFullscreen}
                         <DropdownMenuShortcut>F</DropdownMenuShortcut>
                       </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onSelect={() => {
-                          if (slideId) openPresenterWindow(slideId);
-                          setPlayMode('window');
-                        }}
-                      >
+                      <DropdownMenuItem onSelect={startPresenterMode}>
                         <MonitorSpeaker />
                         {t.slide.presentPresenter}
                         <DropdownMenuShortcut>P</DropdownMenuShortcut>


### PR DESCRIPTION
## Why

When presenting with a projector / second screen, the usual move is to push the **extra** window onto the projector and keep your working window on your laptop.

With the current Presenter Mode this is backwards: the **slides stay in your main window** and the popup is the speaker console. To get the slides onto the projector you have to drag your *main* browser window across — which exposes your tabs, address bar, the editor UI, and anything else on that screen to the audience. The clean popup, which is the natural thing to drag over, is the one you have to keep on your laptop.

This PR swaps the two so the ergonomics match how people actually present:

- the **clean slide window** is the popup → drag *that* to the projector;
- your **main window becomes the speaker console** and stays on your laptop.

## What

- The **current window** becomes the **speaker console** (notes, next slide, timer, navigation).
- The **slides** open in a separate **audience window**, which hosts the `Player` with controls and is the source of truth that broadcasts state over the presenter channel.

## How it works

- `openAudienceWindow()` opens the audience window synchronously (kept out of an `async` wrapper so the click still counts as user activation — otherwise some browsers open a tab instead of a window).
- New `/s/:slideId/screen` route renders the audience `Player`.
- `Presenter` is now embeddable (accepts `slideId` / `onExit`); the current window renders it inline and `Esc` returns to the editor.
- The audience window starts behind a one-click overlay that enters fullscreen — fullscreen requires a user gesture in that window, which `window.open` does not carry across.

## Notes / trade-offs

- **No permissions, works in any browser.** Cross-screen auto-placement (Window Management API) was intentionally left out to avoid a permission prompt — the presenter drags the audience window to the projector, then clicks to go fullscreen.
- Tested manually (Dia + Chrome): role swap, channel sync, click-to-fullscreen, `Esc` to return.
- `P` and the "Presenter Mode" menu item both trigger the new flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)