### PR TITLE
fix(core): keep shared inspector comments page-specific

### DIFF
--- a/.changeset/inspector-shared-comment-guard.md
+++ b/.changeset/inspector-shared-comment-guard.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Prevent inspector comments from being written into shared component definitions.

--- a/packages/core/src/app/components/inspector/comment-widget.tsx
+++ b/packages/core/src/app/components/inspector/comment-widget.tsx
@@ -60,7 +60,7 @@ export function CommentWidget() {
                     </div>
                     <button
                       type="button"
-                      onClick={() => remove(c.id)}
+                      onClick={() => remove(c.id, c.sourceFile)}
                       className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-red-600"
                       title={t.inspector.commentDeleteAria}
                     >

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -11,6 +11,7 @@ import {
   X,
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
 import { Field, NumberField, Section } from '@/components/panel/panel-fields';
 import { PANEL_TRANSITION_MS, PanelShell, useAnimatedOpen } from '@/components/panel/panel-shell';
 import { Button } from '@/components/ui/button';
@@ -28,7 +29,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Toggle } from '@/components/ui/toggle';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { findSlideSource } from '@/lib/inspector/fiber';
+import { findCommentSource, findSlideSource } from '@/lib/inspector/fiber';
 import type { EditOp } from '@/lib/inspector/use-editor';
 import { useAgentSocketConnected } from '@/lib/use-agent-socket';
 import { useLocale } from '@/lib/use-locale';
@@ -260,7 +261,7 @@ export function InspectorPanel() {
           </div>
         </>
       }
-      footer={<CommentsSection selected={pinSelected} onAdd={add} />}
+      footer={<CommentsSection slideId={slideId} selected={pinSelected} onAdd={add} />}
     >
       {pinSnapshot.text !== null && (
         <>
@@ -875,11 +876,13 @@ function AgentWatchingBadge() {
 }
 
 function CommentsSection({
+  slideId,
   selected,
   onAdd,
 }: {
-  selected: { line: number; column: number };
-  onAdd: (line: number, column: number, text: string) => Promise<void>;
+  slideId: string;
+  selected: SelectedTarget;
+  onAdd: (line: number, column: number, text: string, sourceFile?: string) => Promise<void>;
 }) {
   const [draft, setDraft] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -905,8 +908,11 @@ function CommentsSection({
     if (!trimmed) return;
     setSubmitting(true);
     try {
-      await onAdd(selected.line, selected.column, trimmed);
+      const target = findCommentSource(selected.anchor, slideId) ?? selected;
+      await onAdd(target.line, target.column, trimmed, target.sourceFile);
       setDraft('');
+    } catch (err) {
+      toast.error(String((err as Error).message ?? err));
     } finally {
       setSubmitting(false);
     }

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -21,6 +21,7 @@ import { ImageCropDialog, type ImageCropRect } from './image-crop-dialog';
 export type SelectedTarget = {
   line: number;
   column: number;
+  sourceFile?: string;
   anchor: HTMLElement;
 };
 
@@ -250,8 +251,8 @@ type InspectorCtx = {
   comments: SlideComment[];
   error: string | null;
   refetch: () => Promise<void>;
-  add: (line: number, column: number, text: string) => Promise<void>;
-  remove: (id: string) => Promise<void>;
+  add: (line: number, column: number, text: string, sourceFile?: string) => Promise<void>;
+  remove: (id: string, sourceFile?: string) => Promise<void>;
   selected: SelectedTarget | null;
   setSelected: (s: SelectedTarget | null) => void;
   applyEdit: (line: number, column: number, ops: EditOp[]) => Promise<void>;

--- a/packages/core/src/app/lib/inspector/fiber.test.ts
+++ b/packages/core/src/app/lib/inspector/fiber.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
-import { findSlideSource } from './fiber.ts';
+import { findCommentSource, findSlideSource } from './fiber.ts';
 
 class FakeHTMLElement {
   dataset: Record<string, string> = {};
@@ -37,6 +37,7 @@ function makeFiber(opts: {
   line?: number;
   column?: number;
   host?: boolean;
+  stateNode?: unknown;
   parent?: FakeFiber | null;
 }): FakeFiber {
   const source: DebugSource | undefined =
@@ -45,7 +46,7 @@ function makeFiber(opts: {
       : undefined;
   return {
     return: opts.parent ?? null,
-    stateNode: opts.host ? new FakeHTMLElement() : undefined,
+    stateNode: opts.host ? (opts.stateNode ?? new FakeHTMLElement()) : undefined,
     _debugSource: source,
   };
 }
@@ -61,10 +62,12 @@ afterAll(() => {
 describe('findSlideSource primary path', () => {
   it('reads line:column from data-slide-loc', () => {
     const el = makeEl({ slideLoc: '42:7' });
+    el.dataset.slideFile = '01-Cover.tsx';
     const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
     expect(hit).not.toBeNull();
     expect(hit?.line).toBe(42);
     expect(hit?.column).toBe(7);
+    expect(hit?.sourceFile).toBe('01-Cover.tsx');
     expect(hit?.anchor).toBe(el as unknown as HTMLElement);
   });
 });
@@ -150,5 +153,92 @@ describe('findSlideSource fallback', () => {
     expect(hit).not.toBeNull();
     expect(hit?.line).toBe(99);
     expect(hit?.column).toBe(3);
+  });
+});
+
+describe('findCommentSource', () => {
+  it('prefers the component call-site source over the host definition source', () => {
+    const component = makeFiber({
+      fileName: '/repo/slides/cover/index.tsx',
+      line: 20,
+      column: 4,
+      host: false,
+    });
+    const host = makeFiber({
+      fileName: '/repo/slides/cover/index.tsx',
+      line: 3,
+      column: 2,
+      host: true,
+      parent: component,
+    });
+    const el = makeEl({ slideLoc: '3:2', fiber: host });
+    const hit = findCommentSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(20);
+    expect(hit?.column).toBe(4);
+    expect(hit?.sourceFile).toBe('index.tsx');
+  });
+
+  it('prefers component call-sites in non-index slide files under custom slide roots', () => {
+    const component = makeFiber({
+      fileName: '/repo/decks/cover/01-Cover.tsx',
+      line: 20,
+      column: 4,
+      host: false,
+    });
+    const host = makeFiber({
+      fileName: '/repo/decks/cover/shared.tsx',
+      line: 3,
+      column: 2,
+      host: true,
+      parent: component,
+    });
+    const el = makeEl({ slideLoc: '3:2', fiber: host });
+    el.dataset.slideFile = 'shared.tsx';
+    const hit = findCommentSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(20);
+    expect(hit?.column).toBe(4);
+    expect(hit?.sourceFile).toBe('01-Cover.tsx');
+  });
+
+  it('walks nested shared component chains to the page-specific call-site', () => {
+    const pageCallSite = makeFiber({
+      fileName: '/repo/decks/cover/01-Cover.tsx',
+      line: 20,
+      column: 4,
+      host: false,
+    });
+    const sharedCallSite = makeFiber({
+      fileName: '/repo/decks/cover/Card.tsx',
+      line: 8,
+      column: 6,
+      host: false,
+      parent: pageCallSite,
+    });
+    const host = makeFiber({
+      fileName: '/repo/decks/cover/Header.tsx',
+      line: 3,
+      column: 2,
+      host: true,
+      parent: sharedCallSite,
+    });
+    const el = makeEl({ slideLoc: '3:2', fiber: host });
+    el.dataset.slideFile = 'Header.tsx';
+    const hit = findCommentSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(20);
+    expect(hit?.column).toBe(4);
+    expect(hit?.sourceFile).toBe('01-Cover.tsx');
+  });
+
+  it('falls back to data-slide-loc for direct host elements', () => {
+    const el = makeEl({ slideLoc: '42:7' });
+    el.dataset.slideFile = '01-Cover.tsx';
+    const hit = findCommentSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(42);
+    expect(hit?.column).toBe(7);
+    expect(hit?.sourceFile).toBe('01-Cover.tsx');
   });
 });

--- a/packages/core/src/app/lib/inspector/fiber.ts
+++ b/packages/core/src/app/lib/inspector/fiber.ts
@@ -1,6 +1,7 @@
 export type SlideSourceHit = {
   line: number;
   column: number;
+  sourceFile?: string;
   anchor: HTMLElement;
 };
 
@@ -34,6 +35,67 @@ function normalizeDebugFileName(fileName: string): string {
   return fileName.split(/[?#]/)[0].replace(/\\/g, '/');
 }
 
+function slideSourceFileName(fileName: string, slideId: string): string | null {
+  const normalized = normalizeDebugFileName(fileName);
+  const needle = `/${slideId}/`;
+  const idx = normalized.lastIndexOf(needle);
+  if (idx === -1) return null;
+  const sourceFile = normalized.slice(idx + needle.length);
+  if (!sourceFile.endsWith('.tsx')) return null;
+  if (sourceFile.endsWith('.d.ts') || sourceFile.endsWith('.test.tsx')) return null;
+  return sourceFile;
+}
+
+function findTaggedSource(el: HTMLElement): SlideSourceHit | null {
+  const tagged = el.closest<HTMLElement>('[data-slide-loc]');
+  if (!tagged) return null;
+  const loc = tagged.dataset.slideLoc;
+  if (!loc) return null;
+  const idx = loc.indexOf(':');
+  if (idx <= 0) return null;
+  const line = Number(loc.slice(0, idx));
+  const column = Number(loc.slice(idx + 1));
+  if (!Number.isFinite(line) || !Number.isFinite(column)) return null;
+  return { line, column, sourceFile: tagged.dataset.slideFile, anchor: tagged };
+}
+
+function findFiberSource(
+  el: HTMLElement,
+  slideId: string,
+  opts?: FindSlideSourceOptions & { componentOnly?: boolean; outermost?: boolean },
+): SlideSourceHit | null {
+  let fiber = getFiber(el);
+  let anchor: HTMLElement = el;
+  let hit: SlideSourceHit | null = null;
+  while (fiber) {
+    const src = getSource(fiber);
+    const isHost = fiber.stateNode instanceof HTMLElement;
+    const sourceFile = src?.fileName ? slideSourceFileName(src.fileName, slideId) : null;
+    const lineNumber = src?.lineNumber;
+    const columnNumber = src?.columnNumber ?? 0;
+    if (
+      sourceFile &&
+      lineNumber &&
+      (!opts?.hostOnly || isHost) &&
+      (!opts?.componentOnly || !isHost)
+    ) {
+      const nextHit = {
+        line: lineNumber,
+        column: columnNumber,
+        sourceFile,
+        anchor: isHost ? (fiber.stateNode as HTMLElement) : anchor,
+      };
+      if (!opts?.outermost) return nextHit;
+      hit = nextHit;
+    }
+    if (isHost) {
+      anchor = fiber.stateNode as HTMLElement;
+    }
+    fiber = fiber.return;
+  }
+  return hit;
+}
+
 export function findSlideSource(
   el: HTMLElement,
   slideId: string,
@@ -41,45 +103,17 @@ export function findSlideSource(
 ): SlideSourceHit | null {
   // Primary path: the `data-slide-loc` attribute injected by the
   // loc-tags Vite plugin. Immune to HMR-stale fiber state.
-  const tagged = el.closest<HTMLElement>('[data-slide-loc]');
-  if (tagged) {
-    const loc = tagged.dataset.slideLoc;
-    if (loc) {
-      const idx = loc.indexOf(':');
-      if (idx > 0) {
-        const line = Number(loc.slice(0, idx));
-        const column = Number(loc.slice(idx + 1));
-        if (Number.isFinite(line) && Number.isFinite(column)) {
-          return { line, column, anchor: tagged };
-        }
-      }
-    }
-  }
+  const tagged = findTaggedSource(el);
+  if (tagged) return tagged;
 
   // Fallback for JSX rendered from imported component files (which the
   // loc-tags plugin doesn't transform).
-  const needle = `/slides/${slideId}/index.tsx`;
-  let fiber = getFiber(el);
-  let anchor: HTMLElement = el;
-  while (fiber) {
-    const src = getSource(fiber);
-    const isHost = fiber.stateNode instanceof HTMLElement;
-    if (
-      src?.fileName &&
-      normalizeDebugFileName(src.fileName).endsWith(needle) &&
-      src.lineNumber &&
-      (!opts?.hostOnly || isHost)
-    ) {
-      return {
-        line: src.lineNumber,
-        column: src.columnNumber ?? 0,
-        anchor: isHost ? (fiber.stateNode as HTMLElement) : anchor,
-      };
-    }
-    if (isHost) {
-      anchor = fiber.stateNode as HTMLElement;
-    }
-    fiber = fiber.return;
-  }
-  return null;
+  return findFiberSource(el, slideId, opts);
+}
+
+export function findCommentSource(el: HTMLElement, slideId: string): SlideSourceHit | null {
+  return (
+    findFiberSource(el, slideId, { componentOnly: true, outermost: true }) ??
+    findSlideSource(el, slideId)
+  );
 }

--- a/packages/core/src/app/lib/inspector/use-comments.ts
+++ b/packages/core/src/app/lib/inspector/use-comments.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 export type SlideComment = {
   id: string;
+  sourceFile?: string;
   line: number;
   ts: string;
   note: string;
@@ -31,11 +32,11 @@ export function useComments(slideId: string) {
   }, [slideId]);
 
   const add = useCallback(
-    async (line: number, column: number, text: string) => {
+    async (line: number, column: number, text: string, sourceFile?: string) => {
       const res = await fetch('/__comments/add', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ slideId, line, column, text }),
+        body: JSON.stringify({ slideId, sourceFile, line, column, text }),
       });
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string };
@@ -47,10 +48,10 @@ export function useComments(slideId: string) {
   );
 
   const remove = useCallback(
-    async (id: string) => {
-      const res = await fetch(`/__comments/${id}?slideId=${encodeURIComponent(slideId)}`, {
-        method: 'DELETE',
-      });
+    async (id: string, sourceFile?: string) => {
+      const params = new URLSearchParams({ slideId });
+      if (sourceFile) params.set('sourceFile', sourceFile);
+      const res = await fetch(`/__comments/${id}?${params.toString()}`, { method: 'DELETE' });
       if (!res.ok) throw new Error(`DELETE /__comments/${id} → ${res.status}`);
       await refetch();
     },

--- a/packages/core/src/editing/edit-ops.test.ts
+++ b/packages/core/src/editing/edit-ops.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyEdit, safeAssetIdentifier } from './edit-ops.ts';
+import { applyEdit, probeElementSharing, safeAssetIdentifier } from './edit-ops.ts';
 
 describe('applyEdit / set-style', () => {
   // Every JSX opening tag in these synthetic sources sits at column 0;
@@ -956,6 +956,87 @@ describe('applyEdit / combined ops', () => {
     const r = applyEdit(src, 1, 0, []);
     if (!r.ok) throw new Error('expected ok');
     expect(r.source).toBe(src);
+  });
+});
+
+describe('probeElementSharing', () => {
+  it('reports a direct page element as a single instance', () => {
+    const src = [
+      'const Page = () => <h2>Hello</h2>;',
+      'export default [Page] satisfies Page[];',
+      '',
+    ].join('\n');
+    expect(probeElementSharing(src, 1, 19)).toEqual({ instances: 1, viaMap: false });
+  });
+
+  it('counts reused component call sites that share one JSX definition', () => {
+    const src = [
+      'const PageShell = ({ children, heading }: { children: React.ReactNode; heading?: string }) => (',
+      '  <section>',
+      '    <h2>{heading}</h2>',
+      '    <div>{children}</div>',
+      '  </section>',
+      ');',
+      'const PageA = () => <PageShell heading="Intro">content A</PageShell>;',
+      'const PageB = () => <PageShell heading="Details">content B</PageShell>;',
+      'export default [PageA, PageB] satisfies Page[];',
+      '',
+    ].join('\n');
+    expect(probeElementSharing(src, 3, 4)).toEqual({ instances: 2, viaMap: false });
+  });
+
+  it('counts repeated default-export page references', () => {
+    const src = [
+      'const Page = () => (',
+      '  <h2>Hello</h2>',
+      ');',
+      'export default [Page, Page] satisfies Page[];',
+      '',
+    ].join('\n');
+    expect(probeElementSharing(src, 2, 2)).toEqual({ instances: 2, viaMap: false });
+  });
+
+  it('counts shared components rendered by a repeated page', () => {
+    const src = [
+      'const Shared = () => (',
+      '  <h2>Hello</h2>',
+      ');',
+      'const Page = () => (',
+      '  <Shared />',
+      ');',
+      'export default [Page, Page] satisfies Page[];',
+      '',
+    ].join('\n');
+    expect(probeElementSharing(src, 2, 2)).toEqual({ instances: 2, viaMap: false });
+  });
+
+  it('flags elements rendered inside map callbacks', () => {
+    const src = [
+      'const Page = () => (',
+      '  <section>',
+      '    {["A", "B"].map((label) => <span>{label}</span>)}',
+      '  </section>',
+      ');',
+      'export default [Page] satisfies Page[];',
+      '',
+    ].join('\n');
+    expect(probeElementSharing(src, 3, 33)).toEqual({ instances: 1, viaMap: true });
+  });
+
+  it('counts shared components rendered from map callbacks', () => {
+    const src = [
+      'const Shared = () => (',
+      '  <h2>Hello</h2>',
+      ');',
+      'const Page = () => (',
+      '  <section>',
+      '    {["A", "B"].map((label) => <Shared key={label} />)}',
+      '  </section>',
+      ');',
+      'export default [Page] satisfies Page[];',
+      '',
+    ].join('\n');
+    expect(probeElementSharing(src, 2, 2)).toEqual({ instances: 2, viaMap: false });
   });
 });
 

--- a/packages/core/src/editing/edit-ops.ts
+++ b/packages/core/src/editing/edit-ops.ts
@@ -1162,6 +1162,68 @@ function planReplacePlaceholder(
   return { importSplice, elementSplice: spliceRange(element, replacement) };
 }
 
+export type ElementSharing = { instances: number; viaMap: boolean };
+
+function countDefaultExportArrayRefs(ast: t.File, name: string): number {
+  for (const decl of ast.program.body) {
+    if (!t.isExportDefaultDeclaration(decl)) continue;
+    let expr: t.Node = decl.declaration;
+    while (t.isTSSatisfiesExpression(expr) || t.isTSAsExpression(expr)) {
+      expr = expr.expression;
+    }
+    if (!t.isArrayExpression(expr)) return 0;
+    let count = 0;
+    for (const el of expr.elements) {
+      if (el && t.isIdentifier(el) && el.name === name) count++;
+    }
+    return count;
+  }
+  return 0;
+}
+
+function mapRenderMultiplier(ast: t.Node, target: t.Node): number {
+  const map = findEnclosingMapCallback(ast, target);
+  if (!map) return 1;
+  const elements = resolveArrayLiteralElements(ast, map.arrayArg);
+  return elements ? Math.max(1, elements.length) : 2;
+}
+
+function componentRenderCount(ast: t.File, name: string, seen = new Set<string>()): number {
+  if (seen.has(name)) return 1;
+  const nextSeen = new Set(seen);
+  nextSeen.add(name);
+  let count = countDefaultExportArrayRefs(ast, name);
+  walkJsx(ast, (n) => {
+    if (!t.isJSXElement(n)) return;
+    const elName = n.openingElement.name;
+    if (!t.isJSXIdentifier(elName) || elName.name !== name) return;
+    const parent = findEnclosingComponent(ast, n);
+    const parentCount =
+      parent && parent.name !== name ? componentRenderCount(ast, parent.name, nextSeen) : 1;
+    count += parentCount * mapRenderMultiplier(ast, n);
+  });
+  return count;
+}
+
+export function probeElementSharing(
+  source: string,
+  line: number,
+  column: number,
+): ElementSharing | null {
+  const ast = parseSource(source);
+  if (!ast) return null;
+  const element = findInnermostJsxElement(ast, line, column);
+  if (!element) return null;
+  const viaMap = findEnclosingMapCallback(ast, element) !== null;
+  const component = findEnclosingComponent(ast, element);
+  let instances = 1;
+  if (component) {
+    const count = componentRenderCount(ast, component.name);
+    if (count > 1) instances = count;
+  }
+  return { instances, viaMap };
+}
+
 export function applyEdit(
   source: string,
   line: number,

--- a/packages/core/src/vite/loc-tags-plugin.test.ts
+++ b/packages/core/src/vite/loc-tags-plugin.test.ts
@@ -137,6 +137,12 @@ describe('locTagsPlugin', () => {
     expectTaggedTransform('/repo/slides/cover/index.tsx');
   });
 
+  it('adds the slide-relative source file to plugin-injected tags', () => {
+    const out = transformWithLocTags('/repo/slides/cover/01-Cover.tsx');
+    if (out === null) throw new Error('expected tagged transform result');
+    expect(out.code).toContain('data-slide-file="01-Cover.tsx"');
+  });
+
   it('tags shared slide source files', () => {
     expectTaggedTransform('/repo/slides/cover/shared.tsx');
   });

--- a/packages/core/src/vite/loc-tags-plugin.ts
+++ b/packages/core/src/vite/loc-tags-plugin.ts
@@ -24,7 +24,7 @@ function alreadyTagged(opening: t.JSXOpeningElement): boolean {
   );
 }
 
-export function injectLocTags(code: string): string | null {
+export function injectLocTags(code: string, sourceFile?: string): string | null {
   let ast: t.File;
   try {
     ast = babelParse(code, {
@@ -42,9 +42,10 @@ export function injectLocTags(code: string): string | null {
     const opening = node.openingElement;
     const name = opening.name;
     if (!isTaggableJsxName(name) || alreadyTagged(opening)) return;
+    const sourceAttr = sourceFile ? ` data-slide-file="${sourceFile}"` : '';
     insertions.push({
       offset: name.end ?? 0,
-      text: ` data-slide-loc="${node.loc.start.line}:${node.loc.start.column}"`,
+      text: ` data-slide-loc="${node.loc.start.line}:${node.loc.start.column}"${sourceAttr}`,
     });
   });
 
@@ -85,7 +86,10 @@ export function locTagsPlugin(opts: LocTagsPluginOptions): Plugin {
     enforce: 'pre',
     transform(code, id) {
       if (!isSlideSourceFile(id, slidesRoot)) return null;
-      const next = injectLocTags(code);
+      const filePath = id.split(/[?#]/)[0].replace(/\\/g, '/');
+      const rel = filePath.slice(slidesRoot.length + 1).split('/');
+      const sourceFile = rel.slice(1).join('/');
+      const next = injectLocTags(code, sourceFile);
       if (next === null) return null;
       return { code: next, map: null };
     },

--- a/packages/core/src/vite/routes/comments.ts
+++ b/packages/core/src/vite/routes/comments.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import path from 'node:path';
 import type { ViteDevServer } from 'vite';
 import {
   b64urlEncode,
@@ -8,8 +9,9 @@ import {
   offsetToLine,
   parseMarkers,
 } from '../../editing/comments.ts';
+import { probeElementSharing } from '../../editing/edit-ops.ts';
 import { validateMutationRequest } from '../../http/request-guard.ts';
-import { type ApiContext, json, readBody, resolveSlideEntryPath } from './context.ts';
+import { type ApiContext, json, readBody, resolveSlideSourcePath } from './context.ts';
 
 // GET    /__comments        list markers for ?slideId=…
 // POST   /__comments/add    add marker { slideId, line, column?, text, hint? }
@@ -17,11 +19,49 @@ import { type ApiContext, json, readBody, resolveSlideEntryPath } from './contex
 
 type AddCommentBody = {
   slideId?: string;
+  sourceFile?: string;
   line?: number;
   column?: number;
   text?: string;
   hint?: string;
 };
+
+async function listSlideSourceFiles(
+  ctx: ApiContext,
+  slideId: string,
+): Promise<Array<{ file: string; sourceFile: string }>> {
+  const root = resolveSlideSourcePath(ctx, slideId, 'index.tsx');
+  if (!root) return [];
+  const slideRoot = path.dirname(root);
+  const out: Array<{ file: string; sourceFile: string }> = [];
+  async function visit(dir: string) {
+    let entries: Array<import('node:fs').Dirent>;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await visit(full);
+      } else if (
+        entry.isFile() &&
+        entry.name.endsWith('.tsx') &&
+        !entry.name.endsWith('.d.ts') &&
+        !entry.name.endsWith('.test.tsx')
+      ) {
+        out.push({
+          file: full,
+          sourceFile: path.relative(slideRoot, full).replace(/\\/g, '/'),
+        });
+      }
+    }
+  }
+  await visit(slideRoot);
+  out.sort((a, b) => (a.sourceFile === 'index.tsx' ? -1 : b.sourceFile === 'index.tsx' ? 1 : 0));
+  return out;
+}
 
 export function registerCommentRoutes(server: ViteDevServer, ctx: ApiContext): void {
   server.middlewares.use('/__comments', async (req, res, next) => {
@@ -31,15 +71,24 @@ export function registerCommentRoutes(server: ViteDevServer, ctx: ApiContext): v
     try {
       if (method === 'GET' && url.pathname === '/') {
         const slideId = url.searchParams.get('slideId') ?? '';
-        const file = resolveSlideEntryPath(ctx, slideId);
-        if (!file) return json(res, 400, { error: 'invalid slideId' });
-        let source: string;
-        try {
-          source = await fs.readFile(file, 'utf8');
-        } catch {
+        const files = await listSlideSourceFiles(ctx, slideId);
+        if (files.length === 0) {
+          if (!resolveSlideSourcePath(ctx, slideId, 'index.tsx')) {
+            return json(res, 400, { error: 'invalid slideId' });
+          }
           return json(res, 404, { error: 'slide not found' });
         }
-        return json(res, 200, { comments: parseMarkers(source) });
+        const comments = [];
+        for (const { file, sourceFile } of files) {
+          let source: string;
+          try {
+            source = await fs.readFile(file, 'utf8');
+          } catch {
+            continue;
+          }
+          comments.push(...parseMarkers(source).map((c) => ({ ...c, sourceFile })));
+        }
+        return json(res, 200, { comments });
       }
 
       if (method === 'POST' && url.pathname === '/add') {
@@ -49,7 +98,7 @@ export function registerCommentRoutes(server: ViteDevServer, ctx: ApiContext): v
         }
         const body = (await readBody(req)) as AddCommentBody;
         const slideId = body.slideId ?? '';
-        const file = resolveSlideEntryPath(ctx, slideId);
+        const file = resolveSlideSourcePath(ctx, slideId, body.sourceFile);
         if (!file) return json(res, 400, { error: 'invalid slideId' });
         if (!body.line || body.line < 1) return json(res, 400, { error: 'invalid line' });
         if (!body.text || typeof body.text !== 'string') {
@@ -61,6 +110,21 @@ export function registerCommentRoutes(server: ViteDevServer, ctx: ApiContext): v
           source = await fs.readFile(file, 'utf8');
         } catch {
           return json(res, 404, { error: 'slide not found' });
+        }
+
+        const sharing = probeElementSharing(source, body.line, body.column ?? 0);
+        if (sharing && (sharing.instances > 1 || sharing.viaMap)) {
+          const reasons = [];
+          if (sharing.instances > 1) {
+            reasons.push(`${sharing.instances} rendered instances share this JSX definition`);
+          }
+          if (sharing.viaMap) reasons.push('the element is rendered from a map body');
+          return json(res, 422, {
+            error:
+              `Cannot add this inspector comment because ${reasons.join(' and ')}. ` +
+              'Putting a marker here would make the target page ambiguous. ' +
+              'Move the comment to page-specific JSX, or split the shared element first.',
+          });
         }
 
         const plan = findInsertion(source, body.line, body.column);
@@ -91,23 +155,32 @@ export function registerCommentRoutes(server: ViteDevServer, ctx: ApiContext): v
         const id = url.pathname.slice(1);
         if (!/^c-[a-f0-9]+$/.test(id)) return json(res, 400, { error: 'invalid id' });
         const slideId = url.searchParams.get('slideId') ?? '';
-        const file = resolveSlideEntryPath(ctx, slideId);
-        if (!file) return json(res, 400, { error: 'invalid slideId' });
-
-        let source: string;
-        try {
-          source = await fs.readFile(file, 'utf8');
-        } catch {
-          return json(res, 404, { error: 'slide not found' });
+        const sourceFile = url.searchParams.get('sourceFile') ?? undefined;
+        const files = sourceFile
+          ? [{ file: resolveSlideSourcePath(ctx, slideId, sourceFile), sourceFile }]
+          : await listSlideSourceFiles(ctx, slideId);
+        if (files.length === 0 || files.some((f) => !f.file)) {
+          return json(res, 400, { error: 'invalid slideId' });
         }
 
-        const lines = source.split('\n');
         const idRe = markerDeleteRegex(id);
-        const hit = lines.findIndex((l) => idRe.test(l));
-        if (hit === -1) return json(res, 404, { error: 'marker not found' });
-        lines.splice(hit, 1);
-        await fs.writeFile(file, lines.join('\n'), 'utf8');
-        return json(res, 200, { ok: true });
+        for (const item of files) {
+          const file = item.file;
+          if (!file) continue;
+          let source: string;
+          try {
+            source = await fs.readFile(file, 'utf8');
+          } catch {
+            continue;
+          }
+          const lines = source.split('\n');
+          const hit = lines.findIndex((l) => idRe.test(l));
+          if (hit === -1) continue;
+          lines.splice(hit, 1);
+          await fs.writeFile(file, lines.join('\n'), 'utf8');
+          return json(res, 200, { ok: true });
+        }
+        return json(res, 404, { error: 'marker not found' });
       }
 
       next();

--- a/packages/core/src/vite/routes/context.test.ts
+++ b/packages/core/src/vite/routes/context.test.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { makeContext, resolveSlideSourcePath } from './context.ts';
+
+describe('resolveSlideSourcePath', () => {
+  const ctx = makeContext({
+    userCwd: '/repo',
+    coreVersion: '0.0.0',
+  });
+
+  it('resolves index.tsx by default', () => {
+    expect(resolveSlideSourcePath(ctx, 'deck')).toBe(path.resolve('/repo/slides/deck/index.tsx'));
+  });
+
+  it('resolves nested slide-local TSX files', () => {
+    expect(resolveSlideSourcePath(ctx, 'deck', 'components/Card.tsx')).toBe(
+      path.resolve('/repo/slides/deck/components/Card.tsx'),
+    );
+  });
+
+  it('rejects traversal and non-source files', () => {
+    expect(resolveSlideSourcePath(ctx, 'deck', '../other/index.tsx')).toBeNull();
+    expect(resolveSlideSourcePath(ctx, 'deck', '/tmp/file.tsx')).toBeNull();
+    expect(resolveSlideSourcePath(ctx, 'deck', 'index.test.tsx')).toBeNull();
+    expect(resolveSlideSourcePath(ctx, 'deck', 'notes.ts')).toBeNull();
+  });
+});

--- a/packages/core/src/vite/routes/context.ts
+++ b/packages/core/src/vite/routes/context.ts
@@ -74,3 +74,19 @@ export function resolveSlidePath(
 export function resolveSlideEntryPath(ctx: ApiContext, slideId: string): string | null {
   return resolveSlidePath(ctx.userCwd, ctx.slidesDir, slideId);
 }
+
+export function resolveSlideSourcePath(
+  ctx: ApiContext,
+  slideId: string,
+  sourceFile?: string,
+): string | null {
+  if (!sourceFile) return resolveSlideEntryPath(ctx, slideId);
+  if (!SLIDE_ID_RE.test(slideId)) return null;
+  if (path.isAbsolute(sourceFile) || sourceFile.split(/[\\/]/).includes('..')) return null;
+  if (!sourceFile.endsWith('.tsx')) return null;
+  if (sourceFile.endsWith('.d.ts') || sourceFile.endsWith('.test.tsx')) return null;
+  const slideRoot = path.resolve(ctx.slidesRoot, slideId);
+  const full = path.resolve(slideRoot, sourceFile);
+  if (!full.startsWith(slideRoot + path.sep) && full !== slideRoot) return null;
+  return full;
+}


### PR DESCRIPTION
## Summary

- Resolve inspector comment targets through the outermost slide-local component call-site before falling back to host source locations, so comments on shared components land near the page-specific invocation.
- Carry slide-relative `sourceFile` metadata through loc-tags and comment APIs so multi-file slides list, add, and delete markers in the correct TSX file.
- Add guardrails for repeated/shared JSX and map-rendered elements so ambiguous comment markers are rejected instead of written into shared definitions.

Fixes #237

## Test plan

- `pnpm check` (passes with one pre-existing Biome warning in `packages/core/src/http/request-guard.ts`)
- `pnpm typecheck`
- `pnpm test`
- `git diff --check`
