### PR TITLE
fix(core): preserve valid imports when reverting assets

### DIFF
--- a/.changeset/fix-revert-asset-imports.md
+++ b/.changeset/fix-revert-asset-imports.md
@@ -2,4 +2,4 @@
 "@open-slide/core": patch
 ---
 
-Fix asset reversion when side-effect or namespace imports of @open-slide/core are present.
+Fixes asset reversion when side-effect or namespace imports of @open-slide/core are present.

--- a/.changeset/fix-revert-asset-imports.md
+++ b/.changeset/fix-revert-asset-imports.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Fix asset reversion when side-effect or namespace imports of @open-slide/core are present.

--- a/packages/core/src/editing/revert-asset.test.ts
+++ b/packages/core/src/editing/revert-asset.test.ts
@@ -232,4 +232,34 @@ describe('applyRevertAsset', () => {
     if (r.ok) throw new Error('expected failure');
     expect(r.error).toMatch(/outside <img/);
   });
+
+  it('adds a separate value import when the @open-slide/core import is a side-effect import', () => {
+    const src = [
+      "import '@open-slide/core';",
+      "import hero from './assets/hero.png';",
+      'export default [() => (',
+      "  <img src={hero} alt='x' style={{ objectFit: 'cover' }} />",
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyRevertAsset(src, './assets/hero.png');
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("import { ImagePlaceholder } from '@open-slide/core';");
+    expect(r.source).toContain("import '@open-slide/core';");
+  });
+
+  it('adds a separate value import when the @open-slide/core import is a namespace import', () => {
+    const src = [
+      "import * as OpenSlide from '@open-slide/core';",
+      "import hero from './assets/hero.png';",
+      'export default [() => (',
+      "  <img src={hero} alt='x' style={{ objectFit: 'cover' }} />",
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyRevertAsset(src, './assets/hero.png');
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("import { ImagePlaceholder } from '@open-slide/core';");
+    expect(r.source).toContain("import * as OpenSlide from '@open-slide/core';");
+  });
 });

--- a/packages/core/src/editing/revert-asset.ts
+++ b/packages/core/src/editing/revert-asset.ts
@@ -74,7 +74,12 @@ function planEnsureImagePlaceholderImport(ast: t.File): Splice | null {
       const specIsTypeOnly = readKind(spec) || declIsTypeOnly;
       if (!specIsTypeOnly) return null;
     }
-    if (!declIsTypeOnly && !valueImport) valueImport = imp;
+    if (!declIsTypeOnly && !valueImport) {
+      const lastSpec = imp.node.specifiers[imp.node.specifiers.length - 1];
+      if (lastSpec && (t.isImportSpecifier(lastSpec) || t.isImportDefaultSpecifier(lastSpec))) {
+        valueImport = imp;
+      }
+    }
   }
   if (valueImport) {
     const node = valueImport.node;
@@ -87,8 +92,6 @@ function planEnsureImagePlaceholderImport(ast: t.File): Splice | null {
       const insertAt = lastSpec.end ?? 0;
       return { from: insertAt, to: insertAt, text: ', { ImagePlaceholder }' };
     }
-    const insertAt = (node.source.start ?? 0) - 'from '.length;
-    return { from: insertAt, to: insertAt, text: '{ ImagePlaceholder } ' };
   }
   return {
     from: 0,


### PR DESCRIPTION
**Summary**
    Fixes an issue in `@open-slide/core` where reverting an asset (`<img src={asset} />` back to `<ImagePlaceholder />`) corrupted the source file if `@open-slide/core` was already imported via side-effect (`import '@open-slide/core';`) or namespace import (`import * as Core from '@open-slide/core';`).

**Changes**
    - Updated `planEnsureImagePlaceholderImport` in `packages/core/src/editing/revert-asset.ts` to only select existing value imports if they end with named or default specifiers where `,
  ImagePlaceholder` can be safely appended.
    - Added fallback handling to insert a standalone `import { ImagePlaceholder } from '@open-slide/core';` statement when only side-effect or namespace imports are present.
    - Added unit tests covering asset reversion with side-effect and namespace imports.
    - Added patch changeset for `@open-slide/core`.

 **Validation**
    - Ran `pnpm test` (all 275 tests passing).
    - Ran `pnpm typecheck` and `pnpm check` (clean typecheck and formatting).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset reversion to correctly add the `ImagePlaceholder` import when `@open-slide/core` is brought in via side-effect or namespace imports.
  * Improved import handling to avoid disrupting the existing import shape during reversion.
* **Tests**
  * Added new test coverage for asset reversion with side-effect (`import '`@open-slide/core`'`) and namespace (`import * as ...`) import patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->