### PR TITLE
Add per-slide canvas formats and format-correct exports

### DIFF
--- a/.changeset/format-aware-authoring-skills.md
+++ b/.changeset/format-aware-authoring-skills.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Teach the authoring skills to select and design for canvas formats.

--- a/.changeset/format-driven-pdf-export.md
+++ b/.changeset/format-driven-pdf-export.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Export PDFs at each slide's own canvas format, e.g. true 1:1 pages for carousels.

--- a/.changeset/format-driven-pptx-export.md
+++ b/.changeset/format-driven-pptx-export.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Size exported PPTX slides to the deck's canvas format.

--- a/.changeset/format-registry.md
+++ b/.changeset/format-registry.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Add per-slide format presets and canvas overrides via meta.format / meta.canvas.

--- a/.changeset/format-runtime-touchpoints.md
+++ b/.changeset/format-runtime-touchpoints.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Render editor, thumbnails, play mode, and presenter at each slide's own canvas format.

--- a/.changeset/png-export.md
+++ b/.changeset/png-export.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Add in-app PNG export — single image for one page, zip for multi-page decks.

--- a/apps/demo/slides/carousel-demo/index.tsx
+++ b/apps/demo/slides/carousel-demo/index.tsx
@@ -1,0 +1,128 @@
+import type { Page, SlideMeta } from '@open-slide/core';
+import type { CSSProperties } from 'react';
+
+const ink = '#0d0d0f';
+const paper = '#f4f1ea';
+const accent = '#ff4a1c';
+
+const fill: CSSProperties = {
+  width: '100%',
+  height: '100%',
+  boxSizing: 'border-box',
+  padding: 80,
+  display: 'flex',
+  flexDirection: 'column',
+  fontFamily: "'Inter', -apple-system, BlinkMacSystemFont, system-ui, sans-serif",
+};
+
+const eyebrow: CSSProperties = {
+  fontFamily: "'JetBrains Mono', 'SF Mono', Menlo, monospace",
+  fontSize: 22,
+  letterSpacing: '0.22em',
+  textTransform: 'uppercase',
+  fontWeight: 600,
+};
+
+function Cover() {
+  return (
+    <div style={{ ...fill, background: ink, color: paper, justifyContent: 'space-between' }}>
+      <span style={{ ...eyebrow, color: accent }}>Carousel · 1080²</span>
+      <h1
+        style={{
+          margin: 0,
+          fontSize: 132,
+          lineHeight: 0.94,
+          fontWeight: 800,
+          letterSpacing: '-0.03em',
+        }}
+      >
+        Square
+        <br />
+        by design.
+      </h1>
+      <p style={{ margin: 0, fontSize: 30, lineHeight: 1.4, maxWidth: 720, color: '#b9b6ae' }}>
+        One deck, one format. This page renders at its own 1:1 canvas everywhere.
+      </p>
+    </div>
+  );
+}
+
+function Idea() {
+  return (
+    <div style={{ ...fill, background: paper, color: ink, justifyContent: 'center', gap: 40 }}>
+      <span style={{ ...eyebrow, color: accent }}>01 — Rule</span>
+      <h2
+        style={{
+          margin: 0,
+          fontSize: 100,
+          lineHeight: 1.0,
+          fontWeight: 800,
+          letterSpacing: '-0.02em',
+        }}
+      >
+        One idea
+        <br />
+        per page.
+      </h2>
+      <p style={{ margin: 0, fontSize: 30, lineHeight: 1.45, maxWidth: 760, color: '#54524c' }}>
+        Generous type, high contrast, plenty of breathing room. Nothing competes for attention.
+      </p>
+    </div>
+  );
+}
+
+function Contrast() {
+  return (
+    <div style={{ ...fill, background: accent, color: paper, justifyContent: 'center', gap: 40 }}>
+      <span style={{ ...eyebrow, color: ink }}>02 — Legibility</span>
+      <h2
+        style={{
+          margin: 0,
+          fontSize: 108,
+          lineHeight: 0.98,
+          fontWeight: 800,
+          letterSpacing: '-0.02em',
+        }}
+      >
+        Read it
+        <br />
+        from the feed.
+      </h2>
+      <p style={{ margin: 0, fontSize: 30, lineHeight: 1.45, maxWidth: 740, color: '#2a0d05' }}>
+        High-contrast pairings keep every word crisp at thumbnail scale.
+      </p>
+    </div>
+  );
+}
+
+function Close() {
+  return (
+    <div style={{ ...fill, background: ink, color: paper, justifyContent: 'space-between' }}>
+      <span style={{ ...eyebrow, color: accent }}>03 — Ship</span>
+      <h2
+        style={{
+          margin: 0,
+          fontSize: 120,
+          lineHeight: 0.96,
+          fontWeight: 800,
+          letterSpacing: '-0.03em',
+        }}
+      >
+        Same code.
+        <br />
+        Any format.
+      </h2>
+      <p style={{ margin: 0, fontSize: 30, lineHeight: 1.4, maxWidth: 720, color: '#b9b6ae' }}>
+        Editor, thumbnails, play mode, and presenter all follow the canvas.
+      </p>
+    </div>
+  );
+}
+
+export const meta: SlideMeta = {
+  title: 'Carousel demo',
+  format: 'carousel',
+  createdAt: '2026-07-02T00:00:00+05:30',
+};
+
+export default [Cover, Idea, Contrast, Close] satisfies Page[];

--- a/packages/core/skills/create-slide/SKILL.md
+++ b/packages/core/skills/create-slide/SKILL.md
@@ -5,20 +5,44 @@ description: Use this skill when the user wants to create, draft, author, or gen
 
 # Create a slide in open-slide
 
-This skill owns the **workflow** for drafting a new deck. The technical reference — file contract, 1920×1080 canvas, type scale, palette, layout, assets — lives in the **`slide-authoring`** skill. Read that skill whenever you need details on *how* a page is structured. This skill assumes you'll consult it before writing code.
+This skill owns the **workflow** for drafting a new deck. The technical reference — file contract, format-driven canvas (1920×1080 default), type scale, palette, layout, assets — lives in the **`slide-authoring`** skill. Read that skill whenever you need details on *how* a page is structured. This skill assumes you'll consult it before writing code.
 
 You only write files under `slides/<id>/`. Never modify `package.json`, `open-slide.config.ts`, or existing slides.
 
-## Step 1 — Pick a theme
+## Step 1 — Pick a format
+
+A deck's **format** sets its canvas size — every page renders at that aspect ratio in the editor, thumbnails, play mode, presenter, and every export (PDF / PNG / PPTX). Lock it in first: it shapes page count, text density, and layout downstream, so changing it later means reworking those.
+
+Skip the question when the user's request already names a format unambiguously — "make me a LinkedIn carousel about X" → `carousel`, "a YouTube thumbnail for Y" → `thumbnail`, "an OG card for Z" → `og`. Restate the assumption ("Building this as a 1080×1080 carousel") so the user can correct course — the same convention this skill uses for topic and theme. **A plain "deck" / "slides" / "presentation" request (or anything with no hint of a social or single-image format) is the default `slide` — proceed straight to the next step with no `format` key and no question.** Presentation is the default; don't add friction to reach it.
+
+Only when the format is genuinely open — the request could plausibly be a feed post or a talk — call `AskUserQuestion`. The seven presets exceed the 4-option UI limit, so lead with the three most common plus an escape hatch:
+
+- **Presentation — 1920×1080** — 16:9 slides for talks and decks. *The default; recommend this.*
+- **LinkedIn carousel — 1080×1080** — square swipeable feed post.
+- **Story — 1080×1920** — 9:16 full-screen vertical (Instagram / TikTok / Shorts).
+- **Something else** — portrait post, YouTube thumbnail, OG card, or X post.
+
+If the user picks **"Something else"**, ask one follow-up `AskUserQuestion` with the remaining four:
+
+- **Portrait post — 1080×1350** — 4:5 feed post (Instagram / LinkedIn).
+- **YouTube thumbnail — 1280×720** — single-frame 16:9 thumbnail.
+- **OG card — 1200×630** — link-preview / social-share image.
+- **X post — 1600×900** — 16:9 image for an X / Twitter post.
+
+When the chosen format is anything other than **Presentation**, **set `format: '<preset>'` on the `meta` export** — e.g. `export const meta: SlideMeta = { title: '…', format: 'carousel' };`. The Presentation default needs no `format` key; omit it. The preset names are exactly `slide`, `carousel`, `portrait`, `story`, `thumbnail`, `og`, `x-post` — `slide-authoring` lists every dimension.
+
+The format you land on changes later steps — see the format notes in **Step 3** (page count) and **Step 5** (page roles) for how density and structure shift on non-16:9 canvases.
+
+## Step 2 — Pick a theme
 
 List files under `themes/`. If any theme markdown files exist (anything other than `README.md`), call `AskUserQuestion` with each theme id as an option plus a final **"no theme — design from scratch"** option.
 
-- If the user picks a theme: read `themes/<id>.md` end-to-end. The theme's palette, typography, layout, and Title/Footer components are now authoritative — copy them directly into the slide. **Also set `theme: '<theme-id>'` on the `meta` export in `index.tsx`** (e.g. `export const meta: SlideMeta = { title: '…', theme: '<theme-id>' };`) so the slide back-links to the theme (chip on the slide card + listing on `/themes/<id>`). In Step 2, skip the **aesthetic direction** question (the theme already commits to one direction); you still need the topic itself, so confirm it before moving on. Page count, text density, and motion are independent of theme — ask those normally.
-- If the user picks "no theme", or `themes/` is empty (or contains only `README.md`): proceed to Step 2 unchanged.
+- If the user picks a theme: read `themes/<id>.md` end-to-end. The theme's palette, typography, layout, and Title/Footer components are now authoritative — copy them directly into the slide. **Also set `theme: '<theme-id>'` on the `meta` export in `index.tsx`** (e.g. `export const meta: SlideMeta = { title: '…', theme: '<theme-id>' };`) so the slide back-links to the theme (chip on the slide card + listing on `/themes/<id>`). In Step 3, skip the **aesthetic direction** question (the theme already commits to one direction); you still need the topic itself, so confirm it before moving on. Page count, text density, and motion are independent of theme — ask those normally.
+- If the user picks "no theme", or `themes/` is empty (or contains only `README.md`): proceed to Step 3 unchanged.
 
-If you skip the aesthetic question because a theme was picked, restate the theme name in Step 2 so the user can correct course before you start writing.
+If you skip the aesthetic question because a theme was picked, restate the theme name in Step 3 so the user can correct course before you start writing.
 
-## Step 2 — Clarify requirements (MUST ask before writing code)
+## Step 3 — Clarify requirements (MUST ask before writing code)
 
 **Before writing any code, lock in the four key style decisions below via `AskUserQuestion`.** They shape every downstream choice (layout, type scale, asset needs, motion code), so locking them in up front avoids rework. Only skip a question when the user's original message already gave an unambiguous answer for it — and if you skip, restate your assumption so they can correct it.
 
@@ -36,16 +60,17 @@ Then ask these four in a single `AskUserQuestion` call (multi-question form):
    Mark the option that best fits the topic and audience as "(Recommended)" so the user has a sensible default. (`AskUserQuestion` already auto-adds "Other" — don't add a generic catch-all yourself.)
 
 2. **Page count** — rough length. Offer brackets: 3–5 (short), 6–10 (standard), 11–20 (deep dive), custom.
+   - **Format note.** These brackets are presentation-shaped. For `carousel` / `portrait` / `story`, feeds reward brevity — 5–10 pages is typical, and past ~10 readers drop off; offer the shorter brackets and drop "deep dive". For the single-page formats (`thumbnail`, `og`, `x-post`) there is no page count — the deck is exactly **one page**; skip this question entirely.
 3. **Text density per page** — how much copy lives on each page? Offer: minimal (one line / big number), light (heading + 2–3 bullets), standard (heading + 4–5 bullets or short paragraph), dense (multi-column / detailed). This directly drives type scale and layout.
 4. **Motion** — does the user want CSS/React animations and transitions, or a fully static deck? Offer: static (no motion), subtle (fades / entrance only), rich (keyframes, staggered reveals, looping visuals). If animated, plan to use CSS `@keyframes` / inline `style` + `useEffect`; no extra libraries.
 
 After those four, ask follow-ups **only if still unclear**: brand colors, required assets. Don't pad the conversation with questions already answered.
 
-## Step 3 — Pick a slide id
+## Step 4 — Pick a slide id
 
 Use **kebab-case**, short, descriptive. Examples: `rust-intro`, `q2-roadmap`, `team-offsite-2026`. Check `slides/` to avoid collisions.
 
-## Step 4 — Plan the structure
+## Step 5 — Plan the structure
 
 Sketch the slide as a list of page roles before writing code. Common page types:
 
@@ -62,9 +87,14 @@ Sketch the slide as a list of page roles before writing code. Common page types:
 
 **Rule of thumb**: one idea per page. If you're tempted to put two, split them.
 
+**Format note.** The roles above are presentation-shaped. On other canvases the structure shifts:
+
+- **Carousel / portrait / story** — think in feed beats, not chapters: a **hook page** (page 1 has to earn the swipe — a bold claim, number, or question, not a title card), **content pages** (one idea each), and a **CTA page** (follow / link / takeaway). Keep it to 5–10 pages. `slide-authoring`'s *Per-format design guidance* covers swipe cues, type scale, and (for `story`) the top/bottom safe zones.
+- **Thumbnail / OG / X post** — single-page formats. There's no sequence and no page roles: one page, one focal statement. Skip the multi-page planning here and go straight to making that single frame legible at a glance — see the per-format guidance in `slide-authoring`.
+
 If the deck topic naturally calls for specific real images the user must supply (product screenshots, team photos, customer dashboards), plan where those go and use `<ImagePlaceholder>` from `@open-slide/core` — see the **Image placeholders** section in `slide-authoring`. Default is **no placeholders**: only insert one when a real image is genuinely required.
 
-## Step 5 — Commit to a visual direction
+## Step 6 — Commit to a visual direction
 
 Pick one coherent palette / type scale / aesthetic and hold it across every page. The full set of constraints (palette structure, type scale, padding, aesthetic options) lives in `slide-authoring` — apply it.
 
@@ -72,15 +102,15 @@ Pick one coherent palette / type scale / aesthetic and hold it across every page
 
 Consult the `frontend-design` skill for deeper aesthetic guidance if the user wants something bold.
 
-## Step 6 — Write `slides/<id>/index.tsx`
+## Step 7 — Write `slides/<id>/index.tsx`
 
 Read the **`slide-authoring`** skill before writing — it covers the file contract, canvas rules, type scale, spacing, and asset imports, and it includes a starter template you can copy. Don't duplicate that knowledge here; use it.
 
-## Step 7 — Self-review
+## Step 8 — Self-review
 
 Run the checklist in `slide-authoring` ("Self-review before finishing"). It covers structural correctness, layout discipline, and asset existence.
 
-## Step 8 — Hand off to the user
+## Step 9 — Hand off to the user
 
 Tell the user:
 

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slide-authoring
-description: Technical reference for writing or editing open-slide pages — file contract, 1920×1080 canvas, type scale, layout, palette/visual direction, and assets. Consult this whenever you are about to write or modify any file under `slides/<id>/`, including from inside the `create-slide` or `apply-comments` workflows, or for any ad-hoc slide edit. Triggers on phrases like "edit slide", "tweak this page", "fix the layout", "change the palette", "investigate the slide framework", "how do slides work here".
+description: Technical reference for writing or editing open-slide pages — file contract, format-driven canvas (1920×1080 default), type scale, layout, palette/visual direction, and assets. Consult this whenever you are about to write or modify any file under `slides/<id>/`, including from inside the `create-slide` or `apply-comments` workflows, or for any ad-hoc slide edit. Triggers on phrases like "edit slide", "tweak this page", "fix the layout", "change the palette", "investigate the slide framework", "how do slides work here".
 ---
 
 # Authoring open-slide pages
@@ -34,6 +34,7 @@ const Body: Page = () => <div>…</div>;
 export const meta: SlideMeta = {
   title: 'My slide',
   createdAt: '2026-05-16T12:00:00Z',
+  // format: 'carousel', // omit for the default 1920×1080 slide canvas
 };
 export default [Cover, Body] satisfies Page[];
 ```
@@ -42,6 +43,7 @@ export default [Cover, Body] satisfies Page[];
 - `meta.title` (optional) shows in the slide header. Default is the folder name.
 - The slide id is the kebab-case folder name. Pick something short and descriptive (`q2-roadmap`, `team-offsite-2026`).
 - `meta.theme` (optional) marks the slide as built from a theme under `themes/`. The id must match a `<id>.md` basename. Surfaces a back-link chip on the slide card and lists the slide on `/themes/<id>`. Omit if the slide isn't derived from a registered theme.
+- `meta.format` (optional) sets the canvas size from a named preset — `slide` (default, 1920×1080), `carousel`, `portrait`, `story`, `thumbnail`, `og`, `x-post`. Omit it for a standard 1920×1080 deck; set it (`format: 'carousel'`) for social formats. See **Canvas** for every dimension. `meta.canvas: { width, height }` overrides with an arbitrary size, but prefer a named format.
 - `meta.createdAt` is an **ISO 8601 string literal** (e.g. `'2026-05-16T12:00:00Z'`) set once when the slide is scaffolded. The home page uses it for the default "newest first" sort. Always include it on new slides — **immediately before writing the file, run `node -e "console.log(new Date().toISOString())"` via Bash and paste the exact output** as the value. Don't type a timestamp from memory — you will get the date or time wrong. Must be a plain string literal (no `new Date(...)` or imports in the slide itself) — the framework reads it via a regex at build time, not by evaluating the module.
 
 ## Editing an existing slide
@@ -56,13 +58,28 @@ This lists every `const Foo: Page = …` declaration with its line number. Read 
 
 ## Canvas
 
-Every page renders into a fixed **1920 × 1080** canvas. The framework scales it; you design as if the viewport is literally 1920×1080.
+Every page renders into a **fixed canvas** whose size is set by the deck's `meta.format` (default `slide` — 1920×1080). The framework scales that canvas to fit; you design as if the viewport is literally the deck's canvas size — not always 1080 tall. The format is chosen in the `create-slide` workflow; here is what each preset resolves to:
 
+| `meta.format`      | Canvas (px) | Aspect  | Typical use                                  |
+| ------------------ | ----------- | ------- | -------------------------------------------- |
+| `slide` (default)  | 1920 × 1080 | 16:9    | Presentation decks, talks                    |
+| `carousel`         | 1080 × 1080 | 1:1     | LinkedIn / Instagram square carousel         |
+| `portrait`         | 1080 × 1350 | 4:5     | Instagram / LinkedIn feed post               |
+| `story`            | 1080 × 1920 | 9:16    | IG / TikTok / Shorts full-screen vertical    |
+| `thumbnail`        | 1280 × 720  | 16:9    | YouTube thumbnail (single frame)             |
+| `og`               | 1200 × 630  | ~1.91:1 | Open Graph / link-preview card               |
+| `x-post`           | 1600 × 900  | 16:9    | Image for an X / Twitter post                |
+
+Set it once in `meta`: `export const meta: SlideMeta = { title: '…', format: 'carousel' };`. Omit `format` for the default 1920×1080. (`meta.canvas: { width, height }` overrides with an arbitrary size — prefer a named format.) **Non-`slide` formats bend the type-scale, padding, and density rules below — read *Per-format design guidance* before designing one.**
+
+- **Design as if the viewport is literally the deck's canvas size.** The numbers below (type scale, padding, vertical budget) are written for the 1920×1080 `slide` canvas; scale them to the actual canvas for other formats.
 - Use **absolute pixel values** for `font-size`, padding, positioning. No `rem`, no `vw`/`vh`, no `%` for type.
 - The root element of each page should fill the canvas: `width: '100%'; height: '100%'`.
 - Prefer inline `style={{ … }}`. Any CSS you load is global — scope classnames carefully.
 
 ### Type scale (start here, adjust to taste)
+
+Calibrated for the 1920×1080 `slide` canvas. Smaller-canvas formats need their own scale — see **Per-format design guidance** (carousel/portrait run type *bigger* relative to the canvas so it stays legible in a phone feed).
 
 | Element          | Size       |
 | ---------------- | ---------- |
@@ -74,19 +91,19 @@ Every page renders into a fixed **1920 × 1080** canvas. The framework scales it
 
 ### Spacing
 
-- Content padding: **100–160px** from canvas edges. Never let text touch the edge.
+- Content padding: **100–160px** from canvas edges on the 1920×1080 `slide` canvas. Scale it down on smaller canvases — for the 1080-wide formats (`carousel`, `portrait`, `story`) use **64–96px**. Never let text touch the edge.
 - Line-height: 1.2 for headings, 1.5–1.7 for body.
 - Breathing room between elements: 32–64px.
 
-### Vertical budget — content MUST fit 1080px
+### Vertical budget — content MUST fit the canvas height
 
-The canvas does **not** scroll. Anything below 1080px is silently cropped. Before writing JSX, do the math on paper and confirm the page fits. This is the #1 cause of broken slides — assume you will overflow unless you've checked.
+The canvas does **not** scroll. Anything below the canvas height is silently cropped. Before writing JSX, do the math on paper and confirm the page fits. This is the #1 cause of broken slides — assume you will overflow unless you've checked.
 
-**Usable height** = `1080 − top_padding − bottom_padding`. With 120px padding on each side that's **840px**. With 160px each side, **760px**. Pick the padding first, then design within that budget.
+**Usable height** = `canvas_height − top_padding − bottom_padding`. On the 1920×1080 `slide` canvas with 120px padding each side that's **840px** (160px each → 760px). On a 1080×1080 `carousel` with 80px padding each side it's `1080 − 2×80 = 920px`. A 1080×1920 `story` gives far more room (`1920 − 2×96 = 1728px`), but you must also keep the top and bottom ~200px clear of platform UI — see **Per-format design guidance**. Pick the format and padding first, then design within that budget.
 
 **Element height** = `font_size × line_height × number_of_lines`. A bullet that wraps to 2 lines counts as 2 lines. Add the gap below it (32–64px) before summing the next element.
 
-**Worked example — single content page, 120px padding (budget = 840px):**
+**Worked example — `slide` canvas, single content page, 120px padding (budget = 840px):**
 
 | Element                                  | Height                  |
 | ---------------------------------------- | ----------------------- |
@@ -109,6 +126,34 @@ Swap the heading to 120px or add a 6th bullet and you're over. **Verify every pa
 - If you find yourself raising padding, shrinking type below the scale's lower bound, or tightening line-height under 1.4 to make things fit — **split into two pages instead**. Splitting is always the right answer when the budget is tight.
 
 **Never** use `overflow: auto/scroll`, negative margins, or transforms to hide overflow. The canvas is fixed; cropped content is gone.
+
+## Per-format design guidance
+
+The canvas rules above are the `slide` baseline. Each non-`slide` format bends them:
+
+### Carousel & portrait (`carousel` 1080×1080, `portrait` 1080×1350)
+
+Read on a phone, thumb-scrolling a feed — far smaller than a projected slide, so type runs **bigger relative to the canvas**, not smaller:
+
+- **Body text ~40px minimum** on the 1080-wide canvas; heroes **120–200px**. Anything under ~40px disappears at feed scale.
+- **One idea per page, hard** — ≤3 bullets, or a single statement. Less per page than a presentation.
+- **Page 1 is a hook**, not a title card. It has to earn the swipe — a bold claim, a number, a question.
+- **Cue the swipe** on every non-final page — a small "→", arrow, or page dots — so readers know to keep going. The final page drops the cue and carries the CTA.
+
+### Story (`story` 1080×1920)
+
+Full-screen vertical, 9:16:
+
+- **Stack vertically.** You have ~1728px of usable height; use it top-to-bottom rather than cramming one centered block.
+- **Keep critical content out of the top ~200px and bottom ~200px.** Platform UI (profile header, caption, reply bar, progress dots) overlays those zones and covers anything you place there. Treat the middle ~1500px as the safe area.
+
+### Single-page formats (`thumbnail` 1280×720, `og` 1200×630, `x-post` 1600×900)
+
+These are **one page** — a single image, not a deck:
+
+- Author exactly **one page**. There is no sequence, no navigation, no page roles.
+- Build around **one focal statement** that stays legible when the image is shrunk to ~300px wide (a feed thumbnail, a search result, a link card). If it's unreadable small, it fails.
+- **No page counters, no footers, no "01 / 12".** `useSlidePageNumber` and swipe cues are meaningless on a single frame.
 
 ## Visual direction
 
@@ -263,6 +308,7 @@ const Content: Page = () => (
 export const meta: SlideMeta = {
   title: 'The Big Idea',
   createdAt: '2026-05-16T12:00:00Z',
+  // format: 'carousel', // omit for the default 1920×1080 slide canvas
 };
 export default [Cover, Content] satisfies Page[];
 ```
@@ -592,7 +638,7 @@ This applies whenever the *visual element* repeats, not whenever the *data* does
 - [ ] `slides/<id>/index.tsx` `export default`s a non-empty `Page[]`.
 - [ ] Every page's root fills `100% × 100%`.
 - [ ] Content lives inside padding (no text kisses the edge).
-- [ ] **For every page, sum (font_size × line_height × lines) + gaps + 2×padding ≤ 1080px.** If close, split the page. No `overflow: auto` escape hatches.
+- [ ] **For every page, sum (font_size × line_height × lines) + gaps + 2×padding ≤ the canvas height** (1080px on `slide`; use the deck's format height for other canvases). If close, split the page. No `overflow: auto` escape hatches.
 - [ ] No bullet wraps to a second line at the chosen font size.
 - [ ] One coherent visual direction across every page (palette + type scale).
 - [ ] Slide declares a top-level `export const design: DesignSystem = { … }` and references the values via `var(--osd-X)` (use `design.X` only when you need a JS number for arithmetic). Only omit the `design` const for a one-off slide whose palette is intentionally locked.
@@ -607,8 +653,8 @@ This applies whenever the *visual element* repeats, not whenever the *data* does
 ## Anti-patterns
 
 - ❌ Walls of text. If a page has more than ~40 words, split it.
-- ❌ Using the full canvas for body copy. Respect 100–160px padding.
-- ❌ Overflowing 1080px vertically. Cropped content is invisible — split the page.
+- ❌ Using the full canvas for body copy. Respect the format's padding (100–160px on `slide`, 64–96px on 1080-wide formats).
+- ❌ Overflowing the canvas height vertically. Cropped content is invisible — split the page.
 - ❌ `overflow: auto` / `overflow: scroll` / `overflow: hidden` to "hide" too much content. The canvas doesn't scroll; you've just hidden the bug.
 - ❌ Shrinking type below the scale's lower bound, or padding below 100px, to cram more in. Split instead.
 - ❌ Bullets that wrap to a second line — either shorten or move to its own page.

--- a/packages/core/src/app/components/overview-grid.tsx
+++ b/packages/core/src/app/components/overview-grid.tsx
@@ -4,14 +4,13 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import type { DesignSystem } from '../lib/design';
+import { type CanvasSize, FORMAT_PRESETS } from '../lib/formats';
 import { SlidePageProvider } from '../lib/page-context';
 import type { Page } from '../lib/sdk';
-import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
 import type { SlideTransition } from '../lib/transition';
 import { SlideCanvas } from './slide-canvas';
 
 const THUMB_W = 320;
-const THUMB_H = (THUMB_W * CANVAS_HEIGHT) / CANVAS_WIDTH;
 
 export type OverviewVariant = 'present' | 'editor';
 
@@ -25,6 +24,7 @@ type Props = {
   variant?: OverviewVariant;
   moduleTransition?: SlideTransition;
   tooltipContainer?: HTMLElement | null;
+  canvas?: CanvasSize;
 };
 
 export function OverviewGrid({
@@ -37,7 +37,9 @@ export function OverviewGrid({
   variant = 'present',
   moduleTransition,
   tooltipContainer,
+  canvas = FORMAT_PRESETS.slide,
 }: Props) {
+  const thumbHeight = (THUMB_W * canvas.height) / canvas.width;
   const [focused, setFocused] = useState(current);
   const gridRef = useRef<HTMLDivElement>(null);
   const focusedRef = useRef<HTMLButtonElement | null>(null);
@@ -152,6 +154,8 @@ export function OverviewGrid({
                   isFocused={isFocused}
                   isCurrent={isCurrent}
                   styles={styles}
+                  canvas={canvas}
+                  thumbHeight={thumbHeight}
                   moduleTransition={moduleTransition}
                   tooltipContainer={tooltipContainer}
                   onFocus={() => setFocused(i)}
@@ -177,6 +181,8 @@ function OverviewThumb({
   isFocused,
   isCurrent,
   styles,
+  canvas,
+  thumbHeight,
   moduleTransition,
   tooltipContainer,
   onFocus,
@@ -190,6 +196,8 @@ function OverviewThumb({
   isFocused: boolean;
   isCurrent: boolean;
   styles: OverviewStyles;
+  canvas: CanvasSize;
+  thumbHeight: number;
   moduleTransition?: SlideTransition;
   tooltipContainer?: HTMLElement | null;
   onFocus: () => void;
@@ -227,14 +235,15 @@ function OverviewThumb({
           styles.thumbSurface,
           isFocused ? 'ring-2 ring-[var(--brand,#ef4444)]' : styles.thumbRing,
         )}
-        style={{ height: THUMB_H }}
+        style={{ height: thumbHeight }}
       >
         <SlideCanvas
-          scale={THUMB_W / CANVAS_WIDTH}
+          scale={THUMB_W / canvas.width}
           center={false}
           flat
           freezeMotion
           design={design}
+          canvas={canvas}
         >
           <SlidePageProvider index={index} total={total}>
             <PageComp />

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -3,6 +3,7 @@ import { useClickPageNavigation } from '@/lib/use-click-page-navigation';
 import { useWheelPageNavigation } from '@/lib/use-wheel-page-navigation';
 import { cn } from '@/lib/utils';
 import type { DesignSystem } from '../lib/design';
+import { type CanvasSize, FORMAT_PRESETS } from '../lib/formats';
 import type { Page } from '../lib/sdk';
 import type { EntryDirection, StepAggregate, StepController } from '../lib/step-context';
 import type { SlideTransition } from '../lib/transition';
@@ -46,6 +47,7 @@ type Props = {
    * without entering fullscreen. Defaults to true for back-compat.
    */
   fullscreen?: boolean;
+  canvas?: CanvasSize;
 };
 
 export function Player({
@@ -59,6 +61,7 @@ export function Player({
   controls = false,
   slideId,
   fullscreen = true,
+  canvas = FORMAT_PRESETS.slide,
 }: Props) {
   const isMobile = useIsMobile();
   const prefersReducedMotion = usePrefersReducedMotion();
@@ -401,7 +404,7 @@ export function Player({
       )}
       style={design ? { background: design.palette.bg } : undefined}
     >
-      <SlideCanvas flat design={design}>
+      <SlideCanvas flat design={design} canvas={canvas}>
         <SlideTransitionLayer
           pages={pages}
           index={index}
@@ -451,6 +454,7 @@ export function Player({
             variant="present"
             moduleTransition={transition}
             tooltipContainer={rootEl}
+            canvas={canvas}
           />
           <PresentHelpOverlay open={helpOpen} onOpenChange={setHelpOpen} container={rootEl} />
         </div>

--- a/packages/core/src/app/components/png-progress-toast.tsx
+++ b/packages/core/src/app/components/png-progress-toast.tsx
@@ -1,0 +1,32 @@
+import { Loader2 } from 'lucide-react';
+import { format, useLocale } from '@/lib/use-locale';
+import type { PngExportProgress } from '../lib/export-png';
+import { Progress } from './ui/progress';
+
+export function PngProgressToast({ progress }: { progress: PngExportProgress }) {
+  const t = useLocale();
+  const text =
+    progress.phase === 'processing'
+      ? format(t.pngToast.processing, {
+          current: progress.current.toString().padStart(2, '0'),
+          total: progress.total.toString().padStart(2, '0'),
+        })
+      : progress.phase === 'generating'
+        ? t.pngToast.generating
+        : t.pngToast.done;
+
+  return (
+    <div className="flex w-80 items-start gap-3 rounded-[8px] border border-border bg-popover px-3.5 py-3 text-popover-foreground shadow-floating">
+      <Loader2 className="mt-0.5 size-3.5 shrink-0 animate-spin text-brand" />
+      <div className="min-w-0 flex-1">
+        <p className="font-heading text-[12.5px] font-semibold tracking-tight">
+          {t.pngToast.title}
+        </p>
+        <p className="truncate font-mono text-[10.5px] tracking-[0.04em] text-muted-foreground">
+          {text}
+        </p>
+        <Progress value={Math.round(progress.percent)} className="mt-2 h-[3px]" />
+      </div>
+    </div>
+  );
+}

--- a/packages/core/src/app/components/slide-canvas.tsx
+++ b/packages/core/src/app/components/slide-canvas.tsx
@@ -1,7 +1,7 @@
 import { type CSSProperties, type ReactNode, useLayoutEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { type DesignSystem, designToCssVars } from '../lib/design';
-import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
+import { type CanvasSize, FORMAT_PRESETS } from '../lib/formats';
 
 type Props = {
   children: ReactNode;
@@ -12,6 +12,7 @@ type Props = {
   freezeMotion?: boolean;
   className?: string;
   design?: DesignSystem;
+  canvas?: CanvasSize;
 };
 
 export function SlideCanvas({
@@ -22,6 +23,7 @@ export function SlideCanvas({
   freezeMotion = false,
   className,
   design,
+  canvas = FORMAT_PRESETS.slide,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [fitScale, setFitScale] = useState<number | null>(null);
@@ -33,7 +35,7 @@ export function SlideCanvas({
     const measure = () => {
       const { width, height } = el.getBoundingClientRect();
       if (width === 0 || height === 0) return;
-      setFitScale(Math.min(width / CANVAS_WIDTH, height / CANVAS_HEIGHT));
+      setFitScale(Math.min(width / canvas.width, height / canvas.height));
     };
     // Measure synchronously before paint so the fitted scale is applied on the
     // first visible frame — otherwise the canvas flashes at full size.
@@ -41,12 +43,12 @@ export function SlideCanvas({
     const ro = new ResizeObserver(measure);
     ro.observe(el);
     return () => ro.disconnect();
-  }, [scale]);
+  }, [scale, canvas.width, canvas.height]);
 
   const measured = scale ?? fitScale;
   const s = measured ?? 1;
-  const scaledW = CANVAS_WIDTH * s;
-  const scaledH = CANVAS_HEIGHT * s;
+  const scaledW = canvas.width * s;
+  const scaledH = canvas.height * s;
   const designVars = design ? designToCssVars(design) : undefined;
 
   return (
@@ -85,8 +87,8 @@ export function SlideCanvas({
           data-osd-freeze-motion={freezeMotion ? '' : undefined}
           style={
             {
-              width: CANVAS_WIDTH,
-              height: CANVAS_HEIGHT,
+              width: canvas.width,
+              height: canvas.height,
               transform: `scale(${s})`,
               transformOrigin: 'top left',
               ...(designVars ?? {}),

--- a/packages/core/src/app/components/themes/theme-detail.tsx
+++ b/packages/core/src/app/components/themes/theme-detail.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
+import { resolveCanvas } from '../../lib/formats';
 import { SlidePageProvider } from '../../lib/page-context';
 import type { SlideModule } from '../../lib/sdk';
 import { loadSlide, slidesByTheme } from '../../lib/slides';
@@ -229,7 +230,12 @@ function ThemeSlideCard({ id }: { id: string }) {
       <div className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] group-hover:shadow-floating group-hover:ring-foreground/20 motion-safe:transition-[box-shadow,--tw-ring-color] motion-safe:duration-200">
         {FirstPage ? (
           <div className="h-full w-full motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]">
-            <SlideCanvas flat freezeMotion design={slide?.design}>
+            <SlideCanvas
+              flat
+              freezeMotion
+              design={slide?.design}
+              canvas={resolveCanvas(slide?.meta)}
+            >
               <SlidePageProvider index={0} total={slide?.default.length ?? 1}>
                 <FirstPage />
               </SlidePageProvider>

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -29,9 +29,9 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import type { DesignSystem } from '../lib/design';
+import { type CanvasSize, FORMAT_PRESETS } from '../lib/formats';
 import { SlidePageProvider } from '../lib/page-context';
 import type { Page } from '../lib/sdk';
-import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
 import type { SlideTransition } from '../lib/transition';
 import { SlideCanvas } from './slide-canvas';
 
@@ -56,6 +56,7 @@ type Props = {
   moduleTransition?: SlideTransition;
   /** When provided, the vertical rail header renders a button that opens the overview grid. */
   onOverview?: () => void;
+  canvas?: CanvasSize;
 };
 
 const DEFAULT_VERTICAL_THUMB_WIDTH = 184;
@@ -82,6 +83,7 @@ export function ThumbnailRail({
   width,
   moduleTransition,
   onOverview,
+  canvas = FORMAT_PRESETS.slide,
 }: Props) {
   const activeRef = useRef<HTMLButtonElement | null>(null);
   const t = useLocale();
@@ -101,8 +103,8 @@ export function ThumbnailRail({
     width != null
       ? Math.max(MIN_VERTICAL_THUMB_WIDTH, width - VERTICAL_RAIL_CHROME)
       : DEFAULT_VERTICAL_THUMB_WIDTH;
-  const scale = thumbWidth / CANVAS_WIDTH;
-  const height = CANVAS_HEIGHT * scale;
+  const scale = thumbWidth / canvas.width;
+  const height = canvas.height * scale;
   const rowHeight = height + VERTICAL_THUMB_PADDING_Y + VERTICAL_THUMB_GAP;
 
   const renderThumb = useCallback(
@@ -118,6 +120,7 @@ export function ThumbnailRail({
           scale={scale}
           thumbWidth={thumbWidth}
           height={height}
+          canvas={canvas}
           moduleTransition={moduleTransition}
         />
       );
@@ -162,6 +165,7 @@ export function ThumbnailRail({
     },
     [
       actions,
+      canvas,
       current,
       design,
       height,
@@ -177,8 +181,8 @@ export function ThumbnailRail({
   );
 
   if (orientation === 'horizontal') {
-    const scale = HORIZONTAL_THUMB_HEIGHT / CANVAS_HEIGHT;
-    const horizontalWidth = CANVAS_WIDTH * scale;
+    const scale = HORIZONTAL_THUMB_HEIGHT / canvas.height;
+    const horizontalWidth = canvas.width * scale;
     return (
       <div className="bg-sidebar">
         <div className="overflow-x-auto overflow-y-hidden">
@@ -191,6 +195,7 @@ export function ThumbnailRail({
             onSelect={onSelect}
             scale={scale}
             thumbWidth={horizontalWidth}
+            canvas={canvas}
           />
         </div>
       </div>
@@ -276,6 +281,7 @@ function HorizontalVirtualThumbList({
   onSelect,
   scale,
   thumbWidth,
+  canvas,
 }: {
   pages: Page[];
   design?: DesignSystem;
@@ -285,6 +291,7 @@ function HorizontalVirtualThumbList({
   onSelect: (index: number) => void;
   scale: number;
   thumbWidth: number;
+  canvas: CanvasSize;
 }) {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const viewportRef = useRef<HTMLElement | null>(null);
@@ -382,7 +389,14 @@ function HorizontalVirtualThumbList({
           )}
           style={{ width: thumbWidth, height: HORIZONTAL_THUMB_HEIGHT }}
         >
-          <SlideCanvas scale={scale} center={false} flat freezeMotion design={design}>
+          <SlideCanvas
+            scale={scale}
+            center={false}
+            flat
+            freezeMotion
+            design={design}
+            canvas={canvas}
+          >
             <SlidePageProvider index={i} total={pages.length}>
               <PageComp />
             </SlidePageProvider>
@@ -567,6 +581,7 @@ function ThumbContents({
   scale,
   thumbWidth,
   height,
+  canvas,
   moduleTransition,
 }: {
   index: number;
@@ -577,6 +592,7 @@ function ThumbContents({
   scale: number;
   thumbWidth: number;
   height: number;
+  canvas: CanvasSize;
   moduleTransition?: SlideTransition;
 }) {
   const t = useLocale();
@@ -624,7 +640,7 @@ function ThumbContents({
         )}
         style={{ width: thumbWidth, height }}
       >
-        <SlideCanvas scale={scale} center={false} flat freezeMotion design={design}>
+        <SlideCanvas scale={scale} center={false} flat freezeMotion design={design} canvas={canvas}>
           <SlidePageProvider index={index} total={total}>
             <PageComp />
           </SlidePageProvider>

--- a/packages/core/src/app/lib/capture.ts
+++ b/packages/core/src/app/lib/capture.ts
@@ -1,0 +1,149 @@
+import { createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { designToCssVars } from './design';
+import type { CanvasSize } from './formats';
+import { SlidePageProvider } from './page-context';
+import { isFrameAnimationSettled, waitForDataWaitfor, waitForFonts } from './print-ready';
+import type { SlideModule } from './sdk';
+
+const CAPTURE_PIXEL_RATIO = 2;
+
+const ANIMATION_TIMEOUT_MS = 15_000;
+const POLL_INTERVAL_MS = 100;
+
+const CAPTURE_CLASS = 'os-pptx-capture';
+const CAPTURE_STYLE_ID = 'os-pptx-capture-style';
+// Properties intro animations drive from a hidden start state to a visible end
+// state. We read them back once settled and pin them inline so the capture clone
+// can't re-run the keyframes from their invisible 0% frame (see freezeForCapture).
+const FROZEN_PROPS = ['opacity', 'transform', 'filter', 'clip-path'] as const;
+
+export async function capturePagesAsPng(
+  slide: SlideModule,
+  canvas: CanvasSize,
+  onPage?: (captured: number, total: number) => void,
+): Promise<Uint8Array[]> {
+  const pages = slide.default ?? [];
+  if (pages.length === 0) return [];
+
+  const total = pages.length;
+
+  const container = document.createElement('div');
+  container.className = CAPTURE_CLASS;
+  container.setAttribute('aria-hidden', 'true');
+  Object.assign(container.style, {
+    position: 'fixed',
+    left: '-99999px',
+    top: '0',
+    pointerEvents: 'none',
+  });
+  document.body.appendChild(container);
+
+  // html-to-image clones each frame and copies its computed style — including the
+  // intro animation — into the clone, which then re-runs the keyframes from their
+  // hidden 0% frame in the rasterised SVG. Fast-forward every animation to its end
+  // frame in the live DOM (a large negative delay lands past a 1ms duration, so
+  // even pseudo-elements paint their final state on the first frame).
+  const captureStyle = document.createElement('style');
+  captureStyle.id = CAPTURE_STYLE_ID;
+  captureStyle.textContent = `.${CAPTURE_CLASS} *, .${CAPTURE_CLASS} *::before, .${CAPTURE_CLASS} *::after {
+    animation-delay: -1s !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    animation-fill-mode: forwards !important;
+    transition: none !important;
+  }`;
+  document.head.appendChild(captureStyle);
+
+  const designVars = slide.design ? designToCssVars(slide.design) : null;
+
+  const reactRoots: Root[] = [];
+  const frames: HTMLElement[] = [];
+  for (let i = 0; i < pages.length; i++) {
+    const Page = pages[i];
+    if (!Page) continue;
+    const host = document.createElement('div');
+    host.setAttribute('data-osd-canvas', '');
+    host.style.width = `${canvas.width}px`;
+    host.style.height = `${canvas.height}px`;
+    host.style.overflow = 'hidden';
+    host.style.background = '#fff';
+    if (designVars) {
+      for (const [k, v] of Object.entries(designVars)) host.style.setProperty(k, v);
+    }
+    container.appendChild(host);
+    frames.push(host);
+    const r = createRoot(host);
+    r.render(
+      createElement(SlidePageProvider, { index: i, total: pages.length }, createElement(Page)),
+    );
+    reactRoots.push(r);
+  }
+  // Yield once so React commits all pages and intro animations actually start.
+  await nextPaint();
+
+  try {
+    await waitForFonts();
+
+    const deadline = performance.now() + ANIMATION_TIMEOUT_MS;
+    while (performance.now() < deadline) {
+      const settled = frames.every((frame) => isFrameAnimationSettled(frame));
+      if (settled) break;
+      await sleep(POLL_INTERVAL_MS);
+    }
+    await waitForDataWaitfor(container);
+
+    const { toBlob } = await import('html-to-image');
+    const images: Uint8Array[] = [];
+    for (let i = 0; i < frames.length; i++) {
+      freezeForCapture(frames[i]);
+      const blob = await toBlob(frames[i], {
+        width: canvas.width,
+        height: canvas.height,
+        pixelRatio: CAPTURE_PIXEL_RATIO,
+        backgroundColor: '#ffffff',
+        cacheBust: true,
+      });
+      if (!blob) throw new Error(`failed to capture page ${i + 1}`);
+      images.push(new Uint8Array(await blob.arrayBuffer()));
+      onPage?.(i + 1, total);
+    }
+
+    return images;
+  } finally {
+    for (const r of reactRoots) r.unmount();
+    container.remove();
+    captureStyle.remove();
+  }
+}
+
+// Pin each element's settled visual state inline and remove its animation so the
+// clone html-to-image rasterises renders the final frame instead of replaying the
+// (initially invisible) keyframes. Pseudo-elements are handled by CAPTURE_STYLE_ID.
+function freezeForCapture(root: HTMLElement): void {
+  for (const el of root.querySelectorAll<HTMLElement>('*')) {
+    const cs = getComputedStyle(el);
+    for (const prop of FROZEN_PROPS) {
+      el.style.setProperty(prop, cs.getPropertyValue(prop), 'important');
+    }
+    el.style.setProperty('animation', 'none', 'important');
+    el.style.setProperty('transition', 'none', 'important');
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function nextPaint(): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    requestAnimationFrame(settle);
+    setTimeout(settle, 50);
+  });
+}

--- a/packages/core/src/app/lib/download.ts
+++ b/packages/core/src/app/lib/download.ts
@@ -1,0 +1,11 @@
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.rel = 'noopener';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/packages/core/src/app/lib/export-html.ts
+++ b/packages/core/src/app/lib/export-html.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { designToCssVars } from './design';
+import { downloadBlob } from './download';
 import { SlidePageProvider } from './page-context';
 import type { SlideModule } from './sdk';
 
@@ -311,16 +312,4 @@ function escapeHtml(s: string): string {
 
 function escapeAttr(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
-}
-
-function downloadBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.rel = 'noopener';
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  setTimeout(() => URL.revokeObjectURL(url), 0);
 }

--- a/packages/core/src/app/lib/export-pdf.ts
+++ b/packages/core/src/app/lib/export-pdf.ts
@@ -1,7 +1,7 @@
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { designToCssVars } from './design';
-import type { CanvasSize } from './formats';
+import { type CanvasSize, resolveCanvas } from './formats';
 import { SlidePageProvider } from './page-context';
 import { isFrameAnimationSettled, waitForDataWaitfor, waitForFonts } from './print-ready';
 import type { SlideModule } from './sdk';
@@ -110,10 +110,11 @@ export async function exportSlideAsPdf(
   if (pages.length === 0) return;
 
   const total = pages.length;
+  const canvas = resolveCanvas(slide.meta, slideId);
 
   const style = document.createElement('style');
   style.id = PRINT_STYLE_ID;
-  style.textContent = buildPrintStyles({ width: 1920, height: 1080 });
+  style.textContent = buildPrintStyles(canvas);
   document.head.appendChild(style);
 
   const root = document.createElement('div');
@@ -133,15 +134,15 @@ export async function exportSlideAsPdf(
     const host = document.createElement('div');
     host.className = 'os-print-frame';
     host.setAttribute('data-osd-canvas', '');
-    host.style.width = '1920px';
-    host.style.height = '1080px';
+    host.style.width = `${canvas.width}px`;
+    host.style.height = `${canvas.height}px`;
     if (designVars) {
       for (const [k, v] of Object.entries(designVars)) host.style.setProperty(k, v);
     }
     const inner = document.createElement('div');
     inner.className = 'os-print-supersample';
-    inner.style.width = '1920px';
-    inner.style.height = '1080px';
+    inner.style.width = `${canvas.width}px`;
+    inner.style.height = `${canvas.height}px`;
     host.appendChild(inner);
     root.appendChild(host);
     frames.push(host);

--- a/packages/core/src/app/lib/export-pdf.ts
+++ b/packages/core/src/app/lib/export-pdf.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { designToCssVars } from './design';
+import type { CanvasSize } from './formats';
 import { SlidePageProvider } from './page-context';
 import { isFrameAnimationSettled, waitForDataWaitfor, waitForFonts } from './print-ready';
 import type { SlideModule } from './sdk';
@@ -8,8 +9,9 @@ import type { SlideModule } from './sdk';
 const PRINT_ROOT_ID = 'os-print-root';
 const PRINT_STYLE_ID = 'os-print-style';
 
-const PRINT_STYLES = `
-@page { size: 1920px 1080px; margin: 0; }
+function buildPrintStyles(canvas: CanvasSize): string {
+  return `
+@page { size: ${canvas.width}px ${canvas.height}px; margin: 0; }
 
 @media screen {
   #${PRINT_ROOT_ID} {
@@ -36,8 +38,8 @@ const PRINT_STYLES = `
     background: #fff !important;
   }
   #${PRINT_ROOT_ID} .os-print-frame {
-    width: 1920px !important;
-    height: 1080px !important;
+    width: ${canvas.width}px !important;
+    height: ${canvas.height}px !important;
     background: #fff;
     color: #000;
     overflow: hidden;
@@ -52,13 +54,13 @@ const PRINT_STYLES = `
   }
   /* Supersample: Chrome rasterizes filtered/composited layers (e.g. filter:
      blur, mix-blend-mode) at the layer's CSS-pixel size, so a blurred
-     gradient on a 1920×1080 page bakes in at ~1× DPI and bands when the PDF
-     is viewed scaled up. zoom:2 doubles the layer raster size; scale(0.5)
-     composites it back to 1920×1080. Vector content (text, plain CSS
-     gradients, SVG) stays vector through both transforms. */
+     gradient bakes in at ~1× DPI and bands when the PDF is viewed scaled up.
+     zoom:2 doubles the layer raster size; scale(0.5) composites it back to
+     the canvas size. Vector content (text, plain CSS gradients, SVG) stays
+     vector through both transforms. */
   #${PRINT_ROOT_ID} .os-print-supersample {
-    width: 1920px !important;
-    height: 1080px !important;
+    width: ${canvas.width}px !important;
+    height: ${canvas.height}px !important;
     zoom: 2;
     transform: scale(0.5);
     transform-origin: top left;
@@ -79,6 +81,7 @@ const PRINT_STYLES = `
   }
 }
 `;
+}
 
 export function isSafari(): boolean {
   if (typeof navigator === 'undefined') return false;
@@ -110,7 +113,7 @@ export async function exportSlideAsPdf(
 
   const style = document.createElement('style');
   style.id = PRINT_STYLE_ID;
-  style.textContent = PRINT_STYLES;
+  style.textContent = buildPrintStyles({ width: 1920, height: 1080 });
   document.head.appendChild(style);
 
   const root = document.createElement('div');

--- a/packages/core/src/app/lib/export-png.ts
+++ b/packages/core/src/app/lib/export-png.ts
@@ -1,0 +1,52 @@
+import { capturePagesAsPng } from './capture';
+import { downloadBlob } from './download';
+import { resolveCanvas } from './formats';
+import type { SlideModule } from './sdk';
+
+export type PngExportProgress = {
+  phase: 'processing' | 'generating' | 'done';
+  current: number;
+  total: number;
+  percent: number;
+};
+
+export async function exportSlideAsPng(
+  slide: SlideModule,
+  slideId: string,
+  onProgress?: (progress: PngExportProgress) => void,
+): Promise<void> {
+  const pages = slide.default ?? [];
+  if (pages.length === 0) return;
+
+  const total = pages.length;
+  const canvas = resolveCanvas(slide.meta, slideId);
+  onProgress?.({ phase: 'processing', current: 0, total, percent: 0 });
+
+  try {
+    const images = await capturePagesAsPng(slide, canvas, (captured) => {
+      onProgress?.({
+        phase: 'processing',
+        current: captured,
+        total,
+        percent: Math.min(95, (captured / total) * 95),
+      });
+    });
+
+    if (images.length === 1) {
+      downloadBlob(new Blob([images[0] as BlobPart], { type: 'image/png' }), `${slideId}.png`);
+      return;
+    }
+
+    onProgress?.({ phase: 'generating', current: total, total, percent: 98 });
+    const pad = Math.max(2, String(images.length).length);
+    const { zipSync } = await import('fflate');
+    const files: Record<string, Uint8Array> = {};
+    for (let i = 0; i < images.length; i++) {
+      files[`${slideId}-${String(i + 1).padStart(pad, '0')}.png`] = images[i];
+    }
+    const zipped = zipSync(files);
+    downloadBlob(new Blob([zipped as BlobPart], { type: 'application/zip' }), `${slideId}.zip`);
+  } finally {
+    onProgress?.({ phase: 'done', current: total, total, percent: 100 });
+  }
+}

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -1,11 +1,10 @@
 import { capturePagesAsPng } from './capture';
 import { downloadBlob } from './download';
-import { FORMAT_PRESETS } from './formats';
+import { resolveCanvas } from './formats';
 import type { SlideModule } from './sdk';
 
-// 16:9 widescreen in English Metric Units (914400 EMU per inch → 13.333in × 7.5in).
-const EMU_W = 12192000;
-const EMU_H = 6858000;
+// 6350 EMU per CSS px at 96dpi (914400 EMU/in ÷ 96 px/in).
+const EMU_PER_PX = 6350;
 
 export type PptxExportProgress = {
   phase: 'processing' | 'generating' | 'done';
@@ -25,10 +24,13 @@ export async function exportSlideAsImagePptx(
   if (pages.length === 0) return;
 
   const total = pages.length;
+  const canvas = resolveCanvas(slide.meta, slideId);
+  const emuW = Math.round(canvas.width * EMU_PER_PX);
+  const emuH = Math.round(canvas.height * EMU_PER_PX);
   onProgress?.({ phase: 'processing', current: 0, total, percent: 0 });
 
   try {
-    const images = await capturePagesAsPng(slide, FORMAT_PRESETS.slide, (captured) => {
+    const images = await capturePagesAsPng(slide, canvas, (captured) => {
       onProgress?.({
         phase: 'processing',
         current: captured,
@@ -38,7 +40,7 @@ export async function exportSlideAsImagePptx(
     });
 
     onProgress?.({ phase: 'generating', current: total, total, percent: 98 });
-    const pptx = await buildImagePptx(images);
+    const pptx = await buildImagePptx(images, emuW, emuH);
     downloadBlob(
       new Blob([pptx as BlobPart], {
         type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
@@ -54,14 +56,18 @@ const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n';
 const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
 const OD_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
 
-async function buildImagePptx(images: Uint8Array[]): Promise<Uint8Array> {
+async function buildImagePptx(
+  images: Uint8Array[],
+  emuW: number,
+  emuH: number,
+): Promise<Uint8Array> {
   const { zipSync, strToU8 } = await import('fflate');
   const n = images.length;
   const files: Record<string, Uint8Array> = {};
 
   files['[Content_Types].xml'] = strToU8(contentTypesXml(n));
   files['_rels/.rels'] = strToU8(rootRelsXml());
-  files['ppt/presentation.xml'] = strToU8(presentationXml(n));
+  files['ppt/presentation.xml'] = strToU8(presentationXml(n, emuW, emuH));
   files['ppt/_rels/presentation.xml.rels'] = strToU8(presentationRelsXml(n));
   files['ppt/presProps.xml'] = strToU8(presPropsXml());
   files['ppt/theme/theme1.xml'] = strToU8(themeXml());
@@ -72,7 +78,7 @@ async function buildImagePptx(images: Uint8Array[]): Promise<Uint8Array> {
 
   for (let i = 0; i < n; i++) {
     const idx = i + 1;
-    files[`ppt/slides/slide${idx}.xml`] = strToU8(slideXml());
+    files[`ppt/slides/slide${idx}.xml`] = strToU8(slideXml(emuW, emuH));
     files[`ppt/slides/_rels/slide${idx}.xml.rels`] = strToU8(slideRelsXml(idx));
     files[`ppt/media/image${idx}.png`] = images[i];
   }
@@ -93,12 +99,12 @@ function rootRelsXml(): string {
   return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/officeDocument" Target="ppt/presentation.xml"/></Relationships>`;
 }
 
-function presentationXml(n: number): string {
+function presentationXml(n: number, emuW: number, emuH: number): string {
   const sldIds = Array.from(
     { length: n },
     (_, i) => `<p:sldId id="${256 + i}" r:id="rId${i + 3}"/>`,
   ).join('');
-  return `${XML_DECL}<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst><p:sldIdLst>${sldIds}</p:sldIdLst><p:sldSz cx="${EMU_W}" cy="${EMU_H}"/><p:notesSz cx="6858000" cy="9144000"/></p:presentation>`;
+  return `${XML_DECL}<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst><p:sldIdLst>${sldIds}</p:sldIdLst><p:sldSz cx="${emuW}" cy="${emuH}"/><p:notesSz cx="6858000" cy="9144000"/></p:presentation>`;
 }
 
 function presentationRelsXml(n: number): string {
@@ -134,8 +140,8 @@ function slideLayoutRelsXml(): string {
   return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/slideMaster" Target="../slideMasters/slideMaster1.xml"/></Relationships>`;
 }
 
-function slideXml(): string {
-  return `${XML_DECL}<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:pic><p:nvPicPr><p:cNvPr id="2" name="Slide"/><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId2"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="${EMU_W}" cy="${EMU_H}"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic></p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>`;
+function slideXml(emuW: number, emuH: number): string {
+  return `${XML_DECL}<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:pic><p:nvPicPr><p:cNvPr id="2" name="Slide"/><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId2"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="${emuW}" cy="${emuH}"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic></p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>`;
 }
 
 function slideRelsXml(idx: number): string {

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { designToCssVars } from './design';
+import { downloadBlob } from './download';
 import { SlidePageProvider } from './page-context';
 import { isFrameAnimationSettled, waitForDataWaitfor, waitForFonts } from './print-ready';
 import type { SlideModule } from './sdk';
@@ -269,16 +270,4 @@ function nextPaint(): Promise<void> {
     requestAnimationFrame(settle);
     setTimeout(settle, 50);
   });
-}
-
-function downloadBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.rel = 'noopener';
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  setTimeout(() => URL.revokeObjectURL(url), 0);
 }

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -1,27 +1,11 @@
-import { createElement } from 'react';
-import { createRoot, type Root } from 'react-dom/client';
-import { designToCssVars } from './design';
+import { capturePagesAsPng } from './capture';
 import { downloadBlob } from './download';
-import { SlidePageProvider } from './page-context';
-import { isFrameAnimationSettled, waitForDataWaitfor, waitForFonts } from './print-ready';
+import { FORMAT_PRESETS } from './formats';
 import type { SlideModule } from './sdk';
 
-const SLIDE_W = 1920;
-const SLIDE_H = 1080;
 // 16:9 widescreen in English Metric Units (914400 EMU per inch → 13.333in × 7.5in).
 const EMU_W = 12192000;
 const EMU_H = 6858000;
-const CAPTURE_PIXEL_RATIO = 2;
-
-const ANIMATION_TIMEOUT_MS = 15_000;
-const POLL_INTERVAL_MS = 100;
-
-const CAPTURE_CLASS = 'os-pptx-capture';
-const CAPTURE_STYLE_ID = 'os-pptx-capture-style';
-// Properties intro animations drive from a hidden start state to a visible end
-// state. We read them back once settled and pin them inline so the capture clone
-// can't re-run the keyframes from their invisible 0% frame (see freezeForCapture).
-const FROZEN_PROPS = ['opacity', 'transform', 'filter', 'clip-path'] as const;
 
 export type PptxExportProgress = {
   phase: 'processing' | 'generating' | 'done';
@@ -43,91 +27,15 @@ export async function exportSlideAsImagePptx(
   const total = pages.length;
   onProgress?.({ phase: 'processing', current: 0, total, percent: 0 });
 
-  const container = document.createElement('div');
-  container.className = CAPTURE_CLASS;
-  container.setAttribute('aria-hidden', 'true');
-  Object.assign(container.style, {
-    position: 'fixed',
-    left: '-99999px',
-    top: '0',
-    pointerEvents: 'none',
-  });
-  document.body.appendChild(container);
-
-  // html-to-image clones each frame and copies its computed style — including the
-  // intro animation — into the clone, which then re-runs the keyframes from their
-  // hidden 0% frame in the rasterised SVG. Fast-forward every animation to its end
-  // frame in the live DOM (a large negative delay lands past a 1ms duration, so
-  // even pseudo-elements paint their final state on the first frame).
-  const captureStyle = document.createElement('style');
-  captureStyle.id = CAPTURE_STYLE_ID;
-  captureStyle.textContent = `.${CAPTURE_CLASS} *, .${CAPTURE_CLASS} *::before, .${CAPTURE_CLASS} *::after {
-    animation-delay: -1s !important;
-    animation-duration: 1ms !important;
-    animation-iteration-count: 1 !important;
-    animation-fill-mode: forwards !important;
-    transition: none !important;
-  }`;
-  document.head.appendChild(captureStyle);
-
-  const designVars = slide.design ? designToCssVars(slide.design) : null;
-
-  const reactRoots: Root[] = [];
-  const frames: HTMLElement[] = [];
-  for (let i = 0; i < pages.length; i++) {
-    const Page = pages[i];
-    if (!Page) continue;
-    const host = document.createElement('div');
-    host.setAttribute('data-osd-canvas', '');
-    host.style.width = `${SLIDE_W}px`;
-    host.style.height = `${SLIDE_H}px`;
-    host.style.overflow = 'hidden';
-    host.style.background = '#fff';
-    if (designVars) {
-      for (const [k, v] of Object.entries(designVars)) host.style.setProperty(k, v);
-    }
-    container.appendChild(host);
-    frames.push(host);
-    const r = createRoot(host);
-    r.render(
-      createElement(SlidePageProvider, { index: i, total: pages.length }, createElement(Page)),
-    );
-    reactRoots.push(r);
-  }
-  // Yield once so React commits all pages and intro animations actually start.
-  await nextPaint();
-
   try {
-    await waitForFonts();
-
-    const deadline = performance.now() + ANIMATION_TIMEOUT_MS;
-    while (performance.now() < deadline) {
-      const settled = frames.every((frame) => isFrameAnimationSettled(frame));
-      if (settled) break;
-      await sleep(POLL_INTERVAL_MS);
-    }
-    await waitForDataWaitfor(container);
-
-    const { toBlob } = await import('html-to-image');
-    const images: Uint8Array[] = [];
-    for (let i = 0; i < frames.length; i++) {
-      freezeForCapture(frames[i]);
-      const blob = await toBlob(frames[i], {
-        width: SLIDE_W,
-        height: SLIDE_H,
-        pixelRatio: CAPTURE_PIXEL_RATIO,
-        backgroundColor: '#ffffff',
-        cacheBust: true,
-      });
-      if (!blob) throw new Error(`failed to capture page ${i + 1}`);
-      images.push(new Uint8Array(await blob.arrayBuffer()));
+    const images = await capturePagesAsPng(slide, FORMAT_PRESETS.slide, (captured) => {
       onProgress?.({
         phase: 'processing',
-        current: i + 1,
+        current: captured,
         total,
-        percent: Math.min(95, ((i + 1) / total) * 95),
+        percent: Math.min(95, (captured / total) * 95),
       });
-    }
+    });
 
     onProgress?.({ phase: 'generating', current: total, total, percent: 98 });
     const pptx = await buildImagePptx(images);
@@ -139,23 +47,6 @@ export async function exportSlideAsImagePptx(
     );
   } finally {
     onProgress?.({ phase: 'done', current: total, total, percent: 100 });
-    for (const r of reactRoots) r.unmount();
-    container.remove();
-    captureStyle.remove();
-  }
-}
-
-// Pin each element's settled visual state inline and remove its animation so the
-// clone html-to-image rasterises renders the final frame instead of replaying the
-// (initially invisible) keyframes. Pseudo-elements are handled by CAPTURE_STYLE_ID.
-function freezeForCapture(root: HTMLElement): void {
-  for (const el of root.querySelectorAll<HTMLElement>('*')) {
-    const cs = getComputedStyle(el);
-    for (const prop of FROZEN_PROPS) {
-      el.style.setProperty(prop, cs.getPropertyValue(prop), 'important');
-    }
-    el.style.setProperty('animation', 'none', 'important');
-    el.style.setProperty('transition', 'none', 'important');
   }
 }
 
@@ -253,21 +144,4 @@ function slideRelsXml(idx: number): string {
 
 function themeXml(): string {
   return `${XML_DECL}<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme"><a:themeElements><a:clrScheme name="Office"><a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1><a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1><a:dk2><a:srgbClr val="44546A"/></a:dk2><a:lt2><a:srgbClr val="E7E6E6"/></a:lt2><a:accent1><a:srgbClr val="4472C4"/></a:accent1><a:accent2><a:srgbClr val="ED7D31"/></a:accent2><a:accent3><a:srgbClr val="A5A5A5"/></a:accent3><a:accent4><a:srgbClr val="FFC000"/></a:accent4><a:accent5><a:srgbClr val="5B9BD5"/></a:accent5><a:accent6><a:srgbClr val="70AD47"/></a:accent6><a:hlink><a:srgbClr val="0563C1"/></a:hlink><a:folHlink><a:srgbClr val="954F72"/></a:folHlink></a:clrScheme><a:fontScheme name="Office"><a:majorFont><a:latin typeface="Calibri Light"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont><a:minorFont><a:latin typeface="Calibri"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont></a:fontScheme><a:fmtScheme name="Office"><a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:lumMod val="110000"/><a:satMod val="105000"/><a:tint val="67000"/></a:schemeClr></a:gs><a:gs pos="50000"><a:schemeClr val="phClr"><a:lumMod val="105000"/><a:satMod val="103000"/><a:tint val="73000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:lumMod val="105000"/><a:satMod val="109000"/><a:tint val="81000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="5400000" scaled="0"/></a:gradFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:satMod val="103000"/><a:lumMod val="102000"/><a:tint val="94000"/></a:schemeClr></a:gs><a:gs pos="50000"><a:schemeClr val="phClr"><a:satMod val="110000"/><a:lumMod val="100000"/><a:shade val="100000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:lumMod val="99000"/><a:satMod val="120000"/><a:shade val="78000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="5400000" scaled="0"/></a:gradFill></a:fillStyleLst><a:lnStyleLst><a:ln w="6350" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/><a:miter lim="800000"/></a:ln><a:ln w="12700" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/><a:miter lim="800000"/></a:ln><a:ln w="19050" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/><a:miter lim="800000"/></a:ln></a:lnStyleLst><a:effectStyleLst><a:effectStyle><a:effectLst/></a:effectStyle><a:effectStyle><a:effectLst/></a:effectStyle><a:effectStyle><a:effectLst/></a:effectStyle></a:effectStyleLst><a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:solidFill><a:schemeClr val="phClr"><a:tint val="95000"/><a:satMod val="170000"/></a:schemeClr></a:solidFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="93000"/><a:satMod val="150000"/><a:shade val="98000"/><a:lumMod val="102000"/></a:schemeClr></a:gs><a:gs pos="50000"><a:schemeClr val="phClr"><a:tint val="98000"/><a:satMod val="130000"/><a:shade val="90000"/><a:lumMod val="103000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:shade val="63000"/><a:satMod val="120000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="5400000" scaled="0"/></a:gradFill></a:bgFillStyleLst></a:fmtScheme></a:themeElements></a:theme>`;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function nextPaint(): Promise<void> {
-  return new Promise((resolve) => {
-    let settled = false;
-    const settle = () => {
-      if (settled) return;
-      settled = true;
-      resolve();
-    };
-    requestAnimationFrame(settle);
-    setTimeout(settle, 50);
-  });
 }

--- a/packages/core/src/app/lib/formats.test.ts
+++ b/packages/core/src/app/lib/formats.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { type FormatPreset, resolveCanvas } from './formats.ts';
+import type { SlideMeta } from './sdk.ts';
+
+describe('FORMAT_PRESETS', () => {
+  const expected: Record<FormatPreset, { width: number; height: number }> = {
+    slide: { width: 1920, height: 1080 },
+    carousel: { width: 1080, height: 1080 },
+    portrait: { width: 1080, height: 1350 },
+    story: { width: 1080, height: 1920 },
+    thumbnail: { width: 1280, height: 720 },
+    og: { width: 1200, height: 630 },
+    'x-post': { width: 1600, height: 900 },
+  };
+
+  for (const [preset, size] of Object.entries(expected)) {
+    it(`resolves ${preset} to ${size.width}x${size.height}`, () => {
+      const meta: SlideMeta = { format: preset as FormatPreset };
+      expect(resolveCanvas(meta)).toEqual(size);
+    });
+  }
+});
+
+describe('resolveCanvas defaults', () => {
+  it('defaults to the slide preset when meta is undefined', () => {
+    expect(resolveCanvas(undefined)).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it('defaults to the slide preset when meta is empty', () => {
+    expect(resolveCanvas({})).toEqual({ width: 1920, height: 1080 });
+  });
+});
+
+describe('resolveCanvas precedence', () => {
+  it('prefers meta.canvas over meta.format when both are set', () => {
+    const meta: SlideMeta = { format: 'carousel', canvas: { width: 640, height: 480 } };
+    expect(resolveCanvas(meta)).toEqual({ width: 640, height: 480 });
+  });
+});
+
+describe('resolveCanvas error handling', () => {
+  it('throws on an unknown format naming the bad value and listing valid presets', () => {
+    const meta = { format: 'bogus' } as unknown as SlideMeta;
+    expect(() => resolveCanvas(meta)).toThrowError(/bogus/);
+    try {
+      resolveCanvas(meta);
+      throw new Error('expected resolveCanvas to throw');
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).toContain('bogus');
+      for (const preset of [
+        'slide',
+        'carousel',
+        'portrait',
+        'story',
+        'thumbnail',
+        'og',
+        'x-post',
+      ]) {
+        expect(message).toContain(preset);
+      }
+    }
+  });
+
+  it('names the slide id in the unknown-format error when provided', () => {
+    const meta = { format: 'bogus' } as unknown as SlideMeta;
+    expect(() => resolveCanvas(meta, 'my-slide')).toThrowError(/my-slide/);
+  });
+
+  it.each([
+    ['zero width', { width: 0, height: 1080 }],
+    ['negative width', { width: -100, height: 1080 }],
+    ['NaN width', { width: Number.NaN, height: 1080 }],
+    ['Infinity width', { width: Number.POSITIVE_INFINITY, height: 1080 }],
+    ['missing height', { width: 1920 } as { width: number; height: number }],
+    ['zero height', { width: 1920, height: 0 }],
+    ['negative height', { width: 1920, height: -1 }],
+  ])('throws on invalid canvas dims: %s', (_label, canvas) => {
+    const meta: SlideMeta = { canvas };
+    expect(() => resolveCanvas(meta, 'bad-canvas-slide')).toThrowError(/bad-canvas-slide/);
+  });
+
+  it('names the slide id in the invalid-canvas error when provided', () => {
+    const meta: SlideMeta = { canvas: { width: 0, height: 0 } };
+    expect(() => resolveCanvas(meta, 'zero-canvas')).toThrowError(/zero-canvas/);
+  });
+});
+
+describe('resolveCanvas registry immutability', () => {
+  it('does not let callers mutate the underlying preset via the returned object', () => {
+    const first = resolveCanvas({ format: 'og' });
+    first.width = 1;
+    first.height = 1;
+    const second = resolveCanvas({ format: 'og' });
+    expect(second).toEqual({ width: 1200, height: 630 });
+  });
+});

--- a/packages/core/src/app/lib/formats.test.ts
+++ b/packages/core/src/app/lib/formats.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { type FormatPreset, resolveCanvas } from './formats.ts';
+import { FORMAT_PRESETS, type FormatPreset, resolveCanvas } from './formats.ts';
 import type { SlideMeta } from './sdk.ts';
 
 describe('FORMAT_PRESETS', () => {
@@ -93,5 +93,14 @@ describe('resolveCanvas registry immutability', () => {
     first.height = 1;
     const second = resolveCanvas({ format: 'og' });
     expect(second).toEqual({ width: 1200, height: 630 });
+  });
+
+  it('does not let callers mutate FORMAT_PRESETS entries directly', () => {
+    try {
+      FORMAT_PRESETS.slide.width = 1;
+      FORMAT_PRESETS.slide.height = 1;
+    } catch {}
+    expect(FORMAT_PRESETS.slide).toEqual({ width: 1920, height: 1080 });
+    expect(resolveCanvas({ format: 'slide' })).toEqual({ width: 1920, height: 1080 });
   });
 });

--- a/packages/core/src/app/lib/formats.ts
+++ b/packages/core/src/app/lib/formats.ts
@@ -12,13 +12,13 @@ export type FormatPreset =
 export type CanvasSize = { width: number; height: number };
 
 export const FORMAT_PRESETS: Record<FormatPreset, CanvasSize> = Object.freeze({
-  slide: { width: 1920, height: 1080 },
-  carousel: { width: 1080, height: 1080 },
-  portrait: { width: 1080, height: 1350 },
-  story: { width: 1080, height: 1920 },
-  thumbnail: { width: 1280, height: 720 },
-  og: { width: 1200, height: 630 },
-  'x-post': { width: 1600, height: 900 },
+  slide: Object.freeze({ width: 1920, height: 1080 }),
+  carousel: Object.freeze({ width: 1080, height: 1080 }),
+  portrait: Object.freeze({ width: 1080, height: 1350 }),
+  story: Object.freeze({ width: 1080, height: 1920 }),
+  thumbnail: Object.freeze({ width: 1280, height: 720 }),
+  og: Object.freeze({ width: 1200, height: 630 }),
+  'x-post': Object.freeze({ width: 1600, height: 900 }),
 });
 
 function isValidDimension(value: unknown): value is number {

--- a/packages/core/src/app/lib/formats.ts
+++ b/packages/core/src/app/lib/formats.ts
@@ -1,0 +1,55 @@
+import type { SlideMeta } from './sdk.ts';
+
+export type FormatPreset =
+  | 'slide'
+  | 'carousel'
+  | 'portrait'
+  | 'story'
+  | 'thumbnail'
+  | 'og'
+  | 'x-post';
+
+export type CanvasSize = { width: number; height: number };
+
+export const FORMAT_PRESETS: Record<FormatPreset, CanvasSize> = Object.freeze({
+  slide: { width: 1920, height: 1080 },
+  carousel: { width: 1080, height: 1080 },
+  portrait: { width: 1080, height: 1350 },
+  story: { width: 1080, height: 1920 },
+  thumbnail: { width: 1280, height: 720 },
+  og: { width: 1200, height: 630 },
+  'x-post': { width: 1600, height: 900 },
+});
+
+function isValidDimension(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function describeSlide(slideId: string | undefined): string {
+  return slideId ? ` for slide "${slideId}"` : '';
+}
+
+export function resolveCanvas(meta: SlideMeta | undefined, slideId?: string): CanvasSize {
+  if (meta?.canvas) {
+    const { canvas } = meta;
+    if (!isValidDimension(canvas.width) || !isValidDimension(canvas.height)) {
+      throw new Error(
+        `Invalid canvas${describeSlide(slideId)}: width and height must be finite numbers greater than 0 (got ${JSON.stringify(canvas)}).`,
+      );
+    }
+    return { width: canvas.width, height: canvas.height };
+  }
+
+  if (meta?.format) {
+    const preset = FORMAT_PRESETS[meta.format];
+    if (!preset) {
+      const validPresets = Object.keys(FORMAT_PRESETS).join(', ');
+      throw new Error(
+        `Unknown format "${meta.format}"${describeSlide(slideId)}. Valid presets: ${validPresets}.`,
+      );
+    }
+    return { width: preset.width, height: preset.height };
+  }
+
+  return { width: FORMAT_PRESETS.slide.width, height: FORMAT_PRESETS.slide.height };
+}

--- a/packages/core/src/app/lib/sdk.ts
+++ b/packages/core/src/app/lib/sdk.ts
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react';
 import type { DesignSystem } from './design.ts';
+import { FORMAT_PRESETS, type FormatPreset } from './formats.ts';
 import type { SlideTransition } from './transition.ts';
 
 export type Page = ComponentType & { transition?: SlideTransition };
@@ -9,6 +10,8 @@ export type SlideMeta = {
   theme?: string;
   /** ISO 8601 timestamp. Set once at scaffold time; used to sort the slide list. */
   createdAt?: string;
+  format?: FormatPreset;
+  canvas?: { width: number; height: number };
 };
 
 export type SlideModule = {
@@ -33,5 +36,5 @@ export type FoldersManifest = {
   assignments: Record<string, string>;
 };
 
-export const CANVAS_WIDTH = 1920;
-export const CANVAS_HEIGHT = 1080;
+export const CANVAS_WIDTH = FORMAT_PRESETS.slide.width;
+export const CANVAS_HEIGHT = FORMAT_PRESETS.slide.height;

--- a/packages/core/src/app/lib/slides.ts
+++ b/packages/core/src/app/lib/slides.ts
@@ -4,6 +4,7 @@ import {
   loadSlide as load,
   slideThemes as themes,
 } from 'virtual:open-slide/slides';
+import { resolveCanvas } from './formats.ts';
 import type { SlideModule } from './sdk';
 
 export const slideIds: string[] = ids;
@@ -15,7 +16,9 @@ export function slidesByTheme(themeId: string): string[] {
 }
 
 export async function loadSlide(id: string): Promise<SlideModule> {
-  return load(id);
+  const mod = await load(id);
+  resolveCanvas(mod.meta, id);
+  return mod;
 }
 
 export function slideChangeIncludes(data: unknown, slideId: string): boolean {

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -35,6 +35,7 @@ import { cn } from '@/lib/utils';
 import { FolderIconChip, SLIDE_DND_MIME } from '../components/sidebar/folder-item';
 import { DRAFT_ID } from '../components/sidebar/sidebar';
 import { SlideCanvas } from '../components/slide-canvas';
+import { resolveCanvas } from '../lib/formats';
 import { SlidePageProvider } from '../lib/page-context';
 import type { Folder, FolderIcon, SlideModule } from '../lib/sdk';
 import { loadSlide, slideCreatedAt } from '../lib/slides';
@@ -460,7 +461,12 @@ function SlideCard({
           <div className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] group-hover:shadow-floating group-hover:ring-foreground/20 motion-safe:transition-[box-shadow,--tw-ring-color] motion-safe:duration-200">
             {FirstPage ? (
               <div className="h-full w-full motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]">
-                <SlideCanvas flat freezeMotion design={slide?.design}>
+                <SlideCanvas
+                  flat
+                  freezeMotion
+                  design={slide?.design}
+                  canvas={resolveCanvas(slide?.meta)}
+                >
                   <SlidePageProvider index={0} total={slide?.default.length ?? 1}>
                     <FirstPage />
                   </SlidePageProvider>

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -9,8 +9,8 @@ import {
   usePresenterChannel,
 } from '../components/present/use-presenter-channel';
 import { SlideCanvas } from '../components/slide-canvas';
+import { resolveCanvas } from '../lib/formats';
 import { SlidePageProvider } from '../lib/page-context';
-import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
 import { type StepController, StepHost } from '../lib/step-context';
 import { useSlideModule } from '../lib/use-slide-module';
 
@@ -113,6 +113,7 @@ export function Presenter() {
   }
 
   const pages = slide.default;
+  const canvas = resolveCanvas(slide.meta, slideId);
   const total = pages.length;
   const index = Math.max(0, Math.min(total - 1, state?.index ?? 0));
   const note = slide.notes?.[index];
@@ -145,7 +146,7 @@ export function Presenter() {
         <section className="flex min-h-0 flex-col gap-3">
           <SectionLabel>{t.presenter.nowShowing}</SectionLabel>
           <div className="relative min-h-0 flex-1 overflow-hidden rounded-[8px] bg-black ring-1 ring-border">
-            <SlideCanvas flat design={slide.design}>
+            <SlideCanvas flat design={slide.design} canvas={canvas}>
               <SlidePageProvider index={index} total={total}>
                 <PreviewStepHost revealed={stepIndex}>
                   <CurrentPage />
@@ -172,10 +173,10 @@ export function Presenter() {
             <SectionLabel>{hasNext ? t.presenter.upNext : t.presenter.lastSlide}</SectionLabel>
             <div
               className="relative w-full overflow-hidden rounded-[8px] bg-black ring-1 ring-border"
-              style={{ aspectRatio: `${CANVAS_WIDTH}/${CANVAS_HEIGHT}` }}
+              style={{ aspectRatio: `${canvas.width}/${canvas.height}` }}
             >
               {NextPage ? (
-                <SlideCanvas flat freezeMotion design={slide.design}>
+                <SlideCanvas flat freezeMotion design={slide.design} canvas={canvas}>
                   <SlidePageProvider index={nextPageIndex} total={total}>
                     <PreviewStepHost revealed={nextRevealed}>
                       <NextPage />

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -60,6 +60,7 @@ import { type ThumbnailActions, ThumbnailRail } from '../components/thumbnail-ra
 import { exportSlideAsHtml } from '../lib/export-html';
 import { exportSlideAsPdf, isSafari } from '../lib/export-pdf';
 import { exportSlideAsImagePptx } from '../lib/export-pptx';
+import { type CanvasSize, FORMAT_PRESETS, resolveCanvas } from '../lib/formats';
 import { remapNotesSessionCacheAfterReorder } from '../lib/inspector/use-notes';
 import type { SlideModule } from '../lib/sdk';
 import { usePrefersReducedMotion } from '../lib/use-prefers-reduced-motion';
@@ -90,6 +91,10 @@ export function Slide() {
   const prefersReducedMotion = usePrefersReducedMotion();
 
   const modulePages = useMemo(() => slide?.default ?? [], [slide]);
+  const canvas = useMemo(
+    () => (slide ? resolveCanvas(slide.meta, slideId) : FORMAT_PRESETS.slide),
+    [slide, slideId],
+  );
   const [pages, setPages] = useState<typeof modulePages>(modulePages);
   useEffect(() => {
     setPages(modulePages);
@@ -356,6 +361,7 @@ export function Slide() {
         onIndexChange={goTo}
         onExit={() => {}}
         allowExit={false}
+        canvas={canvas}
       />
     );
   }
@@ -372,6 +378,7 @@ export function Slide() {
         controls
         slideId={slideId}
         fullscreen={playMode === 'fullscreen'}
+        canvas={canvas}
       />
     );
   }
@@ -703,6 +710,7 @@ export function Slide() {
                     actions={thumbnailActions}
                     moduleTransition={slide.transition}
                     onOverview={() => setOverviewOpen(true)}
+                    canvas={canvas}
                   />
                   <main
                     ref={slideViewportRef}
@@ -717,7 +725,7 @@ export function Slide() {
                       canPrev={index > 0}
                       canNext={index < pageCount - 1}
                     />
-                    <SlideCanvas design={slide.design}>
+                    <SlideCanvas design={slide.design} canvas={canvas}>
                       <SlideTransitionLayer
                         pages={pages}
                         index={index}
@@ -743,6 +751,7 @@ export function Slide() {
                       onSelect={goTo}
                       orientation="horizontal"
                       actions={thumbnailActions}
+                      canvas={canvas}
                     />
                   </div>
                   <InspectorPanel />
@@ -765,6 +774,7 @@ export function Slide() {
                   onSelect={goTo}
                   variant="editor"
                   moduleTransition={slide.transition}
+                  canvas={canvas}
                 />
               </div>
             </DesignProvider>
@@ -797,6 +807,7 @@ function ResizableRail(props: {
   actions?: ThumbnailActions;
   moduleTransition?: SlideModule['transition'];
   onOverview?: () => void;
+  canvas?: CanvasSize;
 }) {
   const t = useLocale();
   const [width, setWidth] = useState<number>(readStoredRailWidth);

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -429,12 +429,15 @@ export function Slide() {
       await exportSlideAsPng(slide, slideId, (p) => {
         toast.custom(() => <PngProgressToast progress={p} />, { id: toastId, duration: Infinity });
       });
+      toast.dismiss(toastId);
     } catch (err) {
       console.error('[open-slide] png export failed', err);
-      toast.error(t.slide.pngExportFailed, { id: toastId, duration: 4000 });
+      // The error toast must not reuse toastId: sonner keeps rendering a custom
+      // toast's JSX when updated by id, so the error text would never paint.
+      toast.dismiss(toastId);
+      toast.error(t.slide.pngExportFailed, { duration: 4000 });
     } finally {
       setExporting(false);
-      toast.dismiss(toastId);
     }
   };
 

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -7,6 +7,7 @@ import {
   FileCode2,
   FileImage,
   FileText,
+  Image,
   Link2,
   Loader2,
   Maximize,
@@ -53,12 +54,14 @@ import { NotesDrawer } from '../components/notes-drawer';
 import { OverviewGrid } from '../components/overview-grid';
 import { PdfProgressToast } from '../components/pdf-progress-toast';
 import { openPresenterWindow, Player } from '../components/player';
+import { PngProgressToast } from '../components/png-progress-toast';
 import { PptxProgressToast } from '../components/pptx-progress-toast';
 import { SlideCanvas } from '../components/slide-canvas';
 import { SlideTransitionLayer } from '../components/slide-transition-layer';
 import { type ThumbnailActions, ThumbnailRail } from '../components/thumbnail-rail';
 import { exportSlideAsHtml } from '../lib/export-html';
 import { exportSlideAsPdf, isSafari } from '../lib/export-pdf';
+import { exportSlideAsPng } from '../lib/export-png';
 import { exportSlideAsImagePptx } from '../lib/export-pptx';
 import { type CanvasSize, FORMAT_PRESETS, resolveCanvas } from '../lib/formats';
 import { remapNotesSessionCacheAfterReorder } from '../lib/inspector/use-notes';
@@ -410,6 +413,31 @@ export function Slide() {
     }
   };
 
+  const exportPng = async () => {
+    if (!slide || exporting) return;
+    setExporting(true);
+    const toastId = `png-export-${slideId}`;
+    toast.custom(
+      () => (
+        <PngProgressToast
+          progress={{ phase: 'processing', current: 0, total: pages.length, percent: 0 }}
+        />
+      ),
+      { id: toastId, duration: Infinity },
+    );
+    try {
+      await exportSlideAsPng(slide, slideId, (p) => {
+        toast.custom(() => <PngProgressToast progress={p} />, { id: toastId, duration: Infinity });
+      });
+    } catch (err) {
+      console.error('[open-slide] png export failed', err);
+      toast.error(t.slide.pngExportFailed, { id: toastId, duration: 4000 });
+    } finally {
+      setExporting(false);
+      toast.dismiss(toastId);
+    }
+  };
+
   const exportPdf = async () => {
     if (!slide || exporting) return;
     if (isSafari()) {
@@ -469,6 +497,10 @@ export function Slide() {
       <DropdownMenuItem disabled={exporting} onSelect={exportHtml}>
         <FileCode2 />
         {t.slide.exportAsHtml}
+      </DropdownMenuItem>
+      <DropdownMenuItem disabled={exporting} onSelect={exportPng}>
+        <Image />
+        {t.slide.exportAsPng}
       </DropdownMenuItem>
       <DropdownMenuItem disabled={exporting} onSelect={exportPdf}>
         <FileText />

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,8 @@ export type {
   DesignTypeScale,
 } from './app/lib/design.ts';
 export { cssVarsToString, defaultDesign, designToCssVars } from './app/lib/design.ts';
+export type { CanvasSize, FormatPreset } from './app/lib/formats.ts';
+export { FORMAT_PRESETS, resolveCanvas } from './app/lib/formats.ts';
 export { useSlidePageNumber } from './app/lib/page-context.tsx';
 export type { Page, SlideMeta, SlideModule } from './app/lib/sdk.ts';
 export { CANVAS_HEIGHT, CANVAS_WIDTH } from './app/lib/sdk.ts';

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -110,6 +110,7 @@ export const en: Locale = {
     toastCopyLinkSuccess: 'Link copied to clipboard',
     toastCopyLinkFailed: 'Failed to copy link',
     exportAsHtml: 'Export as HTML',
+    exportAsPng: 'Export as PNG',
     exportAsPdf: 'Export as PDF',
     exportAsImagePptx: 'Export as image PPTX',
     exportAsPptx: 'Export as PPTX',
@@ -117,6 +118,7 @@ export const en: Locale = {
     pptxComingSoonTooltip:
       'Editable PPTX export isn’t ready yet. For now, use “Export as image PPTX” instead.',
     pdfExportFailed: 'PDF export failed',
+    pngExportFailed: 'PNG export failed',
     imagePptxExportFailed: 'PPTX export failed',
     pdfExportSafariUnsupported:
       'Export as PDF is not supported on Safari. Please try a Chromium-based browser instead.',
@@ -364,6 +366,13 @@ export const en: Locale = {
     title: 'Exporting PPTX',
     processing: 'Rendering page {current} of {total}',
     generating: 'Building presentation…',
+    done: 'Done',
+  },
+
+  pngToast: {
+    title: 'Exporting PNG',
+    processing: 'Rendering page {current} of {total}',
+    generating: 'Packaging images…',
     done: 'Done',
   },
 

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -111,6 +111,7 @@ export const ja: Locale = {
     toastCopyLinkSuccess: 'リンクをクリップボードにコピーしました',
     toastCopyLinkFailed: 'リンクのコピーに失敗しました',
     exportAsHtml: 'HTML として書き出し',
+    exportAsPng: 'PNG として書き出し',
     exportAsPdf: 'PDF として書き出し',
     exportAsImagePptx: '画像 PPTX として書き出し',
     exportAsPptx: 'PPTX として書き出し',
@@ -118,6 +119,7 @@ export const ja: Locale = {
     pptxComingSoonTooltip:
       '編集可能な PPTX の書き出しはまだ対応していません。それまでは「画像 PPTX として書き出し」をご利用ください。',
     pdfExportFailed: 'PDF の書き出しに失敗しました',
+    pngExportFailed: 'PNG の書き出しに失敗しました',
     imagePptxExportFailed: 'PPTX の書き出しに失敗しました',
     pdfExportSafariUnsupported:
       'PDF の書き出しは現在 Safari では対応していません。Chromium ベースのブラウザでお試しください。',
@@ -369,6 +371,13 @@ export const ja: Locale = {
     title: 'PPTX を書き出し中',
     processing: 'ページ {current} / {total} を描画中',
     generating: 'プレゼンテーションを構築中…',
+    done: '完了',
+  },
+
+  pngToast: {
+    title: 'PNG を書き出し中',
+    processing: 'ページ {current} / {total} を描画中',
+    generating: '画像をパッケージ中…',
     done: '完了',
   },
 

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -112,12 +112,14 @@ export type Locale = {
     toastCopyLinkSuccess: string;
     toastCopyLinkFailed: string;
     exportAsHtml: string;
+    exportAsPng: string;
     exportAsPdf: string;
     exportAsImagePptx: string;
     exportAsPptx: string;
     comingSoon: string;
     pptxComingSoonTooltip: string;
     pdfExportFailed: string;
+    pngExportFailed: string;
     imagePptxExportFailed: string;
     pdfExportSafariUnsupported: string;
     present: string;
@@ -383,6 +385,14 @@ export type Locale = {
   };
 
   pptxToast: {
+    title: string;
+    /** template: "Rendering page {current} of {total}" */
+    processing: string;
+    generating: string;
+    done: string;
+  };
+
+  pngToast: {
     title: string;
     /** template: "Rendering page {current} of {total}" */
     processing: string;

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -109,12 +109,14 @@ export const zhCN: Locale = {
     toastCopyLinkSuccess: '已复制链接到剪贴板',
     toastCopyLinkFailed: '复制链接失败',
     exportAsHtml: '导出为 HTML',
+    exportAsPng: '导出为 PNG',
     exportAsPdf: '导出为 PDF',
     exportAsImagePptx: '导出图片 PPTX',
     exportAsPptx: '导出 PPTX',
     comingSoon: '即将推出',
     pptxComingSoonTooltip: '可编辑的 PPTX 导出尚未支持，在此之前可以先使用“导出图片 PPTX”。',
     pdfExportFailed: 'PDF 导出失败',
+    pngExportFailed: 'PNG 导出失败',
     imagePptxExportFailed: 'PPTX 导出失败',
     pdfExportSafariUnsupported:
       '导出 PDF 目前不支持 Safari 设备，请尝试使用基于 Chromium 的浏览器替代。',
@@ -362,6 +364,13 @@ export const zhCN: Locale = {
     title: '导出 PPTX',
     processing: '正在渲染第 {current} / {total} 页',
     generating: '正在组合演示文稿…',
+    done: '完成',
+  },
+
+  pngToast: {
+    title: '导出 PNG',
+    processing: '正在渲染第 {current} / {total} 页',
+    generating: '正在打包图片…',
     done: '完成',
   },
 

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -109,12 +109,14 @@ export const zhTW: Locale = {
     toastCopyLinkSuccess: '已複製連結到剪貼簿',
     toastCopyLinkFailed: '複製連結失敗',
     exportAsHtml: '匯出為 HTML',
+    exportAsPng: '匯出為 PNG',
     exportAsPdf: '匯出為 PDF',
     exportAsImagePptx: '匯出圖片 PPTX',
     exportAsPptx: '匯出 PPTX',
     comingSoon: '即將推出',
     pptxComingSoonTooltip: '可編輯的 PPTX 匯出尚未支援，在此之前可以先使用「匯出圖片 PPTX」。',
     pdfExportFailed: 'PDF 匯出失敗',
+    pngExportFailed: 'PNG 匯出失敗',
     imagePptxExportFailed: 'PPTX 匯出失敗',
     pdfExportSafariUnsupported:
       '匯出 PDF 目前不支援 Safari 裝置，請嘗試用 Chromium 基底瀏覽器替代。',
@@ -362,6 +364,13 @@ export const zhTW: Locale = {
     title: '匯出 PPTX',
     processing: '正在算繪第 {current} / {total} 頁',
     generating: '正在組合簡報…',
+    done: '完成',
+  },
+
+  pngToast: {
+    title: '匯出 PNG',
+    processing: '正在算繪第 {current} / {total} 頁',
+    generating: '正在打包圖片…',
     done: '完成',
   },
 


### PR DESCRIPTION
This PR turns the fixed 1920x1080 canvas into a per-slide setting, so one repo can hold slides, LinkedIn carousels, story graphics, thumbnails, OG images, and X post images.

## What changed

- New format registry in `packages/core/src/app/lib/formats.ts`. A slide can set `format` ('slide', 'carousel', 'portrait', 'story', 'thumbnail', 'og', 'x-post') or an exact `canvas: { width, height }` in its meta. Everything else reads from `resolveCanvas`. Bad values fail at load time with a clear error that names the slide and lists the valid presets.
- The editor, thumbnail rails, overview grid, play mode, presenter, home cards, and theme pages all render at the slide's own canvas size. Existing 16:9 decks are untouched.
- PDF export prints at the slide's format, so a carousel comes out as true 1:1 pages ready for LinkedIn upload.
- New PNG export in the export menu. One page downloads a single PNG, multiple pages download a zip, both at 2x resolution. The offscreen capture code is now shared between the PNG and PPTX exporters.
- PPTX export sizes its slides to the format.
- The create-slide and slide-authoring skills now ask for a format and give design guidance per format.
- New demo deck `apps/demo/slides/carousel-demo` as a square reference.

## Notes

- 24 commits, meant to be merged with a regular merge, not squashed.
- 295 tests pass, including 22 new ones for the registry. Biome and typecheck are clean. 6 changesets included.
- Known follow-up: the PDF and PPTX handlers have an old bug where the failure toast never shows. This PR fixes it for the new PNG handler only. HTML export still assumes 16:9 on purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PNG export for slides, with progress feedback and automatic download handling.
  * Slide previews, editor, and presenter views now adapt to each slide’s canvas format.
  * Added support for multiple canvas formats and per-slide format overrides.

* **Bug Fixes**
  * PDF and PPTX exports now match the slide’s actual canvas size instead of a fixed layout.

* **Documentation**
  * Updated authoring guidance to reflect format-aware deck creation and design rules.

* **Tests**
  * Added coverage for canvas resolution, format presets, and invalid format handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->