### PR TITLE
docs: clarify agent-agnostic skills setup (Codex, Cursor, …)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cd my-slide
 pnpm dev
 ```
 
-The scaffolded workspace ships with agent skills preconfigured for Claude Code. From there you drive the deck through your agent — or edit `slides/<id>/index.tsx` directly. See [CLAUDE.md](CLAUDE.md) for the hard rules.
+The scaffolded workspace ships with agent skills preconfigured for any coding agent — an `AGENTS.md` guide plus skills in the standard `.agents/skills/` location (read by Codex, Cursor, and others), mirrored to `.claude/skills/` for Claude Code. From there you drive the deck through your agent — or edit `slides/<id>/index.tsx` directly. See [AGENTS.md](AGENTS.md) for the hard rules.
 
 ## Repo layout
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @open-slide/cli
 
-Scaffold a workspace for [open-slide](https://github.com/1weiho/open-slide) — a React-based slide framework with Claude Code skills preconfigured.
+Scaffold a workspace for [open-slide](https://github.com/1weiho/open-slide) — a React-based slide framework with agent skills preconfigured for Claude Code, Codex, Cursor, and any agent that follows the `AGENTS.md` / `.agents/skills/` convention.
 
 ## Usage
 
@@ -16,8 +16,8 @@ This creates a workspace containing:
 - `slides/getting-started/` — a starter slide you can edit or delete.
 - `package.json` — depends on `@open-slide/core`, which provides the runtime (home page, slide viewer, fullscreen mode) and the `open-slide` CLI.
 - `open-slide.config.ts` — optional typed config (slidesDir, port).
-- `.claude/skills/` and `.agents/skills/` — Claude Code skills (`create-slide`, `apply-comments`, …).
-- `CLAUDE.md` — agent guide for authoring slides.
+- `.agents/skills/` — agent skills (`create-slide`, `apply-comments`, …) in the standard location read by Codex, Cursor, and others, mirrored to `.claude/skills/` for Claude Code.
+- `AGENTS.md` (aliased as `CLAUDE.md`) — agent guide for authoring slides.
 
 You won't see any Vite, React, or tsconfig files in the workspace. They live inside `@open-slide/core` and you never touch them.
 
@@ -35,4 +35,4 @@ You won't see any Vite, React, or tsconfig files in the workspace. They live ins
 
 Inside the scaffolded workspace, slides live under `slides/<kebab-case-id>/index.tsx` and default-export an array of `Page` components. Each page renders into a fixed 1920×1080 canvas; the framework handles scaling.
 
-Ask Claude Code to "make slides about X" and the `create-slide` skill will take it from there.
+Ask your coding agent to "make slides about X" and the `create-slide` skill will take it from there.


### PR DESCRIPTION
## What

The README and CLI README describe the scaffold as "preconfigured for Claude Code", but the generated workspace already ships:

- `AGENTS.md` (with `CLAUDE.md` as an alias)
- skills under the standard `.agents/skills/` location, mirrored to `.claude/skills/`

So Codex, Cursor, and other agents that follow the `AGENTS.md` / `.agents/skills/` convention already work today. The docs just don't say so, which is probably why getting started feels Claude-only (see #150).

## Change

Align the wording in `README.md` and `packages/cli/README.md` with what the scaffold actually produces. No code or behavior changes, no new skills.

Refs #150.

## Testing

Docs-only. No changeset added (no `packages/core` / `packages/cli` runtime change). Biome's `check` doesn't include Markdown, so `pnpm check` / `typecheck` / `test` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to describe agent skills for multiple coding agents.
  * Clarified the main skills location and noted how they are mirrored for Claude Code.
  * Reworded guidance to refer to “your coding agent” instead of a Claude Code-specific workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->