### PR TITLE
feat(core): add inspector quick activation gestures

### DIFF
--- a/.changeset/quick-inspector-gestures.md
+++ b/.changeset/quick-inspector-gestures.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Let the inspector open while holding Command on macOS or Control elsewhere, and select elements by double-clicking them.

--- a/.changeset/quick-inspector-gestures.md
+++ b/.changeset/quick-inspector-gestures.md
@@ -2,4 +2,4 @@
 "@open-slide/core": patch
 ---
 
-Let the inspector open while holding Command on macOS or Control elsewhere, and select elements by double-clicking them.
+Let the inspector open while holding Command on macOS or Control elsewhere, and select elements by double-clicking them without selecting slide text.

--- a/packages/core/src/app/components/inspector/inspect-overlay.tsx
+++ b/packages/core/src/app/components/inspector/inspect-overlay.tsx
@@ -16,17 +16,13 @@ const FRAME_MORPH_MS = 180;
 const LAYOUT_TRACK_MS = PANEL_TRANSITION_MS + FRAME_MORPH_MS;
 
 export function InspectOverlay() {
-  const { active, slideId, selected, setSelected, cancel, openCrop } = useInspector();
+  const { active, activate, slideId, selected, setSelected, cancel, openCrop } = useInspector();
   const overlayRef = useRef<HTMLDivElement>(null);
   const [hover, setHover] = useState<Highlight | null>(null);
 
   useEffect(() => {
-    if (!active) {
-      setHover(null);
-      return;
-    }
-
     const onKey = (e: KeyboardEvent) => {
+      if (!active) return;
       if (e.key === 'Escape') {
         e.preventDefault();
         e.stopPropagation();
@@ -35,6 +31,7 @@ export function InspectOverlay() {
     };
 
     const onMove = (e: PointerEvent) => {
+      if (!active) return;
       if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) {
         return setHover(null);
       }
@@ -46,6 +43,7 @@ export function InspectOverlay() {
     };
 
     const onClick = (e: MouseEvent) => {
+      if (!active) return;
       if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) return;
       const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
       if (!el) return;
@@ -53,6 +51,7 @@ export function InspectOverlay() {
       if (!hit) return;
       e.preventDefault();
       e.stopPropagation();
+      activate();
       setSelected({ line: hit.line, column: hit.column, anchor: hit.anchor });
       setHover({ hit });
     };
@@ -63,11 +62,12 @@ export function InspectOverlay() {
       if (!el) return;
       const hit = findSlideSource(el, slideId, { hostOnly: true });
       if (!hit) return;
-      if (!(hit.anchor instanceof HTMLImageElement)) return;
       e.preventDefault();
       e.stopPropagation();
+      if (!active) activate();
       setSelected({ line: hit.line, column: hit.column, anchor: hit.anchor });
-      openCrop(hit.anchor);
+      setHover({ hit });
+      if (active && hit.anchor instanceof HTMLImageElement) openCrop(hit.anchor);
     };
 
     window.addEventListener('pointermove', onMove, true);
@@ -80,7 +80,11 @@ export function InspectOverlay() {
       window.removeEventListener('dblclick', onDblClick, true);
       window.removeEventListener('keydown', onKey, true);
     };
-  }, [active, slideId, setSelected, cancel, openCrop]);
+  }, [active, activate, slideId, setSelected, cancel, openCrop]);
+
+  useEffect(() => {
+    if (!active) setHover(null);
+  }, [active]);
 
   const hoverAnchor = hover?.hit.anchor.isConnected ? hover.hit.anchor : null;
   const selectedAnchor = selected?.anchor.isConnected ? selected.anchor : null;

--- a/packages/core/src/app/components/inspector/inspect-overlay.tsx
+++ b/packages/core/src/app/components/inspector/inspect-overlay.tsx
@@ -35,22 +35,27 @@ export function InspectOverlay() {
       if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) {
         return setHover(null);
       }
-      const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
-      if (!el) return setHover(null);
-      const hit = findSlideSource(el, slideId, { hostOnly: true });
+      const hit = findInspectorHitAtPoint(e.clientX, e.clientY, slideId);
       if (!hit) return setHover(null);
       setHover({ hit });
+    };
+
+    const onMouseDown = (e: MouseEvent) => {
+      if (!active && e.detail < 2) return;
+      if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) return;
+      const hit = findInspectorHitAtPoint(e.clientX, e.clientY, slideId);
+      if (!hit) return;
+      e.preventDefault();
     };
 
     const onClick = (e: MouseEvent) => {
       if (!active) return;
       if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) return;
-      const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
-      if (!el) return;
-      const hit = findSlideSource(el, slideId, { hostOnly: true });
+      const hit = findInspectorHitAtPoint(e.clientX, e.clientY, slideId);
       if (!hit) return;
       e.preventDefault();
       e.stopPropagation();
+      clearTextSelection();
       activate();
       setSelected({ line: hit.line, column: hit.column, anchor: hit.anchor });
       setHover({ hit });
@@ -58,12 +63,11 @@ export function InspectOverlay() {
 
     const onDblClick = (e: MouseEvent) => {
       if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) return;
-      const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
-      if (!el) return;
-      const hit = findSlideSource(el, slideId, { hostOnly: true });
+      const hit = findInspectorHitAtPoint(e.clientX, e.clientY, slideId);
       if (!hit) return;
       e.preventDefault();
       e.stopPropagation();
+      clearTextSelection();
       if (!active) activate();
       setSelected({ line: hit.line, column: hit.column, anchor: hit.anchor });
       setHover({ hit });
@@ -71,11 +75,13 @@ export function InspectOverlay() {
     };
 
     window.addEventListener('pointermove', onMove, true);
+    window.addEventListener('mousedown', onMouseDown, true);
     window.addEventListener('click', onClick, true);
     window.addEventListener('dblclick', onDblClick, true);
     window.addEventListener('keydown', onKey, true);
     return () => {
       window.removeEventListener('pointermove', onMove, true);
+      window.removeEventListener('mousedown', onMouseDown, true);
       window.removeEventListener('click', onClick, true);
       window.removeEventListener('dblclick', onDblClick, true);
       window.removeEventListener('keydown', onKey, true);
@@ -321,6 +327,17 @@ function pickElement(x: number, y: number): HTMLElement | null {
     return el;
   }
   return null;
+}
+
+function findInspectorHitAtPoint(x: number, y: number, slideId: string): SlideSourceHit | null {
+  const el = pickInspectorTarget(pickElement(x, y));
+  if (!el) return null;
+  return findSlideSource(el, slideId, { hostOnly: true });
+}
+
+function clearTextSelection() {
+  const selection = window.getSelection();
+  if (selection && !selection.isCollapsed) selection.removeAllRanges();
 }
 
 const INLINE_TEXT_TAGS = new Set([

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -244,6 +244,7 @@ function replayDomTextRangeStyles(el: HTMLElement, html: string, ops: TextRangeS
 type InspectorCtx = {
   slideId: string;
   active: boolean;
+  activate: () => void;
   toggle: () => void;
   cancel: () => void;
   comments: SlideComment[];
@@ -284,11 +285,14 @@ export function InspectorProvider({
   pageIndex: number;
   children: ReactNode;
 }) {
-  const [active, setActive] = useState(false);
+  const [manualActive, setManualActive] = useState(false);
+  const [heldActive, setHeldActive] = useState(false);
   const [selected, setSelected] = useState<SelectedTarget | null>(null);
   const { comments, error, refetch, add, remove } = useComments(slideId);
   const { applyEdit, applyEdits } = useEditor(slideId);
   const history = useHistory();
+  const active = manualActive || heldActive;
+  const manualActiveRef = useRef(manualActive);
 
   const pendingRef = useRef<Map<string, Bucket>>(new Map());
   const instanceCounterRef = useRef(0);
@@ -915,15 +919,24 @@ export function InspectorProvider({
     return () => observer.disconnect();
   }, [selected]);
 
-  const toggle = useCallback(() => {
-    setActive((a) => {
-      if (a) setSelected(null);
-      return !a;
-    });
+  const activate = useCallback(() => {
+    manualActiveRef.current = true;
+    setManualActive(true);
   }, []);
 
+  const toggle = useCallback(() => {
+    setManualActive((a) => {
+      if (a && !heldActive) setSelected(null);
+      const next = !a;
+      manualActiveRef.current = next;
+      return next;
+    });
+  }, [heldActive]);
+
   const cancel = useCallback(() => {
-    setActive(false);
+    manualActiveRef.current = false;
+    setManualActive(false);
+    setHeldActive(false);
     setSelected(null);
   }, []);
 
@@ -947,6 +960,39 @@ export function InspectorProvider({
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [toggle]);
+
+  useEffect(() => {
+    if (import.meta.env.PROD) return;
+
+    const isApplePlatform = /Mac|iPhone|iPad|iPod/.test(
+      `${navigator.platform} ${navigator.userAgent}`,
+    );
+    const holdKey = isApplePlatform ? 'Meta' : 'Control';
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.repeat) return;
+      if (e.target instanceof HTMLElement && e.target.matches('input, textarea')) return;
+      if (e.key !== holdKey) return;
+      setHeldActive(true);
+    };
+
+    const releaseHeld = (e?: KeyboardEvent) => {
+      if (e && e.key !== holdKey) return;
+      setHeldActive(false);
+      if (!manualActiveRef.current) setSelected(null);
+    };
+
+    const onBlur = () => releaseHeld();
+
+    window.addEventListener('keydown', onKeyDown, true);
+    window.addEventListener('keyup', releaseHeld, true);
+    window.addEventListener('blur', onBlur, true);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, true);
+      window.removeEventListener('keyup', releaseHeld, true);
+      window.removeEventListener('blur', onBlur, true);
+    };
+  }, []);
 
   const openCrop = useCallback((anchor: HTMLImageElement) => {
     const loc = anchor.dataset.slideLoc;
@@ -973,6 +1019,7 @@ export function InspectorProvider({
     () => ({
       slideId,
       active,
+      activate,
       toggle,
       cancel,
       comments,
@@ -995,6 +1042,7 @@ export function InspectorProvider({
     [
       slideId,
       active,
+      activate,
       toggle,
       cancel,
       comments,


### PR DESCRIPTION
## Summary

Adds quick inspector activation while holding Command on macOS or Control elsewhere, and lets double-click selection activate the inspector flow before editing.

## Impact

This makes the inspector easier to invoke during local slide development without keeping it manually toggled on.

## Validation

- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inspector now opens while holding **Command** on macOS or **Control** on other platforms.
  * You can select elements by **double-clicking** within the inspector, without triggering unwanted slide text selection.
* **Bug Fixes**
  * Improved interaction handling so inspector opening/selection behaves more consistently when active or inactive.
  * Updated hit detection and selection clearing for smoother overlay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->