### PR TITLE
fix(core): skip slide folders with non-ASCII ids during discovery

### DIFF
--- a/.changeset/skip-non-ascii-slide-ids.md
+++ b/.changeset/skip-non-ascii-slide-ids.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Skip slide folders whose id isn't ASCII-safe (e.g. CJK folder names) instead of listing slides that then fail to move into folders or be edited; warn once per ignored folder.

--- a/packages/core/src/vite/open-slide-plugin.test.ts
+++ b/packages/core/src/vite/open-slide-plugin.test.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { generateSlidesModule } from './open-slide-plugin.ts';
+
+async function withSlidesRoot<T>(fn: (root: string) => Promise<T>): Promise<T> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'open-slide-test-'));
+  try {
+    return await fn(root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+async function writeSlide(root: string, id: string): Promise<string> {
+  await fs.mkdir(path.join(root, id), { recursive: true });
+  const entry = path.join(root, id, 'index.tsx');
+  await fs.writeFile(
+    entry,
+    `export const meta = { title: '${id}' };\nexport default [];\n`,
+    'utf8',
+  );
+  return entry;
+}
+
+describe('generateSlidesModule', () => {
+  it('keeps slides whose id is ASCII-safe and reports none ignored', async () => {
+    await withSlidesRoot(async (root) => {
+      const files = [await writeSlide(root, 'cover'), await writeSlide(root, 'intro_2')].sort();
+
+      const { code, ignored } = await generateSlidesModule(files, root, false);
+
+      expect(ignored).toEqual([]);
+      expect(code).toContain('export const slideIds = ["cover","intro_2"];');
+    });
+  });
+
+  it('excludes folders whose id is not ASCII-safe and reports them as ignored', async () => {
+    await withSlidesRoot(async (root) => {
+      const files = [await writeSlide(root, 'cover'), await writeSlide(root, '推薦系統')].sort();
+
+      const { code, ignored } = await generateSlidesModule(files, root, false);
+
+      expect(ignored).toEqual(['推薦系統']);
+      expect(code).toContain('export const slideIds = ["cover"];');
+      expect(code).not.toContain('推薦系統');
+    });
+  });
+});

--- a/packages/core/src/vite/open-slide-plugin.ts
+++ b/packages/core/src/vite/open-slide-plugin.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import fg from 'fast-glob';
 import { loadConfigFromFile, normalizePath, type Plugin, type ViteDevServer } from 'vite';
 import type { OpenSlideConfig } from '../config.ts';
+import { SLIDE_ID_RE } from '../editing/slide-ops.ts';
 
 export type { OpenSlideConfig };
 
@@ -114,12 +115,16 @@ function parseCreatedAtMs(iso: string | null): number | null {
   return Number.isFinite(ms) ? ms : null;
 }
 
-async function generateSlidesModule(
+// Deduped across repeated virtual-module regenerations so dev HMR doesn't
+// re-log the same ignored folder on every slide change.
+const warnedInvalidSlideIds = new Set<string>();
+
+export async function generateSlidesModule(
   files: string[],
   slidesRoot: string,
   isDev: boolean,
-): Promise<string> {
-  const entries = await Promise.all(
+): Promise<{ code: string; ignored: string[] }> {
+  const scanned = await Promise.all(
     files.map(async (abs) => {
       const id = toId(abs, slidesRoot);
       const importPath = isDev ? `@fs/${normalizePath(abs).replace(/^\/+/, '')}` : abs;
@@ -127,6 +132,13 @@ async function generateSlidesModule(
       return { id, importPath, theme: meta.theme, createdAt: parseCreatedAtMs(meta.createdAt) };
     }),
   );
+
+  // Discovery globs every `slides/*/index.*`, but a slide id is used in URLs,
+  // filesystem paths, and the editing routes — all guarded by SLIDE_ID_RE. Drop
+  // folders with an unusable id instead of listing them as slides that then fail
+  // every folder/edit action; `load` warns about each ignored folder.
+  const entries = scanned.filter((e) => SLIDE_ID_RE.test(e.id));
+  const ignored = scanned.filter((e) => !SLIDE_ID_RE.test(e.id)).map((e) => e.id);
 
   const ids = JSON.stringify(entries.map((e) => e.id).sort());
   const themesMap: Record<string, string> = {};
@@ -161,7 +173,7 @@ if (import.meta.hot) {
     })
     .join('\n');
 
-  return `// virtual:open-slide/slides — generated
+  const code = `// virtual:open-slide/slides — generated
 export const slideIds = ${ids};
 export const slideThemes = ${themesJson};
 export const slideCreatedAt = ${createdAtJson};
@@ -174,6 +186,7 @@ ${cases}
   }
 }
 `;
+  return { code, ignored };
 }
 
 export function openSlidePlugin(opts: OpenSlidePluginOptions): Plugin {
@@ -227,7 +240,15 @@ export function openSlidePlugin(opts: OpenSlidePluginOptions): Plugin {
     async load(id) {
       if (id === resolved(SLIDES_VMOD)) {
         const files = await findSlides(userCwd, slidesDir);
-        return await generateSlidesModule(files, slidesRoot, isDev);
+        const { code, ignored } = await generateSlidesModule(files, slidesRoot, isDev);
+        for (const slideId of ignored) {
+          if (warnedInvalidSlideIds.has(slideId)) continue;
+          warnedInvalidSlideIds.add(slideId);
+          this.warn(
+            `Ignoring slide folder "${slideId}": slide ids must match ${SLIDE_ID_RE} (lowercase/uppercase letters, digits, "-", "_"). Rename the folder under "${slidesDir}/" to a kebab-case id so it appears in the browser and can be moved into folders.`,
+          );
+        }
+        return code;
       }
       if (id === resolved(CONFIG_VMOD)) {
         const userBuild = config.build ?? {};


### PR DESCRIPTION
## Problem

A slide whose directory name contains non-ASCII characters (e.g. a CJK folder name like `推薦系統`) shows up in the sidebar but can't be moved into a folder — the assign request fails with `400 invalid slideId`. The same guard also blocks rename, duplicate, delete, and asset listing for that slide. Full write-up and reproduction in #269.

## Root cause

Discovery and the mutation routes disagree on what a valid slide id is:

- `findSlides` globs `slides/*/index.*` and `toId` uses the directory name verbatim (`packages/core/src/vite/open-slide-plugin.ts`), so any folder — including a non-ASCII one — becomes a `slideId` in `virtual:open-slide/slides`.
- The editing/folder routes validate ids against `SLIDE_ID_RE = /^[a-z0-9_-]+$/i` (`packages/core/src/editing/slide-ops.ts`), enforced at e.g. `vite/routes/folders.ts` (assign), `vite/routes/slides.ts`, `vite/routes/assets.ts`.

So the slide is discoverable but every operation on it is rejected.

## Change (option A from #269)

Make discovery use the same rule as the routes:

- Filter out folders whose id fails `SLIDE_ID_RE` when generating `virtual:open-slide/slides`, so the sidebar no longer lists slides that can't be operated on.
- Emit a one-time `this.warn` per ignored folder, pointing the author to rename it to a kebab-case id.

A slide's display title (`meta.title`) is unaffected and can still be non-ASCII — only the folder **id** must be ASCII, which matches the documented `slides/<kebab-case-id>/` contract.

This is the conservative option A from #269. Happy to switch to first-class non-ASCII id support (option B) instead if you'd prefer — flagging the direction here rather than assuming.

## Testing

- New unit tests in `packages/core/src/vite/open-slide-plugin.test.ts` cover the all-ASCII case (nothing ignored) and the mixed case (non-ASCII folder excluded + reported).
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, and `pnpm test` (275 passing) are all green locally.

Refs #269


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slide folders with non-ASCII-safe IDs are now excluded from the slide browser instead of causing later failures.
  * Added a single warning per ignored slide folder to reduce repeated noise.
* **Tests**
  * Added coverage for slide listing behavior with valid and invalid folder IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->