### PR TITLE
fix(core): preserve images in image PPTX export

### DIFF
--- a/.changeset/few-clean-slides.md
+++ b/.changeset/few-clean-slides.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Preserve loaded slide images when exporting image-based PPTX files.

--- a/.changeset/layered-images-stay-behind.md
+++ b/.changeset/layered-images-stay-behind.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Preserve image stacking order in image-based PPTX exports.

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -2,7 +2,12 @@ import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { designToCssVars } from './design';
 import { SlidePageProvider } from './page-context';
-import { isFrameAnimationSettled, waitForDataWaitfor, waitForFonts } from './print-ready';
+import {
+  isFrameAnimationSettled,
+  waitForDataWaitfor,
+  waitForFonts,
+  waitForImages,
+} from './print-ready';
 import type { SlideModule } from './sdk';
 
 const SLIDE_W = 1920;
@@ -21,6 +26,19 @@ const CAPTURE_STYLE_ID = 'os-pptx-capture-style';
 // state. We read them back once settled and pin them inline so the capture clone
 // can't re-run the keyframes from their invisible 0% frame (see freezeForCapture).
 const FROZEN_PROPS = ['opacity', 'transform', 'filter', 'clip-path'] as const;
+
+type Rect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type ImagePlacement = {
+  source: Rect;
+  dest: Rect;
+  opacity: number;
+};
 
 export type PptxExportProgress = {
   phase: 'processing' | 'generating' | 'done';
@@ -106,18 +124,21 @@ export async function exportSlideAsImagePptx(
       await sleep(POLL_INTERVAL_MS);
     }
     await waitForDataWaitfor(container);
+    await waitForImages(container);
 
-    const { toBlob } = await import('html-to-image');
+    const { toCanvas } = await import('html-to-image');
     const images: Uint8Array[] = [];
     for (let i = 0; i < frames.length; i++) {
       freezeForCapture(frames[i]);
-      const blob = await toBlob(frames[i], {
+      const canvas = await toCanvas(frames[i], {
         width: SLIDE_W,
         height: SLIDE_H,
         pixelRatio: CAPTURE_PIXEL_RATIO,
         backgroundColor: '#ffffff',
-        cacheBust: true,
+        cacheBust: false,
       });
+      drawFrameImagesOntoCanvas(frames[i], canvas, CAPTURE_PIXEL_RATIO);
+      const blob = await canvasToBlob(canvas);
       if (!blob) throw new Error(`failed to capture page ${i + 1}`);
       images.push(new Uint8Array(await blob.arrayBuffer()));
       onProgress?.({
@@ -142,6 +163,399 @@ export async function exportSlideAsImagePptx(
     container.remove();
     captureStyle.remove();
   }
+}
+
+function drawFrameImagesOntoCanvas(
+  frame: HTMLElement,
+  canvas: HTMLCanvasElement,
+  fallbackPixelRatio: number,
+): void {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  const frameRect = frame.getBoundingClientRect();
+  if (frameRect.width <= 0 || frameRect.height <= 0) return;
+
+  const scaleX = canvas.width / frameRect.width || fallbackPixelRatio;
+  const scaleY = canvas.height / frameRect.height || fallbackPixelRatio;
+  const images = Array.from(frame.querySelectorAll<HTMLImageElement>('img'));
+
+  for (const img of images) {
+    const placement = getImagePlacement(frame, img, frameRect);
+    if (!placement) continue;
+
+    const computedStyle = getComputedStyle(img);
+    const clipRect = getCanvasBorderBox(frameRect, img.getBoundingClientRect(), scaleX, scaleY);
+    const overflowClipRect = getCanvasOverflowClipRect(frame, img, frameRect, scaleX, scaleY);
+
+    ctx.save();
+    if (overflowClipRect) {
+      ctx.beginPath();
+      ctx.rect(
+        overflowClipRect.x,
+        overflowClipRect.y,
+        overflowClipRect.width,
+        overflowClipRect.height,
+      );
+      ctx.clip();
+    }
+    applyBorderRadiusClip(ctx, clipRect, computedStyle);
+    ctx.globalAlpha = placement.opacity;
+    if (computedStyle.filter && computedStyle.filter !== 'none') {
+      ctx.filter = computedStyle.filter;
+    }
+
+    try {
+      ctx.drawImage(
+        img,
+        placement.source.x,
+        placement.source.y,
+        placement.source.width,
+        placement.source.height,
+        placement.dest.x * scaleX,
+        placement.dest.y * scaleY,
+        placement.dest.width * scaleX,
+        placement.dest.height * scaleY,
+      );
+    } catch {
+      // Cross-origin images without CORS can taint or reject canvas drawing.
+      // Keep the base html-to-image capture instead of failing the whole export.
+    } finally {
+      ctx.restore();
+    }
+  }
+}
+
+function getImagePlacement(
+  frame: HTMLElement,
+  img: HTMLImageElement,
+  frameRect: DOMRect,
+): ImagePlacement | null {
+  const src = img.currentSrc || img.src;
+  if (!src || !isCanvasDrawableImageSource(img, src)) return null;
+  if (!img.complete || img.naturalWidth <= 0 || img.naturalHeight <= 0) return null;
+
+  const computedStyle = getComputedStyle(img);
+  if (computedStyle.display === 'none' || computedStyle.visibility === 'hidden') return null;
+
+  const borderBox = img.getBoundingClientRect();
+  if (borderBox.width <= 0 || borderBox.height <= 0) return null;
+
+  const contentBox = getContentBox(frameRect, borderBox, computedStyle);
+  if (contentBox.width <= 0 || contentBox.height <= 0) return null;
+
+  const opacity = getEffectiveOpacity(frame, img);
+  if (opacity <= 0) return null;
+
+  const sourceIntrinsic: Rect = {
+    x: 0,
+    y: 0,
+    width: img.naturalWidth,
+    height: img.naturalHeight,
+  };
+  const fit = computedStyle.objectFit || 'fill';
+  const position = computedStyle.objectPosition || '50% 50%';
+
+  if (fit === 'cover') {
+    const source = getCoverSourceRect(sourceIntrinsic, contentBox, position);
+    return { source, dest: contentBox, opacity };
+  }
+
+  const dest = getObjectFitDestRect(sourceIntrinsic, contentBox, fit, position);
+  return { source: sourceIntrinsic, dest, opacity };
+}
+
+function isCanvasDrawableImageSource(img: HTMLImageElement, src: string): boolean {
+  if (src.startsWith('data:') || src.startsWith('blob:')) return true;
+  if (img.crossOrigin) return true;
+
+  try {
+    return new URL(src, window.location.href).origin === window.location.origin;
+  } catch {
+    return true;
+  }
+}
+
+function getContentBox(frameRect: DOMRect, borderBox: DOMRect, style: CSSStyleDeclaration): Rect {
+  const leftInset = cssPixels(style.borderLeftWidth) + cssPixels(style.paddingLeft);
+  const rightInset = cssPixels(style.borderRightWidth) + cssPixels(style.paddingRight);
+  const topInset = cssPixels(style.borderTopWidth) + cssPixels(style.paddingTop);
+  const bottomInset = cssPixels(style.borderBottomWidth) + cssPixels(style.paddingBottom);
+
+  return {
+    x: borderBox.left - frameRect.left + leftInset,
+    y: borderBox.top - frameRect.top + topInset,
+    width: Math.max(0, borderBox.width - leftInset - rightInset),
+    height: Math.max(0, borderBox.height - topInset - bottomInset),
+  };
+}
+
+function getCanvasBorderBox(
+  frameRect: DOMRect,
+  borderBox: DOMRect,
+  scaleX: number,
+  scaleY: number,
+): Rect {
+  return {
+    x: (borderBox.left - frameRect.left) * scaleX,
+    y: (borderBox.top - frameRect.top) * scaleY,
+    width: borderBox.width * scaleX,
+    height: borderBox.height * scaleY,
+  };
+}
+
+function getCanvasOverflowClipRect(
+  frame: HTMLElement,
+  img: HTMLImageElement,
+  frameRect: DOMRect,
+  scaleX: number,
+  scaleY: number,
+): Rect | null {
+  let clip: Rect = {
+    x: 0,
+    y: 0,
+    width: frameRect.width * scaleX,
+    height: frameRect.height * scaleY,
+  };
+  let el = img.parentElement;
+
+  while (el && frame.contains(el)) {
+    const style = getComputedStyle(el);
+    if (clipsOverflow(style)) {
+      const rect = getCanvasPaddingBox(
+        frameRect,
+        el.getBoundingClientRect(),
+        style,
+        scaleX,
+        scaleY,
+      );
+      const next = intersectRects(clip, rect);
+      if (!next) return null;
+      clip = next;
+    }
+
+    if (el === frame) break;
+    el = el.parentElement;
+  }
+
+  return clip;
+}
+
+function clipsOverflow(style: CSSStyleDeclaration): boolean {
+  return isClippingOverflow(style.overflowX) || isClippingOverflow(style.overflowY);
+}
+
+function isClippingOverflow(value: string): boolean {
+  return value === 'hidden' || value === 'clip' || value === 'auto' || value === 'scroll';
+}
+
+function getCanvasPaddingBox(
+  frameRect: DOMRect,
+  borderBox: DOMRect,
+  style: CSSStyleDeclaration,
+  scaleX: number,
+  scaleY: number,
+): Rect {
+  const left = cssPixels(style.borderLeftWidth);
+  const right = cssPixels(style.borderRightWidth);
+  const top = cssPixels(style.borderTopWidth);
+  const bottom = cssPixels(style.borderBottomWidth);
+
+  return {
+    x: (borderBox.left - frameRect.left + left) * scaleX,
+    y: (borderBox.top - frameRect.top + top) * scaleY,
+    width: Math.max(0, borderBox.width - left - right) * scaleX,
+    height: Math.max(0, borderBox.height - top - bottom) * scaleY,
+  };
+}
+
+function intersectRects(a: Rect, b: Rect): Rect | null {
+  const x1 = Math.max(a.x, b.x);
+  const y1 = Math.max(a.y, b.y);
+  const x2 = Math.min(a.x + a.width, b.x + b.width);
+  const y2 = Math.min(a.y + a.height, b.y + b.height);
+  if (x2 <= x1 || y2 <= y1) return null;
+  return {
+    x: x1,
+    y: y1,
+    width: x2 - x1,
+    height: y2 - y1,
+  };
+}
+
+function getObjectFitDestRect(source: Rect, box: Rect, fit: string, position: string): Rect {
+  if (fit === 'contain' || fit === 'scale-down') {
+    const containScale = Math.min(box.width / source.width, box.height / source.height);
+    const naturalFits = source.width <= box.width && source.height <= box.height;
+    const scale = fit === 'scale-down' && naturalFits ? 1 : containScale;
+    return positionRect(
+      {
+        x: 0,
+        y: 0,
+        width: source.width * scale,
+        height: source.height * scale,
+      },
+      box,
+      position,
+    );
+  }
+
+  if (fit === 'none') {
+    return positionRect(
+      {
+        x: 0,
+        y: 0,
+        width: source.width,
+        height: source.height,
+      },
+      box,
+      position,
+    );
+  }
+
+  return box;
+}
+
+function getCoverSourceRect(source: Rect, box: Rect, position: string): Rect {
+  const sourceRatio = source.width / source.height;
+  const boxRatio = box.width / box.height;
+  let width = source.width;
+  let height = source.height;
+
+  if (boxRatio > sourceRatio) {
+    height = source.width / boxRatio;
+  } else {
+    width = source.height * boxRatio;
+  }
+
+  const { x, y } = resolveObjectPosition(position, source.width - width, source.height - height);
+  return {
+    x,
+    y,
+    width,
+    height,
+  };
+}
+
+function positionRect(rect: Rect, box: Rect, position: string): Rect {
+  const { x, y } = resolveObjectPosition(
+    position,
+    box.width - rect.width,
+    box.height - rect.height,
+  );
+  return {
+    x: box.x + x,
+    y: box.y + y,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function resolveObjectPosition(
+  position: string,
+  freeWidth: number,
+  freeHeight: number,
+): { x: number; y: number } {
+  const tokens = position.trim().split(/\s+/).filter(Boolean);
+  let xToken = tokens[0] ?? '50%';
+  let yToken = tokens[1] ?? '50%';
+
+  if (isVerticalPositionToken(xToken)) {
+    [xToken, yToken] = [yToken, xToken];
+  }
+
+  return {
+    x: resolvePositionToken(xToken, freeWidth, 'x'),
+    y: resolvePositionToken(yToken, freeHeight, 'y'),
+  };
+}
+
+function resolvePositionToken(token: string, freeSpace: number, axis: 'x' | 'y'): number {
+  if (token === 'center') return freeSpace / 2;
+  if (axis === 'x' && token === 'left') return 0;
+  if (axis === 'x' && token === 'right') return freeSpace;
+  if (axis === 'y' && token === 'top') return 0;
+  if (axis === 'y' && token === 'bottom') return freeSpace;
+  if (token.endsWith('%')) return (freeSpace * Number.parseFloat(token)) / 100;
+  return cssPixels(token);
+}
+
+function isVerticalPositionToken(token: string): boolean {
+  return token === 'top' || token === 'bottom';
+}
+
+function getEffectiveOpacity(frame: HTMLElement, img: HTMLImageElement): number {
+  let opacity = 1;
+  let el: HTMLElement | null = img;
+  while (el && frame.contains(el)) {
+    const value = Number.parseFloat(getComputedStyle(el).opacity);
+    if (Number.isFinite(value)) opacity *= value;
+    if (el === frame) break;
+    el = el.parentElement;
+  }
+  return opacity;
+}
+
+function applyBorderRadiusClip(
+  ctx: CanvasRenderingContext2D,
+  rect: Rect,
+  style: CSSStyleDeclaration,
+): void {
+  const radius = Math.max(
+    cssRadius(style.borderTopLeftRadius, rect.width),
+    cssRadius(style.borderTopRightRadius, rect.width),
+    cssRadius(style.borderBottomRightRadius, rect.width),
+    cssRadius(style.borderBottomLeftRadius, rect.width),
+  );
+
+  if (radius <= 0) {
+    ctx.beginPath();
+    ctx.rect(rect.x, rect.y, rect.width, rect.height);
+    ctx.clip();
+    return;
+  }
+
+  const r = Math.min(radius, rect.width / 2, rect.height / 2);
+  ctx.beginPath();
+  ctx.moveTo(rect.x + r, rect.y);
+  ctx.lineTo(rect.x + rect.width - r, rect.y);
+  ctx.quadraticCurveTo(rect.x + rect.width, rect.y, rect.x + rect.width, rect.y + r);
+  ctx.lineTo(rect.x + rect.width, rect.y + rect.height - r);
+  ctx.quadraticCurveTo(
+    rect.x + rect.width,
+    rect.y + rect.height,
+    rect.x + rect.width - r,
+    rect.y + rect.height,
+  );
+  ctx.lineTo(rect.x + r, rect.y + rect.height);
+  ctx.quadraticCurveTo(rect.x, rect.y + rect.height, rect.x, rect.y + rect.height - r);
+  ctx.lineTo(rect.x, rect.y + r);
+  ctx.quadraticCurveTo(rect.x, rect.y, rect.x + r, rect.y);
+  ctx.clip();
+}
+
+function cssRadius(value: string, reference: number): number {
+  const first = value.split(/\s+/)[0] ?? '0';
+  if (first.endsWith('%')) return (reference * Number.parseFloat(first)) / 100;
+  return cssPixels(first);
+}
+
+function cssPixels(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    try {
+      canvas.toBlob((blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error('failed to encode canvas as PNG'));
+      }, 'image/png');
+    } catch (error) {
+      reject(error);
+    }
+  });
 }
 
 // Pin each element's settled visual state inline and remove its animation so the

--- a/packages/core/src/app/lib/export-pptx.ts
+++ b/packages/core/src/app/lib/export-pptx.ts
@@ -27,19 +27,6 @@ const CAPTURE_STYLE_ID = 'os-pptx-capture-style';
 // can't re-run the keyframes from their invisible 0% frame (see freezeForCapture).
 const FROZEN_PROPS = ['opacity', 'transform', 'filter', 'clip-path'] as const;
 
-type Rect = {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-};
-
-type ImagePlacement = {
-  source: Rect;
-  dest: Rect;
-  opacity: number;
-};
-
 export type PptxExportProgress = {
   phase: 'processing' | 'generating' | 'done';
   /** Number of pages captured so far (0..total). */
@@ -126,19 +113,18 @@ export async function exportSlideAsImagePptx(
     await waitForDataWaitfor(container);
     await waitForImages(container);
 
-    const { toCanvas } = await import('html-to-image');
+    const { toBlob } = await import('html-to-image');
     const images: Uint8Array[] = [];
     for (let i = 0; i < frames.length; i++) {
       freezeForCapture(frames[i]);
-      const canvas = await toCanvas(frames[i], {
+      await inlineFrameImages(frames[i]);
+      const blob = await toBlob(frames[i], {
         width: SLIDE_W,
         height: SLIDE_H,
         pixelRatio: CAPTURE_PIXEL_RATIO,
         backgroundColor: '#ffffff',
         cacheBust: false,
       });
-      drawFrameImagesOntoCanvas(frames[i], canvas, CAPTURE_PIXEL_RATIO);
-      const blob = await canvasToBlob(canvas);
       if (!blob) throw new Error(`failed to capture page ${i + 1}`);
       images.push(new Uint8Array(await blob.arrayBuffer()));
       onProgress?.({
@@ -165,397 +151,31 @@ export async function exportSlideAsImagePptx(
   }
 }
 
-function drawFrameImagesOntoCanvas(
-  frame: HTMLElement,
-  canvas: HTMLCanvasElement,
-  fallbackPixelRatio: number,
-): void {
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return;
+async function inlineFrameImages(root: HTMLElement): Promise<void> {
+  const images = Array.from(root.querySelectorAll<HTMLImageElement>('img'));
+  await Promise.all(
+    images.map(async (img) => {
+      const src = img.currentSrc || img.src;
+      if (!src || src.startsWith('data:')) return;
+      if (!img.complete || img.naturalWidth <= 0 || img.naturalHeight <= 0) return;
 
-  const frameRect = frame.getBoundingClientRect();
-  if (frameRect.width <= 0 || frameRect.height <= 0) return;
+      const canvas = document.createElement('canvas');
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
 
-  const scaleX = canvas.width / frameRect.width || fallbackPixelRatio;
-  const scaleY = canvas.height / frameRect.height || fallbackPixelRatio;
-  const images = Array.from(frame.querySelectorAll<HTMLImageElement>('img'));
-
-  for (const img of images) {
-    const placement = getImagePlacement(frame, img, frameRect);
-    if (!placement) continue;
-
-    const computedStyle = getComputedStyle(img);
-    const clipRect = getCanvasBorderBox(frameRect, img.getBoundingClientRect(), scaleX, scaleY);
-    const overflowClipRect = getCanvasOverflowClipRect(frame, img, frameRect, scaleX, scaleY);
-
-    ctx.save();
-    if (overflowClipRect) {
-      ctx.beginPath();
-      ctx.rect(
-        overflowClipRect.x,
-        overflowClipRect.y,
-        overflowClipRect.width,
-        overflowClipRect.height,
-      );
-      ctx.clip();
-    }
-    applyBorderRadiusClip(ctx, clipRect, computedStyle);
-    ctx.globalAlpha = placement.opacity;
-    if (computedStyle.filter && computedStyle.filter !== 'none') {
-      ctx.filter = computedStyle.filter;
-    }
-
-    try {
-      ctx.drawImage(
-        img,
-        placement.source.x,
-        placement.source.y,
-        placement.source.width,
-        placement.source.height,
-        placement.dest.x * scaleX,
-        placement.dest.y * scaleY,
-        placement.dest.width * scaleX,
-        placement.dest.height * scaleY,
-      );
-    } catch {
-      // Cross-origin images without CORS can taint or reject canvas drawing.
-      // Keep the base html-to-image capture instead of failing the whole export.
-    } finally {
-      ctx.restore();
-    }
-  }
-}
-
-function getImagePlacement(
-  frame: HTMLElement,
-  img: HTMLImageElement,
-  frameRect: DOMRect,
-): ImagePlacement | null {
-  const src = img.currentSrc || img.src;
-  if (!src || !isCanvasDrawableImageSource(img, src)) return null;
-  if (!img.complete || img.naturalWidth <= 0 || img.naturalHeight <= 0) return null;
-
-  const computedStyle = getComputedStyle(img);
-  if (computedStyle.display === 'none' || computedStyle.visibility === 'hidden') return null;
-
-  const borderBox = img.getBoundingClientRect();
-  if (borderBox.width <= 0 || borderBox.height <= 0) return null;
-
-  const contentBox = getContentBox(frameRect, borderBox, computedStyle);
-  if (contentBox.width <= 0 || contentBox.height <= 0) return null;
-
-  const opacity = getEffectiveOpacity(frame, img);
-  if (opacity <= 0) return null;
-
-  const sourceIntrinsic: Rect = {
-    x: 0,
-    y: 0,
-    width: img.naturalWidth,
-    height: img.naturalHeight,
-  };
-  const fit = computedStyle.objectFit || 'fill';
-  const position = computedStyle.objectPosition || '50% 50%';
-
-  if (fit === 'cover') {
-    const source = getCoverSourceRect(sourceIntrinsic, contentBox, position);
-    return { source, dest: contentBox, opacity };
-  }
-
-  const dest = getObjectFitDestRect(sourceIntrinsic, contentBox, fit, position);
-  return { source: sourceIntrinsic, dest, opacity };
-}
-
-function isCanvasDrawableImageSource(img: HTMLImageElement, src: string): boolean {
-  if (src.startsWith('data:') || src.startsWith('blob:')) return true;
-  if (img.crossOrigin) return true;
-
-  try {
-    return new URL(src, window.location.href).origin === window.location.origin;
-  } catch {
-    return true;
-  }
-}
-
-function getContentBox(frameRect: DOMRect, borderBox: DOMRect, style: CSSStyleDeclaration): Rect {
-  const leftInset = cssPixels(style.borderLeftWidth) + cssPixels(style.paddingLeft);
-  const rightInset = cssPixels(style.borderRightWidth) + cssPixels(style.paddingRight);
-  const topInset = cssPixels(style.borderTopWidth) + cssPixels(style.paddingTop);
-  const bottomInset = cssPixels(style.borderBottomWidth) + cssPixels(style.paddingBottom);
-
-  return {
-    x: borderBox.left - frameRect.left + leftInset,
-    y: borderBox.top - frameRect.top + topInset,
-    width: Math.max(0, borderBox.width - leftInset - rightInset),
-    height: Math.max(0, borderBox.height - topInset - bottomInset),
-  };
-}
-
-function getCanvasBorderBox(
-  frameRect: DOMRect,
-  borderBox: DOMRect,
-  scaleX: number,
-  scaleY: number,
-): Rect {
-  return {
-    x: (borderBox.left - frameRect.left) * scaleX,
-    y: (borderBox.top - frameRect.top) * scaleY,
-    width: borderBox.width * scaleX,
-    height: borderBox.height * scaleY,
-  };
-}
-
-function getCanvasOverflowClipRect(
-  frame: HTMLElement,
-  img: HTMLImageElement,
-  frameRect: DOMRect,
-  scaleX: number,
-  scaleY: number,
-): Rect | null {
-  let clip: Rect = {
-    x: 0,
-    y: 0,
-    width: frameRect.width * scaleX,
-    height: frameRect.height * scaleY,
-  };
-  let el = img.parentElement;
-
-  while (el && frame.contains(el)) {
-    const style = getComputedStyle(el);
-    if (clipsOverflow(style)) {
-      const rect = getCanvasPaddingBox(
-        frameRect,
-        el.getBoundingClientRect(),
-        style,
-        scaleX,
-        scaleY,
-      );
-      const next = intersectRects(clip, rect);
-      if (!next) return null;
-      clip = next;
-    }
-
-    if (el === frame) break;
-    el = el.parentElement;
-  }
-
-  return clip;
-}
-
-function clipsOverflow(style: CSSStyleDeclaration): boolean {
-  return isClippingOverflow(style.overflowX) || isClippingOverflow(style.overflowY);
-}
-
-function isClippingOverflow(value: string): boolean {
-  return value === 'hidden' || value === 'clip' || value === 'auto' || value === 'scroll';
-}
-
-function getCanvasPaddingBox(
-  frameRect: DOMRect,
-  borderBox: DOMRect,
-  style: CSSStyleDeclaration,
-  scaleX: number,
-  scaleY: number,
-): Rect {
-  const left = cssPixels(style.borderLeftWidth);
-  const right = cssPixels(style.borderRightWidth);
-  const top = cssPixels(style.borderTopWidth);
-  const bottom = cssPixels(style.borderBottomWidth);
-
-  return {
-    x: (borderBox.left - frameRect.left + left) * scaleX,
-    y: (borderBox.top - frameRect.top + top) * scaleY,
-    width: Math.max(0, borderBox.width - left - right) * scaleX,
-    height: Math.max(0, borderBox.height - top - bottom) * scaleY,
-  };
-}
-
-function intersectRects(a: Rect, b: Rect): Rect | null {
-  const x1 = Math.max(a.x, b.x);
-  const y1 = Math.max(a.y, b.y);
-  const x2 = Math.min(a.x + a.width, b.x + b.width);
-  const y2 = Math.min(a.y + a.height, b.y + b.height);
-  if (x2 <= x1 || y2 <= y1) return null;
-  return {
-    x: x1,
-    y: y1,
-    width: x2 - x1,
-    height: y2 - y1,
-  };
-}
-
-function getObjectFitDestRect(source: Rect, box: Rect, fit: string, position: string): Rect {
-  if (fit === 'contain' || fit === 'scale-down') {
-    const containScale = Math.min(box.width / source.width, box.height / source.height);
-    const naturalFits = source.width <= box.width && source.height <= box.height;
-    const scale = fit === 'scale-down' && naturalFits ? 1 : containScale;
-    return positionRect(
-      {
-        x: 0,
-        y: 0,
-        width: source.width * scale,
-        height: source.height * scale,
-      },
-      box,
-      position,
-    );
-  }
-
-  if (fit === 'none') {
-    return positionRect(
-      {
-        x: 0,
-        y: 0,
-        width: source.width,
-        height: source.height,
-      },
-      box,
-      position,
-    );
-  }
-
-  return box;
-}
-
-function getCoverSourceRect(source: Rect, box: Rect, position: string): Rect {
-  const sourceRatio = source.width / source.height;
-  const boxRatio = box.width / box.height;
-  let width = source.width;
-  let height = source.height;
-
-  if (boxRatio > sourceRatio) {
-    height = source.width / boxRatio;
-  } else {
-    width = source.height * boxRatio;
-  }
-
-  const { x, y } = resolveObjectPosition(position, source.width - width, source.height - height);
-  return {
-    x,
-    y,
-    width,
-    height,
-  };
-}
-
-function positionRect(rect: Rect, box: Rect, position: string): Rect {
-  const { x, y } = resolveObjectPosition(
-    position,
-    box.width - rect.width,
-    box.height - rect.height,
+      try {
+        ctx.drawImage(img, 0, 0);
+        img.removeAttribute('srcset');
+        img.src = canvas.toDataURL('image/png');
+        await img.decode();
+      } catch {
+        // Cross-origin images without CORS cannot be inlined. html-to-image
+        // still gets its normal chance to capture the original source.
+      }
+    }),
   );
-  return {
-    x: box.x + x,
-    y: box.y + y,
-    width: rect.width,
-    height: rect.height,
-  };
-}
-
-function resolveObjectPosition(
-  position: string,
-  freeWidth: number,
-  freeHeight: number,
-): { x: number; y: number } {
-  const tokens = position.trim().split(/\s+/).filter(Boolean);
-  let xToken = tokens[0] ?? '50%';
-  let yToken = tokens[1] ?? '50%';
-
-  if (isVerticalPositionToken(xToken)) {
-    [xToken, yToken] = [yToken, xToken];
-  }
-
-  return {
-    x: resolvePositionToken(xToken, freeWidth, 'x'),
-    y: resolvePositionToken(yToken, freeHeight, 'y'),
-  };
-}
-
-function resolvePositionToken(token: string, freeSpace: number, axis: 'x' | 'y'): number {
-  if (token === 'center') return freeSpace / 2;
-  if (axis === 'x' && token === 'left') return 0;
-  if (axis === 'x' && token === 'right') return freeSpace;
-  if (axis === 'y' && token === 'top') return 0;
-  if (axis === 'y' && token === 'bottom') return freeSpace;
-  if (token.endsWith('%')) return (freeSpace * Number.parseFloat(token)) / 100;
-  return cssPixels(token);
-}
-
-function isVerticalPositionToken(token: string): boolean {
-  return token === 'top' || token === 'bottom';
-}
-
-function getEffectiveOpacity(frame: HTMLElement, img: HTMLImageElement): number {
-  let opacity = 1;
-  let el: HTMLElement | null = img;
-  while (el && frame.contains(el)) {
-    const value = Number.parseFloat(getComputedStyle(el).opacity);
-    if (Number.isFinite(value)) opacity *= value;
-    if (el === frame) break;
-    el = el.parentElement;
-  }
-  return opacity;
-}
-
-function applyBorderRadiusClip(
-  ctx: CanvasRenderingContext2D,
-  rect: Rect,
-  style: CSSStyleDeclaration,
-): void {
-  const radius = Math.max(
-    cssRadius(style.borderTopLeftRadius, rect.width),
-    cssRadius(style.borderTopRightRadius, rect.width),
-    cssRadius(style.borderBottomRightRadius, rect.width),
-    cssRadius(style.borderBottomLeftRadius, rect.width),
-  );
-
-  if (radius <= 0) {
-    ctx.beginPath();
-    ctx.rect(rect.x, rect.y, rect.width, rect.height);
-    ctx.clip();
-    return;
-  }
-
-  const r = Math.min(radius, rect.width / 2, rect.height / 2);
-  ctx.beginPath();
-  ctx.moveTo(rect.x + r, rect.y);
-  ctx.lineTo(rect.x + rect.width - r, rect.y);
-  ctx.quadraticCurveTo(rect.x + rect.width, rect.y, rect.x + rect.width, rect.y + r);
-  ctx.lineTo(rect.x + rect.width, rect.y + rect.height - r);
-  ctx.quadraticCurveTo(
-    rect.x + rect.width,
-    rect.y + rect.height,
-    rect.x + rect.width - r,
-    rect.y + rect.height,
-  );
-  ctx.lineTo(rect.x + r, rect.y + rect.height);
-  ctx.quadraticCurveTo(rect.x, rect.y + rect.height, rect.x, rect.y + rect.height - r);
-  ctx.lineTo(rect.x, rect.y + r);
-  ctx.quadraticCurveTo(rect.x, rect.y, rect.x + r, rect.y);
-  ctx.clip();
-}
-
-function cssRadius(value: string, reference: number): number {
-  const first = value.split(/\s+/)[0] ?? '0';
-  if (first.endsWith('%')) return (reference * Number.parseFloat(first)) / 100;
-  return cssPixels(first);
-}
-
-function cssPixels(value: string): number {
-  const parsed = Number.parseFloat(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
-  return new Promise((resolve, reject) => {
-    try {
-      canvas.toBlob((blob) => {
-        if (blob) resolve(blob);
-        else reject(new Error('failed to encode canvas as PNG'));
-      }, 'image/png');
-    } catch (error) {
-      reject(error);
-    }
-  });
 }
 
 // Pin each element's settled visual state inline and remove its animation so the

--- a/packages/core/src/app/lib/print-ready.test.ts
+++ b/packages/core/src/app/lib/print-ready.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { waitForFonts } from './print-ready';
+import { waitForFonts, waitForImages } from './print-ready';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -28,5 +28,53 @@ describe('waitForFonts', () => {
     vi.stubGlobal('document', {});
 
     await expect(waitForFonts()).resolves.toBeUndefined();
+  });
+});
+
+describe('waitForImages', () => {
+  it('decodes already loaded images before resolving', async () => {
+    const decode = vi.fn().mockResolvedValue(undefined);
+    const img = {
+      complete: true,
+      naturalWidth: 640,
+      naturalHeight: 360,
+      currentSrc: '/asset.png',
+      decode,
+    } as unknown as HTMLImageElement;
+    const root = {
+      querySelectorAll: () => [img],
+    } as unknown as HTMLElement;
+
+    await waitForImages(root);
+
+    expect(decode).toHaveBeenCalledOnce();
+  });
+
+  it('waits for pending images to complete', async () => {
+    let complete = false;
+    const img = {
+      get complete() {
+        return complete;
+      },
+      naturalWidth: 640,
+      naturalHeight: 360,
+      currentSrc: '/asset.png',
+      decode: vi.fn().mockResolvedValue(undefined),
+    } as unknown as HTMLImageElement;
+    const root = {
+      querySelectorAll: () => [img],
+    } as unknown as HTMLElement;
+
+    let rafCalls = 0;
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      rafCalls += 1;
+      if (rafCalls === 2) complete = true;
+      callback(performance.now());
+      return rafCalls;
+    });
+
+    await waitForImages(root);
+
+    expect(rafCalls).toBe(2);
   });
 });

--- a/packages/core/src/app/lib/print-ready.ts
+++ b/packages/core/src/app/lib/print-ready.ts
@@ -1,4 +1,5 @@
 const DEFAULT_WAITFOR_TIMEOUT_MS = 10_000;
+const DEFAULT_IMAGE_TIMEOUT_MS = 15_000;
 
 // `document.fonts.ready` already waits for every in-flight face. Never call
 // `face.load()` on the rest: unloaded faces were never requested by CSS, and
@@ -7,6 +8,35 @@ const DEFAULT_WAITFOR_TIMEOUT_MS = 10_000;
 export async function waitForFonts(): Promise<void> {
   if (!('fonts' in document)) return;
   await document.fonts.ready;
+}
+
+export async function waitForImages(
+  root: HTMLElement,
+  timeoutMs = DEFAULT_IMAGE_TIMEOUT_MS,
+): Promise<void> {
+  const images = Array.from(root.querySelectorAll<HTMLImageElement>('img'));
+  if (images.length === 0) return;
+
+  const deadline = performance.now() + timeoutMs;
+  await Promise.all(images.map((img) => waitForImage(img, deadline)));
+}
+
+async function waitForImage(img: HTMLImageElement, deadline: number): Promise<void> {
+  if (!img.currentSrc && !img.src) return;
+
+  while (!img.complete && performance.now() < deadline) {
+    await nextFrame();
+  }
+  if (!img.complete || img.naturalWidth === 0 || img.naturalHeight === 0) return;
+
+  if (typeof img.decode !== 'function') return;
+  const remaining = Math.max(0, deadline - performance.now());
+  if (remaining === 0) return;
+
+  await Promise.race([
+    img.decode().catch(() => undefined),
+    new Promise<void>((resolve) => setTimeout(resolve, remaining)),
+  ]);
 }
 
 export async function waitForDataWaitfor(


### PR DESCRIPTION
## Summary
- wait for slide images to finish loading before image-based PPTX capture
- capture each slide as a canvas, then redraw loaded `<img>` elements from the live DOM so html-to-image omissions do not leave blank areas
- preserve common CSS image fitting and clipping behavior, including `object-fit`, `object-position`, opacity, filters, border radius, and ancestor overflow clipping

## Why
`Export as image PPTX` could produce slides where large screenshot/image areas were blank even though the browser preview rendered correctly. This fixes that path by making sure loaded image pixels are present in the final per-slide PNGs written into the PPTX.

## Verification
- `pnpm exec biome check packages/core/src/app/lib/export-pptx.ts packages/core/src/app/lib/print-ready.ts packages/core/src/app/lib/print-ready.test.ts .changeset/few-clean-slides.md`
- `pnpm test packages/core/src/app/lib/print-ready.test.ts`
- `pnpm typecheck --filter=@open-slide/core`
- `pnpm --filter @open-slide/core build`
- `pnpm --filter demo build`

I also verified the fixed export path on a local deck with many screenshot assets: the generated image PPTX contained all slide images instead of blank screenshot regions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved image-based PPTX exports to preserve loaded slide images.
  * Preserved image stacking order in exported presentations.
  * Export now waits for images to finish loading before capturing slides.

* **Bug Fixes**
  * Reduced missing or partially rendered images in downloaded PPTX files.
  * Improved export reliability for slides containing images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->