### PR TITLE
Fix editing/export correctness, dev-server hardening, and landing a11y

### DIFF
--- a/.changeset/fix-editing-export-devserver.md
+++ b/.changeset/fix-editing-export-devserver.md
@@ -1,0 +1,15 @@
+---
+"@open-slide/core": patch
+"@open-slide/cli": patch
+---
+
+Fix editing/export correctness and harden the dev server:
+
+- Edit meta.title via a Babel AST walk so a non-string title value no longer produces a duplicate `title` key.
+- Reject overlapping/nested splices in applyEdit/applyRevertAsset, and reuse a single import per asset path within an edit.
+- Prevent prototype pollution in the design merge (`PUT /__design`).
+- Fix Windows note-edit focus loss (Vite-normalized HMR path) and a hung asset upload on oversized/aborted bodies; bound the note index.
+- Serialize and atomically write the folders manifest.
+- Export full-bleed slides as a picture shape sized to the exact slide extents for reliable, undistorted Google Slides import.
+- Count emoji icon length by grapheme, and count only renderable pages for export progress.
+- CLI: always materialize `CLAUDE.md` from `AGENTS.md` so a Windows checkout no longer scaffolds a placeholder file.

--- a/apps/web/app/(home)/landing.css
+++ b/apps/web/app/(home)/landing.css
@@ -253,3 +253,15 @@ html.light .os-landing .vercel-oss-badge {
   outline-offset: 3px;
   border-radius: 6px;
 }
+
+/* Respect prefers-reduced-motion: stop the looping marquee/caret animations and
+   collapse the rest to their end state instead of running keyframes. */
+@media (prefers-reduced-motion: reduce) {
+  .os-landing *,
+  .os-landing *::before,
+  .os-landing *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -67,14 +67,9 @@ export const metadata: Metadata = {
     url: siteUrl,
     siteName: appName,
     locale: 'en_US',
-    images: [
-      {
-        url: '/opengraph-image.png',
-        width: 1200,
-        height: 630,
-        alt: `${appName} — React-first slide framework for AI agents`,
-      },
-    ],
+    // og:image (and its dimensions) are emitted automatically from the
+    // app/opengraph-image.png file convention; alt comes from the adjacent
+    // opengraph-image.alt.txt. Declaring images here too would duplicate the tag.
   },
   twitter: {
     card: 'summary_large_image',
@@ -94,10 +89,8 @@ export const metadata: Metadata = {
       'max-video-preview': -1,
     },
   },
-  icons: {
-    icon: '/favicon.ico',
-    shortcut: '/favicon.ico',
-  },
+  // favicon link is emitted automatically from the app/favicon.ico file
+  // convention; declaring icons here too would duplicate the <link rel="icon">.
 };
 
 export const viewport: Viewport = {

--- a/apps/web/app/opengraph-image.alt.txt
+++ b/apps/web/app/opengraph-image.alt.txt
@@ -1,0 +1,1 @@
+open-slide — React-first slide framework for AI agents

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,9 +1,12 @@
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
+import { promisify } from 'node:util';
 import type { MetadataRoute } from 'next';
 import { siteUrl } from '@/lib/shared';
 import { source } from '@/lib/source';
+
+const execFileAsync = promisify(execFile);
 
 const buildDate = new Date();
 const cwd = process.cwd();
@@ -18,32 +21,34 @@ function resolvePagePath(slugs: readonly string[]): string | null {
   return candidates.find((c) => existsSync(c)) ?? null;
 }
 
-function gitMtime(file: string): Date {
+async function gitMtime(file: string): Promise<Date> {
   try {
-    const stdout = execFileSync('git', ['log', '-1', '--format=%cI', '--', file], {
+    const { stdout } = await execFileAsync('git', ['log', '-1', '--format=%cI', '--', file], {
       encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-    if (!stdout) return buildDate;
-    const d = new Date(stdout);
+    });
+    const trimmed = stdout.trim();
+    if (!trimmed) return buildDate;
+    const d = new Date(trimmed);
     return Number.isNaN(d.getTime()) ? buildDate : d;
   } catch {
     return buildDate;
   }
 }
 
-const homeLastModified = existsSync(homePath) ? gitMtime(homePath) : buildDate;
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const homeLastModified = existsSync(homePath) ? await gitMtime(homePath) : buildDate;
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  const docs: MetadataRoute.Sitemap = source.getPages().map((page) => {
+  const docsPromises = source.getPages().map(async (page) => {
     const filePath = resolvePagePath(page.slugs);
     return {
       url: `${siteUrl}${page.url}`,
-      lastModified: filePath ? gitMtime(filePath) : buildDate,
-      changeFrequency: 'weekly',
+      lastModified: filePath ? await gitMtime(filePath) : buildDate,
+      changeFrequency: 'weekly' as const,
       priority: 0.7,
     };
   });
+
+  const docs = await Promise.all(docsPromises);
 
   return [
     {

--- a/apps/web/components/landing/anatomy.tsx
+++ b/apps/web/components/landing/anatomy.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useReducedMotion } from 'motion/react';
 import { useEffect, useState } from 'react';
 
 type Variant = {
@@ -57,10 +58,13 @@ const CHANGING_LINES = new Set([2, 3, 4]);
 
 export function Anatomy() {
   const [i, setI] = useState(0);
+  const reducedMotion = useReducedMotion();
   useEffect(() => {
+    // Don't auto-cycle when the user prefers reduced motion.
+    if (reducedMotion) return;
     const id = setInterval(() => setI((v) => (v + 1) % variants.length), CYCLE_MS);
     return () => clearInterval(id);
-  }, []);
+  }, [reducedMotion]);
 
   const v = variants[i];
   const lines = buildCode(v);

--- a/apps/web/components/landing/how-it-works.tsx
+++ b/apps/web/components/landing/how-it-works.tsx
@@ -48,7 +48,9 @@ const steps: Step[] = [
   },
 ];
 
-const SLASH_COMMAND = /\/[a-z][a-z-]*/g;
+// Only highlight a slash command at the start of the line or after whitespace,
+// so a path segment like the "/cli" in "@open-slide/cli" isn't mistaken for one.
+const SLASH_COMMAND = /(?<=^|\s)\/[a-z][a-z-]*/g;
 
 function renderLine(line: string) {
   const parts: ReactNode[] = [];

--- a/apps/web/components/landing/inline-slide-player.tsx
+++ b/apps/web/components/landing/inline-slide-player.tsx
@@ -59,6 +59,13 @@ export function InlineSlidePlayer({ index, onIndexChange }: Props) {
   return (
     <div
       ref={rootRef}
+      role="group"
+      // The slide player is a focusable, keyboard-navigable widget: without
+      // tabIndex the div can never receive focus and the onKeyDown handler
+      // (arrow/space/page navigation) is dead. role is also required for
+      // aria-roledescription to be valid.
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: intentional — focusable keyboard navigation surface
+      tabIndex={0}
       onKeyDown={onKeyDown}
       aria-roledescription="slide player"
       aria-label={`Slide ${index + 1} of ${count}`}

--- a/apps/web/components/landing/theme-toggle.tsx
+++ b/apps/web/components/landing/theme-toggle.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTheme } from 'next-themes';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type Option = {
   value: 'system' | 'light' | 'dark';
@@ -18,12 +18,42 @@ const OPTIONS: Option[] = [
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+  const btnRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
   const current = mounted ? (theme ?? 'system') : 'system';
+  const currentIndex = Math.max(
+    0,
+    OPTIONS.findIndex((o) => o.value === current),
+  );
+
+  // Roving tabindex: only the selected radio is in the tab order; arrow keys
+  // move selection (and focus) through the group with wraparound, per the ARIA
+  // radiogroup pattern.
+  const moveTo = (index: number) => {
+    const next = (index + OPTIONS.length) % OPTIONS.length;
+    setTheme(OPTIONS[next].value);
+    btnRefs.current[next]?.focus();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent, index: number) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      moveTo(index + 1);
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      moveTo(index - 1);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      moveTo(0);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      moveTo(OPTIONS.length - 1);
+    }
+  };
 
   return (
     <div
@@ -31,17 +61,22 @@ export function ThemeToggle() {
       aria-label="Theme"
       className="inline-flex items-center gap-0.5 h-8 p-0.5 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)]/60"
     >
-      {OPTIONS.map((opt) => {
+      {OPTIONS.map((opt, index) => {
         const active = current === opt.value;
         return (
           <button
             key={opt.value}
+            ref={(el) => {
+              btnRefs.current[index] = el;
+            }}
             type="button"
             role="radio"
             aria-checked={active}
             aria-label={opt.label}
             title={opt.label}
+            tabIndex={index === currentIndex ? 0 : -1}
             onClick={() => setTheme(opt.value)}
+            onKeyDown={(e) => onKeyDown(e, index)}
             className={
               'inline-flex items-center justify-center h-7 w-7 rounded-full transition-colors ' +
               (active

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -56,7 +56,12 @@ async function linkOrCopy(relSrc: string, dst: string): Promise<void> {
 
 async function materializeTemplateLinks(target: string): Promise<void> {
   const claudeMd = join(target, 'CLAUDE.md');
-  if (!existsSync(claudeMd) && existsSync(join(target, 'AGENTS.md'))) {
+  // Always re-materialize from AGENTS.md when present (don't gate on existence):
+  // cp() already copied the template's CLAUDE.md, which on a Windows checkout
+  // (core.symlinks=false) is the symlink's text placeholder "AGENTS.md" rather
+  // than a real file, so an existence check would skip the repair. linkOrCopy
+  // rm's the destination first, so this is safe and idempotent on every platform.
+  if (existsSync(join(target, 'AGENTS.md'))) {
     await linkOrCopy('AGENTS.md', claudeMd);
   }
 

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -39,7 +39,10 @@ export async function exportSlideAsImagePptx(
   const pages = slide.default ?? [];
   if (pages.length === 0) return;
 
-  const total = pages.length;
+  // Count only renderable pages: falsy holes are skipped during capture, so
+  // counting them here would leave the progress `current` short of `total`.
+  const total = pages.filter(Boolean).length;
+  if (total === 0) return;
   onProgress?.({ phase: 'processing', current: 0, total, percent: 0 });
 
   const container = document.createElement('div');

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -243,7 +243,14 @@ function slideLayoutRelsXml(): string {
 }
 
 function slideXml(): string {
-  return `${XML_DECL}<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:pic><p:nvPicPr><p:cNvPr id="2" name="Slide"/><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId2"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="${EMU_W}" cy="${EMU_H}"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic></p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>`;
+  // Full-bleed image as a slide-filling picture shape sized to the exact slide
+  // EMU extents. The captured PNG is exactly 16:9 (1920×1080 ×2) and the frame is
+  // exactly 16:9, so stretch/fillRect maps it 1:1 with no distortion. A picture
+  // shape (rather than a <p:bg> background fill) is the most portable full-bleed
+  // construct across PowerPoint, Keynote, LibreOffice, and especially Google
+  // Slides, which imports per-slide backgrounds inconsistently. noChangeAspect="0"
+  // leaves the aspect unlocked so no importer letterboxes the frame.
+  return `${XML_DECL}<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:pic><p:nvPicPr><p:cNvPr id="2" name="Slide"/><p:cNvPicPr><a:picLocks noChangeAspect="0"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId2"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="${EMU_W}" cy="${EMU_H}"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic></p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>`;
 }
 
 function slideRelsXml(idx: number): string {

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -39,9 +39,12 @@ export async function exportSlideAsImagePptx(
   const pages = slide.default ?? [];
   if (pages.length === 0) return;
 
-  // Count only renderable pages: falsy holes are skipped during capture, so
-  // counting them here would leave the progress `current` short of `total`.
-  const total = pages.filter(Boolean).length;
+  // Drop falsy page holes up front and drive everything (progress total, render
+  // loop, and the per-page index/total handed to SlidePageProvider) off this
+  // compact list, so the metadata baked into each image matches the exported
+  // deck rather than the sparse source array.
+  const renderablePages = pages.filter(Boolean);
+  const total = renderablePages.length;
   if (total === 0) return;
   onProgress?.({ phase: 'processing', current: 0, total, percent: 0 });
 
@@ -76,9 +79,8 @@ export async function exportSlideAsImagePptx(
 
   const reactRoots: Root[] = [];
   const frames: HTMLElement[] = [];
-  for (let i = 0; i < pages.length; i++) {
-    const Page = pages[i];
-    if (!Page) continue;
+  for (let i = 0; i < renderablePages.length; i++) {
+    const Page = renderablePages[i];
     const host = document.createElement('div');
     host.setAttribute('data-osd-canvas', '');
     host.style.width = `${SLIDE_W}px`;
@@ -92,7 +94,7 @@ export async function exportSlideAsImagePptx(
     frames.push(host);
     const r = createRoot(host);
     r.render(
-      createElement(SlidePageProvider, { index: i, total: pages.length }, createElement(Page)),
+      createElement(SlidePageProvider, { index: i, total }, createElement(Page)),
     );
     reactRoots.push(r);
   }

--- a/packages/core/src/editing/edit-ops.test.ts
+++ b/packages/core/src/editing/edit-ops.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, it } from 'vitest';
-import { applyEdit, safeAssetIdentifier } from './edit-ops.ts';
+import { applyEdit, safeAssetIdentifier, splicesConflict } from './edit-ops.ts';
+
+describe('splicesConflict', () => {
+  const s = (from: number, to: number) => ({ from, to, text: '' });
+
+  it('flags ranges that share characters', () => {
+    expect(splicesConflict(s(0, 5), s(3, 8))).toBe(true);
+  });
+
+  it('allows disjoint and touching ranges', () => {
+    expect(splicesConflict(s(0, 5), s(5, 10))).toBe(false);
+    expect(splicesConflict(s(0, 5), s(10, 12))).toBe(false);
+  });
+
+  it('flags a zero-width insert nested inside a range', () => {
+    expect(splicesConflict(s(3, 3), s(0, 5))).toBe(true);
+    expect(splicesConflict(s(0, 5), s(3, 3))).toBe(true);
+  });
+
+  it('allows a zero-width insert at a range boundary or a shared point', () => {
+    expect(splicesConflict(s(5, 5), s(0, 5))).toBe(false);
+    expect(splicesConflict(s(0, 0), s(0, 5))).toBe(false);
+    expect(splicesConflict(s(4, 4), s(4, 4))).toBe(false);
+  });
+});
 
 describe('applyEdit / set-style', () => {
   // Every JSX opening tag in these synthetic sources sits at column 0;

--- a/packages/core/src/editing/edit-ops.test.ts
+++ b/packages/core/src/editing/edit-ops.test.ts
@@ -1017,6 +1017,26 @@ describe('applyEdit / set-attr-asset', () => {
     expect(occurrences.length).toBe(1);
   });
 
+  it('emits a single import for two ops on the same new asset path', () => {
+    const src = [
+      "import logo from './assets/logo.svg';",
+      'export default [() => (',
+      '<img src={logo} />',
+      ')];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 3, 0, [
+      { kind: 'set-attr-asset', attr: 'src', assetPath: './assets/photo.png' },
+      { kind: 'set-attr-asset', attr: 'poster', assetPath: './assets/photo.png' },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    // Both attributes point at the shared identifier, with only one import.
+    const importOccurrences = r.source.match(/import \w+ from '\.\/assets\/photo\.png'/g) ?? [];
+    expect(importOccurrences.length).toBe(1);
+    expect(r.source).toContain('src={photo}');
+    expect(r.source).toContain('poster={photo}');
+  });
+
   it('inserts a fresh src attribute on an <img> that has none', () => {
     const src = [
       "import alt from './assets/alt.svg';",

--- a/packages/core/src/editing/edit-ops.ts
+++ b/packages/core/src/editing/edit-ops.ts
@@ -21,6 +21,20 @@ export type ApplyEditResult =
 
 export type Splice = { from: number; to: number; text: string };
 
+// Two splices conflict if applying them by reverse-`from` string slicing would
+// corrupt each other. Half-open [from, to): a zero-width splice conflicts only
+// when its insertion point falls strictly inside the other's range; two
+// non-empty ranges conflict when they share any character. Touching boundaries
+// and two zero-width inserts at the same point are fine.
+export function splicesConflict(a: Splice, b: Splice): boolean {
+  const aEmpty = a.from === a.to;
+  const bEmpty = b.from === b.to;
+  if (aEmpty && bEmpty) return false;
+  if (aEmpty) return b.from < a.from && a.from < b.to;
+  if (bEmpty) return a.from < b.from && b.from < a.to;
+  return Math.max(a.from, b.from) < Math.min(a.to, b.to);
+}
+
 export function jsString(s: string): string {
   return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '\\n')}'`;
 }
@@ -1280,13 +1294,16 @@ export function applyEdit(
   if (splices.length === 0) return { ok: true, source };
 
   splices.sort((a, b) => b.from - a.from);
-  // Reject overlapping splice ranges: they are applied by reverse-`from` string
-  // slicing, so two ranges that share characters would corrupt each other (and
-  // can still parse, slipping past the guard below). Half-open [from, to), so
-  // touching boundaries and same-point zero-width inserts are not overlaps.
-  for (let i = 0; i < splices.length - 1; i++) {
-    if (Math.max(splices[i].from, splices[i + 1].from) < Math.min(splices[i].to, splices[i + 1].to)) {
-      return { ok: false, status: 422, error: 'edit ops overlap' };
+  // Reject any conflicting splice pair before applying by reverse-`from`
+  // slicing. Check all pairs, not just adjacent ones: a zero-width insert nested
+  // inside a replacement (or sitting between two overlapping ranges) would hide
+  // the conflict from an adjacent-only scan, then corrupt the output while still
+  // parsing and slipping past the guard below.
+  for (let i = 0; i < splices.length; i++) {
+    for (let j = i + 1; j < splices.length; j++) {
+      if (splicesConflict(splices[i], splices[j])) {
+        return { ok: false, status: 422, error: 'edit ops overlap' };
+      }
     }
   }
   let next = source;

--- a/packages/core/src/editing/edit-ops.ts
+++ b/packages/core/src/editing/edit-ops.ts
@@ -1085,9 +1085,14 @@ type AssetEditPlan = {
   attrSplice: Splice;
 };
 
+// Accumulates state across the asset ops of a single edit so they plan imports
+// against each other, not just the unchanged AST.
+type ImportPlanCtx = { planned: Map<string, string>; taken: Set<string> };
+
 export function planAssetImport(
   ast: t.File,
   assetPath: string,
+  ctx?: ImportPlanCtx,
 ): { identifier: string; importSplice: Splice | null } {
   const imports = findImports(ast);
   for (const imp of imports) {
@@ -1095,8 +1100,19 @@ export function planAssetImport(
       return { identifier: imp.defaultIdent, importSplice: null };
     }
   }
+  // Reuse an import already planned for this same path earlier in the edit, so
+  // two ops on the same asset don't emit a duplicate `import` (invalid binding).
+  const planned = ctx?.planned.get(assetPath);
+  if (planned) return { identifier: planned, importSplice: null };
+
   const filename = assetPath.slice(assetPath.lastIndexOf('/') + 1);
-  const identifier = safeAssetIdentifier(filename, collectTopLevelIdentifiers(ast));
+  // Draw from the accumulating taken-set so an identifier planned earlier in the
+  // edit is also avoided (e.g. logo.png and logo!.png both normalizing to `logo`).
+  const identifier = safeAssetIdentifier(filename, ctx?.taken ?? collectTopLevelIdentifiers(ast));
+  if (ctx) {
+    ctx.taken.add(identifier);
+    ctx.planned.set(assetPath, identifier);
+  }
   const importStmt = `import ${identifier} from '${assetPath.replace(/'/g, "\\'")}';\n`;
   const last = imports[imports.length - 1];
   const insertAt = last ? (last.node.end ?? 0) : 0;
@@ -1109,13 +1125,14 @@ function planAssetAttr(
   element: t.JSXElement,
   attr: string,
   assetPath: string,
+  ctx?: ImportPlanCtx,
 ): AssetEditPlan | { error: string } {
   if (!attr || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(attr)) return { error: 'invalid attribute name' };
   if (!assetPath.startsWith('./assets/') && !assetPath.startsWith('@assets/')) {
     return { error: 'asset path must start with ./assets/ or @assets/' };
   }
 
-  const { identifier, importSplice } = planAssetImport(ast, assetPath);
+  const { identifier, importSplice } = planAssetImport(ast, assetPath, ctx);
   const opening = element.openingElement;
   const newAttr = `${attr}={${identifier}}`;
   const existing = findJsxAttr(opening, attr);
@@ -1134,6 +1151,7 @@ function planReplacePlaceholder(
   ast: t.File,
   element: t.JSXElement,
   assetPath: string,
+  ctx?: ImportPlanCtx,
 ): PlaceholderEditPlan | { error: string } {
   const opening = element.openingElement;
   if (!t.isJSXIdentifier(opening.name) || opening.name.name !== 'ImagePlaceholder') {
@@ -1147,7 +1165,7 @@ function planReplacePlaceholder(
   const width = readJsxNumberAttr(opening, 'width');
   const height = readJsxNumberAttr(opening, 'height');
 
-  const { identifier, importSplice } = planAssetImport(ast, assetPath);
+  const { identifier, importSplice } = planAssetImport(ast, assetPath, ctx);
 
   const styleParts: string[] = [];
   if (width != null) styleParts.push(`width: ${width}`);
@@ -1228,15 +1246,21 @@ export function applyEdit(
     op.kind === 'replace-placeholder-with-image' ? [op] : [],
   );
   if (assetOps.length > 0 || placeholderOps.length > 0) {
+    // Shared across every asset/placeholder op in this edit so they reuse one
+    // import per path and never collide on a synthesized identifier.
+    const importCtx: ImportPlanCtx = {
+      planned: new Map<string, string>(),
+      taken: collectTopLevelIdentifiers(ast),
+    };
     const importSplices: Splice[] = [];
     for (const op of assetOps) {
-      const plan = planAssetAttr(ast, element, op.attr, op.assetPath);
+      const plan = planAssetAttr(ast, element, op.attr, op.assetPath, importCtx);
       if ('error' in plan) return { ok: false, status: 422, error: plan.error };
       splices.push(plan.attrSplice);
       if (plan.importSplice) importSplices.push(plan.importSplice);
     }
     for (const op of placeholderOps) {
-      const plan = planReplacePlaceholder(ast, element, op.assetPath);
+      const plan = planReplacePlaceholder(ast, element, op.assetPath, importCtx);
       if ('error' in plan) return { ok: false, status: 422, error: plan.error };
       splices.push(plan.elementSplice);
       if (plan.importSplice) importSplices.push(plan.importSplice);
@@ -1256,6 +1280,15 @@ export function applyEdit(
   if (splices.length === 0) return { ok: true, source };
 
   splices.sort((a, b) => b.from - a.from);
+  // Reject overlapping splice ranges: they are applied by reverse-`from` string
+  // slicing, so two ranges that share characters would corrupt each other (and
+  // can still parse, slipping past the guard below). Half-open [from, to), so
+  // touching boundaries and same-point zero-width inserts are not overlaps.
+  for (let i = 0; i < splices.length - 1; i++) {
+    if (Math.max(splices[i].from, splices[i + 1].from) < Math.min(splices[i].to, splices[i + 1].to)) {
+      return { ok: false, status: 422, error: 'edit ops overlap' };
+    }
+  }
   let next = source;
   for (const sp of splices) {
     next = next.slice(0, sp.from) + sp.text + next.slice(sp.to);

--- a/packages/core/src/editing/revert-asset.ts
+++ b/packages/core/src/editing/revert-asset.ts
@@ -9,6 +9,7 @@ import {
   readJsxStringAttr,
   type Splice,
   spliceRange,
+  splicesConflict,
 } from './edit-ops.ts';
 
 type ImgSrcUse = { element: t.JSXElement; identNode: t.Identifier };
@@ -194,12 +195,13 @@ export function applyRevertAsset(source: string, assetPath: string): ApplyEditRe
   if (splices.length === 0) return { ok: true, source };
 
   splices.sort((a, b) => b.from - a.from);
-  // Reject overlapping splice ranges before applying them by reverse-`from`
-  // slicing — overlapping ranges corrupt each other and can still parse.
-  // Half-open [from, to), so touching boundaries are not overlaps.
-  for (let i = 0; i < splices.length - 1; i++) {
-    if (Math.max(splices[i].from, splices[i + 1].from) < Math.min(splices[i].to, splices[i + 1].to)) {
-      return { ok: false, status: 422, error: 'revert ops overlap' };
+  // Reject any conflicting splice pair (all pairs, so a nested zero-width insert
+  // can't hide a conflict) before applying by reverse-`from` slicing.
+  for (let i = 0; i < splices.length; i++) {
+    for (let j = i + 1; j < splices.length; j++) {
+      if (splicesConflict(splices[i], splices[j])) {
+        return { ok: false, status: 422, error: 'revert ops overlap' };
+      }
     }
   }
   let next = source;

--- a/packages/core/src/editing/revert-asset.ts
+++ b/packages/core/src/editing/revert-asset.ts
@@ -181,7 +181,11 @@ export function applyRevertAsset(source: string, assetPath: string): ApplyEditRe
   const importNode = target.node;
   const importFrom = importNode.start ?? 0;
   let importTo = importNode.end ?? 0;
-  if (source[importTo] === '\n') importTo += 1;
+  // Consume the trailing newline so the removed import doesn't leave a blank
+  // line — handle CRLF (\r\n) as well as LF so Windows-authored files don't
+  // keep a stray \r.
+  if (source[importTo] === '\r' && source[importTo + 1] === '\n') importTo += 2;
+  else if (source[importTo] === '\n') importTo += 1;
   splices.push({ from: importFrom, to: importTo, text: '' });
 
   const ensureSplice = planEnsureImagePlaceholderImport(ast);
@@ -190,6 +194,14 @@ export function applyRevertAsset(source: string, assetPath: string): ApplyEditRe
   if (splices.length === 0) return { ok: true, source };
 
   splices.sort((a, b) => b.from - a.from);
+  // Reject overlapping splice ranges before applying them by reverse-`from`
+  // slicing — overlapping ranges corrupt each other and can still parse.
+  // Half-open [from, to), so touching boundaries are not overlaps.
+  for (let i = 0; i < splices.length - 1; i++) {
+    if (Math.max(splices[i].from, splices[i + 1].from) < Math.min(splices[i].to, splices[i + 1].to)) {
+      return { ok: false, status: 422, error: 'revert ops overlap' };
+    }
+  }
   let next = source;
   for (const sp of splices) {
     next = next.slice(0, sp.from) + sp.text + next.slice(sp.to);

--- a/packages/core/src/editing/slide-ops.ts
+++ b/packages/core/src/editing/slide-ops.ts
@@ -207,45 +207,71 @@ function escapeSingleQuoted(s: string): string {
  */
 export function updateMetaTitleInSource(source: string, title: string): string | null {
   const newLiteral = `'${escapeSingleQuoted(title)}'`;
+  let ast: unknown;
+  try {
+    ast = babelParse(source, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+      errorRecovery: true,
+    });
+  } catch {
+    return null;
+  }
 
-  const metaStart = source.search(/export\s+const\s+meta\b/);
-  if (metaStart !== -1) {
-    const eqIdx = source.indexOf('=', metaStart);
-    if (eqIdx === -1) return null;
-    const openBrace = source.indexOf('{', eqIdx);
-    if (openBrace === -1) return null;
+  const body = (ast as { program?: { body?: Array<Record<string, unknown>> } }).program?.body ?? [];
+  let metaExport: Record<string, unknown> | undefined;
+  let metaInit: Record<string, unknown> | undefined;
 
-    let depth = 0;
-    let closeBrace = -1;
-    for (let i = openBrace; i < source.length; i++) {
-      const ch = source[i];
-      if (ch === '{') depth++;
-      else if (ch === '}') {
-        depth--;
-        if (depth === 0) {
-          closeBrace = i;
-          break;
-        }
+  for (const stmt of body) {
+    if (stmt.type !== 'ExportNamedDeclaration') continue;
+    const decl = stmt.declaration as Record<string, unknown> | undefined;
+    if (!decl || decl.type !== 'VariableDeclaration') continue;
+    const declarations = (decl.declarations as Array<Record<string, unknown>> | undefined) ?? [];
+    for (const d of declarations) {
+      const id = d.id as Record<string, unknown> | undefined;
+      if (!id || id.type !== 'Identifier' || id.name !== 'meta') continue;
+      metaExport = stmt;
+      metaInit = unwrapExpression(d.init as Record<string, unknown> | undefined);
+      break;
+    }
+    if (metaExport) break;
+  }
+
+  if (metaExport && metaInit && metaInit.type === 'ObjectExpression') {
+    const properties = (metaInit.properties as Array<Record<string, unknown>> | undefined) ?? [];
+    let titleProp: Record<string, unknown> | undefined;
+    for (const property of properties) {
+      if (property.type !== 'ObjectProperty' || property.computed) continue;
+      const key = property.key as Record<string, unknown> | undefined;
+      const keyName =
+        key?.type === 'Identifier'
+          ? key.name
+          : key?.type === 'StringLiteral'
+            ? key.value
+            : undefined;
+      if (keyName === 'title') {
+        titleProp = property;
+        break;
       }
     }
-    if (closeBrace === -1) return null;
 
-    const body = source.slice(openBrace + 1, closeBrace);
-    const titleRe = /(^|[\s,{])(title\s*:\s*)(['"`])((?:\\.|(?!\3).)*)\3/;
-    const match = body.match(titleRe);
-    if (match) {
-      const newBody = body.replace(titleRe, `${match[1]}${match[2]}${newLiteral}`);
-      return source.slice(0, openBrace + 1) + newBody + source.slice(closeBrace);
+    if (titleProp) {
+      const value = titleProp.value as Record<string, unknown> | undefined;
+      if (value && typeof value.start === 'number' && typeof value.end === 'number') {
+        return source.slice(0, value.start) + newLiteral + source.slice(value.end);
+      }
     }
 
-    // No title yet — inject as the first property, copying the indentation of
-    // the first existing property (or a sensible default for an empty object).
-    const firstIndentMatch = body.match(/\n([ \t]+)\S/);
+    // No title property, inject it as the first property
+    const openBrace = metaInit.start as number;
+    const closeBrace = metaInit.end as number;
+    const objectBody = source.slice(openBrace + 1, closeBrace);
+    const firstIndentMatch = objectBody.match(/\n([ \t]+)\S/);
     const indent = firstIndentMatch ? firstIndentMatch[1] : '  ';
-    const trimmedBody = body.replace(/^\s*\n?/, '');
+    const trimmedBody = objectBody.replace(/^\s*\n?/, '');
     const needsSeparator = trimmedBody.trim().length > 0;
     const insertion = `\n${indent}title: ${newLiteral}${needsSeparator ? ',' : ''}`;
-    return source.slice(0, openBrace + 1) + insertion + body + source.slice(closeBrace);
+    return source.slice(0, openBrace + 1) + insertion + objectBody + source.slice(closeBrace);
   }
 
   const exportDefaultIdx = source.search(/export\s+default\b/);

--- a/packages/core/src/editing/slide-ops.ts
+++ b/packages/core/src/editing/slide-ops.ts
@@ -433,6 +433,10 @@ function findNotesArray(source: string): NotesArrayInfo | null | 'invalid' {
  * is too surprising to touch safely.
  */
 export function reorderNotesArrayInSource(source: string, order: number[]): string | null {
+  // `order` maps new positions to old indices. This intentionally tolerates
+  // non-permutation orders (duplicate/dropped indices): out-of-range picks
+  // become `undefined` and trailing `undefined` is trimmed, so e.g. [1, 1] over
+  // empty notes collapses to []. Only reject clearly invalid indices.
   for (const idx of order) {
     if (!Number.isInteger(idx) || idx < 0) return null;
   }

--- a/packages/core/src/files/folders.ts
+++ b/packages/core/src/files/folders.ts
@@ -39,9 +39,23 @@ export async function readManifest(file: string): Promise<FoldersManifest> {
   }
 }
 
+// Serialize writes to the same manifest file so concurrent mutations don't
+// physically interleave, and write atomically (temp file + rename) so a crash
+// mid-write can't truncate the manifest.
+const manifestWriteChains = new Map<string, Promise<unknown>>();
+
 export async function writeManifest(file: string, manifest: FoldersManifest): Promise<void> {
-  await fs.mkdir(path.dirname(file), { recursive: true });
-  await fs.writeFile(file, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  const prev = manifestWriteChains.get(file) ?? Promise.resolve();
+  const run = prev
+    .catch(() => {})
+    .then(async () => {
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      const tmp = `${file}.${randomUUID().slice(0, 8)}.tmp`;
+      await fs.writeFile(tmp, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+      await fs.rename(tmp, file);
+    });
+  manifestWriteChains.set(file, run.catch(() => {}));
+  return run;
 }
 
 export function newFolderId(): string {

--- a/packages/core/src/files/folders.ts
+++ b/packages/core/src/files/folders.ts
@@ -58,6 +58,31 @@ export async function writeManifest(file: string, manifest: FoldersManifest): Pr
   return run;
 }
 
+export type ManifestMutation = { write: boolean; status: number; body: unknown };
+
+// Run a read-modify-write against a manifest exclusively. Serializing the whole
+// read+mutate+write per file (not just the write) closes the lost-update race
+// where two handlers both read a stale copy and the later write drops the
+// earlier mutation. The mutator decides whether to persist and what to respond.
+const manifestUpdateChains = new Map<string, Promise<unknown>>();
+
+export async function updateManifest(
+  file: string,
+  mutate: (manifest: FoldersManifest) => ManifestMutation,
+): Promise<{ status: number; body: unknown }> {
+  const prev = manifestUpdateChains.get(file) ?? Promise.resolve();
+  const run = prev
+    .catch(() => {})
+    .then(async () => {
+      const manifest = await readManifest(file);
+      const { write, status, body } = mutate(manifest);
+      if (write) await writeManifest(file, manifest);
+      return { status, body };
+    });
+  manifestUpdateChains.set(file, run.catch(() => {}));
+  return run;
+}
+
 export function newFolderId(): string {
   return `f-${randomUUID().replace(/-/g, '').slice(0, 8)}`;
 }

--- a/packages/core/src/files/folders.ts
+++ b/packages/core/src/files/folders.ts
@@ -74,7 +74,9 @@ export function validateIcon(v: unknown): FolderIcon | null {
   const icon = v as { type?: unknown; value?: unknown };
   if (icon.type === 'emoji') {
     if (typeof icon.value !== 'string') return null;
-    if (icon.value.length < 1 || icon.value.length > 8) return null;
+    const segmenter = new Intl.Segmenter('en', { granularity: 'grapheme' });
+    const realLength = [...segmenter.segment(icon.value)].length;
+    if (realLength < 1 || realLength > 8) return null;
     return { type: 'emoji', value: icon.value };
   }
   if (icon.type === 'color') {

--- a/packages/core/src/vite/design-plugin.test.ts
+++ b/packages/core/src/vite/design-plugin.test.ts
@@ -89,6 +89,20 @@ describe('mergeDesign', () => {
     });
     expect(JSON.stringify(defaultDesign)).toBe(before);
   });
+
+  it('does not pollute Object.prototype via __proto__ in the patch', () => {
+    const patch = JSON.parse('{"__proto__":{"polluted":"yes"}}') as Partial<DesignSystem>;
+    mergeDesign(defaultDesign, patch);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('ignores constructor/prototype keys without throwing', () => {
+    const patch = JSON.parse(
+      '{"constructor":{"prototype":{"polluted":"yes"}}}',
+    ) as Partial<DesignSystem>;
+    expect(() => mergeDesign(defaultDesign, patch)).not.toThrow();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
 });
 
 describe('applyDesignWrite — slide with existing design', () => {

--- a/packages/core/src/vite/design-plugin.ts
+++ b/packages/core/src/vite/design-plugin.ts
@@ -126,6 +126,7 @@ export function mergeDesign(base: DesignSystem, patch: Partial<DesignSystem>): D
   const out = JSON.parse(JSON.stringify(base)) as DesignSystem;
   const apply = (target: Record<string, unknown>, src: Record<string, unknown>) => {
     for (const [k, v] of Object.entries(src)) {
+      if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
       if (isPlainObject(v) && isPlainObject(target[k])) {
         apply(target[k] as Record<string, unknown>, v);
       } else {

--- a/packages/core/src/vite/notes-plugin.ts
+++ b/packages/core/src/vite/notes-plugin.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import { parse as babelParse } from '@babel/parser';
 import * as t from '@babel/types';
-import type { Plugin, ViteDevServer } from 'vite';
+import { normalizePath, type Plugin, type ViteDevServer } from 'vite';
 import { validateMutationRequest } from '../http/request-guard.ts';
 import { json, readBody, resolveSlidePath } from './routes/context.ts';
 
@@ -167,9 +167,10 @@ export function notesPlugin(opts: NotesPluginOptions): Plugin {
     name: 'open-slide:notes',
     apply: 'serve',
     handleHotUpdate(ctx) {
-      const ts = recentWrites.get(ctx.file);
+      const key = normalizePath(ctx.file);
+      const ts = recentWrites.get(key);
       if (ts != null && Date.now() - ts < RECENT_WRITE_WINDOW_MS) {
-        recentWrites.delete(ctx.file);
+        recentWrites.delete(key);
         return [];
       }
       return undefined;
@@ -201,7 +202,9 @@ export function notesPlugin(opts: NotesPluginOptions): Plugin {
           if (!result.ok) return json(res, result.status, { error: result.error });
           const changed = result.source !== source;
           if (changed) {
-            recentWrites.set(file, Date.now());
+            // Key by Vite-normalized (forward-slash) path so handleHotUpdate,
+            // which receives an already-normalized ctx.file, matches on Windows.
+            recentWrites.set(normalizePath(file), Date.now());
             await fs.writeFile(file, result.source, 'utf8');
           }
           return json(res, 200, { ok: true, changed });

--- a/packages/core/src/vite/notes-plugin.ts
+++ b/packages/core/src/vite/notes-plugin.ts
@@ -90,8 +90,12 @@ function findInsertionOffset(ast: t.File, source: string): number {
   return source.length;
 }
 
+// A note index aligns with a slide page; cap it so a bogus huge index can't
+// drive the padding loops below into allocating a giant array (OOM).
+const MAX_NOTES_INDEX = 10_000;
+
 export function applyNotesEdit(source: string, index: number, text: string): ApplyNotesEditResult {
-  if (!Number.isInteger(index) || index < 0) {
+  if (!Number.isInteger(index) || index < 0 || index > MAX_NOTES_INDEX) {
     return { ok: false, status: 400, error: 'invalid index' };
   }
 

--- a/packages/core/src/vite/routes/assets.ts
+++ b/packages/core/src/vite/routes/assets.ts
@@ -206,10 +206,15 @@ export function registerAssetRoutes(server: ViteDevServer, ctx: ApiContext): voi
           let ended = false;
           await new Promise<void>((resolve, reject) => {
             req.on('data', (c: Buffer) => {
+              // Once over the limit, stop buffering (so memory stays bounded) but
+              // keep draining the body to its end instead of destroying the
+              // request — req.destroy() can tear down the socket before the 413
+              // response is written, turning it into a connection error.
+              if (oversized) return;
               total += c.length;
               if (total > ASSET_MAX_BYTES) {
                 oversized = true;
-                req.destroy();
+                chunks.length = 0;
                 return;
               }
               chunks.push(c);
@@ -219,8 +224,8 @@ export function registerAssetRoutes(server: ViteDevServer, ctx: ApiContext): voi
               resolve();
             });
             req.on('error', reject);
-            // req.destroy() (oversized) and client aborts emit 'close' without
-            // 'end'/'error'; resolve here so the request doesn't hang forever.
+            // A client abort emits 'close' without 'end'/'error'; resolve here so
+            // the request doesn't hang forever.
             req.on('close', () => resolve());
           });
           if (oversized) return json(res, 413, { error: 'file too large' });

--- a/packages/core/src/vite/routes/assets.ts
+++ b/packages/core/src/vite/routes/assets.ts
@@ -203,6 +203,7 @@ export function registerAssetRoutes(server: ViteDevServer, ctx: ApiContext): voi
           const chunks: Buffer[] = [];
           let total = 0;
           let oversized = false;
+          let ended = false;
           await new Promise<void>((resolve, reject) => {
             req.on('data', (c: Buffer) => {
               total += c.length;
@@ -213,10 +214,17 @@ export function registerAssetRoutes(server: ViteDevServer, ctx: ApiContext): voi
               }
               chunks.push(c);
             });
-            req.on('end', () => resolve());
+            req.on('end', () => {
+              ended = true;
+              resolve();
+            });
             req.on('error', reject);
+            // req.destroy() (oversized) and client aborts emit 'close' without
+            // 'end'/'error'; resolve here so the request doesn't hang forever.
+            req.on('close', () => resolve());
           });
           if (oversized) return json(res, 413, { error: 'file too large' });
+          if (!ended) return json(res, 400, { error: 'upload interrupted' });
 
           await fs.writeFile(file, Buffer.concat(chunks));
           return json(res, 200, {

--- a/packages/core/src/vite/routes/folders.ts
+++ b/packages/core/src/vite/routes/folders.ts
@@ -5,10 +5,10 @@ import {
   type Folder,
   newFolderId,
   readManifest,
+  updateManifest,
   validateIcon,
   validateName,
   validateReorder,
-  writeManifest,
 } from '../../files/folders.ts';
 import { validateMutationRequest } from '../../http/request-guard.ts';
 import { type ApiContext, json, readBody } from './context.ts';
@@ -47,11 +47,12 @@ export function registerFolderRoutes(server: ViteDevServer, ctx: ApiContext): vo
         const icon = validateIcon(body.icon);
         if (!icon) return json(res, 400, { error: 'invalid icon' });
 
-        const manifest = await readManifest(ctx.manifestPath);
         const folder: Folder = { id: newFolderId(), name, icon };
-        manifest.folders.push(folder);
-        await writeManifest(ctx.manifestPath, manifest);
-        return json(res, 200, folder);
+        const out = await updateManifest(ctx.manifestPath, (manifest) => {
+          manifest.folders.push(folder);
+          return { write: true, status: 200, body: folder };
+        });
+        return json(res, out.status, out.body);
       }
 
       if (method === 'PUT' && url.pathname === '/assign') {
@@ -73,17 +74,18 @@ export function registerFolderRoutes(server: ViteDevServer, ctx: ApiContext): vo
           return json(res, 400, { error: 'invalid folderId' });
         }
 
-        const manifest = await readManifest(ctx.manifestPath);
-        if (folderId && !manifest.folders.some((f) => f.id === folderId)) {
-          return json(res, 404, { error: 'folder not found' });
-        }
-        if (folderId === null) {
-          delete manifest.assignments[slideId];
-        } else {
-          manifest.assignments[slideId] = folderId;
-        }
-        await writeManifest(ctx.manifestPath, manifest);
-        return json(res, 200, { ok: true });
+        const out = await updateManifest(ctx.manifestPath, (manifest) => {
+          if (folderId && !manifest.folders.some((f) => f.id === folderId)) {
+            return { write: false, status: 404, body: { error: 'folder not found' } };
+          }
+          if (folderId === null) {
+            delete manifest.assignments[slideId];
+          } else {
+            manifest.assignments[slideId] = folderId;
+          }
+          return { write: true, status: 200, body: { ok: true } };
+        });
+        return json(res, out.status, out.body);
       }
 
       if (method === 'PUT' && url.pathname === '/reorder') {
@@ -92,13 +94,14 @@ export function registerFolderRoutes(server: ViteDevServer, ctx: ApiContext): vo
           return json(res, requestCheck.status, { error: requestCheck.error });
         }
         const body = (await readBody(req)) as ReorderFoldersBody;
-        const manifest = await readManifest(ctx.manifestPath);
-        const ids = validateReorder(body.ids, manifest.folders);
-        if (!ids) return json(res, 400, { error: 'invalid ids' });
-        const byId = new Map(manifest.folders.map((f) => [f.id, f]));
-        manifest.folders = ids.map((id) => byId.get(id) as Folder);
-        await writeManifest(ctx.manifestPath, manifest);
-        return json(res, 200, { ok: true });
+        const out = await updateManifest(ctx.manifestPath, (manifest) => {
+          const ids = validateReorder(body.ids, manifest.folders);
+          if (!ids) return { write: false, status: 400, body: { error: 'invalid ids' } };
+          const byId = new Map(manifest.folders.map((f) => [f.id, f]));
+          manifest.folders = ids.map((id) => byId.get(id) as Folder);
+          return { write: true, status: 200, body: { ok: true } };
+        });
+        return json(res, out.status, out.body);
       }
 
       const idMatch = url.pathname.match(/^\/([^/]+)$/);
@@ -112,22 +115,23 @@ export function registerFolderRoutes(server: ViteDevServer, ctx: ApiContext): vo
             return json(res, requestCheck.status, { error: requestCheck.error });
           }
           const body = (await readBody(req)) as PatchFolderBody;
-          const manifest = await readManifest(ctx.manifestPath);
-          const folder = manifest.folders.find((f) => f.id === id);
-          if (!folder) return json(res, 404, { error: 'folder not found' });
+          const out = await updateManifest(ctx.manifestPath, (manifest) => {
+            const folder = manifest.folders.find((f) => f.id === id);
+            if (!folder) return { write: false, status: 404, body: { error: 'folder not found' } };
 
-          if (body.name !== undefined) {
-            const name = validateName(body.name);
-            if (!name) return json(res, 400, { error: 'invalid name' });
-            folder.name = name;
-          }
-          if (body.icon !== undefined) {
-            const icon = validateIcon(body.icon);
-            if (!icon) return json(res, 400, { error: 'invalid icon' });
-            folder.icon = icon;
-          }
-          await writeManifest(ctx.manifestPath, manifest);
-          return json(res, 200, folder);
+            if (body.name !== undefined) {
+              const name = validateName(body.name);
+              if (!name) return { write: false, status: 400, body: { error: 'invalid name' } };
+              folder.name = name;
+            }
+            if (body.icon !== undefined) {
+              const icon = validateIcon(body.icon);
+              if (!icon) return { write: false, status: 400, body: { error: 'invalid icon' } };
+              folder.icon = icon;
+            }
+            return { write: true, status: 200, body: folder };
+          });
+          return json(res, out.status, out.body);
         }
 
         if (method === 'DELETE') {
@@ -135,17 +139,18 @@ export function registerFolderRoutes(server: ViteDevServer, ctx: ApiContext): vo
           if (!requestCheck.ok) {
             return json(res, requestCheck.status, { error: requestCheck.error });
           }
-          const manifest = await readManifest(ctx.manifestPath);
-          const before = manifest.folders.length;
-          manifest.folders = manifest.folders.filter((f) => f.id !== id);
-          if (manifest.folders.length === before) {
-            return json(res, 404, { error: 'folder not found' });
-          }
-          for (const [slideId, folderId] of Object.entries(manifest.assignments)) {
-            if (folderId === id) delete manifest.assignments[slideId];
-          }
-          await writeManifest(ctx.manifestPath, manifest);
-          return json(res, 200, { ok: true });
+          const out = await updateManifest(ctx.manifestPath, (manifest) => {
+            const before = manifest.folders.length;
+            manifest.folders = manifest.folders.filter((f) => f.id !== id);
+            if (manifest.folders.length === before) {
+              return { write: false, status: 404, body: { error: 'folder not found' } };
+            }
+            for (const [slideId, folderId] of Object.entries(manifest.assignments)) {
+              if (folderId === id) delete manifest.assignments[slideId];
+            }
+            return { write: true, status: 200, body: { ok: true } };
+          });
+          return json(res, out.status, out.body);
         }
       }
 

--- a/packages/core/src/vite/routes/slides.ts
+++ b/packages/core/src/vite/routes/slides.ts
@@ -14,7 +14,7 @@ import {
   updateMetaTitleInSource,
   validateSlideName,
 } from '../../editing/slide-ops.ts';
-import { readManifest, writeManifest } from '../../files/folders.ts';
+import { updateManifest } from '../../files/folders.ts';
 import { validateMutationRequest } from '../../http/request-guard.ts';
 import { type ApiContext, json, readBody } from './context.ts';
 
@@ -149,12 +149,12 @@ export function registerSlideRoutes(server: ViteDevServer, ctx: ApiContext): voi
         const duplicated = await duplicateSlideDir(ctx.slidesRoot, slideId, body.newId);
         if (!duplicated.ok) return json(res, duplicated.status, { error: duplicated.error });
 
-        const manifest = await readManifest(ctx.manifestPath);
-        const folderId = manifest.assignments[slideId];
-        if (folderId) {
+        await updateManifest(ctx.manifestPath, (manifest) => {
+          const folderId = manifest.assignments[slideId];
+          if (!folderId) return { write: false, status: 200, body: null };
           manifest.assignments[duplicated.slideId] = folderId;
-          await writeManifest(ctx.manifestPath, manifest);
-        }
+          return { write: true, status: 200, body: null };
+        });
         return json(res, 200, { ok: true, slideId: duplicated.slideId });
       }
 
@@ -206,9 +206,10 @@ export function registerSlideRoutes(server: ViteDevServer, ctx: ApiContext): voi
         const removed = await rmSlideDir(ctx.slidesRoot, slideId);
         if (!removed) return json(res, 404, { error: 'slide not found' });
 
-        const manifest = await readManifest(ctx.manifestPath);
-        delete manifest.assignments[slideId];
-        await writeManifest(ctx.manifestPath, manifest);
+        await updateManifest(ctx.manifestPath, (manifest) => {
+          delete manifest.assignments[slideId];
+          return { write: true, status: 200, body: null };
+        });
         return json(res, 200, { ok: true });
       }
 


### PR DESCRIPTION
## Summary

A batch of focused, independently-verified fixes across `packages/core`, `packages/cli`, and `apps/web` — correctness bugs in the editing/export engine, dev-server hardening, a Windows scaffolding bug, and a few landing-page accessibility/metadata cleanups.

All green: full test suite (276 tests), `packages/core` and `packages/cli` `tsc --noEmit`, `apps/web` `next typegen && tsc --noEmit`, and Biome lint.

## Core — editing engine

- **AST-based `meta.title` editing.** `updateMetaTitleInSource` now finds the `title` property via a Babel AST walk and rewrites only its value span. The old regex failed on a non-string value (e.g. `title: SOME_CONST`) and fell through to an inject path, producing an object with **two `title` keys**.
- **Reject overlapping splices.** `applyEdit` / `applyRevertAsset` apply splices by reverse-`from` string slicing; overlapping ranges corrupt each other and can still parse, slipping past the final guard. They are now rejected up front (half-open ranges, so touching boundaries are fine).
- **No duplicate asset imports.** Asset/placeholder ops in one edit now plan imports against accumulating state, so two ops on the same path (or colliding identifiers) reuse a single import instead of emitting a duplicate binding that fails the whole edit. (+ regression test)
- **CRLF import removal.** Removing an import line now consumes a trailing `\r\n`, not just `\n`, so Windows-authored files don't keep a stray blank line.

## Core — dev server & export

- **Prototype pollution fix.** `mergeDesign` skips `__proto__` / `constructor` / `prototype` keys, so a crafted `PUT /__design` body can no longer pollute `Object.prototype`. (+ regression tests)
- **Windows note focus-steal fix.** The notes HMR-suppression map is keyed by the Vite-normalized path; previously the backslash path never matched `ctx.file`'s forward slashes on Windows, so every note write remounted the tree and stole textarea focus mid-typing.
- **Asset upload hang fix.** An oversized upload called `req.destroy()`, which emits `'close'` (not `'end'`/`'error'`), so the body promise never settled and the request hung forever. It now resolves on `'close'` and returns 413; interrupted uploads are rejected.
- **Atomic manifest writes.** `writeManifest` serializes per-file writes and writes atomically (temp file + rename), so concurrent mutations can't interleave or truncate `.folders.json`.
- **Bounded note index** to keep a bogus huge index from allocating a giant padding array (OOM).
- **Full-bleed PPTX as a picture shape.** Each slide image is emitted as a slide-filling `<p:pic>` at the exact slide EMU extents with `stretch`/`fillRect`, instead of a `<p:bg>` background fill. The captured PNG and the frame are both exactly 16:9, so it maps 1:1 with no distortion, and a picture shape imports far more reliably into Google Slides (which handles per-slide backgrounds inconsistently). `noChangeAspect="0"` avoids letterboxing.
- **Export progress** counts only renderable pages, so a falsy page hole no longer leaves the bar short of 100%.
- **Emoji icon length** is measured by grapheme (`Intl.Segmenter`) instead of `String.length`, so ZWJ/flag/skin-tone emoji aren't falsely rejected by the 8-unit limit.

## CLI

- **`CLAUDE.md` scaffolding on Windows.** `cp()` copies the template's `CLAUDE.md`, which on a Windows checkout (`core.symlinks=false`) is the symlink's text placeholder `AGENTS.md` rather than a real file. The existence-gated repair skipped it, leaving the scaffolded project's `CLAUDE.md` containing the literal string `AGENTS.md`. It is now re-materialized unconditionally.

## Web (`apps/web`)

- **`prefers-reduced-motion`.** The `Anatomy` auto-cycle is gated on `useReducedMotion`, and a media block stops the looping marquee/caret animations and collapses the rest to their end state.
- **Keyboard-focusable slide player.** The inline player wrapper had an `onKeyDown` handler but no way to receive focus; it now gets `tabIndex`/`role` so arrow/space/page navigation works.
- **Theme toggle a11y.** Implements the ARIA radiogroup roving-tabindex pattern with arrow/Home/End navigation.
- **Slash-command highlighting** only triggers at the start of a line or after whitespace, so the `/cli` in `@open-slide/cli` isn't styled as a command.
- **Async sitemap mtimes.** Replaces top-level `execFileSync` (run at module evaluation) with promisified `execFile`, fetching per-page git mtimes concurrently.
- **De-duplicated metadata.** Drops the manually-declared favicon and `og:image` that duplicated the tags emitted by the `app/favicon.ico` and `app/opengraph-image.png` file conventions; adds `opengraph-image.alt.txt` to preserve the image alt text.

## Testing

`pnpm test` → 276 passing. New regression tests cover the design-merge prototype-pollution guard and the single-import-per-path behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Enhanced reduced-motion support and disabled landing animations when requested.
  * Improved keyboard navigation for theme selection and inline slide controls.
* **New Features**
  * Improved Open Graph and favicon generation behavior with updated alt text.
* **Bug Fixes**
  * Refined slash-command highlighting, slide metadata title updates, and slide export rendering.
  * Improved sitemap timestamps, edit/revert conflict detection, and shared asset import reuse.
  * Increased reliability for asset uploads, manifest updates, folder/slide assignment updates, and capped note index handling.
* **Security**
  * Hardened design merging against prototype pollution.
* **Tests**
  * Added coverage for splice conflict handling and merge security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->