### PR TITLE
Add editable PPTX export

### DIFF
--- a/.changeset/editable-pptx-export.md
+++ b/.changeset/editable-pptx-export.md
@@ -2,4 +2,4 @@
 "@open-slide/core": minor
 ---
 
-Add editable PPTX export with native text, image, shape, table, and gradient objects.
+Add high-fidelity editable PPTX export with native objects and visual snapshots.

--- a/.changeset/editable-pptx-export.md
+++ b/.changeset/editable-pptx-export.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Add editable PPTX export with native text, image, shape, table, and gradient objects.

--- a/.changeset/editable-pptx-export.md
+++ b/.changeset/editable-pptx-export.md
@@ -2,4 +2,4 @@
 "@open-slide/core": minor
 ---
 
-Add high-fidelity editable PPTX export with native objects and visual snapshots.
+Add editable PPTX export with native objects, image fitting, and CJK text fidelity.

--- a/.changeset/pptx-high-fidelity-notes.md
+++ b/.changeset/pptx-high-fidelity-notes.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Preserve slide geometry, translucent overlays, masked artwork, text flow, and speaker notes in editable PPTX exports.

--- a/.changeset/pptx-mixed-icon-labels.md
+++ b/.changeset/pptx-mixed-icon-labels.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Export mixed icon and text chips as editable PPTX labels.

--- a/.changeset/pptx-progress-success.md
+++ b/.changeset/pptx-progress-success.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Report editable PPTX export completion only after a successful download.

--- a/packages/core/src/app/lib/export-pptx-editable.ts
+++ b/packages/core/src/app/lib/export-pptx-editable.ts
@@ -8,6 +8,8 @@ const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n';
 const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
 const OD_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
 const IMAGE_REL = `${OD_REL}/image`;
+const NOTES_REL = `${OD_REL}/notesSlide`;
+const NOTES_MASTER_REL = `${OD_REL}/notesMaster`;
 
 type PptxGradientStop = {
   color: string;
@@ -74,6 +76,7 @@ type PptxTextObject = PptxBox & {
   color?: string;
   fontFamily?: string;
   fontSize?: number;
+  lineHeight?: number;
   wrap?: boolean;
 };
 
@@ -144,7 +147,6 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
   const rootRect = frame.getBoundingClientRect();
   const rootStyles = getComputedStyle(frame);
   const background = fillFromStyles(rootStyles) ?? '#ffffff';
-  const compositeBase = frameCompositeBase(frame, rootRect, background);
   const objects: PptxObject[] = [];
   const skipped = new WeakSet<Element>();
 
@@ -188,7 +190,7 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
       continue;
     }
 
-    const fill = fillFromStyles(styles, compositeBase);
+    const fill = fillFromStyles(styles);
     const stroke = strokeFromStyles(styles);
     const borderShapes = stroke ? [] : borderShapesFromStyles(box, styles);
     if (fill || stroke) {
@@ -216,21 +218,32 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
   };
 }
 
-export async function buildEditablePptx(slides: EditablePptxSlide[]): Promise<Uint8Array> {
+export async function buildEditablePptx(
+  slides: EditablePptxSlide[],
+  notes: (string | undefined)[] = [],
+): Promise<Uint8Array> {
   const { zipSync, strToU8 } = await import('fflate');
   const files: Record<string, Uint8Array> = {};
   const slideRels: SlideRels[] = [];
+  const noteIndexes = slides
+    .map((_, index) => index)
+    .filter((index) => Boolean(notes[index]?.trim()));
+  const hasNotes = noteIndexes.length > 0;
 
-  files['[Content_Types].xml'] = strToU8(editableContentTypesXml(slides.length));
+  files['[Content_Types].xml'] = strToU8(editableContentTypesXml(slides.length, noteIndexes));
   files['_rels/.rels'] = strToU8(rootRelsXml());
-  files['ppt/presentation.xml'] = strToU8(presentationXml(slides.length));
-  files['ppt/_rels/presentation.xml.rels'] = strToU8(presentationRelsXml(slides.length));
+  files['ppt/presentation.xml'] = strToU8(presentationXml(slides.length, hasNotes));
+  files['ppt/_rels/presentation.xml.rels'] = strToU8(presentationRelsXml(slides.length, hasNotes));
   files['ppt/presProps.xml'] = strToU8(presPropsXml());
   files['ppt/theme/theme1.xml'] = strToU8(themeXml());
   files['ppt/slideMasters/slideMaster1.xml'] = strToU8(slideMasterXml());
   files['ppt/slideMasters/_rels/slideMaster1.xml.rels'] = strToU8(slideMasterRelsXml());
   files['ppt/slideLayouts/slideLayout1.xml'] = strToU8(slideLayoutXml());
   files['ppt/slideLayouts/_rels/slideLayout1.xml.rels'] = strToU8(slideLayoutRelsXml());
+  if (hasNotes) {
+    files['ppt/notesMasters/notesMaster1.xml'] = strToU8(notesMasterXml());
+    files['ppt/notesMasters/_rels/notesMaster1.xml.rels'] = strToU8(notesMasterRelsXml());
+  }
 
   for (let i = 0; i < slides.length; i++) {
     const ctx: SlideBuildContext = {
@@ -252,6 +265,16 @@ export async function buildEditablePptx(slides: EditablePptxSlide[]): Promise<Ui
       );
       mediaIndex++;
     }
+    if (notes[i]?.trim()) {
+      const noteRelId = `rId${rels.rels.length + 2}`;
+      rels.rels.push(
+        `<Relationship Id="${noteRelId}" Type="${NOTES_REL}" Target="../notesSlides/notesSlide${i + 1}.xml"/>`,
+      );
+      files[`ppt/notesSlides/notesSlide${i + 1}.xml`] = strToU8(notesSlideXml(notes[i] ?? ''));
+      files[`ppt/notesSlides/_rels/notesSlide${i + 1}.xml.rels`] = strToU8(
+        notesSlideRelsXml(i + 1),
+      );
+    }
     files[`ppt/slides/_rels/slide${i + 1}.xml.rels`] = strToU8(editableSlideRelsXml(rels.rels));
   }
 
@@ -268,14 +291,20 @@ function elementBox(
   if (opacity <= 0) return null;
 
   const rect = el.getBoundingClientRect();
-  const w = clamp(rect.width, 0, SLIDE_W);
-  const h = clamp(rect.height, 0, SLIDE_H);
+  const scaleX = rootRect.width > 0 ? SLIDE_W / rootRect.width : 1;
+  const scaleY = rootRect.height > 0 ? SLIDE_H / rootRect.height : 1;
   const rotate = rotationFromTransform(styles.transform);
+  const logicalW = rotate && el.offsetWidth > 0 ? el.offsetWidth * scaleX : rect.width * scaleX;
+  const logicalH = rotate && el.offsetHeight > 0 ? el.offsetHeight * scaleY : rect.height * scaleY;
+  const w = clamp(logicalW, 0, SLIDE_W);
+  const h = clamp(logicalH, 0, SLIDE_H);
   if (w < 1 || h < 1) return null;
+  const centerX = (rect.left + rect.width / 2 - rootRect.left) * scaleX;
+  const centerY = (rect.top + rect.height / 2 - rootRect.top) * scaleY;
 
   return {
-    x: clamp(rect.left - rootRect.left, 0, SLIDE_W),
-    y: clamp(rect.top - rootRect.top, 0, SLIDE_H),
+    x: clamp(rotate ? centerX - w / 2 : (rect.left - rootRect.left) * scaleX, 0, SLIDE_W),
+    y: clamp(rotate ? centerY - h / 2 : (rect.top - rootRect.top) * scaleY, 0, SLIDE_H),
     w,
     h,
     opacity: opacity < 1 ? opacity : undefined,
@@ -283,64 +312,10 @@ function elementBox(
   };
 }
 
-function fillFromStyles(styles: CSSStyleDeclaration, compositeBase?: ParsedColor | null): PptxFill {
+function fillFromStyles(styles: CSSStyleDeclaration): PptxFill {
   const gradient = parseLinearGradient(styles.backgroundImage);
-  if (gradient) return compositeBase ? compositeGradientStops(gradient, compositeBase) : gradient;
+  if (gradient) return gradient;
   return colorWithPaint(styles.backgroundColor);
-}
-
-function solidCompositeBase(fill: PptxFill): ParsedColor | null {
-  if (typeof fill !== 'string') return null;
-  const color = parseColor(fill);
-  if (!color || color.alpha < 0.999) return null;
-  return color;
-}
-
-function frameCompositeBase(
-  frame: HTMLElement,
-  rootRect: DOMRect,
-  fallback: PptxFill,
-): ParsedColor | null {
-  for (const el of Array.from(frame.querySelectorAll<HTMLElement>('*'))) {
-    const styles = getComputedStyle(el);
-    const box = elementBox(el, rootRect, styles);
-    if (!box || box.opacity !== undefined || !coversSlide(box)) continue;
-    const fill = fillFromStyles(styles);
-    const base = solidCompositeBase(fill);
-    if (base) return base;
-  }
-  return solidCompositeBase(fallback);
-}
-
-function coversSlide(box: PptxBox): boolean {
-  return box.x <= 1 && box.y <= 1 && box.w >= SLIDE_W - 1 && box.h >= SLIDE_H - 1;
-}
-
-function compositeGradientStops(
-  gradient: PptxLinearGradientFill,
-  base: ParsedColor,
-): PptxLinearGradientFill {
-  return {
-    ...gradient,
-    stops: gradient.stops.map((stop) => ({
-      ...stop,
-      color: compositeColorOverBase(stop.color, base),
-    })),
-  };
-}
-
-function compositeColorOverBase(value: string, base: ParsedColor): string {
-  const foreground = parseColor(value);
-  if (!foreground) return value;
-  if (foreground.alpha >= 0.999) return `#${foreground.hex}`;
-  if (foreground.alpha <= 0.001) return `#${base.hex}`;
-
-  const fg = hexToRgb(foreground.hex);
-  const bg = hexToRgb(base.hex);
-  const alpha = foreground.alpha;
-  return `#${byteToHex(fg.r * alpha + bg.r * (1 - alpha))}${byteToHex(
-    fg.g * alpha + bg.g * (1 - alpha),
-  )}${byteToHex(fg.b * alpha + bg.b * (1 - alpha))}`;
 }
 
 function strokeFromStyles(styles: CSSStyleDeclaration): PptxStroke | null {
@@ -448,6 +423,8 @@ function textFromElement(
   const hasText = paragraphs.some((paragraph) => paragraph.some((run) => run.text.trim()));
   if (!hasText) return null;
   const textBox = adjustedTextBoxForEmbeddedLeadingContent(el, box, styles);
+  const fontSize = parseCssPx(styles.fontSize) || 18;
+  const lineHeightPx = parseCssPx(styles.lineHeight);
 
   return {
     kind: 'text',
@@ -457,8 +434,9 @@ function textFromElement(
     vertical: verticalTextAnchor(textBox, styles),
     color: colorWithPaint(styles.color) ?? undefined,
     fontFamily: normalizeFontFamily(styles.fontFamily),
-    fontSize: parseCssPx(styles.fontSize) || undefined,
-    wrap: shouldWrapTextBox(textBox, styles),
+    fontSize,
+    lineHeight: lineHeightPx > 0 ? lineHeightPx / fontSize : undefined,
+    wrap: paragraphs.length > 1 ? false : shouldWrapTextBox(textBox, styles),
     shadow: parseCssShadow(styles.textShadow),
   };
 }
@@ -684,12 +662,23 @@ async function rasterizeElement(el: HTMLElement, box: PptxBox): Promise<PptxImag
     }
 
     const { toBlob } = await import('html-to-image');
+    const captureWidth = el.offsetWidth || box.w;
+    const captureHeight = el.offsetHeight || box.h;
     const blob = await toBlob(el, {
-      width: Math.max(1, Math.round(box.w)),
-      height: Math.max(1, Math.round(box.h)),
+      width: Math.max(1, Math.round(captureWidth)),
+      height: Math.max(1, Math.round(captureHeight)),
       pixelRatio: 2,
       backgroundColor: undefined,
       cacheBust: true,
+      style: {
+        position: 'relative',
+        left: '0',
+        top: '0',
+        right: 'auto',
+        bottom: 'auto',
+        margin: '0',
+        transform: 'none',
+      },
     });
     if (!blob) return null;
     return {
@@ -1024,14 +1013,23 @@ function textXml(text: PptxTextObject, ctx: SlideBuildContext): string {
   const paragraphs = text.paragraphs.map((paragraph) => paragraphXml(paragraph, text)).join('');
   const wrap = text.wrap === false ? 'none' : 'square';
   const anchor = textAnchorXml(text.vertical);
-  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Text ${id}"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(text)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln>${effectXml(text.shadow ?? null, text.opacity)}</p:spPr><p:txBody><a:bodyPr wrap="${wrap}"${anchor} lIns="0" tIns="0" rIns="0" bIns="0"/><a:lstStyle/>${paragraphs}</p:txBody></p:sp>`;
+  const bodyPrAttrs = `wrap="${wrap}"${anchor} lIns="0" tIns="0" rIns="0" bIns="0"`;
+  const bodyPr =
+    text.wrap === false
+      ? `<a:bodyPr ${bodyPrAttrs}><a:normAutofit/></a:bodyPr>`
+      : `<a:bodyPr ${bodyPrAttrs}/>`;
+  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Text ${id}"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(text)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln>${effectXml(text.shadow ?? null, text.opacity)}</p:spPr><p:txBody>${bodyPr}<a:lstStyle/>${paragraphs}</p:txBody></p:sp>`;
 }
 
 function paragraphXml(paragraph: PptxTextRun[], text: PptxTextObject): string {
   const align =
     text.align && text.align !== 'left' ? ` algn="${pptxTextAlignValue(text.align)}"` : '';
+  const lineSpacing = text.lineHeight
+    ? `<a:lnSpc><a:spcPct val="${Math.round(text.lineHeight * 100000)}"/></a:lnSpc><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="0"/></a:spcAft>`
+    : '';
   const runs = paragraph.map((run) => runXml(run, text)).join('');
-  return `<a:p><a:pPr${align}/>${runs}</a:p>`;
+  const properties = lineSpacing ? `<a:pPr${align}>${lineSpacing}</a:pPr>` : `<a:pPr${align}/>`;
+  return `<a:p>${properties}${runs}</a:p>`;
 }
 
 function runXml(run: PptxTextRun, text: PptxTextObject): string {
@@ -1230,13 +1228,22 @@ function effectXml(shadow: PptxShadow | null, opacity?: number): string {
   return `<a:effectLst><a:outerShdw blurRad="${Math.round(shadow.blur * CSS_PX_EMU)}" dist="${Math.round(shadow.distance * CSS_PX_EMU)}" dir="${angleToOoxml(shadow.angle)}" algn="ctr" rotWithShape="0">${colorXml(shadow.color, opacity, '000000')}</a:outerShdw></a:effectLst>`;
 }
 
-function editableContentTypesXml(n: number): string {
+function editableContentTypesXml(n: number, noteIndexes: number[]): string {
   const slideOverrides = Array.from(
     { length: n },
     (_, i) =>
       `<Override PartName="/ppt/slides/slide${i + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>`,
   ).join('');
-  return `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Default Extension="jpg" ContentType="image/jpeg"/><Default Extension="jpeg" ContentType="image/jpeg"/><Default Extension="gif" ContentType="image/gif"/><Default Extension="svg" ContentType="image/svg+xml"/><Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/><Override PartName="/ppt/presProps.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presProps+xml"/><Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/><Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/><Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>${slideOverrides}</Types>`;
+  const noteOverrides = noteIndexes
+    .map(
+      (index) =>
+        `<Override PartName="/ppt/notesSlides/notesSlide${index + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.notesSlide+xml"/>`,
+    )
+    .join('');
+  const notesMasterOverride = noteIndexes.length
+    ? '<Override PartName="/ppt/notesMasters/notesMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.notesMaster+xml"/>'
+    : '';
+  return `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Default Extension="jpg" ContentType="image/jpeg"/><Default Extension="jpeg" ContentType="image/jpeg"/><Default Extension="gif" ContentType="image/gif"/><Default Extension="svg" ContentType="image/svg+xml"/><Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/><Override PartName="/ppt/presProps.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presProps+xml"/><Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/><Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/><Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>${notesMasterOverride}${slideOverrides}${noteOverrides}</Types>`;
 }
 
 function editableSlideRelsXml(imageRels: string[]): string {
@@ -1247,15 +1254,18 @@ function rootRelsXml(): string {
   return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/officeDocument" Target="ppt/presentation.xml"/></Relationships>`;
 }
 
-function presentationXml(n: number): string {
+function presentationXml(n: number, hasNotes: boolean): string {
   const sldIds = Array.from(
     { length: n },
     (_, i) => `<p:sldId id="${256 + i}" r:id="rId${i + 3}"/>`,
   ).join('');
-  return `${XML_DECL}<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst><p:sldIdLst>${sldIds}</p:sldIdLst><p:sldSz cx="${EMU_W}" cy="${EMU_H}"/><p:notesSz cx="6858000" cy="9144000"/></p:presentation>`;
+  const notesMaster = hasNotes
+    ? `<p:notesMasterIdLst><p:notesMasterId r:id="rId${n + 3}"/></p:notesMasterIdLst>`
+    : '';
+  return `${XML_DECL}<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst>${notesMaster}<p:sldIdLst>${sldIds}</p:sldIdLst><p:sldSz cx="${EMU_W}" cy="${EMU_H}"/><p:notesSz cx="6858000" cy="9144000"/></p:presentation>`;
 }
 
-function presentationRelsXml(n: number): string {
+function presentationRelsXml(n: number, hasNotes: boolean): string {
   const rels = [
     `<Relationship Id="rId1" Type="${OD_REL}/slideMaster" Target="slideMasters/slideMaster1.xml"/>`,
     `<Relationship Id="rId2" Type="${OD_REL}/presProps" Target="presProps.xml"/>`,
@@ -1265,11 +1275,41 @@ function presentationRelsXml(n: number): string {
       `<Relationship Id="rId${i + 3}" Type="${OD_REL}/slide" Target="slides/slide${i + 1}.xml"/>`,
     );
   }
+  if (hasNotes) {
+    rels.push(
+      `<Relationship Id="rId${n + 3}" Type="${NOTES_MASTER_REL}" Target="notesMasters/notesMaster1.xml"/>`,
+    );
+  }
   return `${XML_DECL}<Relationships xmlns="${REL_NS}">${rels.join('')}</Relationships>`;
 }
 
 function presPropsXml(): string {
   return `${XML_DECL}<p:presentationPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"/>`;
+}
+
+function notesSlideXml(note: string): string {
+  const paragraphs = note
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((line) =>
+      line
+        ? `<a:p><a:r><a:rPr lang="zh-CN" altLang="en-US" sz="1200"/><a:t xml:space="preserve">${escapeXml(line)}</a:t></a:r></a:p>`
+        : '<a:p><a:endParaRPr lang="zh-CN" altLang="en-US" sz="1200"/></a:p>',
+    )
+    .join('');
+  return `${XML_DECL}<p:notes xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="2" name="Speaker Notes"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="685800" y="3429000"/><a:ext cx="5486400" cy="4572000"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln></p:spPr><p:txBody><a:bodyPr lIns="91440" tIns="45720" rIns="91440" bIns="45720"/><a:lstStyle/>${paragraphs}</p:txBody></p:sp></p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:notes>`;
+}
+
+function notesSlideRelsXml(slideNumber: number): string {
+  return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${NOTES_MASTER_REL}" Target="../notesMasters/notesMaster1.xml"/><Relationship Id="rId2" Type="${OD_REL}/slide" Target="../slides/slide${slideNumber}.xml"/></Relationships>`;
+}
+
+function notesMasterXml(): string {
+  return `${XML_DECL}<p:notesMaster xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="2" name="Notes Placeholder"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="685800" y="3429000"/><a:ext cx="5486400" cy="4572000"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln></p:spPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr lang="zh-CN" sz="1200"/></a:p></p:txBody></p:sp></p:spTree></p:cSld><p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/><p:notesStyle><a:lvl1pPr marL="0" algn="l"><a:defRPr sz="1200"><a:solidFill><a:schemeClr val="tx1"/></a:solidFill><a:latin typeface="+mn-lt"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:defRPr></a:lvl1pPr></p:notesStyle></p:notesMaster>`;
+}
+
+function notesMasterRelsXml(): string {
+  return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/theme" Target="../theme/theme1.xml"/></Relationships>`;
 }
 
 function slideMasterXml(): string {
@@ -1644,14 +1684,6 @@ function byteToHex(value: number): string {
   return clamp(Math.round(byte), 0, 255).toString(16).padStart(2, '0').toUpperCase();
 }
 
-function hexToRgb(hex: string): { r: number; g: number; b: number } {
-  return {
-    r: Number.parseInt(hex.slice(0, 2), 16),
-    g: Number.parseInt(hex.slice(2, 4), 16),
-    b: Number.parseInt(hex.slice(4, 6), 16),
-  };
-}
-
 function horizontalTextAlign(box: PptxBox, styles: CSSStyleDeclaration): PptxTextObject['align'] {
   const explicit = textAlign(styles.textAlign);
   if (explicit !== 'left') return explicit;
@@ -1731,9 +1763,10 @@ function mapPowerPointFontFamily(family: string): string | undefined {
   ) {
     return 'Menlo';
   }
+  if (normalized === 'sf pro display' || normalized === 'sf pro text') {
+    return family;
+  }
   if (
-    normalized === 'sf pro display' ||
-    normalized === 'sf pro text' ||
     normalized === '-apple-system' ||
     normalized === 'blinkmacsystemfont' ||
     normalized === 'system-ui' ||

--- a/packages/core/src/app/lib/export-pptx-editable.ts
+++ b/packages/core/src/app/lib/export-pptx-editable.ts
@@ -2,6 +2,7 @@ const SLIDE_W = 1920;
 const SLIDE_H = 1080;
 const EMU_W = 12192000;
 const EMU_H = 6858000;
+const CSS_PX_EMU = 9525;
 const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n';
 const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
 const OD_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
@@ -26,11 +27,21 @@ type PptxStroke = {
   width: number;
 };
 
+type PptxShadow = {
+  color: string;
+  blur: number;
+  distance: number;
+  angle: number;
+};
+
 type PptxBox = {
   x: number;
   y: number;
   w: number;
   h: number;
+  rotate?: number;
+  opacity?: number;
+  shadow?: PptxShadow | null;
 };
 
 type PptxTextRun = {
@@ -41,6 +52,7 @@ type PptxTextRun = {
   fontFamily?: string;
   fontSize?: number;
   letterSpacing?: number;
+  opacity?: number;
 };
 
 type PptxTextStyle = Omit<PptxTextRun, 'text'>;
@@ -50,6 +62,7 @@ type PptxShapeObject = PptxBox & {
   radius?: number;
   fill?: PptxFill;
   stroke?: PptxStroke | null;
+  shadow?: PptxShadow | null;
 };
 
 type PptxTextObject = PptxBox & {
@@ -99,6 +112,11 @@ type MediaRef = {
   relId: string;
 };
 
+type ParsedColor = {
+  hex: string;
+  alpha: number;
+};
+
 type SlideRels = {
   rels: string[];
   media: MediaRef[];
@@ -126,7 +144,7 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
     if (shouldRasterizeElement(el, styles)) {
       const image = await rasterizeElement(el, box);
       if (image) {
-        objects.push(image);
+        objects.push({ ...image, shadow: parseCssShadow(styles.boxShadow) });
         markDescendants(el, skipped);
       }
       continue;
@@ -134,7 +152,7 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
 
     if (el instanceof HTMLImageElement) {
       const image = await imageFromElement(el, box);
-      if (image) objects.push(image);
+      if (image) objects.push({ ...image, shadow: parseCssShadow(styles.boxShadow) });
       continue;
     }
 
@@ -156,6 +174,7 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
         radius: maxBorderRadius(styles),
         fill,
         stroke,
+        shadow: parseCssShadow(styles.boxShadow),
       });
     }
 
@@ -220,11 +239,13 @@ function elementBox(
   styles: CSSStyleDeclaration,
 ): PptxBox | null {
   if (styles.display === 'none' || styles.visibility === 'hidden') return null;
-  if (Number(styles.opacity) <= 0) return null;
+  const opacity = parseOpacity(styles.opacity);
+  if (opacity <= 0) return null;
 
   const rect = el.getBoundingClientRect();
   const w = clamp(rect.width, 0, SLIDE_W);
   const h = clamp(rect.height, 0, SLIDE_H);
+  const rotate = rotationFromTransform(styles.transform);
   if (w < 1 || h < 1) return null;
 
   return {
@@ -232,13 +253,15 @@ function elementBox(
     y: clamp(rect.top - rootRect.top, 0, SLIDE_H),
     w,
     h,
+    opacity: opacity < 1 ? opacity : undefined,
+    rotate,
   };
 }
 
 function fillFromStyles(styles: CSSStyleDeclaration): PptxFill {
   const gradient = parseLinearGradient(styles.backgroundImage);
   if (gradient) return gradient;
-  return normalizeColor(styles.backgroundColor);
+  return colorWithPaint(styles.backgroundColor);
 }
 
 function strokeFromStyles(styles: CSSStyleDeclaration): PptxStroke | null {
@@ -250,10 +273,10 @@ function strokeFromStyles(styles: CSSStyleDeclaration): PptxStroke | null {
   );
   if (width <= 0) return null;
   const color =
-    normalizeColor(styles.borderTopColor) ??
-    normalizeColor(styles.borderRightColor) ??
-    normalizeColor(styles.borderBottomColor) ??
-    normalizeColor(styles.borderLeftColor);
+    colorWithPaint(styles.borderTopColor) ??
+    colorWithPaint(styles.borderRightColor) ??
+    colorWithPaint(styles.borderBottomColor) ??
+    colorWithPaint(styles.borderLeftColor);
   if (!color) return null;
   return { color, width };
 }
@@ -266,7 +289,7 @@ function textFromElement(
   if (!isTextCandidate(el)) return null;
 
   const paragraphs = collectTextParagraphs(el, {
-    color: normalizeColor(styles.color) ?? '#000000',
+    color: colorOrFallback(styles.color, '#000000'),
     fontFamily: normalizeFontFamily(styles.fontFamily),
     fontSize: parseCssPx(styles.fontSize) || 18,
     bold: isBold(styles.fontWeight),
@@ -281,9 +304,10 @@ function textFromElement(
     ...box,
     paragraphs,
     align: textAlign(styles.textAlign),
-    color: normalizeColor(styles.color) ?? undefined,
+    color: colorWithPaint(styles.color) ?? undefined,
     fontFamily: normalizeFontFamily(styles.fontFamily),
     fontSize: parseCssPx(styles.fontSize) || undefined,
+    shadow: parseCssShadow(styles.textShadow),
   };
 }
 
@@ -342,9 +366,10 @@ function collectTextParagraphs(el: HTMLElement, inherited: PptxTextStyle): PptxT
     }
 
     const computed = getComputedStyle(node);
+    const opacity = (style.opacity ?? 1) * parseOpacity(computed.opacity);
     const next: PptxTextStyle = {
       ...style,
-      color: normalizeColor(computed.color) ?? style.color,
+      color: colorWithPaint(computed.color) ?? style.color,
       fontFamily: normalizeFontFamily(computed.fontFamily) ?? style.fontFamily,
       fontSize: parseCssPx(computed.fontSize) || style.fontSize,
       bold:
@@ -359,6 +384,7 @@ function collectTextParagraphs(el: HTMLElement, inherited: PptxTextStyle): PptxT
         computed.fontStyle === 'oblique' ||
         style.italic,
       letterSpacing: parseCssPx(computed.letterSpacing) || style.letterSpacing,
+      opacity: opacity < 1 ? opacity : style.opacity,
     };
     for (const child of Array.from(node.childNodes)) walk(child, next);
   };
@@ -441,7 +467,7 @@ function tableFromElement(table: HTMLTableElement, box: PptxBox): PptxTableObjec
       return {
         text: collapseText(cell.innerText || cell.textContent || '').trim(),
         fill: fillFromStyles(styles),
-        color: normalizeColor(styles.color) ?? undefined,
+        color: colorWithPaint(styles.color) ?? undefined,
         fontFamily: normalizeFontFamily(styles.fontFamily),
         fontSize: parseCssPx(styles.fontSize) || undefined,
         bold: isBold(styles.fontWeight),
@@ -492,7 +518,7 @@ function readDataUrl(src: string): { mime: string; data: Uint8Array } | null {
 
 function editableSlideXml(slide: EditablePptxSlide, ctx: SlideBuildContext): string {
   const background = slide.background
-    ? `<p:bg><p:bgPr>${fillXml(slide.background)}</p:bgPr></p:bg>`
+    ? `<p:bg><p:bgPr>${fillXml(slide.background)}<a:effectLst/></p:bgPr></p:bg>`
     : '';
   const objects = slide.objects.map((object) => objectXml(object, ctx)).join('');
   return `${XML_DECL}<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld>${background}<p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>${objects}</p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>`;
@@ -508,13 +534,13 @@ function objectXml(object: PptxObject, ctx: SlideBuildContext): string {
 function shapeXml(shape: PptxShapeObject, ctx: SlideBuildContext): string {
   const id = ctx.shapeId++;
   const geom = shape.radius && shape.radius > 0 ? 'roundRect' : 'rect';
-  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Shape ${id}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(shape)}<a:prstGeom prst="${geom}"><a:avLst/></a:prstGeom>${fillXml(shape.fill ?? null)}${lineXml(shape.stroke ?? null)}</p:spPr></p:sp>`;
+  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Shape ${id}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(shape)}<a:prstGeom prst="${geom}"><a:avLst/></a:prstGeom>${fillXml(shape.fill ?? null, shape.opacity)}${lineXml(shape.stroke ?? null, shape.opacity)}${effectXml(shape.shadow ?? null, shape.opacity)}</p:spPr></p:sp>`;
 }
 
 function textXml(text: PptxTextObject, ctx: SlideBuildContext): string {
   const id = ctx.shapeId++;
   const paragraphs = text.paragraphs.map((paragraph) => paragraphXml(paragraph, text)).join('');
-  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Text ${id}"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(text)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln></p:spPr><p:txBody><a:bodyPr wrap="square" lIns="0" tIns="0" rIns="0" bIns="0"/><a:lstStyle/>${paragraphs}</p:txBody></p:sp>`;
+  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Text ${id}"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(text)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln>${effectXml(text.shadow ?? null, text.opacity)}</p:spPr><p:txBody><a:bodyPr wrap="square" lIns="0" tIns="0" rIns="0" bIns="0"/><a:lstStyle/>${paragraphs}</p:txBody></p:sp>`;
 }
 
 function paragraphXml(paragraph: PptxTextRun[], text: PptxTextObject): string {
@@ -525,7 +551,6 @@ function paragraphXml(paragraph: PptxTextRun[], text: PptxTextObject): string {
 }
 
 function runXml(run: PptxTextRun, text: PptxTextObject): string {
-  const color = normalizeColor(run.color ?? text.color ?? '#000000') ?? '000000';
   const fontSize = Math.max(1, Math.round((run.fontSize ?? text.fontSize ?? 18) * 100));
   const attrs = [
     `sz="${fontSize}"`,
@@ -537,7 +562,11 @@ function runXml(run: PptxTextRun, text: PptxTextObject): string {
     .join(' ');
   const fontFamily = run.fontFamily ?? text.fontFamily;
   const latin = fontFamily ? `<a:latin typeface="${escapeXml(fontFamily)}"/>` : '';
-  return `<a:r><a:rPr ${attrs}><a:solidFill><a:srgbClr val="${color}"/></a:solidFill>${latin}</a:rPr><a:t>${escapeXml(run.text)}</a:t></a:r>`;
+  return `<a:r><a:rPr ${attrs}><a:solidFill>${colorXml(
+    run.color ?? text.color ?? '#000000',
+    combinedOpacity(text.opacity, run.opacity),
+    '#000000',
+  )}</a:solidFill>${latin}</a:rPr><a:t>${escapeXml(run.text)}</a:t></a:r>`;
 }
 
 function pictureXml(image: PptxImageObject, ctx: SlideBuildContext): string {
@@ -545,7 +574,12 @@ function pictureXml(image: PptxImageObject, ctx: SlideBuildContext): string {
   const relId = `rId${ctx.media.length + 2}`;
   ctx.media.push({ data: image.data, ext: imageExt(image.mime), relId });
   const name = escapeXml(image.alt || `Picture ${id}`);
-  return `<p:pic><p:nvPicPr><p:cNvPr id="${id}" name="${name}"/><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="${relId}"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr>${xfrmXml(image)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>`;
+  const opacity = image.opacity === undefined ? 1 : clamp(image.opacity, 0, 1);
+  const blipAlpha = opacity < 1 ? `<a:alphaModFix amt="${Math.round(opacity * 100000)}"/>` : '';
+  const blip = blipAlpha
+    ? `<a:blip r:embed="${relId}">${blipAlpha}</a:blip>`
+    : `<a:blip r:embed="${relId}"/>`;
+  return `<p:pic><p:nvPicPr><p:cNvPr id="${id}" name="${name}"/><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill>${blip}<a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr>${xfrmXml(image)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>${effectXml(image.shadow ?? null, image.opacity)}</p:spPr></p:pic>`;
 }
 
 function tableXml(table: PptxTableObject, ctx: SlideBuildContext): string {
@@ -574,13 +608,12 @@ function tableXml(table: PptxTableObject, ctx: SlideBuildContext): string {
 function tableCellXml(cell: PptxTableCell): string {
   const align =
     cell.align && cell.align !== 'left' ? ` algn="${pptxTextAlignValue(cell.align)}"` : '';
-  const color = normalizeColor(cell.color ?? '#000000') ?? '000000';
   const fontSize = Math.max(1, Math.round((cell.fontSize ?? 18) * 100));
   const attrs = [`sz="${fontSize}"`, cell.bold ? 'b="1"' : '', cell.italic ? 'i="1"' : '']
     .filter(Boolean)
     .join(' ');
   const latin = cell.fontFamily ? `<a:latin typeface="${escapeXml(cell.fontFamily)}"/>` : '';
-  return `<a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:pPr${align}/><a:r><a:rPr ${attrs}><a:solidFill><a:srgbClr val="${color}"/></a:solidFill>${latin}</a:rPr><a:t>${escapeXml(cell.text)}</a:t></a:r></a:p></a:txBody><a:tcPr>${fillXml(cell.fill ?? null)}</a:tcPr></a:tc>`;
+  return `<a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:pPr${align}/><a:r><a:rPr ${attrs}><a:solidFill>${colorXml(cell.color ?? '#000000', 1, '#000000')}</a:solidFill>${latin}</a:rPr><a:t>${escapeXml(cell.text)}</a:t></a:r></a:p></a:txBody><a:tcPr>${fillXml(cell.fill ?? null)}</a:tcPr></a:tc>`;
 }
 
 function pptxTextAlignValue(align: NonNullable<PptxTextObject['align']>): string {
@@ -588,18 +621,19 @@ function pptxTextAlignValue(align: NonNullable<PptxTextObject['align']>): string
 }
 
 function xfrmXml(box: PptxBox): string {
-  return `<a:xfrm><a:off x="${pxToEmuX(box.x)}" y="${pxToEmuY(box.y)}"/><a:ext cx="${pxToEmuX(box.w)}" cy="${pxToEmuY(box.h)}"/></a:xfrm>`;
+  const rotate = box.rotate ? ` rot="${angleToOoxml(box.rotate)}"` : '';
+  return `<a:xfrm${rotate}><a:off x="${pxToEmuX(box.x)}" y="${pxToEmuY(box.y)}"/><a:ext cx="${pxToEmuX(box.w)}" cy="${pxToEmuY(box.h)}"/></a:xfrm>`;
 }
 
 function graphicFrameXfrmXml(box: PptxBox): string {
   return `<p:xfrm><a:off x="${pxToEmuX(box.x)}" y="${pxToEmuY(box.y)}"/><a:ext cx="${pxToEmuX(box.w)}" cy="${pxToEmuY(box.h)}"/></p:xfrm>`;
 }
 
-function fillXml(fill: PptxFill): string {
+function fillXml(fill: PptxFill, opacity?: number): string {
   if (!fill) return '<a:noFill/>';
   if (typeof fill === 'string') {
-    const color = normalizeColor(fill);
-    return color ? `<a:solidFill><a:srgbClr val="${color}"/></a:solidFill>` : '<a:noFill/>';
+    const color = parseColor(fill);
+    return color ? `<a:solidFill>${colorXml(fill, opacity)}</a:solidFill>` : '<a:noFill/>';
   }
 
   const stops = fill.stops.length
@@ -611,15 +645,20 @@ function fillXml(fill: PptxFill): string {
   const gs = stops
     .map((stop) => {
       const pos = clamp(Math.round(stop.position * 100000), 0, 100000);
-      return `<a:gs pos="${pos}"><a:srgbClr val="${normalizeColor(stop.color) ?? 'FFFFFF'}"/></a:gs>`;
+      return `<a:gs pos="${pos}">${colorXml(stop.color, opacity)}</a:gs>`;
     })
     .join('');
   return `<a:gradFill rotWithShape="1"><a:gsLst>${gs}</a:gsLst><a:lin ang="${Math.round(fill.angle * 60000)}" scaled="0"/></a:gradFill>`;
 }
 
-function lineXml(stroke: PptxStroke | null): string {
+function lineXml(stroke: PptxStroke | null, opacity?: number): string {
   if (!stroke) return '<a:ln><a:noFill/></a:ln>';
-  return `<a:ln w="${Math.round(stroke.width * 12700)}"><a:solidFill><a:srgbClr val="${normalizeColor(stroke.color) ?? '000000'}"/></a:solidFill><a:prstDash val="solid"/></a:ln>`;
+  return `<a:ln w="${Math.round(stroke.width * 12700)}"><a:solidFill>${colorXml(stroke.color, opacity, '000000')}</a:solidFill><a:prstDash val="solid"/></a:ln>`;
+}
+
+function effectXml(shadow: PptxShadow | null, opacity?: number): string {
+  if (!shadow) return '';
+  return `<a:effectLst><a:outerShdw blurRad="${Math.round(shadow.blur * CSS_PX_EMU)}" dist="${Math.round(shadow.distance * CSS_PX_EMU)}" dir="${angleToOoxml(shadow.angle)}" algn="ctr" rotWithShape="0">${colorXml(shadow.color, opacity, '000000')}</a:outerShdw></a:effectLst>`;
 }
 
 function editableContentTypesXml(n: number): string {
@@ -714,7 +753,7 @@ function parseGradientStop(input: string, index: number, count: number): PptxGra
     input.trim(),
   );
   if (!colorMatch) return null;
-  const color = normalizeColor(colorMatch[1]);
+  const color = parseColor(colorMatch[1]);
   if (!color) return null;
   const posMatch = /(-?\d+(?:\.\d+)?)%/.exec(colorMatch[2] ?? '');
   const position = posMatch
@@ -722,7 +761,7 @@ function parseGradientStop(input: string, index: number, count: number): PptxGra
     : count <= 1
       ? 0
       : index / (count - 1);
-  return { color, position };
+  return { color: colorMatch[1], position };
 }
 
 function contentInFunction(value: string, fn: string): string | null {
@@ -764,41 +803,264 @@ function directionToAngle(direction: string): number {
   return 180;
 }
 
-function normalizeColor(value?: string | null): string | null {
+function parseColor(value?: string | null): ParsedColor | null {
   if (!value) return null;
   const color = value.trim();
-  if (!color || color === 'transparent') return null;
+  const lower = color.toLowerCase();
+  if (!color) return null;
+  if (lower === 'transparent') return { hex: '000000', alpha: 0 };
+  if (lower === 'black') return { hex: '000000', alpha: 1 };
+  if (lower === 'white') return { hex: 'FFFFFF', alpha: 1 };
   if (color.startsWith('#')) {
     const hex = color.slice(1);
-    if (hex.length === 3) return hex.replace(/./g, (char) => char + char).toUpperCase();
-    if (hex.length === 4) {
-      if (hex[3] === '0') return null;
-      return hex
-        .slice(0, 3)
-        .replace(/./g, (char) => char + char)
-        .toUpperCase();
+    if (hex.length === 3) {
+      return { hex: hex.replace(/./g, (char) => char + char).toUpperCase(), alpha: 1 };
     }
-    if (hex.length === 6) return hex.toUpperCase();
-    if (hex.length === 8) return hex.slice(6) === '00' ? null : hex.slice(0, 6).toUpperCase();
+    if (hex.length === 4) {
+      const alpha = Number.parseInt(hex[3], 16) / 15;
+      return {
+        hex: hex
+          .slice(0, 3)
+          .replace(/./g, (char) => char + char)
+          .toUpperCase(),
+        alpha,
+      };
+    }
+    if (hex.length === 6) return { hex: hex.toUpperCase(), alpha: 1 };
+    if (hex.length === 8) {
+      const alpha = Number.parseInt(hex.slice(6), 16) / 255;
+      return { hex: hex.slice(0, 6).toUpperCase(), alpha };
+    }
   }
 
   const rgb = /^rgba?\((.+)\)$/i.exec(color);
   if (rgb) {
-    const parts = rgb[1].split(',').map((part) => part.trim());
-    const alpha = parts[3] === undefined ? 1 : Number.parseFloat(parts[3]);
-    if (alpha <= 0) return null;
-    return parts
-      .slice(0, 3)
-      .map((part) =>
-        clamp(Math.round(Number.parseFloat(part)), 0, 255)
-          .toString(16)
-          .padStart(2, '0'),
-      )
-      .join('')
-      .toUpperCase();
+    const parsed = parseColorParts(rgb[1]);
+    if (!parsed) return null;
+    return {
+      hex: parsed.channels.map((part) => byteToHex(parseRgbChannel(part))).join(''),
+      alpha: parsed.alpha,
+    };
   }
 
+  const srgb = /^color\(\s*srgb\s+(.+)\)$/i.exec(color);
+  if (srgb) {
+    const parsed = parseColorParts(srgb[1]);
+    if (!parsed) return null;
+    return {
+      hex: parsed.channels.map((part) => byteToHex(parseSrgbChannel(part))).join(''),
+      alpha: parsed.alpha,
+    };
+  }
+
+  const oklch = /^oklch\((.+)\)$/i.exec(color);
+  if (oklch) return parseOklch(oklch[1]);
+
   return null;
+}
+
+function colorXml(value: string, opacity = 1, fallback = 'FFFFFF'): string {
+  const color = parseColor(value) ?? parseColor(fallback) ?? { hex: fallback, alpha: 1 };
+  const alpha = clamp(color.alpha * opacity, 0, 1);
+  const alphaXml = alpha < 1 ? `<a:alpha val="${Math.round(alpha * 100000)}"/>` : '';
+  return alphaXml
+    ? `<a:srgbClr val="${color.hex}">${alphaXml}</a:srgbClr>`
+    : `<a:srgbClr val="${color.hex}"/>`;
+}
+
+function colorWithPaint(value?: string | null): string | null {
+  const color = parseColor(value);
+  if (!color || color.alpha <= 0) return null;
+  return value?.trim() ?? null;
+}
+
+function colorOrFallback(value: string, fallback: string): string {
+  return colorWithPaint(value) ?? fallback;
+}
+
+function parseOpacity(value?: string | null): number {
+  const opacity = Number.parseFloat(value ?? '');
+  return Number.isFinite(opacity) ? clamp(opacity, 0, 1) : 1;
+}
+
+function combinedOpacity(...values: (number | undefined)[]): number {
+  let opacity = 1;
+  for (const value of values) {
+    if (value === undefined || !Number.isFinite(value)) continue;
+    opacity *= clamp(value, 0, 1);
+  }
+  return opacity;
+}
+
+function rotationFromTransform(value?: string | null): number | undefined {
+  if (!value || value === 'none') return undefined;
+
+  const matrix = /^matrix\((.+)\)$/i.exec(value);
+  if (matrix) {
+    const parts = matrix[1].split(',').map((part) => Number.parseFloat(part.trim()));
+    if (parts.length >= 2 && Number.isFinite(parts[0]) && Number.isFinite(parts[1])) {
+      const angle = (Math.atan2(parts[1], parts[0]) * 180) / Math.PI;
+      return normalizedVisibleAngle(angle);
+    }
+  }
+
+  const matrix3d = /^matrix3d\((.+)\)$/i.exec(value);
+  if (matrix3d) {
+    const parts = matrix3d[1].split(',').map((part) => Number.parseFloat(part.trim()));
+    if (parts.length >= 2 && Number.isFinite(parts[0]) && Number.isFinite(parts[1])) {
+      const angle = (Math.atan2(parts[1], parts[0]) * 180) / Math.PI;
+      return normalizedVisibleAngle(angle);
+    }
+  }
+
+  return undefined;
+}
+
+function parseCssShadow(value?: string | null): PptxShadow | null {
+  if (!value || value === 'none') return null;
+  const layer = splitTopLevel(value)[0]?.trim();
+  if (!layer || layer === 'none' || /\binset\b/i.test(layer)) return null;
+
+  const color = firstCssColorToken(layer);
+  const colorValue = color?.value ?? 'rgba(0, 0, 0, 0.35)';
+  const lengthSource = color
+    ? `${layer.slice(0, color.index)} ${layer.slice(color.index + color.value.length)}`
+    : layer;
+  const lengths = lengthSource
+    .split(/\s+/)
+    .filter((part) => /^-?\d/.test(part))
+    .map(parseCssPx);
+  if (lengths.length < 2) return null;
+
+  const [offsetX, offsetY, blur = 0] = lengths;
+  return {
+    color: colorValue,
+    blur: Math.max(0, blur),
+    distance: Math.hypot(offsetX, offsetY),
+    angle: shadowAngle(offsetX, offsetY),
+  };
+}
+
+function firstCssColorToken(input: string): { value: string; index: number } | null {
+  const pattern = /#[0-9a-f]{3,8}\b|(?:rgba?|color)\([^)]+\)|\b[a-z]+\b/gi;
+  for (const match of input.matchAll(pattern)) {
+    if (parseColor(match[0])) return { value: match[0], index: match.index ?? 0 };
+  }
+  return null;
+}
+
+function shadowAngle(offsetX: number, offsetY: number): number {
+  if (offsetX === 0 && offsetY === 0) return 0;
+  return normalizeDegrees((Math.atan2(offsetY, offsetX) * 180) / Math.PI);
+}
+
+function angleToOoxml(angle: number): number {
+  return Math.round(normalizeDegrees(angle) * 60000);
+}
+
+function normalizedVisibleAngle(angle: number): number | undefined {
+  const normalized = normalizeDegrees(angle);
+  return Math.abs(normalized) < 0.001 ? undefined : normalized;
+}
+
+function normalizeDegrees(angle: number): number {
+  const normalized = ((angle % 360) + 360) % 360;
+  return Math.abs(normalized - 360) < 0.001 ? 0 : normalized;
+}
+
+function parseColorParts(input: string): { channels: string[]; alpha: number } | null {
+  const [channelInput = '', alphaInput] = input.split('/').map((part) => part.trim());
+  const commaParts = channelInput.includes(',')
+    ? channelInput.split(',').map((part) => part.trim())
+    : channelInput.split(/\s+/).filter(Boolean);
+  if (commaParts.length < 3) return null;
+
+  return {
+    channels: commaParts.slice(0, 3),
+    alpha: parseAlpha(alphaInput ?? commaParts[3]),
+  };
+}
+
+function parseOklch(input: string): ParsedColor | null {
+  const [channelInput = '', alphaInput] = input.split('/').map((part) => part.trim());
+  const [lightnessInput, chromaInput, hueInput] = channelInput.split(/\s+/).filter(Boolean);
+  if (!lightnessInput || !chromaInput || !hueInput) return null;
+
+  const lightness = parseOklchLightness(lightnessInput);
+  const chroma = parseOklchChroma(chromaInput);
+  const hue = parseHue(hueInput);
+  if (!Number.isFinite(lightness) || !Number.isFinite(chroma) || !Number.isFinite(hue)) {
+    return null;
+  }
+
+  return {
+    hex: oklchToSrgbHex(lightness, chroma, hue),
+    alpha: parseAlpha(alphaInput),
+  };
+}
+
+function parseOklchLightness(value: string): number {
+  if (value.endsWith('%')) return Number.parseFloat(value) / 100;
+  return Number.parseFloat(value);
+}
+
+function parseOklchChroma(value: string): number {
+  if (value.endsWith('%')) return Number.parseFloat(value) / 100;
+  return Number.parseFloat(value);
+}
+
+function parseHue(value: string): number {
+  if (value.endsWith('turn')) return Number.parseFloat(value) * 360;
+  if (value.endsWith('rad')) return (Number.parseFloat(value) * 180) / Math.PI;
+  if (value.endsWith('grad')) return Number.parseFloat(value) * 0.9;
+  return Number.parseFloat(value);
+}
+
+function oklchToSrgbHex(lightness: number, chroma: number, hue: number): string {
+  const radians = (hue * Math.PI) / 180;
+  const a = chroma * Math.cos(radians);
+  const b = chroma * Math.sin(radians);
+  const lPrime = lightness + 0.3963377774 * a + 0.2158037573 * b;
+  const mPrime = lightness - 0.1055613458 * a - 0.0638541728 * b;
+  const sPrime = lightness - 0.0894841775 * a - 1.291485548 * b;
+  const l = lPrime ** 3;
+  const m = mPrime ** 3;
+  const s = sPrime ** 3;
+  const r = 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
+  const g = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
+  const blue = -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s;
+  return [r, g, blue].map((channel) => byteToHex(linearSrgbToByte(channel))).join('');
+}
+
+function linearSrgbToByte(value: number): number {
+  const channel = clamp(value, 0, 1);
+  const encoded = channel <= 0.0031308 ? 12.92 * channel : 1.055 * channel ** (1 / 2.4) - 0.055;
+  return encoded * 255;
+}
+
+function parseRgbChannel(value: string): number {
+  const channel = value.endsWith('%')
+    ? (Number.parseFloat(value) / 100) * 255
+    : Number.parseFloat(value);
+  return Number.isFinite(channel) ? channel : 0;
+}
+
+function parseSrgbChannel(value: string): number {
+  const channel = value.endsWith('%')
+    ? (Number.parseFloat(value) / 100) * 255
+    : Number.parseFloat(value) * 255;
+  return Number.isFinite(channel) ? channel : 0;
+}
+
+function parseAlpha(value?: string): number {
+  if (!value) return 1;
+  const alpha = value.endsWith('%') ? Number.parseFloat(value) / 100 : Number.parseFloat(value);
+  return Number.isFinite(alpha) ? clamp(alpha, 0, 1) : 1;
+}
+
+function byteToHex(value: number): string {
+  const byte = Number.isFinite(value) ? value : 0;
+  return clamp(Math.round(byte), 0, 255).toString(16).padStart(2, '0').toUpperCase();
 }
 
 function textAlign(value: string): PptxTextObject['align'] {

--- a/packages/core/src/app/lib/export-pptx-editable.ts
+++ b/packages/core/src/app/lib/export-pptx-editable.ts
@@ -82,6 +82,14 @@ type PptxImageObject = PptxBox & {
   alt?: string;
   mime: string;
   data: Uint8Array;
+  crop?: PptxImageCrop;
+};
+
+type PptxImageCrop = {
+  left?: number;
+  right?: number;
+  top?: number;
+  bottom?: number;
 };
 
 type PptxTableCell = {
@@ -107,6 +115,7 @@ type PptxObject = PptxShapeObject | PptxTextObject | PptxImageObject | PptxTable
 export type EditablePptxSlide = {
   background?: PptxFill;
   objects: PptxObject[];
+  visualSnapshot?: PptxImageObject;
 };
 
 type MediaRef = {
@@ -154,7 +163,7 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
     }
 
     if (el instanceof HTMLImageElement) {
-      const image = await imageFromElement(el, box);
+      const image = await imageFromElement(el, box, styles);
       if (image) objects.push({ ...image, shadow: parseCssShadow(styles.boxShadow) });
       continue;
     }
@@ -388,7 +397,7 @@ function textFromElement(
 }
 
 function shouldWrapTextBox(box: PptxBox, styles: CSSStyleDeclaration): boolean {
-  if (/\bnowrap\b|\bpre\b/.test(styles.whiteSpace)) return false;
+  if (styles.whiteSpace === 'nowrap' || styles.whiteSpace === 'pre') return false;
   const fontSize = parseCssPx(styles.fontSize) || 16;
   const lineHeight = parseCssPx(styles.lineHeight) || fontSize * 1.2;
   return box.h > lineHeight * 1.35;
@@ -572,20 +581,125 @@ async function rasterizeElement(el: HTMLElement, box: PptxBox): Promise<PptxImag
 async function imageFromElement(
   img: HTMLImageElement,
   box: PptxBox,
+  styles: CSSStyleDeclaration,
 ): Promise<PptxImageObject | null> {
   const src = img.currentSrc || img.src;
   if (!src) return null;
 
   const image = await readImage(src);
   if (!image) return null;
+  const fitted = fitImageBox(img, box, styles);
 
   return {
     kind: 'image',
-    ...box,
+    ...fitted.box,
     alt: img.alt || undefined,
     mime: image.mime,
     data: image.data,
+    crop: fitted.crop,
   };
+}
+
+function fitImageBox(
+  img: HTMLImageElement,
+  box: PptxBox,
+  styles: CSSStyleDeclaration,
+): { box: PptxBox; crop?: PptxImageCrop } {
+  const naturalW = img.naturalWidth || img.width || 0;
+  const naturalH = img.naturalHeight || img.height || 0;
+  if (naturalW <= 0 || naturalH <= 0 || box.w <= 0 || box.h <= 0) return { box };
+
+  const fit = styles.objectFit || 'fill';
+  if (fit === 'cover') {
+    const scale = Math.max(box.w / naturalW, box.h / naturalH);
+    const visibleW = Math.min(naturalW, box.w / scale);
+    const visibleH = Math.min(naturalH, box.h / scale);
+    const overflowX = Math.max(0, naturalW - visibleW);
+    const overflowY = Math.max(0, naturalH - visibleH);
+    const position = parseObjectPosition(styles.objectPosition);
+    return {
+      box,
+      crop: normalizeCrop({
+        left: (overflowX * position.x) / naturalW,
+        right: (overflowX * (1 - position.x)) / naturalW,
+        top: (overflowY * position.y) / naturalH,
+        bottom: (overflowY * (1 - position.y)) / naturalH,
+      }),
+    };
+  }
+
+  if (fit === 'contain' || fit === 'scale-down') {
+    const containScale = Math.min(box.w / naturalW, box.h / naturalH);
+    const scale = fit === 'scale-down' ? Math.min(1, containScale) : containScale;
+    const w = naturalW * scale;
+    const h = naturalH * scale;
+    const position = parseObjectPosition(styles.objectPosition);
+    return {
+      box: {
+        ...box,
+        x: box.x + (box.w - w) * position.x,
+        y: box.y + (box.h - h) * position.y,
+        w,
+        h,
+      },
+    };
+  }
+
+  return { box };
+}
+
+function parseObjectPosition(value?: string | null): { x: number; y: number } {
+  const parts = value?.trim().split(/\s+/).filter(Boolean) ?? [];
+  if (parts.length === 0) return { x: 0.5, y: 0.5 };
+  if (parts.length === 1) {
+    const only = objectPositionPart(parts[0], 'x');
+    return { x: only.axis === 'y' ? 0.5 : only.value, y: only.axis === 'y' ? only.value : 0.5 };
+  }
+
+  let x = 0.5;
+  let y = 0.5;
+  for (const part of parts) {
+    const parsed = objectPositionPart(part, x === 0.5 ? 'x' : 'y');
+    if (parsed.axis === 'x') x = parsed.value;
+    else y = parsed.value;
+  }
+  return { x, y };
+}
+
+function objectPositionPart(
+  part: string,
+  fallbackAxis: 'x' | 'y',
+): { axis: 'x' | 'y'; value: number } {
+  const lower = part.toLowerCase();
+  if (lower === 'left') return { axis: 'x', value: 0 };
+  if (lower === 'right') return { axis: 'x', value: 1 };
+  if (lower === 'top') return { axis: 'y', value: 0 };
+  if (lower === 'bottom') return { axis: 'y', value: 1 };
+  if (lower === 'center') return { axis: fallbackAxis, value: 0.5 };
+  if (lower.endsWith('%')) {
+    return { axis: fallbackAxis, value: clamp(Number.parseFloat(lower) / 100, 0, 1) };
+  }
+  return { axis: fallbackAxis, value: 0.5 };
+}
+
+function normalizeCrop(crop: Required<PptxImageCrop>): PptxImageCrop | undefined {
+  const normalized = {
+    left: clamp(crop.left, 0, 1),
+    right: clamp(crop.right, 0, 1),
+    top: clamp(crop.top, 0, 1),
+    bottom: clamp(crop.bottom, 0, 1),
+  };
+  if (normalized.left + normalized.right >= 0.999) {
+    normalized.left = 0;
+    normalized.right = 0;
+  }
+  if (normalized.top + normalized.bottom >= 0.999) {
+    normalized.top = 0;
+    normalized.bottom = 0;
+  }
+  return normalized.left || normalized.right || normalized.top || normalized.bottom
+    ? normalized
+    : undefined;
 }
 
 function tableFromElement(table: HTMLTableElement, box: PptxBox): PptxTableObject | null {
@@ -651,7 +765,9 @@ function editableSlideXml(slide: EditablePptxSlide, ctx: SlideBuildContext): str
   const background = slide.background
     ? `<p:bg><p:bgPr>${fillXml(slide.background)}<a:effectLst/></p:bgPr></p:bg>`
     : '';
-  const objects = slide.objects.map((object) => objectXml(object, ctx)).join('');
+  const objects = [...slide.objects, ...(slide.visualSnapshot ? [slide.visualSnapshot] : [])]
+    .map((object) => objectXml(object, ctx))
+    .join('');
   return `${XML_DECL}<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld>${background}<p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>${objects}</p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>`;
 }
 
@@ -693,12 +809,12 @@ function runXml(run: PptxTextRun, text: PptxTextObject): string {
     .filter(Boolean)
     .join(' ');
   const fontFamily = run.fontFamily ?? text.fontFamily;
-  const latin = fontFamily ? `<a:latin typeface="${escapeXml(fontFamily)}"/>` : '';
+  const font = fontXml(fontFamily, run.text);
   return `<a:r><a:rPr ${attrs}><a:solidFill>${colorXml(
     run.color ?? text.color ?? '#000000',
     combinedOpacity(text.opacity, run.opacity),
     '#000000',
-  )}</a:solidFill>${latin}</a:rPr><a:t>${escapeXml(run.text)}</a:t></a:r>`;
+  )}</a:solidFill>${font}</a:rPr><a:t>${escapeXml(run.text)}</a:t></a:r>`;
 }
 
 function pictureXml(image: PptxImageObject, ctx: SlideBuildContext): string {
@@ -711,7 +827,7 @@ function pictureXml(image: PptxImageObject, ctx: SlideBuildContext): string {
   const blip = blipAlpha
     ? `<a:blip r:embed="${relId}">${blipAlpha}</a:blip>`
     : `<a:blip r:embed="${relId}"/>`;
-  return `<p:pic><p:nvPicPr><p:cNvPr id="${id}" name="${name}"/><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill>${blip}<a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr>${xfrmXml(image)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>${effectXml(image.shadow ?? null, image.opacity)}</p:spPr></p:pic>`;
+  return `<p:pic><p:nvPicPr><p:cNvPr id="${id}" name="${name}"/><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill>${blip}${sourceRectXml(image.crop)}<a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr>${xfrmXml(image)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>${effectXml(image.shadow ?? null, image.opacity)}</p:spPr></p:pic>`;
 }
 
 function tableXml(table: PptxTableObject, ctx: SlideBuildContext): string {
@@ -744,8 +860,8 @@ function tableCellXml(cell: PptxTableCell): string {
   const attrs = [`sz="${fontSize}"`, cell.bold ? 'b="1"' : '', cell.italic ? 'i="1"' : '']
     .filter(Boolean)
     .join(' ');
-  const latin = cell.fontFamily ? `<a:latin typeface="${escapeXml(cell.fontFamily)}"/>` : '';
-  return `<a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:pPr${align}/><a:r><a:rPr ${attrs}><a:solidFill>${colorXml(cell.color ?? '#000000', 1, '#000000')}</a:solidFill>${latin}</a:rPr><a:t>${escapeXml(cell.text)}</a:t></a:r></a:p></a:txBody><a:tcPr>${fillXml(cell.fill ?? null)}</a:tcPr></a:tc>`;
+  const font = fontXml(cell.fontFamily, cell.text);
+  return `<a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:pPr${align}/><a:r><a:rPr ${attrs}><a:solidFill>${colorXml(cell.color ?? '#000000', 1, '#000000')}</a:solidFill>${font}</a:rPr><a:t>${escapeXml(cell.text)}</a:t></a:r></a:p></a:txBody><a:tcPr>${fillXml(cell.fill ?? null)}</a:tcPr></a:tc>`;
 }
 
 function pptxTextAlignValue(align: NonNullable<PptxTextObject['align']>): string {
@@ -789,6 +905,42 @@ function fillXml(fill: PptxFill, opacity?: number): string {
 function lineXml(stroke: PptxStroke | null, opacity?: number): string {
   if (!stroke) return '<a:ln><a:noFill/></a:ln>';
   return `<a:ln w="${Math.round(stroke.width * CSS_PX_EMU)}"><a:solidFill>${colorXml(stroke.color, opacity, '000000')}</a:solidFill><a:prstDash val="solid"/></a:ln>`;
+}
+
+function sourceRectXml(crop?: PptxImageCrop): string {
+  if (!crop) return '';
+  const attrs = [
+    crop.left ? `l="${Math.round(clamp(crop.left, 0, 1) * 100000)}"` : '',
+    crop.right ? `r="${Math.round(clamp(crop.right, 0, 1) * 100000)}"` : '',
+    crop.top ? `t="${Math.round(clamp(crop.top, 0, 1) * 100000)}"` : '',
+    crop.bottom ? `b="${Math.round(clamp(crop.bottom, 0, 1) * 100000)}"` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  return attrs ? `<a:srcRect ${attrs}/>` : '';
+}
+
+function fontXml(fontFamily: string | undefined, text: string): string {
+  const latin = fontFamily ? `<a:latin typeface="${escapeXml(fontFamily)}"/>` : '';
+  const eastAsian = eastAsianFontFamily(fontFamily, text);
+  const ea = eastAsian ? `<a:ea typeface="${escapeXml(eastAsian)}"/>` : '';
+  return `${latin}${ea}`;
+}
+
+function eastAsianFontFamily(fontFamily: string | undefined, text: string): string | undefined {
+  if (!hasEastAsianText(text)) return undefined;
+  if (fontFamily && isEastAsianFontFamily(fontFamily)) return fontFamily;
+  return 'PingFang SC';
+}
+
+function hasEastAsianText(text: string): boolean {
+  return /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(text);
+}
+
+function isEastAsianFontFamily(fontFamily: string): boolean {
+  return /pingfang|hiragino|noto sans cjk|source han|microsoft yahei|yahei|simsun|simhei|heiti|songti|kaiti|malgun|meiryo|yu gothic/i.test(
+    fontFamily,
+  );
 }
 
 function effectXml(shadow: PptxShadow | null, opacity?: number): string {

--- a/packages/core/src/app/lib/export-pptx-editable.ts
+++ b/packages/core/src/app/lib/export-pptx-editable.ts
@@ -1,0 +1,878 @@
+const SLIDE_W = 1920;
+const SLIDE_H = 1080;
+const EMU_W = 12192000;
+const EMU_H = 6858000;
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n';
+const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const IMAGE_REL = `${OD_REL}/image`;
+
+type PptxGradientStop = {
+  color: string;
+  position: number;
+};
+
+type PptxFill =
+  | string
+  | {
+      kind: 'linearGradient';
+      angle: number;
+      stops: PptxGradientStop[];
+    }
+  | null;
+
+type PptxStroke = {
+  color: string;
+  width: number;
+};
+
+type PptxBox = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+type PptxTextRun = {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  color?: string;
+  fontFamily?: string;
+  fontSize?: number;
+  letterSpacing?: number;
+};
+
+type PptxTextStyle = Omit<PptxTextRun, 'text'>;
+
+type PptxShapeObject = PptxBox & {
+  kind: 'shape';
+  radius?: number;
+  fill?: PptxFill;
+  stroke?: PptxStroke | null;
+};
+
+type PptxTextObject = PptxBox & {
+  kind: 'text';
+  paragraphs: PptxTextRun[][];
+  align?: 'left' | 'center' | 'right' | 'justify';
+  color?: string;
+  fontFamily?: string;
+  fontSize?: number;
+};
+
+type PptxImageObject = PptxBox & {
+  kind: 'image';
+  alt?: string;
+  mime: string;
+  data: Uint8Array;
+};
+
+type PptxTableCell = {
+  text: string;
+  fill?: PptxFill;
+  color?: string;
+  fontFamily?: string;
+  fontSize?: number;
+  bold?: boolean;
+  italic?: boolean;
+  align?: PptxTextObject['align'];
+};
+
+type PptxTableObject = PptxBox & {
+  kind: 'table';
+  rows: PptxTableCell[][];
+  columnWidths?: number[];
+  rowHeights?: number[];
+};
+
+type PptxObject = PptxShapeObject | PptxTextObject | PptxImageObject | PptxTableObject;
+
+export type EditablePptxSlide = {
+  background?: PptxFill;
+  objects: PptxObject[];
+};
+
+type MediaRef = {
+  data: Uint8Array;
+  ext: string;
+  relId: string;
+};
+
+type SlideRels = {
+  rels: string[];
+  media: MediaRef[];
+};
+
+type SlideBuildContext = {
+  shapeId: number;
+  rels: string[];
+  media: MediaRef[];
+};
+
+export async function collectEditableSlide(frame: HTMLElement): Promise<EditablePptxSlide> {
+  const rootRect = frame.getBoundingClientRect();
+  const rootStyles = getComputedStyle(frame);
+  const objects: PptxObject[] = [];
+  const skipped = new WeakSet<Element>();
+
+  for (const el of Array.from(frame.querySelectorAll<HTMLElement>('*'))) {
+    if (skipped.has(el)) continue;
+
+    const styles = getComputedStyle(el);
+    const box = elementBox(el, rootRect, styles);
+    if (!box) continue;
+
+    if (shouldRasterizeElement(el, styles)) {
+      const image = await rasterizeElement(el, box);
+      if (image) {
+        objects.push(image);
+        markDescendants(el, skipped);
+      }
+      continue;
+    }
+
+    if (el instanceof HTMLImageElement) {
+      const image = await imageFromElement(el, box);
+      if (image) objects.push(image);
+      continue;
+    }
+
+    if (el instanceof HTMLTableElement) {
+      const table = tableFromElement(el, box);
+      if (table) {
+        objects.push(table);
+        markDescendants(el, skipped);
+      }
+      continue;
+    }
+
+    const fill = fillFromStyles(styles);
+    const stroke = strokeFromStyles(styles);
+    if (fill || stroke) {
+      objects.push({
+        kind: 'shape',
+        ...box,
+        radius: maxBorderRadius(styles),
+        fill,
+        stroke,
+      });
+    }
+
+    const text = textFromElement(el, box, styles);
+    if (text) {
+      objects.push(text);
+      markDescendants(el, skipped);
+    }
+  }
+
+  return {
+    background: fillFromStyles(rootStyles) ?? '#ffffff',
+    objects,
+  };
+}
+
+export async function buildEditablePptx(slides: EditablePptxSlide[]): Promise<Uint8Array> {
+  const { zipSync, strToU8 } = await import('fflate');
+  const files: Record<string, Uint8Array> = {};
+  const slideRels: SlideRels[] = [];
+
+  files['[Content_Types].xml'] = strToU8(editableContentTypesXml(slides.length));
+  files['_rels/.rels'] = strToU8(rootRelsXml());
+  files['ppt/presentation.xml'] = strToU8(presentationXml(slides.length));
+  files['ppt/_rels/presentation.xml.rels'] = strToU8(presentationRelsXml(slides.length));
+  files['ppt/presProps.xml'] = strToU8(presPropsXml());
+  files['ppt/theme/theme1.xml'] = strToU8(themeXml());
+  files['ppt/slideMasters/slideMaster1.xml'] = strToU8(slideMasterXml());
+  files['ppt/slideMasters/_rels/slideMaster1.xml.rels'] = strToU8(slideMasterRelsXml());
+  files['ppt/slideLayouts/slideLayout1.xml'] = strToU8(slideLayoutXml());
+  files['ppt/slideLayouts/_rels/slideLayout1.xml.rels'] = strToU8(slideLayoutRelsXml());
+
+  for (let i = 0; i < slides.length; i++) {
+    const ctx: SlideBuildContext = {
+      shapeId: 2,
+      rels: [],
+      media: [],
+    };
+    files[`ppt/slides/slide${i + 1}.xml`] = strToU8(editableSlideXml(slides[i], ctx));
+    slideRels.push({ rels: ctx.rels, media: ctx.media });
+  }
+
+  let mediaIndex = 1;
+  for (let i = 0; i < slideRels.length; i++) {
+    const rels = slideRels[i];
+    for (const media of rels.media) {
+      files[`ppt/media/image${mediaIndex}.${media.ext}`] = media.data;
+      rels.rels.push(
+        `<Relationship Id="${media.relId}" Type="${IMAGE_REL}" Target="../media/image${mediaIndex}.${media.ext}"/>`,
+      );
+      mediaIndex++;
+    }
+    files[`ppt/slides/_rels/slide${i + 1}.xml.rels`] = strToU8(editableSlideRelsXml(rels.rels));
+  }
+
+  return zipSync(files);
+}
+
+function elementBox(
+  el: HTMLElement,
+  rootRect: DOMRect,
+  styles: CSSStyleDeclaration,
+): PptxBox | null {
+  if (styles.display === 'none' || styles.visibility === 'hidden') return null;
+  if (Number(styles.opacity) <= 0) return null;
+
+  const rect = el.getBoundingClientRect();
+  const w = clamp(rect.width, 0, SLIDE_W);
+  const h = clamp(rect.height, 0, SLIDE_H);
+  if (w < 1 || h < 1) return null;
+
+  return {
+    x: clamp(rect.left - rootRect.left, 0, SLIDE_W),
+    y: clamp(rect.top - rootRect.top, 0, SLIDE_H),
+    w,
+    h,
+  };
+}
+
+function fillFromStyles(styles: CSSStyleDeclaration): PptxFill {
+  const gradient = parseLinearGradient(styles.backgroundImage);
+  if (gradient) return gradient;
+  return normalizeColor(styles.backgroundColor);
+}
+
+function strokeFromStyles(styles: CSSStyleDeclaration): PptxStroke | null {
+  const width = Math.max(
+    parseCssPx(styles.borderTopWidth),
+    parseCssPx(styles.borderRightWidth),
+    parseCssPx(styles.borderBottomWidth),
+    parseCssPx(styles.borderLeftWidth),
+  );
+  if (width <= 0) return null;
+  const color =
+    normalizeColor(styles.borderTopColor) ??
+    normalizeColor(styles.borderRightColor) ??
+    normalizeColor(styles.borderBottomColor) ??
+    normalizeColor(styles.borderLeftColor);
+  if (!color) return null;
+  return { color, width };
+}
+
+function textFromElement(
+  el: HTMLElement,
+  box: PptxBox,
+  styles: CSSStyleDeclaration,
+): PptxTextObject | null {
+  if (!isTextCandidate(el)) return null;
+
+  const paragraphs = collectTextParagraphs(el, {
+    color: normalizeColor(styles.color) ?? '#000000',
+    fontFamily: normalizeFontFamily(styles.fontFamily),
+    fontSize: parseCssPx(styles.fontSize) || 18,
+    bold: isBold(styles.fontWeight),
+    italic: styles.fontStyle === 'italic' || styles.fontStyle === 'oblique',
+    letterSpacing: parseCssPx(styles.letterSpacing),
+  });
+  const hasText = paragraphs.some((paragraph) => paragraph.some((run) => run.text.trim()));
+  if (!hasText) return null;
+
+  return {
+    kind: 'text',
+    ...box,
+    paragraphs,
+    align: textAlign(styles.textAlign),
+    color: normalizeColor(styles.color) ?? undefined,
+    fontFamily: normalizeFontFamily(styles.fontFamily),
+    fontSize: parseCssPx(styles.fontSize) || undefined,
+  };
+}
+
+function isTextCandidate(el: HTMLElement): boolean {
+  if (['SCRIPT', 'STYLE', 'SVG', 'CANVAS', 'IMG', 'VIDEO', 'PICTURE'].includes(el.tagName)) {
+    return false;
+  }
+  if (!el.textContent?.trim()) return false;
+  for (const child of Array.from(el.children)) {
+    if (!isInlineTextElement(child as HTMLElement)) return false;
+  }
+  return true;
+}
+
+function isInlineTextElement(el: HTMLElement): boolean {
+  const display = getComputedStyle(el).display;
+  return (
+    display.startsWith('inline') ||
+    [
+      'A',
+      'ABBR',
+      'B',
+      'BR',
+      'CODE',
+      'EM',
+      'I',
+      'KBD',
+      'MARK',
+      'SMALL',
+      'SPAN',
+      'STRONG',
+      'SUB',
+      'SUP',
+      'U',
+    ].includes(el.tagName)
+  );
+}
+
+function collectTextParagraphs(el: HTMLElement, inherited: PptxTextStyle): PptxTextRun[][] {
+  const paragraphs: PptxTextRun[][] = [[]];
+
+  const pushBreak = () => {
+    if (paragraphs[paragraphs.length - 1]?.length) paragraphs.push([]);
+  };
+
+  const walk = (node: Node, style: PptxTextStyle) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = collapseText(node.textContent ?? '');
+      if (text) paragraphs[paragraphs.length - 1].push({ ...style, text });
+      return;
+    }
+    if (!(node instanceof HTMLElement)) return;
+    if (node.tagName === 'BR') {
+      pushBreak();
+      return;
+    }
+
+    const computed = getComputedStyle(node);
+    const next: PptxTextStyle = {
+      ...style,
+      color: normalizeColor(computed.color) ?? style.color,
+      fontFamily: normalizeFontFamily(computed.fontFamily) ?? style.fontFamily,
+      fontSize: parseCssPx(computed.fontSize) || style.fontSize,
+      bold:
+        node.tagName === 'B' ||
+        node.tagName === 'STRONG' ||
+        isBold(computed.fontWeight) ||
+        style.bold,
+      italic:
+        node.tagName === 'I' ||
+        node.tagName === 'EM' ||
+        computed.fontStyle === 'italic' ||
+        computed.fontStyle === 'oblique' ||
+        style.italic,
+      letterSpacing: parseCssPx(computed.letterSpacing) || style.letterSpacing,
+    };
+    for (const child of Array.from(node.childNodes)) walk(child, next);
+  };
+
+  for (const child of Array.from(el.childNodes)) walk(child, inherited);
+  return paragraphs.filter((paragraph) => paragraph.length > 0);
+}
+
+function shouldRasterizeElement(el: HTMLElement, styles: CSSStyleDeclaration): boolean {
+  if (
+    el instanceof HTMLCanvasElement ||
+    el instanceof SVGElement ||
+    el instanceof HTMLVideoElement
+  ) {
+    return true;
+  }
+  if (styles.filter && styles.filter !== 'none') return true;
+  return Boolean(styles.mixBlendMode && styles.mixBlendMode !== 'normal');
+}
+
+async function rasterizeElement(el: HTMLElement, box: PptxBox): Promise<PptxImageObject | null> {
+  try {
+    if (el instanceof HTMLCanvasElement) {
+      const blob = await new Promise<Blob | null>((resolve) => el.toBlob(resolve, 'image/png'));
+      if (!blob) return null;
+      return {
+        kind: 'image',
+        ...box,
+        mime: 'image/png',
+        data: new Uint8Array(await blob.arrayBuffer()),
+      };
+    }
+
+    const { toBlob } = await import('html-to-image');
+    const blob = await toBlob(el, {
+      width: Math.max(1, Math.round(box.w)),
+      height: Math.max(1, Math.round(box.h)),
+      pixelRatio: 2,
+      backgroundColor: undefined,
+      cacheBust: true,
+    });
+    if (!blob) return null;
+    return {
+      kind: 'image',
+      ...box,
+      mime: 'image/png',
+      data: new Uint8Array(await blob.arrayBuffer()),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function imageFromElement(
+  img: HTMLImageElement,
+  box: PptxBox,
+): Promise<PptxImageObject | null> {
+  const src = img.currentSrc || img.src;
+  if (!src) return null;
+
+  const image = await readImage(src);
+  if (!image) return null;
+
+  return {
+    kind: 'image',
+    ...box,
+    alt: img.alt || undefined,
+    mime: image.mime,
+    data: image.data,
+  };
+}
+
+function tableFromElement(table: HTMLTableElement, box: PptxBox): PptxTableObject | null {
+  const domRows = Array.from(table.rows);
+  if (domRows.length === 0) return null;
+
+  const rows = domRows.map((row) =>
+    Array.from(row.cells).map((cell) => {
+      const styles = getComputedStyle(cell);
+      return {
+        text: collapseText(cell.innerText || cell.textContent || '').trim(),
+        fill: fillFromStyles(styles),
+        color: normalizeColor(styles.color) ?? undefined,
+        fontFamily: normalizeFontFamily(styles.fontFamily),
+        fontSize: parseCssPx(styles.fontSize) || undefined,
+        bold: isBold(styles.fontWeight),
+        italic: styles.fontStyle === 'italic' || styles.fontStyle === 'oblique',
+        align: textAlign(styles.textAlign),
+      };
+    }),
+  );
+  if (!rows.some((row) => row.length > 0)) return null;
+
+  const firstRow = domRows[0];
+  const columnWidths = firstRow
+    ? Array.from(firstRow.cells).map((cell) => cell.getBoundingClientRect().width)
+    : undefined;
+  const rowHeights = domRows.map((row) => row.getBoundingClientRect().height);
+
+  return { kind: 'table', ...box, rows, columnWidths, rowHeights };
+}
+
+async function readImage(src: string): Promise<{ mime: string; data: Uint8Array } | null> {
+  if (src.startsWith('data:')) return readDataUrl(src);
+  try {
+    const res = await fetch(src);
+    if (!res.ok) return null;
+    return {
+      mime: res.headers.get('content-type')?.split(';')[0] || mimeFromUrl(src),
+      data: new Uint8Array(await res.arrayBuffer()),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readDataUrl(src: string): { mime: string; data: Uint8Array } | null {
+  const match = /^data:([^;,]+)?(;base64)?,(.*)$/i.exec(src);
+  if (!match) return null;
+  const mime = match[1] || 'image/png';
+  const payload = decodeURIComponent(match[3] ?? '');
+  if (match[2]) {
+    const binary = atob(payload);
+    return {
+      mime,
+      data: Uint8Array.from(binary, (char) => char.charCodeAt(0)),
+    };
+  }
+  return { mime, data: new TextEncoder().encode(payload) };
+}
+
+function editableSlideXml(slide: EditablePptxSlide, ctx: SlideBuildContext): string {
+  const background = slide.background
+    ? `<p:bg><p:bgPr>${fillXml(slide.background)}</p:bgPr></p:bg>`
+    : '';
+  const objects = slide.objects.map((object) => objectXml(object, ctx)).join('');
+  return `${XML_DECL}<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld>${background}<p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>${objects}</p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>`;
+}
+
+function objectXml(object: PptxObject, ctx: SlideBuildContext): string {
+  if (object.kind === 'text') return textXml(object, ctx);
+  if (object.kind === 'image') return pictureXml(object, ctx);
+  if (object.kind === 'table') return tableXml(object, ctx);
+  return shapeXml(object, ctx);
+}
+
+function shapeXml(shape: PptxShapeObject, ctx: SlideBuildContext): string {
+  const id = ctx.shapeId++;
+  const geom = shape.radius && shape.radius > 0 ? 'roundRect' : 'rect';
+  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Shape ${id}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(shape)}<a:prstGeom prst="${geom}"><a:avLst/></a:prstGeom>${fillXml(shape.fill ?? null)}${lineXml(shape.stroke ?? null)}</p:spPr></p:sp>`;
+}
+
+function textXml(text: PptxTextObject, ctx: SlideBuildContext): string {
+  const id = ctx.shapeId++;
+  const paragraphs = text.paragraphs.map((paragraph) => paragraphXml(paragraph, text)).join('');
+  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Text ${id}"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(text)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln></p:spPr><p:txBody><a:bodyPr wrap="square" lIns="0" tIns="0" rIns="0" bIns="0"/><a:lstStyle/>${paragraphs}</p:txBody></p:sp>`;
+}
+
+function paragraphXml(paragraph: PptxTextRun[], text: PptxTextObject): string {
+  const align =
+    text.align && text.align !== 'left' ? ` algn="${pptxTextAlignValue(text.align)}"` : '';
+  const runs = paragraph.map((run) => runXml(run, text)).join('');
+  return `<a:p><a:pPr${align}/>${runs}</a:p>`;
+}
+
+function runXml(run: PptxTextRun, text: PptxTextObject): string {
+  const color = normalizeColor(run.color ?? text.color ?? '#000000') ?? '000000';
+  const fontSize = Math.max(1, Math.round((run.fontSize ?? text.fontSize ?? 18) * 100));
+  const attrs = [
+    `sz="${fontSize}"`,
+    run.bold ? 'b="1"' : '',
+    run.italic ? 'i="1"' : '',
+    run.letterSpacing ? `spc="${Math.round(run.letterSpacing * 100)}"` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const fontFamily = run.fontFamily ?? text.fontFamily;
+  const latin = fontFamily ? `<a:latin typeface="${escapeXml(fontFamily)}"/>` : '';
+  return `<a:r><a:rPr ${attrs}><a:solidFill><a:srgbClr val="${color}"/></a:solidFill>${latin}</a:rPr><a:t>${escapeXml(run.text)}</a:t></a:r>`;
+}
+
+function pictureXml(image: PptxImageObject, ctx: SlideBuildContext): string {
+  const id = ctx.shapeId++;
+  const relId = `rId${ctx.media.length + 2}`;
+  ctx.media.push({ data: image.data, ext: imageExt(image.mime), relId });
+  const name = escapeXml(image.alt || `Picture ${id}`);
+  return `<p:pic><p:nvPicPr><p:cNvPr id="${id}" name="${name}"/><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="${relId}"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr>${xfrmXml(image)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>`;
+}
+
+function tableXml(table: PptxTableObject, ctx: SlideBuildContext): string {
+  const id = ctx.shapeId++;
+  const colCount = Math.max(...table.rows.map((row) => row.length));
+  if (colCount <= 0) return '';
+  const columnWidth = table.w / colCount;
+  const rowHeight = table.h / Math.max(1, table.rows.length);
+  const grid = Array.from({ length: colCount }, (_, i) => {
+    const width = table.columnWidths?.[i] ?? columnWidth;
+    return `<a:gridCol w="${pxToEmuX(width)}"/>`;
+  }).join('');
+  const rows = table.rows
+    .map((row, rowIndex) => {
+      const height = table.rowHeights?.[rowIndex] ?? rowHeight;
+      const cells = Array.from({ length: colCount }, (_, cellIndex) =>
+        tableCellXml(row[cellIndex] ?? { text: '' }),
+      ).join('');
+      return `<a:tr h="${pxToEmuY(height)}">${cells}</a:tr>`;
+    })
+    .join('');
+
+  return `<p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="${id}" name="Table ${id}"/><p:cNvGraphicFramePr><a:graphicFrameLocks noGrp="1"/></p:cNvGraphicFramePr><p:nvPr/></p:nvGraphicFramePr>${graphicFrameXfrmXml(table)}<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr firstRow="0" bandRow="0"/><a:tblGrid>${grid}</a:tblGrid>${rows}</a:tbl></a:graphicData></a:graphic></p:graphicFrame>`;
+}
+
+function tableCellXml(cell: PptxTableCell): string {
+  const align =
+    cell.align && cell.align !== 'left' ? ` algn="${pptxTextAlignValue(cell.align)}"` : '';
+  const color = normalizeColor(cell.color ?? '#000000') ?? '000000';
+  const fontSize = Math.max(1, Math.round((cell.fontSize ?? 18) * 100));
+  const attrs = [`sz="${fontSize}"`, cell.bold ? 'b="1"' : '', cell.italic ? 'i="1"' : '']
+    .filter(Boolean)
+    .join(' ');
+  const latin = cell.fontFamily ? `<a:latin typeface="${escapeXml(cell.fontFamily)}"/>` : '';
+  return `<a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:pPr${align}/><a:r><a:rPr ${attrs}><a:solidFill><a:srgbClr val="${color}"/></a:solidFill>${latin}</a:rPr><a:t>${escapeXml(cell.text)}</a:t></a:r></a:p></a:txBody><a:tcPr>${fillXml(cell.fill ?? null)}</a:tcPr></a:tc>`;
+}
+
+function pptxTextAlignValue(align: NonNullable<PptxTextObject['align']>): string {
+  return align === 'justify' ? 'just' : align;
+}
+
+function xfrmXml(box: PptxBox): string {
+  return `<a:xfrm><a:off x="${pxToEmuX(box.x)}" y="${pxToEmuY(box.y)}"/><a:ext cx="${pxToEmuX(box.w)}" cy="${pxToEmuY(box.h)}"/></a:xfrm>`;
+}
+
+function graphicFrameXfrmXml(box: PptxBox): string {
+  return `<p:xfrm><a:off x="${pxToEmuX(box.x)}" y="${pxToEmuY(box.y)}"/><a:ext cx="${pxToEmuX(box.w)}" cy="${pxToEmuY(box.h)}"/></p:xfrm>`;
+}
+
+function fillXml(fill: PptxFill): string {
+  if (!fill) return '<a:noFill/>';
+  if (typeof fill === 'string') {
+    const color = normalizeColor(fill);
+    return color ? `<a:solidFill><a:srgbClr val="${color}"/></a:solidFill>` : '<a:noFill/>';
+  }
+
+  const stops = fill.stops.length
+    ? fill.stops
+    : [
+        { color: '#ffffff', position: 0 },
+        { color: '#ffffff', position: 1 },
+      ];
+  const gs = stops
+    .map((stop) => {
+      const pos = clamp(Math.round(stop.position * 100000), 0, 100000);
+      return `<a:gs pos="${pos}"><a:srgbClr val="${normalizeColor(stop.color) ?? 'FFFFFF'}"/></a:gs>`;
+    })
+    .join('');
+  return `<a:gradFill rotWithShape="1"><a:gsLst>${gs}</a:gsLst><a:lin ang="${Math.round(fill.angle * 60000)}" scaled="0"/></a:gradFill>`;
+}
+
+function lineXml(stroke: PptxStroke | null): string {
+  if (!stroke) return '<a:ln><a:noFill/></a:ln>';
+  return `<a:ln w="${Math.round(stroke.width * 12700)}"><a:solidFill><a:srgbClr val="${normalizeColor(stroke.color) ?? '000000'}"/></a:solidFill><a:prstDash val="solid"/></a:ln>`;
+}
+
+function editableContentTypesXml(n: number): string {
+  const slideOverrides = Array.from(
+    { length: n },
+    (_, i) =>
+      `<Override PartName="/ppt/slides/slide${i + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>`,
+  ).join('');
+  return `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Default Extension="jpg" ContentType="image/jpeg"/><Default Extension="jpeg" ContentType="image/jpeg"/><Default Extension="gif" ContentType="image/gif"/><Default Extension="svg" ContentType="image/svg+xml"/><Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/><Override PartName="/ppt/presProps.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presProps+xml"/><Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/><Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/><Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>${slideOverrides}</Types>`;
+}
+
+function editableSlideRelsXml(imageRels: string[]): string {
+  return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>${imageRels.join('')}</Relationships>`;
+}
+
+function rootRelsXml(): string {
+  return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/officeDocument" Target="ppt/presentation.xml"/></Relationships>`;
+}
+
+function presentationXml(n: number): string {
+  const sldIds = Array.from(
+    { length: n },
+    (_, i) => `<p:sldId id="${256 + i}" r:id="rId${i + 3}"/>`,
+  ).join('');
+  return `${XML_DECL}<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst><p:sldIdLst>${sldIds}</p:sldIdLst><p:sldSz cx="${EMU_W}" cy="${EMU_H}"/><p:notesSz cx="6858000" cy="9144000"/></p:presentation>`;
+}
+
+function presentationRelsXml(n: number): string {
+  const rels = [
+    `<Relationship Id="rId1" Type="${OD_REL}/slideMaster" Target="slideMasters/slideMaster1.xml"/>`,
+    `<Relationship Id="rId2" Type="${OD_REL}/presProps" Target="presProps.xml"/>`,
+  ];
+  for (let i = 0; i < n; i++) {
+    rels.push(
+      `<Relationship Id="rId${i + 3}" Type="${OD_REL}/slide" Target="slides/slide${i + 1}.xml"/>`,
+    );
+  }
+  return `${XML_DECL}<Relationships xmlns="${REL_NS}">${rels.join('')}</Relationships>`;
+}
+
+function presPropsXml(): string {
+  return `${XML_DECL}<p:presentationPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"/>`;
+}
+
+function slideMasterXml(): string {
+  return `${XML_DECL}<p:sldMaster xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr></p:spTree></p:cSld><p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/><p:sldLayoutIdLst><p:sldLayoutId id="2147483649" r:id="rId1"/></p:sldLayoutIdLst></p:sldMaster>`;
+}
+
+function slideMasterRelsXml(): string {
+  return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/slideLayout" Target="../slideLayouts/slideLayout1.xml"/><Relationship Id="rId2" Type="${OD_REL}/theme" Target="../theme/theme1.xml"/></Relationships>`;
+}
+
+function slideLayoutXml(): string {
+  return `${XML_DECL}<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="blank" preserve="1"><p:cSld name="Blank"><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr></p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sldLayout>`;
+}
+
+function slideLayoutRelsXml(): string {
+  return `${XML_DECL}<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="${OD_REL}/slideMaster" Target="../slideMasters/slideMaster1.xml"/></Relationships>`;
+}
+
+function themeXml(): string {
+  return `${XML_DECL}<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme"><a:themeElements><a:clrScheme name="Office"><a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1><a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1><a:dk2><a:srgbClr val="44546A"/></a:dk2><a:lt2><a:srgbClr val="E7E6E6"/></a:lt2><a:accent1><a:srgbClr val="4472C4"/></a:accent1><a:accent2><a:srgbClr val="ED7D31"/></a:accent2><a:accent3><a:srgbClr val="A5A5A5"/></a:accent3><a:accent4><a:srgbClr val="FFC000"/></a:accent4><a:accent5><a:srgbClr val="5B9BD5"/></a:accent5><a:accent6><a:srgbClr val="70AD47"/></a:accent6><a:hlink><a:srgbClr val="0563C1"/></a:hlink><a:folHlink><a:srgbClr val="954F72"/></a:folHlink></a:clrScheme><a:fontScheme name="Office"><a:majorFont><a:latin typeface="Calibri Light"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont><a:minorFont><a:latin typeface="Calibri"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont></a:fontScheme><a:fmtScheme name="Office"><a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:lumMod val="110000"/><a:satMod val="105000"/><a:tint val="67000"/></a:schemeClr></a:gs><a:gs pos="50000"><a:schemeClr val="phClr"><a:lumMod val="105000"/><a:satMod val="103000"/><a:tint val="73000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:lumMod val="105000"/><a:satMod val="109000"/><a:tint val="81000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="5400000" scaled="0"/></a:gradFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:satMod val="103000"/><a:lumMod val="102000"/><a:tint val="94000"/></a:schemeClr></a:gs><a:gs pos="50000"><a:schemeClr val="phClr"><a:satMod val="110000"/><a:lumMod val="100000"/><a:shade val="100000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:lumMod val="99000"/><a:satMod val="120000"/><a:shade val="78000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="5400000" scaled="0"/></a:gradFill></a:fillStyleLst><a:lnStyleLst><a:ln w="6350" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/><a:miter lim="800000"/></a:ln><a:ln w="12700" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/><a:miter lim="800000"/></a:ln><a:ln w="19050" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/><a:miter lim="800000"/></a:ln></a:lnStyleLst><a:effectStyleLst><a:effectStyle><a:effectLst/></a:effectStyle><a:effectStyle><a:effectLst/></a:effectStyle><a:effectStyle><a:effectLst/></a:effectStyle></a:effectStyleLst><a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:solidFill><a:schemeClr val="phClr"><a:tint val="95000"/><a:satMod val="170000"/></a:schemeClr></a:solidFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="93000"/><a:satMod val="150000"/><a:shade val="98000"/><a:lumMod val="102000"/></a:schemeClr></a:gs><a:gs pos="50000"><a:schemeClr val="phClr"><a:tint val="98000"/><a:satMod val="130000"/><a:shade val="90000"/><a:lumMod val="103000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:shade val="63000"/><a:satMod val="120000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="5400000" scaled="0"/></a:gradFill></a:bgFillStyleLst></a:fmtScheme></a:themeElements></a:theme>`;
+}
+
+function parseLinearGradient(value: string): PptxFill {
+  if (!value?.includes('linear-gradient(')) return null;
+  const start = value.indexOf('linear-gradient(');
+  const inner = contentInFunction(value.slice(start), 'linear-gradient');
+  if (!inner) return null;
+  const parts = splitTopLevel(inner);
+  if (parts.length < 2) return null;
+
+  let angle = 180;
+  let stops = parts;
+  const first = parts[0].trim();
+  if (first.endsWith('deg')) {
+    angle = Number.parseFloat(first);
+    stops = parts.slice(1);
+  } else if (first.startsWith('to ')) {
+    angle = directionToAngle(first);
+    stops = parts.slice(1);
+  }
+
+  const parsed = stops.map((stop, index) => parseGradientStop(stop, index, stops.length));
+  const valid = parsed.filter((stop): stop is PptxGradientStop => Boolean(stop));
+  if (valid.length < 2) return null;
+  return { kind: 'linearGradient', angle, stops: valid };
+}
+
+function parseGradientStop(input: string, index: number, count: number): PptxGradientStop | null {
+  const colorMatch = /(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|[a-z]+)\s*(.*)$/i.exec(
+    input.trim(),
+  );
+  if (!colorMatch) return null;
+  const color = normalizeColor(colorMatch[1]);
+  if (!color) return null;
+  const posMatch = /(-?\d+(?:\.\d+)?)%/.exec(colorMatch[2] ?? '');
+  const position = posMatch
+    ? clamp(Number.parseFloat(posMatch[1]) / 100, 0, 1)
+    : count <= 1
+      ? 0
+      : index / (count - 1);
+  return { color, position };
+}
+
+function contentInFunction(value: string, fn: string): string | null {
+  const prefix = `${fn}(`;
+  if (!value.startsWith(prefix)) return null;
+  let depth = 0;
+  for (let i = fn.length; i < value.length; i++) {
+    const char = value[i];
+    if (char === '(') depth++;
+    if (char === ')') {
+      depth--;
+      if (depth === 0) return value.slice(prefix.length, i);
+    }
+  }
+  return null;
+}
+
+function splitTopLevel(input: string): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let depth = 0;
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+    if (char === '(') depth++;
+    if (char === ')') depth--;
+    if (char === ',' && depth === 0) {
+      parts.push(input.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  parts.push(input.slice(start).trim());
+  return parts.filter(Boolean);
+}
+
+function directionToAngle(direction: string): number {
+  if (direction.includes('right')) return 90;
+  if (direction.includes('left')) return 270;
+  if (direction.includes('top')) return 0;
+  return 180;
+}
+
+function normalizeColor(value?: string | null): string | null {
+  if (!value) return null;
+  const color = value.trim();
+  if (!color || color === 'transparent') return null;
+  if (color.startsWith('#')) {
+    const hex = color.slice(1);
+    if (hex.length === 3) return hex.replace(/./g, (char) => char + char).toUpperCase();
+    if (hex.length === 4) {
+      if (hex[3] === '0') return null;
+      return hex
+        .slice(0, 3)
+        .replace(/./g, (char) => char + char)
+        .toUpperCase();
+    }
+    if (hex.length === 6) return hex.toUpperCase();
+    if (hex.length === 8) return hex.slice(6) === '00' ? null : hex.slice(0, 6).toUpperCase();
+  }
+
+  const rgb = /^rgba?\((.+)\)$/i.exec(color);
+  if (rgb) {
+    const parts = rgb[1].split(',').map((part) => part.trim());
+    const alpha = parts[3] === undefined ? 1 : Number.parseFloat(parts[3]);
+    if (alpha <= 0) return null;
+    return parts
+      .slice(0, 3)
+      .map((part) =>
+        clamp(Math.round(Number.parseFloat(part)), 0, 255)
+          .toString(16)
+          .padStart(2, '0'),
+      )
+      .join('')
+      .toUpperCase();
+  }
+
+  return null;
+}
+
+function textAlign(value: string): PptxTextObject['align'] {
+  if (value === 'center' || value === 'right' || value === 'justify') return value;
+  return 'left';
+}
+
+function normalizeFontFamily(value: string): string | undefined {
+  return value
+    .split(',')[0]
+    ?.trim()
+    .replace(/^['"]|['"]$/g, '');
+}
+
+function isBold(weight: string): boolean {
+  const numeric = Number.parseInt(weight, 10);
+  return Number.isFinite(numeric) ? numeric >= 600 : weight === 'bold' || weight === 'bolder';
+}
+
+function maxBorderRadius(styles: CSSStyleDeclaration): number {
+  return Math.max(
+    parseCssPx(styles.borderTopLeftRadius),
+    parseCssPx(styles.borderTopRightRadius),
+    parseCssPx(styles.borderBottomRightRadius),
+    parseCssPx(styles.borderBottomLeftRadius),
+  );
+}
+
+function parseCssPx(value: string): number {
+  if (!value || value === 'normal' || value === 'medium' || value === 'none') return 0;
+  const n = Number.parseFloat(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function collapseText(value: string): string {
+  return value.replace(/\s+/g, ' ');
+}
+
+function markDescendants(el: Element, skipped: WeakSet<Element>): void {
+  for (const child of Array.from(el.querySelectorAll('*'))) skipped.add(child);
+}
+
+function imageExt(mime: string): string {
+  if (mime.includes('jpeg') || mime.includes('jpg')) return 'jpg';
+  if (mime.includes('gif')) return 'gif';
+  if (mime.includes('svg')) return 'svg';
+  return 'png';
+}
+
+function mimeFromUrl(url: string): string {
+  const clean = url.split(/[?#]/)[0]?.toLowerCase() ?? '';
+  if (clean.endsWith('.jpg') || clean.endsWith('.jpeg')) return 'image/jpeg';
+  if (clean.endsWith('.gif')) return 'image/gif';
+  if (clean.endsWith('.svg')) return 'image/svg+xml';
+  return 'image/png';
+}
+
+function pxToEmuX(px: number): number {
+  return Math.round((px / SLIDE_W) * EMU_W);
+}
+
+function pxToEmuY(px: number): number {
+  return Math.round((px / SLIDE_H) * EMU_H);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/packages/core/src/app/lib/export-pptx-editable.ts
+++ b/packages/core/src/app/lib/export-pptx-editable.ts
@@ -685,6 +685,7 @@ function serializeSvgElement(
     const color = colorWithPaint(styles.color);
     if (color) clone.setAttribute('color', svgColorValue(color));
     inlineSvgComputedPaint(svg, clone);
+    stripSvgCaptureAttributes(clone);
 
     return new XMLSerializer().serializeToString(clone);
   } catch {
@@ -747,6 +748,13 @@ function normalizeSvgPaintAttr(el: SVGElement, attr: 'fill' | 'stroke', value: s
 function svgColorValue(value: string): string {
   const color = parseColor(value);
   return color ? `#${color.hex}` : value;
+}
+
+function stripSvgCaptureAttributes(root: SVGElement): void {
+  for (const el of [root, ...Array.from(root.querySelectorAll<SVGElement>('*'))]) {
+    el.removeAttribute('style');
+    el.removeAttribute('data-slide-loc');
+  }
 }
 
 async function imageFromElement(

--- a/packages/core/src/app/lib/export-pptx-editable.ts
+++ b/packages/core/src/app/lib/export-pptx-editable.ts
@@ -14,14 +14,13 @@ type PptxGradientStop = {
   position: number;
 };
 
-type PptxFill =
-  | string
-  | {
-      kind: 'linearGradient';
-      angle: number;
-      stops: PptxGradientStop[];
-    }
-  | null;
+type PptxLinearGradientFill = {
+  kind: 'linearGradient';
+  angle: number;
+  stops: PptxGradientStop[];
+};
+
+type PptxFill = string | PptxLinearGradientFill | null;
 
 type PptxStroke = {
   color: string;
@@ -71,6 +70,7 @@ type PptxTextObject = PptxBox & {
   kind: 'text';
   paragraphs: PptxTextRun[][];
   align?: 'left' | 'center' | 'right' | 'justify';
+  vertical?: 'top' | 'middle' | 'bottom';
   color?: string;
   fontFamily?: string;
   fontSize?: number;
@@ -83,6 +83,7 @@ type PptxImageObject = PptxBox & {
   mime: string;
   data: Uint8Array;
   crop?: PptxImageCrop;
+  svgData?: Uint8Array;
 };
 
 type PptxImageCrop = {
@@ -142,6 +143,8 @@ type SlideBuildContext = {
 export async function collectEditableSlide(frame: HTMLElement): Promise<EditablePptxSlide> {
   const rootRect = frame.getBoundingClientRect();
   const rootStyles = getComputedStyle(frame);
+  const background = fillFromStyles(rootStyles) ?? '#ffffff';
+  const compositeBase = frameCompositeBase(frame, rootRect, background);
   const objects: PptxObject[] = [];
   const skipped = new WeakSet<Element>();
 
@@ -151,6 +154,15 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
     const styles = getComputedStyle(el);
     const box = elementBox(el, rootRect, styles);
     if (!box) continue;
+
+    if (el instanceof SVGElement && !el.ownerSVGElement) {
+      const image = await svgImageFromElement(el, box, styles);
+      if (image) {
+        objects.push({ ...image, shadow: parseCssShadow(styles.boxShadow) });
+        markDescendants(el, skipped);
+        continue;
+      }
+    }
 
     if (shouldRasterizeElement(el, styles)) {
       const image = await rasterizeElement(el, box);
@@ -176,7 +188,7 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
       continue;
     }
 
-    const fill = fillFromStyles(styles);
+    const fill = fillFromStyles(styles, compositeBase);
     const stroke = strokeFromStyles(styles);
     const borderShapes = stroke ? [] : borderShapesFromStyles(box, styles);
     if (fill || stroke) {
@@ -199,7 +211,7 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
   }
 
   return {
-    background: fillFromStyles(rootStyles) ?? '#ffffff',
+    background,
     objects,
   };
 }
@@ -271,10 +283,64 @@ function elementBox(
   };
 }
 
-function fillFromStyles(styles: CSSStyleDeclaration): PptxFill {
+function fillFromStyles(styles: CSSStyleDeclaration, compositeBase?: ParsedColor | null): PptxFill {
   const gradient = parseLinearGradient(styles.backgroundImage);
-  if (gradient) return gradient;
+  if (gradient) return compositeBase ? compositeGradientStops(gradient, compositeBase) : gradient;
   return colorWithPaint(styles.backgroundColor);
+}
+
+function solidCompositeBase(fill: PptxFill): ParsedColor | null {
+  if (typeof fill !== 'string') return null;
+  const color = parseColor(fill);
+  if (!color || color.alpha < 0.999) return null;
+  return color;
+}
+
+function frameCompositeBase(
+  frame: HTMLElement,
+  rootRect: DOMRect,
+  fallback: PptxFill,
+): ParsedColor | null {
+  for (const el of Array.from(frame.querySelectorAll<HTMLElement>('*'))) {
+    const styles = getComputedStyle(el);
+    const box = elementBox(el, rootRect, styles);
+    if (!box || box.opacity !== undefined || !coversSlide(box)) continue;
+    const fill = fillFromStyles(styles);
+    const base = solidCompositeBase(fill);
+    if (base) return base;
+  }
+  return solidCompositeBase(fallback);
+}
+
+function coversSlide(box: PptxBox): boolean {
+  return box.x <= 1 && box.y <= 1 && box.w >= SLIDE_W - 1 && box.h >= SLIDE_H - 1;
+}
+
+function compositeGradientStops(
+  gradient: PptxLinearGradientFill,
+  base: ParsedColor,
+): PptxLinearGradientFill {
+  return {
+    ...gradient,
+    stops: gradient.stops.map((stop) => ({
+      ...stop,
+      color: compositeColorOverBase(stop.color, base),
+    })),
+  };
+}
+
+function compositeColorOverBase(value: string, base: ParsedColor): string {
+  const foreground = parseColor(value);
+  if (!foreground) return value;
+  if (foreground.alpha >= 0.999) return `#${foreground.hex}`;
+  if (foreground.alpha <= 0.001) return `#${base.hex}`;
+
+  const fg = hexToRgb(foreground.hex);
+  const bg = hexToRgb(base.hex);
+  const alpha = foreground.alpha;
+  return `#${byteToHex(fg.r * alpha + bg.r * (1 - alpha))}${byteToHex(
+    fg.g * alpha + bg.g * (1 - alpha),
+  )}${byteToHex(fg.b * alpha + bg.b * (1 - alpha))}`;
 }
 
 function strokeFromStyles(styles: CSSStyleDeclaration): PptxStroke | null {
@@ -386,7 +452,8 @@ function textFromElement(
     kind: 'text',
     ...box,
     paragraphs,
-    align: textAlign(styles.textAlign),
+    align: horizontalTextAlign(box, styles),
+    vertical: verticalTextAnchor(box, styles),
     color: colorWithPaint(styles.color) ?? undefined,
     fontFamily: normalizeFontFamily(styles.fontFamily),
     fontSize: parseCssPx(styles.fontSize) || undefined,
@@ -407,7 +474,7 @@ function isTextCandidate(el: HTMLElement): boolean {
     return false;
   }
   const display = getComputedStyle(el).display;
-  if (isLayoutTextContainer(display)) return false;
+  if (isTableLayoutTextContainer(display)) return false;
   if (!el.textContent?.trim()) return false;
   for (const child of Array.from(el.children)) {
     if (!isInlineTextElement(child as HTMLElement)) return false;
@@ -415,8 +482,8 @@ function isTextCandidate(el: HTMLElement): boolean {
   return true;
 }
 
-function isLayoutTextContainer(display: string): boolean {
-  return /\b(flex|grid|table)\b/.test(display);
+function isTableLayoutTextContainer(display: string): boolean {
+  return /\btable\b/.test(display);
 }
 
 function isInlineTextElement(el: HTMLElement): boolean {
@@ -575,6 +642,111 @@ async function rasterizeElement(el: HTMLElement, box: PptxBox): Promise<PptxImag
   } catch {
     return null;
   }
+}
+
+async function svgImageFromElement(
+  svg: SVGElement,
+  box: PptxBox,
+  styles: CSSStyleDeclaration,
+): Promise<PptxImageObject | null> {
+  const serialized = serializeSvgElement(svg, box, styles);
+  if (!serialized) return null;
+  const svgData = new TextEncoder().encode(serialized);
+  const fallback = await rasterizeElement(svg as unknown as HTMLElement, box);
+  if (fallback) return { ...fallback, svgData };
+
+  return {
+    kind: 'image',
+    ...box,
+    mime: 'image/svg+xml',
+    data: svgData,
+  };
+}
+
+function serializeSvgElement(
+  svg: SVGElement,
+  box: PptxBox,
+  styles: CSSStyleDeclaration,
+): string | null {
+  try {
+    const clone = svg.cloneNode(true) as SVGElement;
+    if (clone.tagName.toLowerCase() !== 'svg') return null;
+
+    if (!clone.getAttribute('xmlns')) clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    if (!clone.getAttribute('width')) clone.setAttribute('width', String(Math.max(1, box.w)));
+    if (!clone.getAttribute('height')) clone.setAttribute('height', String(Math.max(1, box.h)));
+    if (!clone.getAttribute('viewBox')) {
+      clone.setAttribute('viewBox', `0 0 ${Math.max(1, box.w)} ${Math.max(1, box.h)}`);
+    }
+    if (!clone.getAttribute('preserveAspectRatio')) {
+      clone.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+    }
+
+    const color = colorWithPaint(styles.color);
+    if (color) clone.setAttribute('color', svgColorValue(color));
+    inlineSvgComputedPaint(svg, clone);
+
+    return new XMLSerializer().serializeToString(clone);
+  } catch {
+    return null;
+  }
+}
+
+function inlineSvgComputedPaint(sourceRoot: SVGElement, cloneRoot: SVGElement): void {
+  const sourceElements = [sourceRoot, ...Array.from(sourceRoot.querySelectorAll<SVGElement>('*'))];
+  const cloneElements = [cloneRoot, ...Array.from(cloneRoot.querySelectorAll<SVGElement>('*'))];
+  for (let i = 0; i < sourceElements.length; i++) {
+    const source = sourceElements[i];
+    const clone = cloneElements[i];
+    if (!source || !clone) continue;
+    const styles = getComputedStyle(source);
+
+    const color = colorWithPaint(styles.color);
+    if (color && (!clone.getAttribute('color') || clone.getAttribute('color') === 'currentColor')) {
+      clone.setAttribute('color', svgColorValue(color));
+    }
+
+    inlineSvgPaintAttr(clone, 'fill', styles.fill, color);
+    inlineSvgPaintAttr(clone, 'stroke', styles.stroke, color);
+
+    const opacity = parseOpacity(styles.opacity);
+    if (opacity < 1 && !clone.getAttribute('opacity')) {
+      clone.setAttribute('opacity', String(round4(opacity)));
+    }
+  }
+}
+
+function inlineSvgPaintAttr(
+  el: SVGElement,
+  attr: 'fill' | 'stroke',
+  computedValue: string,
+  currentColor: string | null,
+): void {
+  const existing = el.getAttribute(attr);
+  if (existing && existing !== 'currentColor') {
+    normalizeSvgPaintAttr(el, attr, existing);
+    return;
+  }
+  if (existing === 'currentColor' && currentColor) {
+    normalizeSvgPaintAttr(el, attr, currentColor);
+    return;
+  }
+  const color = colorWithPaint(computedValue);
+  if (color) normalizeSvgPaintAttr(el, attr, color);
+}
+
+function normalizeSvgPaintAttr(el: SVGElement, attr: 'fill' | 'stroke', value: string): void {
+  const color = parseColor(value);
+  if (!color) return;
+  el.setAttribute(attr, `#${color.hex}`);
+  if (color.alpha < 0.999) {
+    el.setAttribute(`${attr}-opacity`, String(round4(color.alpha)));
+  }
+}
+
+function svgColorValue(value: string): string {
+  const color = parseColor(value);
+  return color ? `#${color.hex}` : value;
 }
 
 async function imageFromElement(
@@ -777,15 +949,15 @@ function objectXml(object: PptxObject, ctx: SlideBuildContext): string {
 
 function shapeXml(shape: PptxShapeObject, ctx: SlideBuildContext): string {
   const id = ctx.shapeId++;
-  const geom = shape.radius && shape.radius > 0 ? 'roundRect' : 'rect';
-  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Shape ${id}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(shape)}<a:prstGeom prst="${geom}"><a:avLst/></a:prstGeom>${fillXml(shape.fill ?? null, shape.opacity)}${lineXml(shape.stroke ?? null, shape.opacity)}${effectXml(shape.shadow ?? null, shape.opacity)}</p:spPr></p:sp>`;
+  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Shape ${id}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(shape)}${shapeGeometryXml(shape)}${fillXml(shape.fill ?? null, shape.opacity)}${lineXml(shape.stroke ?? null, shape.opacity)}${effectXml(shape.shadow ?? null, shape.opacity)}</p:spPr></p:sp>`;
 }
 
 function textXml(text: PptxTextObject, ctx: SlideBuildContext): string {
   const id = ctx.shapeId++;
   const paragraphs = text.paragraphs.map((paragraph) => paragraphXml(paragraph, text)).join('');
   const wrap = text.wrap === false ? 'none' : 'square';
-  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Text ${id}"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(text)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln>${effectXml(text.shadow ?? null, text.opacity)}</p:spPr><p:txBody><a:bodyPr wrap="${wrap}" lIns="0" tIns="0" rIns="0" bIns="0"/><a:lstStyle/>${paragraphs}</p:txBody></p:sp>`;
+  const anchor = textAnchorXml(text.vertical);
+  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Text ${id}"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(text)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln>${effectXml(text.shadow ?? null, text.opacity)}</p:spPr><p:txBody><a:bodyPr wrap="${wrap}"${anchor} lIns="0" tIns="0" rIns="0" bIns="0"/><a:lstStyle/>${paragraphs}</p:txBody></p:sp>`;
 }
 
 function paragraphXml(paragraph: PptxTextRun[], text: PptxTextObject): string {
@@ -816,15 +988,27 @@ function runXml(run: PptxTextRun, text: PptxTextObject): string {
 
 function pictureXml(image: PptxImageObject, ctx: SlideBuildContext): string {
   const id = ctx.shapeId++;
-  const relId = `rId${ctx.media.length + 2}`;
+  const relId = nextMediaRelId(ctx);
   ctx.media.push({ data: image.data, ext: imageExt(image.mime), relId });
+  const svgRelId = image.svgData ? nextMediaRelId(ctx) : null;
+  if (image.svgData && svgRelId) {
+    ctx.media.push({ data: image.svgData, ext: 'svg', relId: svgRelId });
+  }
   const name = escapeXml(image.alt || `Picture ${id}`);
   const opacity = image.opacity === undefined ? 1 : clamp(image.opacity, 0, 1);
   const blipAlpha = opacity < 1 ? `<a:alphaModFix amt="${Math.round(opacity * 100000)}"/>` : '';
-  const blip = blipAlpha
-    ? `<a:blip r:embed="${relId}">${blipAlpha}</a:blip>`
+  const svgBlip = svgRelId
+    ? `<a:extLst><a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}"><asvg:svgBlip xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main" r:embed="${svgRelId}"/></a:ext></a:extLst>`
+    : '';
+  const blipChildren = `${blipAlpha}${svgBlip}`;
+  const blip = blipChildren
+    ? `<a:blip r:embed="${relId}">${blipChildren}</a:blip>`
     : `<a:blip r:embed="${relId}"/>`;
   return `<p:pic><p:nvPicPr><p:cNvPr id="${id}" name="${name}"/><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill>${blip}${sourceRectXml(image.crop)}<a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr>${xfrmXml(image)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>${effectXml(image.shadow ?? null, image.opacity)}</p:spPr></p:pic>`;
+}
+
+function nextMediaRelId(ctx: SlideBuildContext): string {
+  return `rId${ctx.media.length + 2}`;
 }
 
 function tableXml(table: PptxTableObject, ctx: SlideBuildContext): string {
@@ -859,6 +1043,40 @@ function tableCellXml(cell: PptxTableCell): string {
     .join(' ');
   const font = fontXml(cell.fontFamily, cell.text);
   return `<a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:pPr${align}/><a:r><a:rPr ${attrs}><a:solidFill>${colorXml(cell.color ?? '#000000', 1, '#000000')}</a:solidFill>${font}</a:rPr><a:t>${escapeXml(cell.text)}</a:t></a:r></a:p></a:txBody><a:tcPr>${fillXml(cell.fill ?? null)}</a:tcPr></a:tc>`;
+}
+
+function shapeGeometryXml(shape: PptxShapeObject): string {
+  if (!shape.radius || shape.radius <= 0) return '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>';
+  if (isCircleLikeShape(shape)) return '<a:prstGeom prst="ellipse"><a:avLst/></a:prstGeom>';
+  const adj = roundRectAdjustment(shape.radius, shape.w, shape.h);
+  return `<a:prstGeom prst="roundRect"><a:avLst><a:gd name="adj" fmla="val ${adj}"/></a:avLst></a:prstGeom>`;
+}
+
+function isCircleLikeShape(shape: PptxShapeObject): boolean {
+  return isCircleLikeBox(shape.w, shape.h, shape.radius);
+}
+
+function isCircleLikeBox(width: number, height: number, radius?: number): boolean {
+  if (!radius || radius <= 0) return false;
+  const shortest = Math.min(width, height);
+  const longest = Math.max(width, height);
+  if (shortest <= 0) return false;
+  const nearlySquare = longest - shortest <= Math.max(1, shortest * 0.05);
+  const fullyRounded = radius >= shortest / 2 - 0.5;
+  return nearlySquare && fullyRounded;
+}
+
+function roundRectAdjustment(radius: number, width: number, height: number): number {
+  const shortest = Math.min(width, height);
+  if (shortest <= 0) return 0;
+  const clampedRadius = clamp(radius, 0, shortest / 2);
+  return Math.round(clamp(clampedRadius / shortest, 0, 0.5) * 100000);
+}
+
+function textAnchorXml(vertical: PptxTextObject['vertical']): string {
+  if (vertical === 'middle') return ' anchor="ctr"';
+  if (vertical === 'bottom') return ' anchor="b"';
+  return '';
 }
 
 function pptxTextAlignValue(align: NonNullable<PptxTextObject['align']>): string {
@@ -896,7 +1114,7 @@ function fillXml(fill: PptxFill, opacity?: number): string {
       return `<a:gs pos="${pos}">${colorXml(stop.color, opacity)}</a:gs>`;
     })
     .join('');
-  return `<a:gradFill rotWithShape="1"><a:gsLst>${gs}</a:gsLst><a:lin ang="${Math.round(fill.angle * 60000)}" scaled="0"/></a:gradFill>`;
+  return `<a:gradFill rotWithShape="1"><a:gsLst>${gs}</a:gsLst><a:lin ang="${cssGradientAngleToOoxml(fill.angle)}" scaled="0"/></a:gradFill>`;
 }
 
 function lineXml(stroke: PptxStroke | null, opacity?: number): string {
@@ -1007,7 +1225,7 @@ function themeXml(): string {
   return `${XML_DECL}<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme"><a:themeElements><a:clrScheme name="Office"><a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1><a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1><a:dk2><a:srgbClr val="44546A"/></a:dk2><a:lt2><a:srgbClr val="E7E6E6"/></a:lt2><a:accent1><a:srgbClr val="4472C4"/></a:accent1><a:accent2><a:srgbClr val="ED7D31"/></a:accent2><a:accent3><a:srgbClr val="A5A5A5"/></a:accent3><a:accent4><a:srgbClr val="FFC000"/></a:accent4><a:accent5><a:srgbClr val="5B9BD5"/></a:accent5><a:accent6><a:srgbClr val="70AD47"/></a:accent6><a:hlink><a:srgbClr val="0563C1"/></a:hlink><a:folHlink><a:srgbClr val="954F72"/></a:folHlink></a:clrScheme><a:fontScheme name="Office"><a:majorFont><a:latin typeface="Calibri Light"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont><a:minorFont><a:latin typeface="Calibri"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont></a:fontScheme><a:fmtScheme name="Office"><a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:lumMod val="110000"/><a:satMod val="105000"/><a:tint val="67000"/></a:schemeClr></a:gs><a:gs pos="50000"><a:schemeClr val="phClr"><a:lumMod val="105000"/><a:satMod val="103000"/><a:tint val="73000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:lumMod val="105000"/><a:satMod val="109000"/><a:tint val="81000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="5400000" scaled="0"/></a:gradFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:satMod val="103000"/><a:lumMod val="102000"/><a:tint val="94000"/></a:schemeClr></a:gs><a:gs pos="50000"><a:schemeClr val="phClr"><a:satMod val="110000"/><a:lumMod val="100000"/><a:shade val="100000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:lumMod val="99000"/><a:satMod val="120000"/><a:shade val="78000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="5400000" scaled="0"/></a:gradFill></a:fillStyleLst><a:lnStyleLst><a:ln w="6350" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/><a:miter lim="800000"/></a:ln><a:ln w="12700" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/><a:miter lim="800000"/></a:ln><a:ln w="19050" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/><a:miter lim="800000"/></a:ln></a:lnStyleLst><a:effectStyleLst><a:effectStyle><a:effectLst/></a:effectStyle><a:effectStyle><a:effectLst/></a:effectStyle><a:effectStyle><a:effectLst/></a:effectStyle></a:effectStyleLst><a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:solidFill><a:schemeClr val="phClr"><a:tint val="95000"/><a:satMod val="170000"/></a:schemeClr></a:solidFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="93000"/><a:satMod val="150000"/><a:shade val="98000"/><a:lumMod val="102000"/></a:schemeClr></a:gs><a:gs pos="50000"><a:schemeClr val="phClr"><a:tint val="98000"/><a:satMod val="130000"/><a:shade val="90000"/><a:lumMod val="103000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:shade val="63000"/><a:satMod val="120000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="5400000" scaled="0"/></a:gradFill></a:bgFillStyleLst></a:fmtScheme></a:themeElements></a:theme>`;
 }
 
-function parseLinearGradient(value: string): PptxFill {
+function parseLinearGradient(value: string): PptxLinearGradientFill | null {
   if (!value?.includes('linear-gradient(')) return null;
   const start = value.indexOf('linear-gradient(');
   const inner = contentInFunction(value.slice(start), 'linear-gradient');
@@ -1081,9 +1299,17 @@ function splitTopLevel(input: string): string[] {
 }
 
 function directionToAngle(direction: string): number {
-  if (direction.includes('right')) return 90;
-  if (direction.includes('left')) return 270;
-  if (direction.includes('top')) return 0;
+  const hasTop = direction.includes('top');
+  const hasBottom = direction.includes('bottom');
+  const hasRight = direction.includes('right');
+  const hasLeft = direction.includes('left');
+  if (hasTop && hasRight) return 45;
+  if (hasBottom && hasRight) return 135;
+  if (hasBottom && hasLeft) return 225;
+  if (hasTop && hasLeft) return 315;
+  if (hasRight) return 90;
+  if (hasLeft) return 270;
+  if (hasTop) return 0;
   return 180;
 }
 
@@ -1242,6 +1468,10 @@ function angleToOoxml(angle: number): number {
   return Math.round(normalizeDegrees(angle) * 60000);
 }
 
+function cssGradientAngleToOoxml(angle: number): number {
+  return angleToOoxml(angle - 90);
+}
+
 function normalizedVisibleAngle(angle: number): number | undefined {
   const normalized = normalizeDegrees(angle);
   return Math.abs(normalized) < 0.001 ? undefined : normalized;
@@ -1347,6 +1577,66 @@ function byteToHex(value: number): string {
   return clamp(Math.round(byte), 0, 255).toString(16).padStart(2, '0').toUpperCase();
 }
 
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  return {
+    r: Number.parseInt(hex.slice(0, 2), 16),
+    g: Number.parseInt(hex.slice(2, 4), 16),
+    b: Number.parseInt(hex.slice(4, 6), 16),
+  };
+}
+
+function horizontalTextAlign(box: PptxBox, styles: CSSStyleDeclaration): PptxTextObject['align'] {
+  const explicit = textAlign(styles.textAlign);
+  if (explicit !== 'left') return explicit;
+  if (isCircleLikeBox(box.w, box.h, maxBorderRadius(styles))) return 'center';
+  if (isRoundedChipTextBox(box, styles)) return 'center';
+
+  const display = styles.display;
+  if (!/\b(flex|grid)\b/.test(display)) return explicit;
+
+  const flexColumn = styles.flexDirection?.startsWith('column');
+  const source = flexColumn ? styles.alignItems : styles.justifyContent;
+  if (isCenterAlignment(source)) return 'center';
+  if (isEndAlignment(source)) return 'right';
+  return explicit;
+}
+
+function verticalTextAnchor(
+  box: PptxBox,
+  styles: CSSStyleDeclaration,
+): PptxTextObject['vertical'] | undefined {
+  if (isRoundedChipTextBox(box, styles)) return 'middle';
+
+  const display = styles.display;
+  if (!/\b(flex|grid)\b/.test(display)) return undefined;
+
+  const flexColumn = styles.flexDirection?.startsWith('column');
+  const source = flexColumn ? styles.justifyContent : styles.alignItems;
+  if (isCenterAlignment(source)) return 'middle';
+  if (isEndAlignment(source)) return 'bottom';
+  return undefined;
+}
+
+function isCenterAlignment(value?: string | null): boolean {
+  return value === 'center';
+}
+
+function isEndAlignment(value?: string | null): boolean {
+  return value === 'flex-end' || value === 'end' || value === 'right' || value === 'bottom';
+}
+
+function isRoundedChipTextBox(box: PptxBox, styles: CSSStyleDeclaration): boolean {
+  if (box.h > 56 || !maxBorderRadius(styles)) return false;
+  if (styles.whiteSpace && !['normal', 'nowrap'].includes(styles.whiteSpace)) return false;
+  return hasVisibleBoxDecoration(styles);
+}
+
+function hasVisibleBoxDecoration(styles: CSSStyleDeclaration): boolean {
+  if (colorWithPaint(styles.backgroundColor)) return true;
+  if (parseLinearGradient(styles.backgroundImage)) return true;
+  return borderSidesFromStyles(styles).some(Boolean);
+}
+
 function textAlign(value: string): PptxTextObject['align'] {
   if (value === 'center' || value === 'right' || value === 'justify') return value;
   return 'left';
@@ -1406,6 +1696,10 @@ function parseCssPx(value: string): number {
   if (!value || value === 'normal' || value === 'medium' || value === 'none') return 0;
   const n = Number.parseFloat(value);
   return Number.isFinite(n) ? n : 0;
+}
+
+function round4(value: number): number {
+  return Math.round(value * 10000) / 10000;
 }
 
 function collapseText(value: string): string {

--- a/packages/core/src/app/lib/export-pptx-editable.ts
+++ b/packages/core/src/app/lib/export-pptx-editable.ts
@@ -2,7 +2,8 @@ const SLIDE_W = 1920;
 const SLIDE_H = 1080;
 const EMU_W = 12192000;
 const EMU_H = 6858000;
-const CSS_PX_EMU = 9525;
+const CSS_PX_EMU = EMU_W / SLIDE_W;
+const CSS_PX_PT = CSS_PX_EMU / 12700;
 const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n';
 const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
 const OD_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
@@ -53,6 +54,7 @@ type PptxTextRun = {
   fontSize?: number;
   letterSpacing?: number;
   opacity?: number;
+  textTransform?: string;
 };
 
 type PptxTextStyle = Omit<PptxTextRun, 'text'>;
@@ -72,6 +74,7 @@ type PptxTextObject = PptxBox & {
   color?: string;
   fontFamily?: string;
   fontSize?: number;
+  wrap?: boolean;
 };
 
 type PptxImageObject = PptxBox & {
@@ -167,6 +170,7 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
 
     const fill = fillFromStyles(styles);
     const stroke = strokeFromStyles(styles);
+    const borderShapes = stroke ? [] : borderShapesFromStyles(box, styles);
     if (fill || stroke) {
       objects.push({
         kind: 'shape',
@@ -177,6 +181,7 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
         shadow: parseCssShadow(styles.boxShadow),
       });
     }
+    objects.push(...borderShapes);
 
     const text = textFromElement(el, box, styles);
     if (text) {
@@ -265,18 +270,87 @@ function fillFromStyles(styles: CSSStyleDeclaration): PptxFill {
 }
 
 function strokeFromStyles(styles: CSSStyleDeclaration): PptxStroke | null {
-  const width = Math.max(
-    parseCssPx(styles.borderTopWidth),
-    parseCssPx(styles.borderRightWidth),
-    parseCssPx(styles.borderBottomWidth),
-    parseCssPx(styles.borderLeftWidth),
-  );
+  const sides = borderSidesFromStyles(styles);
+  if (sides.some((side) => !side)) return null;
+  const [top, right, bottom, left] = sides as [PptxStroke, PptxStroke, PptxStroke, PptxStroke];
+  if (
+    top.width !== right.width ||
+    top.width !== bottom.width ||
+    top.width !== left.width ||
+    top.color !== right.color ||
+    top.color !== bottom.color ||
+    top.color !== left.color
+  ) {
+    return null;
+  }
+  return top;
+}
+
+function borderShapesFromStyles(box: PptxBox, styles: CSSStyleDeclaration): PptxShapeObject[] {
+  const [top, right, bottom, left] = borderSidesFromStyles(styles);
+  const shapes: PptxShapeObject[] = [];
+  if (top) {
+    shapes.push({
+      kind: 'shape',
+      x: box.x,
+      y: box.y,
+      w: box.w,
+      h: top.width,
+      fill: top.color,
+      opacity: box.opacity,
+    });
+  }
+  if (right) {
+    shapes.push({
+      kind: 'shape',
+      x: box.x + box.w - right.width,
+      y: box.y,
+      w: right.width,
+      h: box.h,
+      fill: right.color,
+      opacity: box.opacity,
+    });
+  }
+  if (bottom) {
+    shapes.push({
+      kind: 'shape',
+      x: box.x,
+      y: box.y + box.h - bottom.width,
+      w: box.w,
+      h: bottom.width,
+      fill: bottom.color,
+      opacity: box.opacity,
+    });
+  }
+  if (left) {
+    shapes.push({
+      kind: 'shape',
+      x: box.x,
+      y: box.y,
+      w: left.width,
+      h: box.h,
+      fill: left.color,
+      opacity: box.opacity,
+    });
+  }
+  return shapes;
+}
+
+function borderSidesFromStyles(
+  styles: CSSStyleDeclaration,
+): [PptxStroke | null, PptxStroke | null, PptxStroke | null, PptxStroke | null] {
+  return [
+    borderSideFromStyles(styles.borderTopWidth, styles.borderTopColor),
+    borderSideFromStyles(styles.borderRightWidth, styles.borderRightColor),
+    borderSideFromStyles(styles.borderBottomWidth, styles.borderBottomColor),
+    borderSideFromStyles(styles.borderLeftWidth, styles.borderLeftColor),
+  ];
+}
+
+function borderSideFromStyles(widthValue: string, colorValue: string): PptxStroke | null {
+  const width = parseCssPx(widthValue);
   if (width <= 0) return null;
-  const color =
-    colorWithPaint(styles.borderTopColor) ??
-    colorWithPaint(styles.borderRightColor) ??
-    colorWithPaint(styles.borderBottomColor) ??
-    colorWithPaint(styles.borderLeftColor);
+  const color = colorWithPaint(colorValue);
   if (!color) return null;
   return { color, width };
 }
@@ -295,6 +369,7 @@ function textFromElement(
     bold: isBold(styles.fontWeight),
     italic: styles.fontStyle === 'italic' || styles.fontStyle === 'oblique',
     letterSpacing: parseCssPx(styles.letterSpacing),
+    textTransform: styles.textTransform,
   });
   const hasText = paragraphs.some((paragraph) => paragraph.some((run) => run.text.trim()));
   if (!hasText) return null;
@@ -307,19 +382,33 @@ function textFromElement(
     color: colorWithPaint(styles.color) ?? undefined,
     fontFamily: normalizeFontFamily(styles.fontFamily),
     fontSize: parseCssPx(styles.fontSize) || undefined,
+    wrap: shouldWrapTextBox(box, styles),
     shadow: parseCssShadow(styles.textShadow),
   };
+}
+
+function shouldWrapTextBox(box: PptxBox, styles: CSSStyleDeclaration): boolean {
+  if (/\bnowrap\b|\bpre\b/.test(styles.whiteSpace)) return false;
+  const fontSize = parseCssPx(styles.fontSize) || 16;
+  const lineHeight = parseCssPx(styles.lineHeight) || fontSize * 1.2;
+  return box.h > lineHeight * 1.35;
 }
 
 function isTextCandidate(el: HTMLElement): boolean {
   if (['SCRIPT', 'STYLE', 'SVG', 'CANVAS', 'IMG', 'VIDEO', 'PICTURE'].includes(el.tagName)) {
     return false;
   }
+  const display = getComputedStyle(el).display;
+  if (isLayoutTextContainer(display)) return false;
   if (!el.textContent?.trim()) return false;
   for (const child of Array.from(el.children)) {
     if (!isInlineTextElement(child as HTMLElement)) return false;
   }
   return true;
+}
+
+function isLayoutTextContainer(display: string): boolean {
+  return /\b(flex|grid|table)\b/.test(display);
 }
 
 function isInlineTextElement(el: HTMLElement): boolean {
@@ -355,7 +444,7 @@ function collectTextParagraphs(el: HTMLElement, inherited: PptxTextStyle): PptxT
 
   const walk = (node: Node, style: PptxTextStyle) => {
     if (node.nodeType === Node.TEXT_NODE) {
-      const text = collapseText(node.textContent ?? '');
+      const text = applyTextTransform(collapseText(node.textContent ?? ''), style.textTransform);
       if (text) paragraphs[paragraphs.length - 1].push({ ...style, text });
       return;
     }
@@ -385,6 +474,10 @@ function collectTextParagraphs(el: HTMLElement, inherited: PptxTextStyle): PptxT
         style.italic,
       letterSpacing: parseCssPx(computed.letterSpacing) || style.letterSpacing,
       opacity: opacity < 1 ? opacity : style.opacity,
+      textTransform:
+        computed.textTransform && computed.textTransform !== 'none'
+          ? computed.textTransform
+          : style.textTransform,
     };
     for (const child of Array.from(node.childNodes)) walk(child, next);
   };
@@ -401,8 +494,46 @@ function shouldRasterizeElement(el: HTMLElement, styles: CSSStyleDeclaration): b
   ) {
     return true;
   }
-  if (styles.filter && styles.filter !== 'none') return true;
+  if (hasNonIdentityFilter(styles.filter)) return true;
+  if (hasNonIdentityFilter(styles.backdropFilter)) return true;
+  if (isTextlessDecorativeElement(el) && hasUnsupportedVisualStyle(styles)) return true;
   return Boolean(styles.mixBlendMode && styles.mixBlendMode !== 'normal');
+}
+
+function isTextlessDecorativeElement(el: HTMLElement): boolean {
+  return !el.textContent?.trim();
+}
+
+function hasUnsupportedVisualStyle(styles: CSSStyleDeclaration): boolean {
+  if (hasUnsupportedBackgroundImage(styles.backgroundImage)) return true;
+  const maskImage =
+    styles.maskImage ||
+    (styles as CSSStyleDeclaration & { webkitMaskImage?: string }).webkitMaskImage;
+  if (maskImage && maskImage !== 'none') return true;
+  if (hasNonIdentityClipPath(styles.clipPath)) return true;
+  return false;
+}
+
+function hasNonIdentityFilter(value?: string | null): boolean {
+  if (!value || value === 'none') return false;
+  const normalized = value.replace(/\s+/g, '').toLowerCase();
+  return !/^(?:blur\\(0(?:\\.0+)?px\\)|opacity\\(1\\)|opacity\\(100%\\)|brightness\\(1\\)|brightness\\(100%\\)|contrast\\(1\\)|contrast\\(100%\\)|saturate\\(1\\)|saturate\\(100%\\)|grayscale\\(0\\)|grayscale\\(0%\\)|sepia\\(0\\)|sepia\\(0%\\)|hue-rotate\\(0(?:\\.0+)?deg\\))+$/.test(
+    normalized,
+  );
+}
+
+function hasNonIdentityClipPath(value?: string | null): boolean {
+  if (!value || value === 'none') return false;
+  const normalized = value.replace(/\s+/g, '').toLowerCase();
+  return !/^inset\\(0(?:px|%)?(?:0(?:px|%)?){0,3}\\)$/.test(normalized);
+}
+
+function hasUnsupportedBackgroundImage(value?: string | null): boolean {
+  if (!value || value === 'none') return false;
+  if (/radial-gradient|conic-gradient|repeating-/i.test(value)) return true;
+  const layers = splitTopLevel(value);
+  if (layers.length > 1) return true;
+  return !parseLinearGradient(value);
 }
 
 async function rasterizeElement(el: HTMLElement, box: PptxBox): Promise<PptxImageObject | null> {
@@ -540,7 +671,8 @@ function shapeXml(shape: PptxShapeObject, ctx: SlideBuildContext): string {
 function textXml(text: PptxTextObject, ctx: SlideBuildContext): string {
   const id = ctx.shapeId++;
   const paragraphs = text.paragraphs.map((paragraph) => paragraphXml(paragraph, text)).join('');
-  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Text ${id}"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(text)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln>${effectXml(text.shadow ?? null, text.opacity)}</p:spPr><p:txBody><a:bodyPr wrap="square" lIns="0" tIns="0" rIns="0" bIns="0"/><a:lstStyle/>${paragraphs}</p:txBody></p:sp>`;
+  const wrap = text.wrap === false ? 'none' : 'square';
+  return `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="Text ${id}"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr><p:spPr>${xfrmXml(text)}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln>${effectXml(text.shadow ?? null, text.opacity)}</p:spPr><p:txBody><a:bodyPr wrap="${wrap}" lIns="0" tIns="0" rIns="0" bIns="0"/><a:lstStyle/>${paragraphs}</p:txBody></p:sp>`;
 }
 
 function paragraphXml(paragraph: PptxTextRun[], text: PptxTextObject): string {
@@ -551,12 +683,12 @@ function paragraphXml(paragraph: PptxTextRun[], text: PptxTextObject): string {
 }
 
 function runXml(run: PptxTextRun, text: PptxTextObject): string {
-  const fontSize = Math.max(1, Math.round((run.fontSize ?? text.fontSize ?? 18) * 100));
+  const fontSize = cssPxToTextPoint(run.fontSize ?? text.fontSize ?? 18);
   const attrs = [
     `sz="${fontSize}"`,
     run.bold ? 'b="1"' : '',
     run.italic ? 'i="1"' : '',
-    run.letterSpacing ? `spc="${Math.round(run.letterSpacing * 100)}"` : '',
+    run.letterSpacing ? `spc="${Math.round(run.letterSpacing * CSS_PX_PT * 100)}"` : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -608,7 +740,7 @@ function tableXml(table: PptxTableObject, ctx: SlideBuildContext): string {
 function tableCellXml(cell: PptxTableCell): string {
   const align =
     cell.align && cell.align !== 'left' ? ` algn="${pptxTextAlignValue(cell.align)}"` : '';
-  const fontSize = Math.max(1, Math.round((cell.fontSize ?? 18) * 100));
+  const fontSize = cssPxToTextPoint(cell.fontSize ?? 18);
   const attrs = [`sz="${fontSize}"`, cell.bold ? 'b="1"' : '', cell.italic ? 'i="1"' : '']
     .filter(Boolean)
     .join(' ');
@@ -617,7 +749,10 @@ function tableCellXml(cell: PptxTableCell): string {
 }
 
 function pptxTextAlignValue(align: NonNullable<PptxTextObject['align']>): string {
-  return align === 'justify' ? 'just' : align;
+  if (align === 'center') return 'ctr';
+  if (align === 'right') return 'r';
+  if (align === 'justify') return 'just';
+  return 'l';
 }
 
 function xfrmXml(box: PptxBox): string {
@@ -653,7 +788,7 @@ function fillXml(fill: PptxFill, opacity?: number): string {
 
 function lineXml(stroke: PptxStroke | null, opacity?: number): string {
   if (!stroke) return '<a:ln><a:noFill/></a:ln>';
-  return `<a:ln w="${Math.round(stroke.width * 12700)}"><a:solidFill>${colorXml(stroke.color, opacity, '000000')}</a:solidFill><a:prstDash val="solid"/></a:ln>`;
+  return `<a:ln w="${Math.round(stroke.width * CSS_PX_EMU)}"><a:solidFill>${colorXml(stroke.color, opacity, '000000')}</a:solidFill><a:prstDash val="solid"/></a:ln>`;
 }
 
 function effectXml(shadow: PptxShadow | null, opacity?: number): string {
@@ -1069,10 +1204,39 @@ function textAlign(value: string): PptxTextObject['align'] {
 }
 
 function normalizeFontFamily(value: string): string | undefined {
-  return value
-    .split(',')[0]
-    ?.trim()
-    .replace(/^['"]|['"]$/g, '');
+  const families = value
+    .split(',')
+    .map((part) => part.trim().replace(/^['"]|['"]$/g, ''))
+    .filter(Boolean);
+  for (const family of families) {
+    const mapped = mapPowerPointFontFamily(family);
+    if (mapped) return mapped;
+  }
+  return families[0];
+}
+
+function mapPowerPointFontFamily(family: string): string | undefined {
+  const normalized = family.toLowerCase();
+  if (
+    normalized.includes('sf mono') ||
+    normalized === 'ui-monospace' ||
+    normalized === 'monospace' ||
+    normalized.includes('consolas')
+  ) {
+    return 'Menlo';
+  }
+  if (
+    normalized === 'sf pro display' ||
+    normalized === 'sf pro text' ||
+    normalized === '-apple-system' ||
+    normalized === 'blinkmacsystemfont' ||
+    normalized === 'system-ui' ||
+    normalized === 'sans-serif'
+  ) {
+    return 'Arial';
+  }
+  if (normalized === 'serif') return 'Times New Roman';
+  return family;
 }
 
 function isBold(weight: string): boolean {
@@ -1097,6 +1261,19 @@ function parseCssPx(value: string): number {
 
 function collapseText(value: string): string {
   return value.replace(/\s+/g, ' ');
+}
+
+function applyTextTransform(text: string, transform?: string): string {
+  if (!transform || transform === 'none') return text;
+  if (transform === 'uppercase') return text.toLocaleUpperCase();
+  if (transform === 'lowercase') return text.toLocaleLowerCase();
+  if (transform === 'capitalize') {
+    return text.replace(/\p{L}[\p{L}\p{N}'-]*/gu, (word) => {
+      const [first = '', ...rest] = Array.from(word);
+      return `${first.toLocaleUpperCase()}${rest.join('').toLocaleLowerCase()}`;
+    });
+  }
+  return text;
 }
 
 function markDescendants(el: Element, skipped: WeakSet<Element>): void {
@@ -1124,6 +1301,10 @@ function pxToEmuX(px: number): number {
 
 function pxToEmuY(px: number): number {
   return Math.round((px / SLIDE_H) * EMU_H);
+}
+
+function cssPxToTextPoint(px: number): number {
+  return Math.max(1, Math.round(px * CSS_PX_PT * 100));
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/packages/core/src/app/lib/export-pptx-editable.ts
+++ b/packages/core/src/app/lib/export-pptx-editable.ts
@@ -206,7 +206,7 @@ export async function collectEditableSlide(frame: HTMLElement): Promise<Editable
     const text = textFromElement(el, box, styles);
     if (text) {
       objects.push(text);
-      markDescendants(el, skipped);
+      markTextDescendants(el, skipped);
     }
   }
 
@@ -447,19 +447,57 @@ function textFromElement(
   });
   const hasText = paragraphs.some((paragraph) => paragraph.some((run) => run.text.trim()));
   if (!hasText) return null;
+  const textBox = adjustedTextBoxForEmbeddedLeadingContent(el, box, styles);
 
   return {
     kind: 'text',
-    ...box,
+    ...textBox,
     paragraphs,
-    align: horizontalTextAlign(box, styles),
-    vertical: verticalTextAnchor(box, styles),
+    align: horizontalTextAlign(textBox, styles),
+    vertical: verticalTextAnchor(textBox, styles),
     color: colorWithPaint(styles.color) ?? undefined,
     fontFamily: normalizeFontFamily(styles.fontFamily),
     fontSize: parseCssPx(styles.fontSize) || undefined,
-    wrap: shouldWrapTextBox(box, styles),
+    wrap: shouldWrapTextBox(textBox, styles),
     shadow: parseCssShadow(styles.textShadow),
   };
+}
+
+function adjustedTextBoxForEmbeddedLeadingContent(
+  el: HTMLElement,
+  box: PptxBox,
+  styles: CSSStyleDeclaration,
+): PptxBox {
+  const offset = leadingEmbeddedInlineOffset(el, styles);
+  if (offset <= 0 || offset >= box.w) return box;
+  return {
+    ...box,
+    x: box.x + offset,
+    w: box.w - offset,
+  };
+}
+
+function leadingEmbeddedInlineOffset(el: HTMLElement, styles: CSSStyleDeclaration): number {
+  if (!/\bflex\b/.test(styles.display)) return 0;
+  if (styles.flexDirection && !styles.flexDirection.startsWith('row')) return 0;
+  if (!hasDirectText(el)) return 0;
+
+  let embeddedWidth = 0;
+  let hasLeadingEmbedded = false;
+  for (const child of Array.from(el.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      if (child.textContent?.trim()) break;
+      continue;
+    }
+    if (!(child instanceof Element)) continue;
+    if (!isTextlessEmbeddedElement(child)) break;
+    embeddedWidth += child.getBoundingClientRect().width;
+    hasLeadingEmbedded = true;
+  }
+  if (!hasLeadingEmbedded) return 0;
+
+  const gap = parseCssPx(styles.columnGap) || parseCssPx(styles.gap);
+  return embeddedWidth + gap;
 }
 
 function shouldWrapTextBox(box: PptxBox, styles: CSSStyleDeclaration): boolean {
@@ -476,8 +514,12 @@ function isTextCandidate(el: HTMLElement): boolean {
   const display = getComputedStyle(el).display;
   if (isTableLayoutTextContainer(display)) return false;
   if (!el.textContent?.trim()) return false;
-  for (const child of Array.from(el.children)) {
-    if (!isInlineTextElement(child as HTMLElement)) return false;
+  const children = Array.from(el.children);
+  if (children.some(isTextlessEmbeddedElement) && !hasDirectText(el)) return false;
+  for (const child of children) {
+    if (isInlineTextElement(child as HTMLElement)) continue;
+    if (isTextlessEmbeddedElement(child)) continue;
+    return false;
   }
   return true;
 }
@@ -507,6 +549,23 @@ function isInlineTextElement(el: HTMLElement): boolean {
       'SUP',
       'U',
     ].includes(el.tagName)
+  );
+}
+
+function isTextlessEmbeddedElement(el: Element): boolean {
+  if (el.textContent?.trim()) return false;
+  return (
+    el instanceof SVGElement ||
+    el instanceof HTMLImageElement ||
+    el instanceof HTMLCanvasElement ||
+    el instanceof HTMLVideoElement ||
+    ['IMG', 'SVG', 'CANVAS', 'VIDEO', 'PICTURE'].includes(el.tagName)
+  );
+}
+
+function hasDirectText(el: HTMLElement): boolean {
+  return Array.from(el.childNodes).some(
+    (child) => child.nodeType === Node.TEXT_NODE && Boolean(child.textContent?.trim()),
   );
 }
 
@@ -1729,6 +1788,12 @@ function applyTextTransform(text: string, transform?: string): string {
 
 function markDescendants(el: Element, skipped: WeakSet<Element>): void {
   for (const child of Array.from(el.querySelectorAll('*'))) skipped.add(child);
+}
+
+function markTextDescendants(el: Element, skipped: WeakSet<Element>): void {
+  for (const child of Array.from(el.querySelectorAll('*'))) {
+    if (!isTextlessEmbeddedElement(child)) skipped.add(child);
+  }
 }
 
 function imageExt(mime: string): string {

--- a/packages/core/src/app/lib/export-pptx-editable.ts
+++ b/packages/core/src/app/lib/export-pptx-editable.ts
@@ -115,7 +115,6 @@ type PptxObject = PptxShapeObject | PptxTextObject | PptxImageObject | PptxTable
 export type EditablePptxSlide = {
   background?: PptxFill;
   objects: PptxObject[];
-  visualSnapshot?: PptxImageObject;
 };
 
 type MediaRef = {
@@ -765,9 +764,7 @@ function editableSlideXml(slide: EditablePptxSlide, ctx: SlideBuildContext): str
   const background = slide.background
     ? `<p:bg><p:bgPr>${fillXml(slide.background)}<a:effectLst/></p:bgPr></p:bg>`
     : '';
-  const objects = [...slide.objects, ...(slide.visualSnapshot ? [slide.visualSnapshot] : [])]
-    .map((object) => objectXml(object, ctx))
-    .join('');
+  const objects = slide.objects.map((object) => objectXml(object, ctx)).join('');
   return `${XML_DECL}<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="${OD_REL}" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld>${background}<p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>${objects}</p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>`;
 }
 

--- a/packages/core/src/app/lib/export-pptx-progress.test.ts
+++ b/packages/core/src/app/lib/export-pptx-progress.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { exportSlideAsPptx, type PptxExportProgress } from './export-pptx';
+import type { SlideModule } from './sdk';
+
+const mocks = vi.hoisted(() => ({
+  buildEditablePptx: vi.fn(),
+  collectEditableSlide: vi.fn(),
+  createRoot: vi.fn(),
+  isFrameAnimationSettled: vi.fn(),
+  waitForDataWaitfor: vi.fn(),
+  waitForFonts: vi.fn(),
+}));
+
+vi.mock('react-dom/client', () => ({
+  createRoot: mocks.createRoot,
+}));
+
+vi.mock('./export-pptx-editable', () => ({
+  buildEditablePptx: mocks.buildEditablePptx,
+  collectEditableSlide: mocks.collectEditableSlide,
+}));
+
+vi.mock('./print-ready', () => ({
+  isFrameAnimationSettled: mocks.isFrameAnimationSettled,
+  waitForDataWaitfor: mocks.waitForDataWaitfor,
+  waitForFonts: mocks.waitForFonts,
+}));
+
+function createFakeElement() {
+  return {
+    appendChild: vi.fn(),
+    click: vi.fn(),
+    remove: vi.fn(),
+    setAttribute: vi.fn(),
+    querySelectorAll: vi.fn(() => []),
+    style: {
+      setProperty: vi.fn(),
+    },
+  };
+}
+
+describe('exportSlideAsPptx progress', () => {
+  beforeEach(() => {
+    mocks.createRoot.mockReturnValue({ render: vi.fn(), unmount: vi.fn() });
+    mocks.waitForFonts.mockResolvedValue(undefined);
+    mocks.waitForDataWaitfor.mockResolvedValue(undefined);
+    mocks.isFrameAnimationSettled.mockReturnValue(true);
+    mocks.collectEditableSlide.mockResolvedValue({ background: '#ffffff', objects: [] });
+    mocks.buildEditablePptx.mockRejectedValue(new Error('build failed'));
+
+    vi.stubGlobal('document', {
+      body: createFakeElement(),
+      createElement: vi.fn(() => createFakeElement()),
+      head: createFakeElement(),
+    });
+    vi.stubGlobal('getComputedStyle', vi.fn());
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not report done when editable PPTX generation fails', async () => {
+    const Page = () => null;
+    const slide = { default: [Page] } as unknown as SlideModule;
+    const progress: PptxExportProgress[] = [];
+
+    await expect(exportSlideAsPptx(slide, 'demo', (event) => progress.push(event))).rejects.toThrow(
+      'build failed',
+    );
+
+    expect(progress.map((event) => event.phase)).toEqual([
+      'processing',
+      'processing',
+      'generating',
+    ]);
+  });
+});

--- a/packages/core/src/app/lib/export-pptx.test.ts
+++ b/packages/core/src/app/lib/export-pptx.test.ts
@@ -40,7 +40,7 @@ describe('editable PPTX OOXML', () => {
             align: 'center',
             paragraphs: [
               [
-                { text: 'Hello ', bold: true },
+                { text: 'Hello ', bold: true, letterSpacing: 2 },
                 { text: 'world', italic: true, color: '#ef4444' },
               ],
             ],
@@ -70,6 +70,9 @@ describe('editable PPTX OOXML', () => {
     expect(slide).toContain('name="Text 3"');
     expect(slide).toContain('<a:t>Hello </a:t>');
     expect(slide).toContain('<a:t>world</a:t>');
+    expect(slide).toContain('<a:pPr algn="ctr"/>');
+    expect(slide).toContain('sz="2400"');
+    expect(slide).toContain('spc="100"');
     expect(slide).toContain('b="1"');
     expect(slide).toContain('i="1"');
     expect(slide).toContain('<p:pic>');
@@ -111,6 +114,29 @@ describe('editable PPTX OOXML', () => {
     expect(slide).toContain('<a:lin ang="5400000" scaled="0"/>');
   });
 
+  it('can disable wrapping for single-line text boxes', async () => {
+    const bytes = await buildEditablePptx([
+      {
+        background: '#ffffff',
+        objects: [
+          {
+            kind: 'text',
+            x: 80,
+            y: 96,
+            w: 180,
+            h: 28,
+            wrap: false,
+            paragraphs: [[{ text: 'open-slide dev' }]],
+          },
+        ],
+      },
+    ]);
+
+    const slide = xml(unzip(bytes), 'ppt/slides/slide1.xml');
+
+    expect(slide).toContain('<a:bodyPr wrap="none"');
+  });
+
   it('preserves transparent colors, opacity, shadows, and rotation', async () => {
     const bytes = await buildEditablePptx([
       {
@@ -146,7 +172,7 @@ describe('editable PPTX OOXML', () => {
     expect(slide).toContain('<a:xfrm rot="720000">');
     expect(slide).toContain('<a:srgbClr val="0F172A"><a:alpha val="30000"/></a:srgbClr>');
     expect(slide).toContain('<a:srgbClr val="6EE7FF"><a:alpha val="22500"/></a:srgbClr>');
-    expect(slide).toContain('<a:outerShdw blurRad="171450" dist="57150" dir="8100000"');
+    expect(slide).toContain('<a:outerShdw blurRad="114300" dist="38100" dir="8100000"');
     expect(slide).toContain('<a:srgbClr val="6EE7FF"><a:alpha val="25000"/></a:srgbClr>');
     expect(slide).toContain('<a:srgbClr val="FFFFFF"><a:alpha val="60000"/></a:srgbClr>');
   });

--- a/packages/core/src/app/lib/export-pptx.test.ts
+++ b/packages/core/src/app/lib/export-pptx.test.ts
@@ -71,6 +71,7 @@ describe('editable PPTX OOXML', () => {
       '<p:bg><p:bgPr><a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill><a:effectLst/></p:bgPr></p:bg>',
     );
     expect(slide).toContain('<p:sp>');
+    expect(slide).toContain('<a:gd name="adj" fmla="val 16000"/>');
     expect(slide).toContain('name="Text 3"');
     expect(slide).toContain('<a:t>Hello </a:t>');
     expect(slide).toContain('<a:t>world</a:t>');
@@ -115,7 +116,123 @@ describe('editable PPTX OOXML', () => {
     expect(slide).toContain('<a:gradFill rotWithShape="1">');
     expect(slide).toContain('<a:gs pos="0"><a:srgbClr val="FF0000"/></a:gs>');
     expect(slide).toContain('<a:gs pos="100000"><a:srgbClr val="0000FF"/></a:gs>');
-    expect(slide).toContain('<a:lin ang="5400000" scaled="0"/>');
+    expect(slide).toContain('<a:lin ang="0" scaled="0"/>');
+  });
+
+  it('uses ellipse geometry for square fully-rounded number badges', async () => {
+    const bytes = await buildEditablePptx([
+      {
+        background: '#ffffff',
+        objects: [
+          {
+            kind: 'shape',
+            x: 80,
+            y: 96,
+            w: 41,
+            h: 41,
+            radius: 999,
+            fill: '#0f172a',
+          },
+          {
+            kind: 'shape',
+            x: 160,
+            y: 96,
+            w: 120,
+            h: 41,
+            radius: 999,
+            fill: '#0f172a',
+          },
+        ],
+      },
+    ]);
+
+    const slide = xml(unzip(bytes), 'ppt/slides/slide1.xml');
+
+    expect(slide).toContain('<a:prstGeom prst="ellipse"><a:avLst/></a:prstGeom>');
+    expect(slide).toContain('<a:prstGeom prst="roundRect">');
+    expect(slide).toContain('<a:gd name="adj" fmla="val 50000"/>');
+  });
+
+  it('maps diagonal CSS linear-gradient directions to PowerPoint angles', async () => {
+    const panel = fakeElement('DIV', {
+      rect: { left: 40, top: 48, width: 320, height: 180 },
+      styles: {
+        display: 'block',
+        backgroundImage: 'linear-gradient(to bottom right, #ff0000 0%, #0000ff 100%)',
+      },
+    });
+    const frame = fakeElement('DIV', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      children: [panel],
+      queryResults: [panel],
+      styles: { backgroundColor: '#050505', display: 'block' },
+    });
+    stubDom();
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+    const shape = slide.objects.find((object) => object.kind === 'shape');
+
+    expect(shape).toMatchObject({
+      kind: 'shape',
+      fill: { kind: 'linearGradient', angle: 135 },
+    });
+
+    const bytes = await buildEditablePptx([slide]);
+    expect(xml(unzip(bytes), 'ppt/slides/slide1.xml')).toContain(
+      '<a:lin ang="2700000" scaled="0"/>',
+    );
+  });
+
+  it('keeps vertical gradient direction and 8px corner radius for planning cards', async () => {
+    const slideRoot = fakeElement('SECTION', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      styles: { backgroundColor: '#050505', display: 'block' },
+    });
+    const panel = fakeElement('DIV', {
+      rect: { left: 75, top: 295, width: 510, height: 265 },
+      styles: {
+        display: 'block',
+        backgroundImage:
+          'linear-gradient(180deg, rgba(7,35,28,0.72) 0%, rgba(255,255,255,0.025) 100%)',
+        borderTopLeftRadius: '8px',
+        borderTopRightRadius: '8px',
+        borderBottomRightRadius: '8px',
+        borderBottomLeftRadius: '8px',
+        borderTopWidth: '1px',
+        borderRightWidth: '1px',
+        borderBottomWidth: '1px',
+        borderLeftWidth: '1px',
+        borderTopColor: 'rgba(110,231,183,0.34)',
+        borderRightColor: 'rgba(110,231,183,0.34)',
+        borderBottomColor: 'rgba(110,231,183,0.34)',
+        borderLeftColor: 'rgba(110,231,183,0.34)',
+      },
+    });
+    const frame = fakeElement('DIV', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      children: [slideRoot, panel],
+      queryResults: [slideRoot, panel],
+      styles: { backgroundColor: '#ffffff', display: 'block' },
+    });
+    stubDom();
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+    const shape = slide.objects.find(
+      (object) => object.kind === 'shape' && object.x === 75 && object.y === 295,
+    );
+
+    expect(shape).toMatchObject({
+      kind: 'shape',
+      radius: 8,
+      fill: { kind: 'linearGradient', angle: 180 },
+    });
+
+    const slideXml = xml(unzip(await buildEditablePptx([slide])), 'ppt/slides/slide1.xml');
+    expect(slideXml).toContain('<a:gd name="adj" fmla="val 3019"/>');
+    expect(slideXml).toContain('<a:gs pos="0"><a:srgbClr val="061B16"/></a:gs>');
+    expect(slideXml).toContain('<a:gs pos="100000"><a:srgbClr val="0B0B0B"/></a:gs>');
+    expect(slideXml).toContain('<a:lin ang="5400000" scaled="0"/>');
+    expect(slideXml).toContain('<a:srgbClr val="6EE7B7"><a:alpha val="34000"/></a:srgbClr>');
   });
 
   it('can disable wrapping for single-line text boxes', async () => {
@@ -166,6 +283,251 @@ describe('editable PPTX OOXML', () => {
     const textObject = slide.objects.find((object) => object.kind === 'text');
 
     expect(textObject).toMatchObject({ kind: 'text', wrap: true });
+  });
+
+  it('uses flex centering for native PowerPoint text boxes', async () => {
+    const text = fakeTextNode('Center');
+    const badge = fakeElement('DIV', {
+      rect: { left: 32, top: 44, width: 180, height: 72 },
+      textContent: text.textContent,
+      childNodes: [text],
+      styles: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'row',
+        fontSize: '24px',
+      },
+    });
+    const frame = fakeElement('DIV', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      children: [badge],
+      queryResults: [badge],
+      styles: { backgroundColor: '#ffffff', display: 'block' },
+    });
+    stubDom();
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+    const textObject = slide.objects.find((object) => object.kind === 'text');
+
+    expect(textObject).toMatchObject({
+      kind: 'text',
+      x: 32,
+      y: 44,
+      w: 180,
+      h: 72,
+      align: 'center',
+      vertical: 'middle',
+    });
+
+    const bytes = await buildEditablePptx([slide]);
+    const slideXml = xml(unzip(bytes), 'ppt/slides/slide1.xml');
+    expect(slideXml).toContain('<a:bodyPr wrap="square" anchor="ctr"');
+    expect(slideXml).toContain('<a:pPr algn="ctr"/>');
+  });
+
+  it('centers text inside rounded single-line chips', async () => {
+    const text = fakeTextNode('设计结构化');
+    const chip = fakeElement('SPAN', {
+      rect: { left: 1127, top: 686, width: 171, height: 31 },
+      textContent: text.textContent,
+      childNodes: [text],
+      styles: {
+        display: 'block',
+        whiteSpace: 'nowrap',
+        fontSize: '15px',
+        lineHeight: '15px',
+        borderTopLeftRadius: '8px',
+        borderTopRightRadius: '8px',
+        borderBottomRightRadius: '8px',
+        borderBottomLeftRadius: '8px',
+        borderTopWidth: '1px',
+        borderRightWidth: '1px',
+        borderBottomWidth: '1px',
+        borderLeftWidth: '1px',
+        borderTopColor: 'rgba(110,231,183,0.36)',
+        borderRightColor: 'rgba(110,231,183,0.36)',
+        borderBottomColor: 'rgba(110,231,183,0.36)',
+        borderLeftColor: 'rgba(110,231,183,0.36)',
+        backgroundColor: 'rgba(110,231,183,0.08)',
+      },
+    });
+    const frame = fakeElement('DIV', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      children: [chip],
+      queryResults: [chip],
+      styles: { backgroundColor: '#050505', display: 'block' },
+    });
+    stubDom();
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+    const textObject = slide.objects.find((object) => object.kind === 'text');
+
+    expect(textObject).toMatchObject({
+      kind: 'text',
+      align: 'center',
+      vertical: 'middle',
+    });
+
+    const slideXml = xml(unzip(await buildEditablePptx([slide])), 'ppt/slides/slide1.xml');
+    expect(slideXml).toContain('<a:bodyPr wrap="none" anchor="ctr"');
+    expect(slideXml).toContain('<a:pPr algn="ctr"/>');
+  });
+
+  it('centers text inside circle-like number badges', async () => {
+    const text = fakeTextNode('01');
+    const badge = fakeElement('DIV', {
+      rect: { left: 91, top: 239, width: 41, height: 41 },
+      textContent: text.textContent,
+      childNodes: [text],
+      styles: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'normal',
+        borderTopLeftRadius: '999px',
+        borderTopRightRadius: '999px',
+        borderBottomRightRadius: '999px',
+        borderBottomLeftRadius: '999px',
+        backgroundColor: '#0f172a',
+      },
+    });
+    const frame = fakeElement('DIV', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      children: [badge],
+      queryResults: [badge],
+      styles: { backgroundColor: '#ffffff', display: 'block' },
+    });
+    stubDom();
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+    const shape = slide.objects.find((object) => object.kind === 'shape');
+    const textObject = slide.objects.find((object) => object.kind === 'text');
+
+    expect(shape).toMatchObject({ kind: 'shape', radius: 999 });
+    expect(textObject).toMatchObject({
+      kind: 'text',
+      align: 'center',
+      vertical: 'middle',
+    });
+
+    const slideXml = xml(unzip(await buildEditablePptx([slide])), 'ppt/slides/slide1.xml');
+    expect(slideXml).toContain('<a:prstGeom prst="ellipse"><a:avLst/></a:prstGeom>');
+    expect(slideXml).toContain('<a:bodyPr wrap="square" anchor="ctr"');
+    expect(slideXml).toContain('<a:pPr algn="ctr"/>');
+  });
+
+  it('collects inline SVG roots as vector SVG media', async () => {
+    const svg = fakeSvgElement({
+      rect: { left: 12, top: 24, width: 96, height: 48 },
+      styles: {
+        color: 'rgb(110, 231, 183)',
+        fill: 'none',
+        stroke: 'rgb(110, 231, 183)',
+      },
+    });
+    const frame = fakeElement('DIV', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      children: [svg],
+      queryResults: [svg],
+      styles: { backgroundColor: '#ffffff', display: 'block' },
+    });
+    stubDom();
+    vi.stubGlobal(
+      'XMLSerializer',
+      class FakeXmlSerializer {
+        serializeToString(node: FakeSvgElement) {
+          return `<svg xmlns="${node.getAttribute('xmlns')}" width="${node.getAttribute('width')}" height="${node.getAttribute('height')}" color="${node.getAttribute('color')}"></svg>`;
+        }
+      },
+    );
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+    const image = slide.objects.find((object) => object.kind === 'image');
+
+    expect(image).toMatchObject({
+      kind: 'image',
+      mime: 'image/svg+xml',
+      x: 12,
+      y: 24,
+      w: 96,
+      h: 48,
+    });
+    expect(new TextDecoder().decode((image as { data: Uint8Array }).data)).toContain('#6EE7B7');
+
+    const bytes = await buildEditablePptx([slide]);
+    const files = unzip(bytes);
+    expect(files['ppt/media/image1.svg']).toEqual((image as { data: Uint8Array }).data);
+  });
+
+  it('normalizes SVG rgba paint attributes for PowerPoint compatibility', async () => {
+    const svg = fakeSvgElement({
+      rect: { left: 12, top: 24, width: 96, height: 48 },
+      styles: {
+        color: 'rgb(110, 231, 183)',
+        fill: 'rgba(110, 231, 183, 0.2)',
+        stroke: 'rgba(255, 255, 255, 0.34)',
+      },
+    });
+    svg.setAttribute('fill', 'rgba(110, 231, 183, 0.2)');
+    svg.setAttribute('stroke', 'rgba(255, 255, 255, 0.34)');
+    const frame = fakeElement('DIV', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      children: [svg],
+      queryResults: [svg],
+      styles: { backgroundColor: '#ffffff', display: 'block' },
+    });
+    stubDom();
+    vi.stubGlobal(
+      'XMLSerializer',
+      class FakeXmlSerializer {
+        serializeToString(node: FakeSvgElement) {
+          return `<svg fill="${node.getAttribute('fill')}" fill-opacity="${node.getAttribute('fill-opacity')}" stroke="${node.getAttribute('stroke')}" stroke-opacity="${node.getAttribute('stroke-opacity')}"></svg>`;
+        }
+      },
+    );
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+    const image = slide.objects.find((object) => object.kind === 'image');
+    const svgText = new TextDecoder().decode((image as { data: Uint8Array }).data);
+
+    expect(svgText).toContain('fill="#6EE7B7"');
+    expect(svgText).toContain('fill-opacity="0.2"');
+    expect(svgText).toContain('stroke="#FFFFFF"');
+    expect(svgText).toContain('stroke-opacity="0.34"');
+    expect(svgText).not.toContain('rgba(');
+  });
+
+  it('writes SVG images with a PNG fallback blip for PowerPoint compatibility', async () => {
+    const svgBytes = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg"/>');
+    const bytes = await buildEditablePptx([
+      {
+        background: '#ffffff',
+        objects: [
+          {
+            kind: 'image',
+            x: 0,
+            y: 0,
+            w: 120,
+            h: 80,
+            mime: 'image/png',
+            data: pngBytes,
+            svgData: svgBytes,
+          },
+        ],
+      },
+    ]);
+
+    const files = unzip(bytes);
+    const slide = xml(files, 'ppt/slides/slide1.xml');
+    const rels = xml(files, 'ppt/slides/_rels/slide1.xml.rels');
+
+    expect(slide).toContain('<a:blip r:embed="rId2">');
+    expect(slide).toContain('<asvg:svgBlip');
+    expect(slide).toContain('r:embed="rId3"');
+    expect(rels).toContain('Target="../media/image1.png"');
+    expect(rels).toContain('Target="../media/image2.svg"');
+    expect(files['ppt/media/image1.png']).toEqual(pngBytes);
+    expect(files['ppt/media/image2.svg']).toEqual(svgBytes);
   });
 
   it('writes image source cropping for cover-fitted images', async () => {
@@ -397,18 +759,46 @@ function fakeElement(tagName: string, options: FakeElementOptions): FakeElement 
   return new FakeElement(tagName, options);
 }
 
+class FakeSvgElement extends FakeElement {
+  ownerSVGElement: FakeSvgElement | null = null;
+  private attrs = new Map<string, string>();
+
+  getAttribute(name: string) {
+    return this.attrs.get(name) ?? null;
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attrs.set(name, value);
+  }
+
+  cloneNode() {
+    const clone = new FakeSvgElement('svg', {
+      rect: { left: 0, top: 0, width: 1, height: 1 },
+      styles: this.styleMap,
+    });
+    clone.attrs = new Map(this.attrs);
+    return clone;
+  }
+}
+
+function fakeSvgElement(options: FakeElementOptions): FakeSvgElement {
+  return new FakeSvgElement('svg', options);
+}
+
 function fakeTextNode(textContent: string) {
   return { nodeType: 3, textContent };
 }
 
 function stubDom(): void {
-  vi.stubGlobal('Node', { TEXT_NODE: 3 });
+  function FakeNode() {}
+  Object.assign(FakeNode, { TEXT_NODE: 3 });
+  vi.stubGlobal('Node', FakeNode);
   vi.stubGlobal('Element', FakeElement);
   vi.stubGlobal('HTMLElement', FakeElement);
   vi.stubGlobal('HTMLImageElement', class FakeImageElement extends FakeElement {});
   vi.stubGlobal('HTMLTableElement', class FakeTableElement extends FakeElement {});
   vi.stubGlobal('HTMLCanvasElement', class FakeCanvasElement extends FakeElement {});
-  vi.stubGlobal('SVGElement', class FakeSvgElement extends FakeElement {});
+  vi.stubGlobal('SVGElement', FakeSvgElement);
   vi.stubGlobal('HTMLVideoElement', class FakeVideoElement extends FakeElement {});
   vi.stubGlobal('getComputedStyle', (el: FakeElement) =>
     styleDeclaration({
@@ -441,6 +831,11 @@ function stubDom(): void {
       textAlign: 'left',
       textTransform: 'none',
       whiteSpace: 'normal',
+      alignItems: 'normal',
+      justifyContent: 'normal',
+      flexDirection: 'row',
+      fill: 'rgb(0, 0, 0)',
+      stroke: 'none',
       filter: 'none',
       backdropFilter: 'none',
       clipPath: 'none',

--- a/packages/core/src/app/lib/export-pptx.test.ts
+++ b/packages/core/src/app/lib/export-pptx.test.ts
@@ -63,6 +63,9 @@ describe('editable PPTX OOXML', () => {
     const slide = xml(files, 'ppt/slides/slide1.xml');
     const rels = xml(files, 'ppt/slides/_rels/slide1.xml.rels');
 
+    expect(slide).toContain(
+      '<p:bg><p:bgPr><a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill><a:effectLst/></p:bgPr></p:bg>',
+    );
     expect(slide).toContain('<p:sp>');
     expect(slide).toContain('name="Text 3"');
     expect(slide).toContain('<a:t>Hello </a:t>');
@@ -106,6 +109,94 @@ describe('editable PPTX OOXML', () => {
     expect(slide).toContain('<a:gs pos="0"><a:srgbClr val="FF0000"/></a:gs>');
     expect(slide).toContain('<a:gs pos="100000"><a:srgbClr val="0000FF"/></a:gs>');
     expect(slide).toContain('<a:lin ang="5400000" scaled="0"/>');
+  });
+
+  it('preserves transparent colors, opacity, shadows, and rotation', async () => {
+    const bytes = await buildEditablePptx([
+      {
+        background: '#ffffff',
+        objects: [
+          {
+            kind: 'shape',
+            x: 100,
+            y: 120,
+            w: 320,
+            h: 180,
+            rotate: 12,
+            opacity: 0.5,
+            fill: 'rgba(15, 23, 42, 0.6)',
+            stroke: { color: 'rgba(110, 231, 255, 0.45)', width: 2 },
+            shadow: { color: 'rgba(110, 231, 255, 0.5)', blur: 18, distance: 6, angle: 135 },
+          },
+          {
+            kind: 'text',
+            x: 140,
+            y: 150,
+            w: 240,
+            h: 80,
+            opacity: 0.75,
+            paragraphs: [[{ text: 'Dim text', color: 'rgba(255, 255, 255, 0.8)' }]],
+          },
+        ],
+      },
+    ]);
+
+    const slide = xml(unzip(bytes), 'ppt/slides/slide1.xml');
+
+    expect(slide).toContain('<a:xfrm rot="720000">');
+    expect(slide).toContain('<a:srgbClr val="0F172A"><a:alpha val="30000"/></a:srgbClr>');
+    expect(slide).toContain('<a:srgbClr val="6EE7FF"><a:alpha val="22500"/></a:srgbClr>');
+    expect(slide).toContain('<a:outerShdw blurRad="171450" dist="57150" dir="8100000"');
+    expect(slide).toContain('<a:srgbClr val="6EE7FF"><a:alpha val="25000"/></a:srgbClr>');
+    expect(slide).toContain('<a:srgbClr val="FFFFFF"><a:alpha val="60000"/></a:srgbClr>');
+  });
+
+  it('normalizes CSS Color 4 srgb colors from computed styles', async () => {
+    const bytes = await buildEditablePptx([
+      {
+        background: 'color(srgb 0.039216 0.043137 0.058824)',
+        objects: [
+          {
+            kind: 'text',
+            x: 60,
+            y: 52,
+            w: 120,
+            h: 40,
+            color: 'color(srgb 0.952941 0.94902 0.92549)',
+            paragraphs: [[{ text: 'Tone' }]],
+          },
+        ],
+      },
+    ]);
+
+    const slide = xml(unzip(bytes), 'ppt/slides/slide1.xml');
+
+    expect(slide).toContain('<p:bg><p:bgPr><a:solidFill><a:srgbClr val="0A0B0F"/>');
+    expect(slide).toContain('<a:srgbClr val="F3F2EC"/>');
+  });
+
+  it('normalizes OKLCH colors from computed styles', async () => {
+    const bytes = await buildEditablePptx([
+      {
+        background: 'oklch(0.66 0.19 28 / 0.5)',
+        objects: [
+          {
+            kind: 'text',
+            x: 60,
+            y: 52,
+            w: 120,
+            h: 40,
+            color: 'oklch(0.945 0.005 80)',
+            paragraphs: [[{ text: 'Tone' }]],
+          },
+        ],
+      },
+    ]);
+
+    const slide = xml(unzip(bytes), 'ppt/slides/slide1.xml');
+
+    expect(slide).toContain('<a:srgbClr val="F0584B"><a:alpha val="50000"/></a:srgbClr>');
+    expect(slide).toContain('<a:srgbClr val="EEECE9"/>');
   });
 
   it('writes tables as native PowerPoint table objects', async () => {

--- a/packages/core/src/app/lib/export-pptx.test.ts
+++ b/packages/core/src/app/lib/export-pptx.test.ts
@@ -215,41 +215,6 @@ describe('editable PPTX OOXML', () => {
     expect(slide).toContain('<a:latin typeface="Arial"/><a:ea typeface="PingFang SC"/>');
   });
 
-  it('places a high-fidelity visual snapshot above editable objects', async () => {
-    const bytes = await buildEditablePptx([
-      {
-        background: '#ffffff',
-        objects: [
-          {
-            kind: 'text',
-            x: 80,
-            y: 96,
-            w: 360,
-            h: 80,
-            paragraphs: [[{ text: 'Editable title' }]],
-          },
-        ],
-        visualSnapshot: {
-          kind: 'image',
-          x: 0,
-          y: 0,
-          w: 1920,
-          h: 1080,
-          alt: 'High fidelity visual snapshot',
-          mime: 'image/png',
-          data: pngBytes,
-        },
-      },
-    ]);
-
-    const slide = xml(unzip(bytes), 'ppt/slides/slide1.xml');
-
-    expect(slide.indexOf('name="Text 2"')).toBeLessThan(
-      slide.indexOf('name="High fidelity visual snapshot"'),
-    );
-    expect(slide).toContain('name="High fidelity visual snapshot"');
-  });
-
   it('preserves transparent colors, opacity, shadows, and rotation', async () => {
     const bytes = await buildEditablePptx([
       {

--- a/packages/core/src/app/lib/export-pptx.test.ts
+++ b/packages/core/src/app/lib/export-pptx.test.ts
@@ -497,6 +497,48 @@ describe('editable PPTX OOXML', () => {
     expect(svgText).not.toContain('rgba(');
   });
 
+  it('removes capture-only SVG style attributes before embedding', async () => {
+    const svg = fakeSvgElement({
+      rect: { left: 12, top: 24, width: 96, height: 48 },
+      styles: {
+        color: 'rgb(110, 231, 183)',
+        fill: 'none',
+        stroke: 'rgb(110, 231, 183)',
+      },
+    });
+    svg.setAttribute(
+      'style',
+      'opacity: 1 !important; filter: none !important; transition: none !important;',
+    );
+    svg.setAttribute('data-slide-loc', '1927:4');
+    const frame = fakeElement('DIV', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      children: [svg],
+      queryResults: [svg],
+      styles: { backgroundColor: '#ffffff', display: 'block' },
+    });
+    stubDom();
+    vi.stubGlobal(
+      'XMLSerializer',
+      class FakeXmlSerializer {
+        serializeToString(node: FakeSvgElement) {
+          const style = node.getAttribute('style');
+          const loc = node.getAttribute('data-slide-loc');
+          return `<svg${style ? ` style="${style}"` : ''}${loc ? ` data-slide-loc="${loc}"` : ''} stroke="${node.getAttribute('stroke')}"></svg>`;
+        }
+      },
+    );
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+    const image = slide.objects.find((object) => object.kind === 'image');
+    const svgText = new TextDecoder().decode((image as { data: Uint8Array }).data);
+
+    expect(svgText).not.toContain('!important');
+    expect(svgText).not.toContain('style=');
+    expect(svgText).not.toContain('data-slide-loc');
+    expect(svgText).toContain('stroke="#6EE7B7"');
+  });
+
   it('writes SVG images with a PNG fallback blip for PowerPoint compatibility', async () => {
     const svgBytes = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg"/>');
     const bytes = await buildEditablePptx([
@@ -769,6 +811,10 @@ class FakeSvgElement extends FakeElement {
 
   setAttribute(name: string, value: string) {
     this.attrs.set(name, value);
+  }
+
+  removeAttribute(name: string) {
+    this.attrs.delete(name);
   }
 
   cloneNode() {

--- a/packages/core/src/app/lib/export-pptx.test.ts
+++ b/packages/core/src/app/lib/export-pptx.test.ts
@@ -87,6 +87,36 @@ describe('editable PPTX OOXML', () => {
     expect(files['ppt/media/image1.png']).toEqual(pngBytes);
   });
 
+  it('writes index-aligned speaker notes into native PowerPoint notes slides', async () => {
+    const bytes = await buildEditablePptx(
+      [
+        { background: '#ffffff', objects: [] },
+        { background: '#ffffff', objects: [] },
+      ],
+      ['第一段\n\nSecond paragraph', undefined],
+    );
+
+    const files = unzip(bytes);
+    const presentation = xml(files, 'ppt/presentation.xml');
+    const presentationRels = xml(files, 'ppt/_rels/presentation.xml.rels');
+    const slideRels = xml(files, 'ppt/slides/_rels/slide1.xml.rels');
+    const notes = xml(files, 'ppt/notesSlides/notesSlide1.xml');
+    const noteRels = xml(files, 'ppt/notesSlides/_rels/notesSlide1.xml.rels');
+    const contentTypes = xml(files, '[Content_Types].xml');
+
+    expect(presentation).toContain('<p:notesMasterId r:id="rId5"/>');
+    expect(presentationRels).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster"',
+    );
+    expect(slideRels).toContain('Target="../notesSlides/notesSlide1.xml"');
+    expect(notes).toContain('<a:t xml:space="preserve">第一段</a:t>');
+    expect(notes).toContain('<a:t xml:space="preserve">Second paragraph</a:t>');
+    expect(noteRels).toContain('Target="../slides/slide1.xml"');
+    expect(contentTypes).toContain('/ppt/notesMasters/notesMaster1.xml');
+    expect(contentTypes).toContain('/ppt/notesSlides/notesSlide1.xml');
+    expect(files['ppt/notesSlides/notesSlide2.xml']).toBeUndefined();
+  });
+
   it('writes linear gradients as vector gradient fills', async () => {
     const bytes = await buildEditablePptx([
       {
@@ -229,10 +259,42 @@ describe('editable PPTX OOXML', () => {
 
     const slideXml = xml(unzip(await buildEditablePptx([slide])), 'ppt/slides/slide1.xml');
     expect(slideXml).toContain('<a:gd name="adj" fmla="val 3019"/>');
-    expect(slideXml).toContain('<a:gs pos="0"><a:srgbClr val="061B16"/></a:gs>');
-    expect(slideXml).toContain('<a:gs pos="100000"><a:srgbClr val="0B0B0B"/></a:gs>');
+    expect(slideXml).toContain(
+      '<a:gs pos="0"><a:srgbClr val="07231C"><a:alpha val="72000"/></a:srgbClr></a:gs>',
+    );
+    expect(slideXml).toContain(
+      '<a:gs pos="100000"><a:srgbClr val="FFFFFF"><a:alpha val="2500"/></a:srgbClr></a:gs>',
+    );
     expect(slideXml).toContain('<a:lin ang="5400000" scaled="0"/>');
     expect(slideXml).toContain('<a:srgbClr val="6EE7B7"><a:alpha val="34000"/></a:srgbClr>');
+  });
+
+  it('normalizes scaled preview coordinates back to the 1920 by 1080 slide canvas', async () => {
+    const panel = fakeElement('DIV', {
+      rect: { left: 150, top: 100, width: 200, height: 100 },
+      styles: {
+        display: 'block',
+        backgroundColor: '#0071e3',
+      },
+    });
+    const frame = fakeElement('DIV', {
+      rect: { left: 100, top: 50, width: 960, height: 540 },
+      children: [panel],
+      queryResults: [panel],
+      styles: { backgroundColor: '#ffffff', display: 'block' },
+    });
+    stubDom();
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+    const shape = slide.objects.find((object) => object.kind === 'shape');
+
+    expect(shape).toMatchObject({
+      kind: 'shape',
+      x: 100,
+      y: 100,
+      w: 400,
+      h: 200,
+    });
   });
 
   it('can disable wrapping for single-line text boxes', async () => {
@@ -283,6 +345,50 @@ describe('editable PPTX OOXML', () => {
     const textObject = slide.objects.find((object) => object.kind === 'text');
 
     expect(textObject).toMatchObject({ kind: 'text', wrap: true });
+  });
+
+  it('preserves explicit line breaks and CSS line height without adding extra wrapping', async () => {
+    const first = fakeTextNode('AI');
+    const second = fakeTextNode('Engineering');
+    const br = fakeElement('BR', {
+      rect: { left: 0, top: 0, width: 1, height: 1 },
+      styles: { display: 'inline' },
+    });
+    const heading = fakeElement('H1', {
+      rect: { left: 128, top: 264, width: 820, height: 304 },
+      textContent: 'AIEngineering',
+      childNodes: [first, br, second],
+      styles: {
+        display: 'block',
+        fontFamily: '"SF Pro Text", Arial, sans-serif',
+        fontSize: '176px',
+        fontWeight: '760',
+        lineHeight: '151.36px',
+        whiteSpace: 'normal',
+      },
+    });
+    const frame = fakeElement('DIV', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      children: [heading],
+      queryResults: [heading],
+      styles: { backgroundColor: '#ffffff', display: 'block' },
+    });
+    stubDom();
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+    const textObject = slide.objects.find((object) => object.kind === 'text');
+
+    expect(textObject).toMatchObject({
+      kind: 'text',
+      fontFamily: 'SF Pro Text',
+      wrap: false,
+    });
+    expect((textObject as { lineHeight?: number }).lineHeight).toBeCloseTo(0.86);
+
+    const slideXml = xml(unzip(await buildEditablePptx([slide])), 'ppt/slides/slide1.xml');
+    expect(slideXml).toContain('<a:bodyPr wrap="none"');
+    expect(slideXml).toContain('<a:normAutofit/>');
+    expect(slideXml).toContain('<a:spcPct val="86000"/>');
   });
 
   it('uses flex centering for native PowerPoint text boxes', async () => {
@@ -499,7 +605,7 @@ describe('editable PPTX OOXML', () => {
 
     const slideXml = xml(unzip(await buildEditablePptx([slide])), 'ppt/slides/slide1.xml');
     expect(slideXml).toContain('<a:bodyPr wrap="none" anchor="ctr"');
-    expect(slideXml).toContain('<a:pPr algn="ctr"/>');
+    expect(slideXml).toContain('<a:pPr algn="ctr">');
   });
 
   it('centers text inside circle-like number badges', async () => {

--- a/packages/core/src/app/lib/export-pptx.test.ts
+++ b/packages/core/src/app/lib/export-pptx.test.ts
@@ -1,0 +1,143 @@
+import { strFromU8, unzipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { buildEditablePptx } from './export-pptx-editable';
+
+const pngBytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+
+function unzip(bytes: Uint8Array): Record<string, Uint8Array> {
+  return unzipSync(bytes);
+}
+
+function xml(files: Record<string, Uint8Array>, path: string): string {
+  return strFromU8(files[path]);
+}
+
+describe('editable PPTX OOXML', () => {
+  it('writes text, shape, and image nodes as editable PowerPoint objects', async () => {
+    const bytes = await buildEditablePptx([
+      {
+        background: '#ffffff',
+        objects: [
+          {
+            kind: 'shape',
+            x: 80,
+            y: 96,
+            w: 420,
+            h: 150,
+            radius: 24,
+            fill: '#f8fafc',
+            stroke: { color: '#0f172a', width: 4 },
+          },
+          {
+            kind: 'text',
+            x: 120,
+            y: 132,
+            w: 340,
+            h: 84,
+            fontFamily: 'Arial',
+            fontSize: 48,
+            color: '#111827',
+            align: 'center',
+            paragraphs: [
+              [
+                { text: 'Hello ', bold: true },
+                { text: 'world', italic: true, color: '#ef4444' },
+              ],
+            ],
+          },
+          {
+            kind: 'image',
+            x: 560,
+            y: 150,
+            w: 220,
+            h: 120,
+            alt: 'Logo',
+            mime: 'image/png',
+            data: pngBytes,
+          },
+        ],
+      },
+    ]);
+
+    const files = unzip(bytes);
+    const slide = xml(files, 'ppt/slides/slide1.xml');
+    const rels = xml(files, 'ppt/slides/_rels/slide1.xml.rels');
+
+    expect(slide).toContain('<p:sp>');
+    expect(slide).toContain('name="Text 3"');
+    expect(slide).toContain('<a:t>Hello </a:t>');
+    expect(slide).toContain('<a:t>world</a:t>');
+    expect(slide).toContain('b="1"');
+    expect(slide).toContain('i="1"');
+    expect(slide).toContain('<p:pic>');
+    expect(slide).toContain('name="Logo"');
+    expect(slide).not.toContain('name="Slide"');
+    expect(rels).toContain('Target="../media/image1.png"');
+    expect(files['ppt/media/image1.png']).toEqual(pngBytes);
+  });
+
+  it('writes linear gradients as vector gradient fills', async () => {
+    const bytes = await buildEditablePptx([
+      {
+        background: '#ffffff',
+        objects: [
+          {
+            kind: 'shape',
+            x: 0,
+            y: 0,
+            w: 1920,
+            h: 1080,
+            fill: {
+              kind: 'linearGradient',
+              angle: 90,
+              stops: [
+                { color: '#ff0000', position: 0 },
+                { color: '#0000ff', position: 1 },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const slide = xml(unzip(bytes), 'ppt/slides/slide1.xml');
+
+    expect(slide).toContain('<a:gradFill rotWithShape="1">');
+    expect(slide).toContain('<a:gs pos="0"><a:srgbClr val="FF0000"/></a:gs>');
+    expect(slide).toContain('<a:gs pos="100000"><a:srgbClr val="0000FF"/></a:gs>');
+    expect(slide).toContain('<a:lin ang="5400000" scaled="0"/>');
+  });
+
+  it('writes tables as native PowerPoint table objects', async () => {
+    const bytes = await buildEditablePptx([
+      {
+        background: '#ffffff',
+        objects: [
+          {
+            kind: 'table',
+            x: 100,
+            y: 120,
+            w: 600,
+            h: 180,
+            rows: [
+              [
+                { text: 'Name', bold: true, fill: '#e2e8f0' },
+                { text: 'Count', bold: true, fill: '#e2e8f0' },
+              ],
+              [{ text: 'Slides' }, { text: '12' }],
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const slide = xml(unzip(bytes), 'ppt/slides/slide1.xml');
+
+    expect(slide).toContain('<p:graphicFrame>');
+    expect(slide).toContain('<a:tbl>');
+    expect(slide).toContain('<a:t>Name</a:t>');
+    expect(slide).toContain('<a:t>Count</a:t>');
+    expect(slide).toContain('<a:t>Slides</a:t>');
+    expect(slide).toContain('<a:solidFill><a:srgbClr val="E2E8F0"/></a:solidFill>');
+  });
+});

--- a/packages/core/src/app/lib/export-pptx.test.ts
+++ b/packages/core/src/app/lib/export-pptx.test.ts
@@ -1,8 +1,12 @@
 import { strFromU8, unzipSync } from 'fflate';
-import { describe, expect, it } from 'vitest';
-import { buildEditablePptx } from './export-pptx-editable';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildEditablePptx, collectEditableSlide } from './export-pptx-editable';
 
 const pngBytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 function unzip(bytes: Uint8Array): Record<string, Uint8Array> {
   return unzipSync(bytes);
@@ -137,6 +141,115 @@ describe('editable PPTX OOXML', () => {
     expect(slide).toContain('<a:bodyPr wrap="none"');
   });
 
+  it('keeps pre-line text boxes wrappable', async () => {
+    const text = fakeTextNode('From AI Coding to AI Engineering');
+    const heading = fakeElement('H1', {
+      rect: { left: 0, top: 0, width: 900, height: 128 },
+      textContent: text.textContent,
+      childNodes: [text],
+      styles: {
+        display: 'block',
+        fontSize: '48px',
+        lineHeight: '56px',
+        whiteSpace: 'pre-line',
+      },
+    });
+    const frame = fakeElement('DIV', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      children: [heading],
+      queryResults: [heading],
+      styles: { backgroundColor: '#ffffff', display: 'block' },
+    });
+    stubDom();
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+    const textObject = slide.objects.find((object) => object.kind === 'text');
+
+    expect(textObject).toMatchObject({ kind: 'text', wrap: true });
+  });
+
+  it('writes image source cropping for cover-fitted images', async () => {
+    const bytes = await buildEditablePptx([
+      {
+        background: '#ffffff',
+        objects: [
+          {
+            kind: 'image',
+            x: 0,
+            y: 0,
+            w: 400,
+            h: 300,
+            mime: 'image/png',
+            data: pngBytes,
+            crop: { left: 0.125, right: 0.125, top: 0, bottom: 0 },
+          },
+        ],
+      },
+    ]);
+
+    const slide = xml(unzip(bytes), 'ppt/slides/slide1.xml');
+
+    expect(slide).toContain('<a:srcRect l="12500" r="12500"/>');
+  });
+
+  it('writes an East Asian font fallback for CJK text runs', async () => {
+    const bytes = await buildEditablePptx([
+      {
+        background: '#ffffff',
+        objects: [
+          {
+            kind: 'text',
+            x: 80,
+            y: 96,
+            w: 360,
+            h: 80,
+            fontFamily: 'Arial',
+            paragraphs: [[{ text: '研发效率', fontFamily: 'Arial' }]],
+          },
+        ],
+      },
+    ]);
+
+    const slide = xml(unzip(bytes), 'ppt/slides/slide1.xml');
+
+    expect(slide).toContain('<a:latin typeface="Arial"/><a:ea typeface="PingFang SC"/>');
+  });
+
+  it('places a high-fidelity visual snapshot above editable objects', async () => {
+    const bytes = await buildEditablePptx([
+      {
+        background: '#ffffff',
+        objects: [
+          {
+            kind: 'text',
+            x: 80,
+            y: 96,
+            w: 360,
+            h: 80,
+            paragraphs: [[{ text: 'Editable title' }]],
+          },
+        ],
+        visualSnapshot: {
+          kind: 'image',
+          x: 0,
+          y: 0,
+          w: 1920,
+          h: 1080,
+          alt: 'High fidelity visual snapshot',
+          mime: 'image/png',
+          data: pngBytes,
+        },
+      },
+    ]);
+
+    const slide = xml(unzip(bytes), 'ppt/slides/slide1.xml');
+
+    expect(slide.indexOf('name="Text 2"')).toBeLessThan(
+      slide.indexOf('name="High fidelity visual snapshot"'),
+    );
+    expect(slide).toContain('name="High fidelity visual snapshot"');
+  });
+
   it('preserves transparent colors, opacity, shadows, and rotation', async () => {
     const bytes = await buildEditablePptx([
       {
@@ -258,3 +371,133 @@ describe('editable PPTX OOXML', () => {
     expect(slide).toContain('<a:solidFill><a:srgbClr val="E2E8F0"/></a:solidFill>');
   });
 });
+
+type FakeRect = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type FakeElementOptions = {
+  rect: FakeRect;
+  textContent?: string;
+  children?: FakeElement[];
+  childNodes?: unknown[];
+  queryResults?: FakeElement[];
+  styles?: Partial<CSSStyleDeclaration>;
+};
+
+class FakeElement {
+  tagName: string;
+  textContent: string;
+  children: FakeElement[];
+  childNodes: unknown[];
+  private rect: FakeRect;
+  private queryResults: FakeElement[];
+  private styles: Partial<CSSStyleDeclaration>;
+
+  constructor(tagName: string, options: FakeElementOptions) {
+    this.tagName = tagName;
+    this.textContent = options.textContent ?? '';
+    this.children = options.children ?? [];
+    this.childNodes = options.childNodes ?? this.children;
+    this.rect = options.rect;
+    this.queryResults = options.queryResults ?? [];
+    this.styles = options.styles ?? {};
+  }
+
+  getBoundingClientRect() {
+    const { left, top, width, height } = this.rect;
+    return {
+      left,
+      top,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+    };
+  }
+
+  querySelectorAll() {
+    return this.queryResults;
+  }
+
+  get styleMap() {
+    return this.styles;
+  }
+}
+
+function fakeElement(tagName: string, options: FakeElementOptions): FakeElement {
+  return new FakeElement(tagName, options);
+}
+
+function fakeTextNode(textContent: string) {
+  return { nodeType: 3, textContent };
+}
+
+function stubDom(): void {
+  vi.stubGlobal('Node', { TEXT_NODE: 3 });
+  vi.stubGlobal('Element', FakeElement);
+  vi.stubGlobal('HTMLElement', FakeElement);
+  vi.stubGlobal('HTMLImageElement', class FakeImageElement extends FakeElement {});
+  vi.stubGlobal('HTMLTableElement', class FakeTableElement extends FakeElement {});
+  vi.stubGlobal('HTMLCanvasElement', class FakeCanvasElement extends FakeElement {});
+  vi.stubGlobal('SVGElement', class FakeSvgElement extends FakeElement {});
+  vi.stubGlobal('HTMLVideoElement', class FakeVideoElement extends FakeElement {});
+  vi.stubGlobal('getComputedStyle', (el: FakeElement) =>
+    styleDeclaration({
+      display: 'block',
+      visibility: 'visible',
+      opacity: '1',
+      backgroundColor: 'rgba(0, 0, 0, 0)',
+      backgroundImage: 'none',
+      borderTopWidth: '0px',
+      borderRightWidth: '0px',
+      borderBottomWidth: '0px',
+      borderLeftWidth: '0px',
+      borderTopColor: 'rgba(0, 0, 0, 0)',
+      borderRightColor: 'rgba(0, 0, 0, 0)',
+      borderBottomColor: 'rgba(0, 0, 0, 0)',
+      borderLeftColor: 'rgba(0, 0, 0, 0)',
+      borderTopLeftRadius: '0px',
+      borderTopRightRadius: '0px',
+      borderBottomRightRadius: '0px',
+      borderBottomLeftRadius: '0px',
+      boxShadow: 'none',
+      textShadow: 'none',
+      color: '#000000',
+      fontFamily: 'Arial',
+      fontSize: '18px',
+      fontStyle: 'normal',
+      fontWeight: '400',
+      letterSpacing: 'normal',
+      lineHeight: 'normal',
+      textAlign: 'left',
+      textTransform: 'none',
+      whiteSpace: 'normal',
+      filter: 'none',
+      backdropFilter: 'none',
+      clipPath: 'none',
+      maskImage: 'none',
+      mixBlendMode: 'normal',
+      transform: 'none',
+      ...el.styleMap,
+    }),
+  );
+}
+
+function styleDeclaration(styles: Record<string, unknown>): CSSStyleDeclaration {
+  return new Proxy(styles, {
+    get(target, prop) {
+      if (prop === 'getPropertyValue') {
+        return (name: string) => {
+          const value = target[name];
+          return typeof value === 'string' ? value : '';
+        };
+      }
+      const value = target[prop as string];
+      return typeof value === 'string' ? value : '';
+    },
+  }) as unknown as CSSStyleDeclaration;
+}

--- a/packages/core/src/app/lib/export-pptx.test.ts
+++ b/packages/core/src/app/lib/export-pptx.test.ts
@@ -326,6 +326,134 @@ describe('editable PPTX OOXML', () => {
     expect(slideXml).toContain('<a:pPr algn="ctr"/>');
   });
 
+  it('exports text labels from flex chips that also contain SVG icons', async () => {
+    const icon = fakeSvgElement({
+      rect: { left: 88, top: 136, width: 20, height: 20 },
+      styles: {
+        color: '#6EE7B7',
+        fill: 'none',
+        stroke: '#6EE7B7',
+      },
+    });
+    const label = fakeTextNode('知识库');
+    const chip = fakeElement('DIV', {
+      rect: { left: 72, top: 112, width: 226, height: 73 },
+      textContent: label.textContent,
+      children: [icon],
+      childNodes: [icon, label],
+      queryResults: [icon],
+      styles: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '12px',
+        backgroundColor: 'rgba(110, 231, 183, 0.11)',
+        color: '#6EE7B7',
+        fontSize: '28px',
+        fontWeight: '700',
+      },
+    });
+    const frame = fakeElement('DIV', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      children: [chip],
+      queryResults: [chip, icon],
+      styles: { backgroundColor: '#050505', display: 'block' },
+    });
+    stubDom();
+    vi.stubGlobal(
+      'XMLSerializer',
+      class FakeXmlSerializer {
+        serializeToString(node: FakeSvgElement) {
+          return `<svg stroke="${node.getAttribute('stroke')}"></svg>`;
+        }
+      },
+    );
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+
+    expect(slide.objects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'shape', x: 72, y: 112, w: 226, h: 73 }),
+        expect.objectContaining({ kind: 'image', x: 88, y: 136, w: 20, h: 20 }),
+        expect.objectContaining({
+          kind: 'text',
+          x: 104,
+          y: 112,
+          w: 194,
+          h: 73,
+          align: 'center',
+          vertical: 'middle',
+        }),
+      ]),
+    );
+
+    const slideXml = xml(unzip(await buildEditablePptx([slide])), 'ppt/slides/slide1.xml');
+    expect(slideXml).toContain('<a:t>知识库</a:t>');
+    expect(slideXml).toContain('<p:pic>');
+  });
+
+  it('keeps SVG plus span rows from exporting the parent as a duplicate text box', async () => {
+    const icon = fakeSvgElement({
+      rect: { left: 112, top: 142, width: 20, height: 20 },
+      styles: {
+        color: '#6EE7B7',
+        fill: 'none',
+        stroke: '#6EE7B7',
+      },
+    });
+    const text = fakeTextNode('直播 / 社交：BIGO LIVE 周报');
+    const span = fakeElement('SPAN', {
+      rect: { left: 145, top: 136, width: 620, height: 36 },
+      textContent: text.textContent,
+      childNodes: [text],
+      styles: {
+        display: 'inline',
+        color: '#F7F8F8',
+        fontSize: '23px',
+      },
+    });
+    const row = fakeElement('DIV', {
+      rect: { left: 112, top: 128, width: 787, height: 56 },
+      textContent: text.textContent,
+      children: [icon, span],
+      childNodes: [icon, span],
+      queryResults: [icon, span],
+      styles: {
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: '13px',
+        fontSize: '23px',
+      },
+    });
+    const frame = fakeElement('DIV', {
+      rect: { left: 0, top: 0, width: 1920, height: 1080 },
+      children: [row],
+      queryResults: [row, icon, span],
+      styles: { backgroundColor: '#050505', display: 'block' },
+    });
+    stubDom();
+    vi.stubGlobal(
+      'XMLSerializer',
+      class FakeXmlSerializer {
+        serializeToString(node: FakeSvgElement) {
+          return `<svg stroke="${node.getAttribute('stroke')}"></svg>`;
+        }
+      },
+    );
+
+    const slide = await collectEditableSlide(frame as unknown as HTMLElement);
+    const textObjects = slide.objects.filter((object) => object.kind === 'text');
+
+    expect(textObjects).toHaveLength(1);
+    expect(textObjects[0]).toMatchObject({
+      kind: 'text',
+      x: 145,
+      y: 136,
+      w: 620,
+      h: 36,
+    });
+  });
+
   it('centers text inside rounded single-line chips', async () => {
     const text = fakeTextNode('设计结构化');
     const chip = fakeElement('SPAN', {

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -116,7 +116,7 @@ export async function exportSlideAsPptx(
     }
 
     onProgress?.({ phase: 'generating', current: total, total, percent: 98 });
-    const pptx = await buildEditablePptx(editableSlides);
+    const pptx = await buildEditablePptx(editableSlides, slide.notes);
     downloadBlob(
       new Blob([pptx as BlobPart], {
         type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -123,8 +123,8 @@ export async function exportSlideAsPptx(
       }),
       `${slideId}.pptx`,
     );
-  } finally {
     onProgress?.({ phase: 'done', current: total, total, percent: 100 });
+  } finally {
     for (const r of reactRoots) r.unmount();
     container.remove();
     captureStyle.remove();

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { designToCssVars } from './design';
+import { buildEditablePptx, collectEditableSlide } from './export-pptx-editable';
 import { SlidePageProvider } from './page-context';
 import { isFrameAnimationSettled, waitForDataWaitfor, waitForFonts } from './print-ready';
 import type { SlideModule } from './sdk';
@@ -30,6 +31,105 @@ export type PptxExportProgress = {
   /** 0–95 while capturing, 98 while assembling, 100 when done. */
   percent: number;
 };
+
+export async function exportSlideAsPptx(
+  slide: SlideModule,
+  slideId: string,
+  onProgress?: (progress: PptxExportProgress) => void,
+): Promise<void> {
+  const pages = slide.default ?? [];
+  if (pages.length === 0) return;
+
+  const total = pages.length;
+  onProgress?.({ phase: 'processing', current: 0, total, percent: 0 });
+
+  const container = document.createElement('div');
+  container.className = CAPTURE_CLASS;
+  container.setAttribute('aria-hidden', 'true');
+  Object.assign(container.style, {
+    position: 'fixed',
+    left: '-99999px',
+    top: '0',
+    pointerEvents: 'none',
+  });
+  document.body.appendChild(container);
+
+  const captureStyle = document.createElement('style');
+  captureStyle.id = CAPTURE_STYLE_ID;
+  captureStyle.textContent = `.${CAPTURE_CLASS} *, .${CAPTURE_CLASS} *::before, .${CAPTURE_CLASS} *::after {
+    animation-delay: -1s !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    animation-fill-mode: forwards !important;
+    transition: none !important;
+  }`;
+  document.head.appendChild(captureStyle);
+
+  const designVars = slide.design ? designToCssVars(slide.design) : null;
+
+  const reactRoots: Root[] = [];
+  const frames: HTMLElement[] = [];
+  for (let i = 0; i < pages.length; i++) {
+    const Page = pages[i];
+    if (!Page) continue;
+    const host = document.createElement('div');
+    host.setAttribute('data-osd-canvas', '');
+    host.style.width = `${SLIDE_W}px`;
+    host.style.height = `${SLIDE_H}px`;
+    host.style.overflow = 'hidden';
+    host.style.background = '#fff';
+    if (designVars) {
+      for (const [k, v] of Object.entries(designVars)) host.style.setProperty(k, v);
+    }
+    container.appendChild(host);
+    frames.push(host);
+    const r = createRoot(host);
+    r.render(
+      createElement(SlidePageProvider, { index: i, total: pages.length }, createElement(Page)),
+    );
+    reactRoots.push(r);
+  }
+
+  await nextPaint();
+
+  try {
+    await waitForFonts();
+
+    const deadline = performance.now() + ANIMATION_TIMEOUT_MS;
+    while (performance.now() < deadline) {
+      const settled = frames.every((frame) => isFrameAnimationSettled(frame));
+      if (settled) break;
+      await sleep(POLL_INTERVAL_MS);
+    }
+    await waitForDataWaitfor(container);
+
+    const editableSlides = [];
+    for (let i = 0; i < frames.length; i++) {
+      freezeForCapture(frames[i]);
+      editableSlides.push(await collectEditableSlide(frames[i]));
+      onProgress?.({
+        phase: 'processing',
+        current: i + 1,
+        total,
+        percent: Math.min(95, ((i + 1) / total) * 95),
+      });
+    }
+
+    onProgress?.({ phase: 'generating', current: total, total, percent: 98 });
+    const pptx = await buildEditablePptx(editableSlides);
+    downloadBlob(
+      new Blob([pptx as BlobPart], {
+        type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      }),
+      `${slideId}.pptx`,
+    );
+  } finally {
+    onProgress?.({ phase: 'done', current: total, total, percent: 100 });
+    for (const r of reactRoots) r.unmount();
+    container.remove();
+    captureStyle.remove();
+  }
+}
 
 export async function exportSlideAsImagePptx(
   slide: SlideModule,

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -103,32 +103,10 @@ export async function exportSlideAsPptx(
     }
     await waitForDataWaitfor(container);
 
-    const { toBlob } = await import('html-to-image');
     const editableSlides = [];
     for (let i = 0; i < frames.length; i++) {
       freezeForCapture(frames[i]);
-      const editableSlide = await collectEditableSlide(frames[i]);
-      const snapshot = await toBlob(frames[i], {
-        width: SLIDE_W,
-        height: SLIDE_H,
-        pixelRatio: CAPTURE_PIXEL_RATIO,
-        backgroundColor: '#ffffff',
-        cacheBust: true,
-      });
-      if (!snapshot) throw new Error(`failed to capture page ${i + 1}`);
-      editableSlides.push({
-        ...editableSlide,
-        visualSnapshot: {
-          kind: 'image' as const,
-          x: 0,
-          y: 0,
-          w: SLIDE_W,
-          h: SLIDE_H,
-          alt: 'High fidelity visual snapshot',
-          mime: 'image/png',
-          data: new Uint8Array(await snapshot.arrayBuffer()),
-        },
-      });
+      editableSlides.push(await collectEditableSlide(frames[i]));
       onProgress?.({
         phase: 'processing',
         current: i + 1,

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -103,10 +103,32 @@ export async function exportSlideAsPptx(
     }
     await waitForDataWaitfor(container);
 
+    const { toBlob } = await import('html-to-image');
     const editableSlides = [];
     for (let i = 0; i < frames.length; i++) {
       freezeForCapture(frames[i]);
-      editableSlides.push(await collectEditableSlide(frames[i]));
+      const editableSlide = await collectEditableSlide(frames[i]);
+      const snapshot = await toBlob(frames[i], {
+        width: SLIDE_W,
+        height: SLIDE_H,
+        pixelRatio: CAPTURE_PIXEL_RATIO,
+        backgroundColor: '#ffffff',
+        cacheBust: true,
+      });
+      if (!snapshot) throw new Error(`failed to capture page ${i + 1}`);
+      editableSlides.push({
+        ...editableSlide,
+        visualSnapshot: {
+          kind: 'image' as const,
+          x: 0,
+          y: 0,
+          w: SLIDE_W,
+          h: SLIDE_H,
+          alt: 'High fidelity visual snapshot',
+          mime: 'image/png',
+          data: new Uint8Array(await snapshot.arrayBuffer()),
+        },
+      });
       onProgress?.({
         phase: 'processing',
         current: i + 1,

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -59,7 +59,7 @@ import { SlideTransitionLayer } from '../components/slide-transition-layer';
 import { type ThumbnailActions, ThumbnailRail } from '../components/thumbnail-rail';
 import { exportSlideAsHtml } from '../lib/export-html';
 import { exportSlideAsPdf, isSafari } from '../lib/export-pdf';
-import { exportSlideAsImagePptx } from '../lib/export-pptx';
+import { exportSlideAsImagePptx, exportSlideAsPptx } from '../lib/export-pptx';
 import { remapNotesSessionCacheAfterReorder } from '../lib/inspector/use-notes';
 import type { SlideModule } from '../lib/sdk';
 import { usePrefersReducedMotion } from '../lib/use-prefers-reduced-motion';
@@ -457,6 +457,31 @@ export function Slide() {
     }
   };
 
+  const exportPptx = async () => {
+    if (!slide || exporting) return;
+    setExporting(true);
+    const toastId = `pptx-export-${slideId}`;
+    toast.custom(
+      () => (
+        <PptxProgressToast
+          progress={{ phase: 'processing', current: 0, total: pages.length, percent: 0 }}
+        />
+      ),
+      { id: toastId, duration: Infinity },
+    );
+    try {
+      await exportSlideAsPptx(slide, slideId, (p) => {
+        toast.custom(() => <PptxProgressToast progress={p} />, { id: toastId, duration: Infinity });
+      });
+    } catch (err) {
+      console.error('[open-slide] pptx export failed', err);
+      toast.error(t.slide.imagePptxExportFailed, { id: toastId, duration: 4000 });
+    } finally {
+      setExporting(false);
+      toast.dismiss(toastId);
+    }
+  };
+
   const exportMenuItems = (
     <>
       <DropdownMenuItem disabled={exporting} onSelect={exportHtml}>
@@ -468,34 +493,14 @@ export function Slide() {
         {t.slide.exportAsPdf}
       </DropdownMenuItem>
       <DropdownMenuSeparator />
+      <DropdownMenuItem disabled={exporting} onSelect={exportPptx}>
+        <Presentation />
+        {t.slide.exportAsPptx}
+      </DropdownMenuItem>
       <DropdownMenuItem disabled={exporting} onSelect={exportImagePptx}>
         <FileImage />
         {t.slide.exportAsImagePptx}
       </DropdownMenuItem>
-      <TooltipProvider delayDuration={200}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div
-              aria-disabled
-              className="relative flex cursor-help items-center justify-between gap-2 rounded-[5px] px-2 py-1.5 text-[12.5px] opacity-45 select-none [&_svg]:size-3.5 [&_svg]:shrink-0 [&_svg]:opacity-80"
-            >
-              <span className="flex items-center gap-2">
-                <Presentation />
-                {t.slide.exportAsPptx}
-              </span>
-              <span className="rounded-[3px] bg-muted px-1.5 py-0.5 font-mono text-[9.5px] tracking-[0.04em] text-muted-foreground">
-                {t.slide.comingSoon}
-              </span>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent
-            side="left"
-            className="w-max max-w-[min(520px,calc(100vw-2rem))] text-center leading-relaxed"
-          >
-            {t.slide.pptxComingSoonTooltip}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
     </>
   );
 

--- a/packages/core/src/editing/edit-ops.test.ts
+++ b/packages/core/src/editing/edit-ops.test.ts
@@ -828,6 +828,26 @@ describe('applyEdit / set-text', () => {
     expect(r.source).toContain(`<Card label={'with "quotes"'} />`);
   });
 
+  it('routes a reused const prop pass-through edit to the const definition', () => {
+    const src = [
+      "const SECTION = '优秀实践案例';",
+      'const Frame = ({ label }: { label: string }) => (',
+      '  <span>{label}</span>',
+      ');',
+      'export default [',
+      '  () => <Frame label={SECTION} />,',
+      '  () => <Frame label={SECTION} />,',
+      '];',
+      '',
+    ].join('\n');
+    const r = applyEdit(src, 3, 8, [
+      { kind: 'set-text', value: '业务实践案例', prevText: '优秀实践案例' },
+    ]);
+    if (!r.ok) throw new Error(`expected ok, got ${r.error}`);
+    expect(r.source).toContain("const SECTION = '业务实践案例';");
+    expect(r.source).toContain('<Frame label={SECTION} />');
+  });
+
   it('bails on a prop pass-through when the prop is not destructured', () => {
     const src = [
       'const Card = (props) => (',
@@ -924,7 +944,7 @@ describe('applyEdit / set-text', () => {
 
   it('bails on a prop pass-through when the call site uses a non-literal value', () => {
     const src = [
-      'const heading = "Hello";',
+      'const heading = getHeading();',
       'const Card = ({ title }: { title: string }) => (',
       '  <h2>{title}</h2>',
       ');',

--- a/packages/core/src/editing/edit-ops.ts
+++ b/packages/core/src/editing/edit-ops.ts
@@ -362,6 +362,17 @@ type TextCandidate = {
   splice: (value: string) => Splice;
 };
 
+function dedupeTextCandidates(candidates: TextCandidate[]): TextCandidate[] {
+  const seen = new Set<string>();
+  return candidates.filter((candidate) => {
+    const splice = candidate.splice(candidate.current);
+    const key = `${candidate.current}:${splice.from}:${splice.to}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 type JsxParent = t.JSXElement | t.JSXFragment;
 type TextRangeLeaf = {
   node: t.JSXText | t.JSXExpressionContainer;
@@ -867,6 +878,40 @@ function collectCallSiteCandidates(ast: t.Node, componentName: string): TextCand
   return out;
 }
 
+function unwrapTextLiteral(node: t.Node): t.StringLiteral | t.NumericLiteral | null {
+  if (t.isStringLiteral(node) || t.isNumericLiteral(node)) return node;
+  if (t.isTSAsExpression(node) || t.isTSTypeAssertion(node))
+    return unwrapTextLiteral(node.expression);
+  return null;
+}
+
+function collectIdentifierTextCandidate(
+  ast: t.Node,
+  identifier: t.Identifier,
+): TextCandidate | null {
+  const name = identifier.name;
+  const useStart = identifier.start ?? 0;
+  const matches: Array<{ node: t.StringLiteral | t.NumericLiteral; start: number }> = [];
+  walkAll(ast, (node) => {
+    if (!t.isVariableDeclarator(node)) return;
+    if (!t.isIdentifier(node.id) || node.id.name !== name) return;
+    if (!node.init) return;
+    const start = node.start ?? 0;
+    if (start > useStart) return;
+    const literal = unwrapTextLiteral(node.init);
+    if (!literal) return;
+    matches.push({ node: literal, start });
+  });
+  matches.sort((a, b) => b.start - a.start);
+  const match = matches[0];
+  if (!match) return null;
+  const literal = match.node;
+  return {
+    current: String(literal.value),
+    splice: (s) => spliceRange(literal, jsString(s)),
+  };
+}
+
 function collectPropCallSiteCandidates(
   ast: t.Node,
   componentName: string,
@@ -892,10 +937,13 @@ function collectPropCallSiteCandidates(
           current: String(expr.value),
           splice: (s) => spliceRange(v, formatJsxAttrValue(s)),
         });
+      } else if (t.isIdentifier(expr)) {
+        const candidate = collectIdentifierTextCandidate(ast, expr);
+        if (candidate) out.push(candidate);
       }
     }
   });
-  return out;
+  return dedupeTextCandidates(out);
 }
 
 // Smallest enclosing `arr.map((p) => …)` callback (or `.flatMap`) that

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,8 @@ export type {
   DesignTypeScale,
 } from './app/lib/design.ts';
 export { cssVarsToString, defaultDesign, designToCssVars } from './app/lib/design.ts';
+export type { PptxExportProgress } from './app/lib/export-pptx.ts';
+export { exportSlideAsPptx } from './app/lib/export-pptx.ts';
 export { useSlidePageNumber } from './app/lib/page-context.tsx';
 export type { Page, SlideMeta, SlideModule } from './app/lib/sdk.ts';
 export { CANVAS_HEIGHT, CANVAS_WIDTH } from './app/lib/sdk.ts';

--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -34,6 +34,9 @@ function readCoreVersion(): string {
 }
 
 const CORE_VERSION = readCoreVersion();
+const REACT_ROOT = path.join(PKG_ROOT, 'node_modules', 'react');
+const REACT_DOM_ROOT = path.join(PKG_ROOT, 'node_modules', 'react-dom');
+const WORKSPACE_NODE_MODULES = path.resolve(PKG_ROOT, '..', '..', 'node_modules');
 
 export type CreateViteConfigOptions = {
   userCwd: string;
@@ -68,13 +71,20 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
       currentPlugin({ userCwd, slidesDir }),
     ],
     resolve: {
-      alias: {
-        '@': APP_ROOT,
-        '@assets': assetsAbs,
-      },
+      alias: [
+        { find: /^@open-slide\/core$/, replacement: path.join(PKG_ROOT, 'src', 'index.ts') },
+        { find: /^react$/, replacement: path.join(REACT_ROOT, 'index.js') },
+        { find: /^react\/jsx-runtime$/, replacement: path.join(REACT_ROOT, 'jsx-runtime.js') },
+        { find: /^react-dom$/, replacement: path.join(REACT_DOM_ROOT, 'index.js') },
+        { find: /^react-dom\/client$/, replacement: path.join(REACT_DOM_ROOT, 'client.js') },
+        { find: '@assets', replacement: assetsAbs },
+        { find: '@', replacement: APP_ROOT },
+      ],
+      dedupe: ['react', 'react-dom', '@open-slide/core'],
     },
     optimizeDeps: {
       entries: [path.join(APP_ROOT, 'main.tsx')],
+      exclude: ['@open-slide/core'],
       include: [
         'react',
         'react-dom',
@@ -107,7 +117,18 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
     },
     server: {
       port: config.port ?? 5173,
-      fs: { allow: [APP_ROOT, userCwd, slidesAbs, themesAbs, assetsAbs] },
+      fs: {
+        allow: [
+          APP_ROOT,
+          PKG_ROOT,
+          path.join(PKG_ROOT, 'node_modules'),
+          WORKSPACE_NODE_MODULES,
+          userCwd,
+          slidesAbs,
+          themesAbs,
+          assetsAbs,
+        ],
+      },
     },
     build: {
       outDir: path.resolve(userCwd, 'dist'),


### PR DESCRIPTION
## Summary

Editable PPTX export now produces a PowerPoint deck that can stay native without relying on a full-slide screenshot overlay. Text, shapes, images, SVG icons, tables, borders, rounded corners, gradients, and CJK font fallback are emitted as editable PowerPoint objects where possible, with image fallback retained for unsupported content.

The latest pass fixes the visible mixed icon-label chips from the demo deck: buttons such as `知识库`, `业务报告`, `数据资产`, and `复用 Skill` now export as editable labels next to their SVG icons instead of losing the label text. The text collector also avoids re-exporting parent rows when the actual text lives in child spans, so nearby icon/text list rows do not get duplicate or oversized text boxes.

## Related

Related: #194

## Validation

- `pnpm test packages/core/src/app/lib/export-pptx.test.ts`
  - 22 tests passed.
- `pnpm core typecheck`
  - `tsc --noEmit` passed.
- `pnpm core build`
  - build passed; existing `virtual:open-slide/config` external warning remains.
- `pnpm check`
  - exited 0; reports one pre-existing warning in `packages/core/src/http/request-guard.ts`.
- Demo export acceptance on `http://127.0.0.1:5173/s/ai-engineering-h1`
  - exported a 21-slide editable PPTX from the real Download menu.
  - verified the PPTX has no full-slide snapshot overlay.
  - opened the exported deck in Microsoft PowerPoint and checked slide 9 against the web view: the green asset chips render with both icon and label text.
  - ran `slides_test.py`; no overflow detected.

## External checks

- Vercel preview checks may require deployment authorization for this fork/PR.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
