### PR TITLE
revert: inspector quick activation gestures (#247)

### DIFF
--- a/.changeset/revert-inspector-gestures.md
+++ b/.changeset/revert-inspector-gestures.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Revert inspector quick activation gestures (Command/Control hold and double-click selection).

--- a/packages/core/src/app/components/inspector/inspect-overlay.tsx
+++ b/packages/core/src/app/components/inspector/inspect-overlay.tsx
@@ -16,13 +16,17 @@ const FRAME_MORPH_MS = 180;
 const LAYOUT_TRACK_MS = PANEL_TRANSITION_MS + FRAME_MORPH_MS;
 
 export function InspectOverlay() {
-  const { active, activate, slideId, selected, setSelected, cancel, openCrop } = useInspector();
+  const { active, slideId, selected, setSelected, cancel, openCrop } = useInspector();
   const overlayRef = useRef<HTMLDivElement>(null);
   const [hover, setHover] = useState<Highlight | null>(null);
 
   useEffect(() => {
+    if (!active) {
+      setHover(null);
+      return;
+    }
+
     const onKey = (e: KeyboardEvent) => {
-      if (!active) return;
       if (e.key === 'Escape') {
         e.preventDefault();
         e.stopPropagation();
@@ -31,66 +35,52 @@ export function InspectOverlay() {
     };
 
     const onMove = (e: PointerEvent) => {
-      if (!active) return;
       if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) {
         return setHover(null);
       }
-      const hit = findInspectorHitAtPoint(e.clientX, e.clientY, slideId);
+      const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
+      if (!el) return setHover(null);
+      const hit = findSlideSource(el, slideId, { hostOnly: true });
       if (!hit) return setHover(null);
       setHover({ hit });
     };
 
-    const onMouseDown = (e: MouseEvent) => {
-      if (!active && e.detail < 2) return;
-      if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) return;
-      const hit = findInspectorHitAtPoint(e.clientX, e.clientY, slideId);
-      if (!hit) return;
-      e.preventDefault();
-    };
-
     const onClick = (e: MouseEvent) => {
-      if (!active) return;
       if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) return;
-      const hit = findInspectorHitAtPoint(e.clientX, e.clientY, slideId);
+      const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
+      if (!el) return;
+      const hit = findSlideSource(el, slideId, { hostOnly: true });
       if (!hit) return;
       e.preventDefault();
       e.stopPropagation();
-      clearTextSelection();
-      activate();
       setSelected({ line: hit.line, column: hit.column, anchor: hit.anchor });
       setHover({ hit });
     };
 
     const onDblClick = (e: MouseEvent) => {
       if (e.target instanceof Element && e.target.closest('[data-inspector-ui]')) return;
-      const hit = findInspectorHitAtPoint(e.clientX, e.clientY, slideId);
+      const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
+      if (!el) return;
+      const hit = findSlideSource(el, slideId, { hostOnly: true });
       if (!hit) return;
+      if (!(hit.anchor instanceof HTMLImageElement)) return;
       e.preventDefault();
       e.stopPropagation();
-      clearTextSelection();
-      if (!active) activate();
       setSelected({ line: hit.line, column: hit.column, anchor: hit.anchor });
-      setHover({ hit });
-      if (active && hit.anchor instanceof HTMLImageElement) openCrop(hit.anchor);
+      openCrop(hit.anchor);
     };
 
     window.addEventListener('pointermove', onMove, true);
-    window.addEventListener('mousedown', onMouseDown, true);
     window.addEventListener('click', onClick, true);
     window.addEventListener('dblclick', onDblClick, true);
     window.addEventListener('keydown', onKey, true);
     return () => {
       window.removeEventListener('pointermove', onMove, true);
-      window.removeEventListener('mousedown', onMouseDown, true);
       window.removeEventListener('click', onClick, true);
       window.removeEventListener('dblclick', onDblClick, true);
       window.removeEventListener('keydown', onKey, true);
     };
-  }, [active, activate, slideId, setSelected, cancel, openCrop]);
-
-  useEffect(() => {
-    if (!active) setHover(null);
-  }, [active]);
+  }, [active, slideId, setSelected, cancel, openCrop]);
 
   const hoverAnchor = hover?.hit.anchor.isConnected ? hover.hit.anchor : null;
   const selectedAnchor = selected?.anchor.isConnected ? selected.anchor : null;
@@ -327,17 +317,6 @@ function pickElement(x: number, y: number): HTMLElement | null {
     return el;
   }
   return null;
-}
-
-function findInspectorHitAtPoint(x: number, y: number, slideId: string): SlideSourceHit | null {
-  const el = pickInspectorTarget(pickElement(x, y));
-  if (!el) return null;
-  return findSlideSource(el, slideId, { hostOnly: true });
-}
-
-function clearTextSelection() {
-  const selection = window.getSelection();
-  if (selection && !selection.isCollapsed) selection.removeAllRanges();
 }
 
 const INLINE_TEXT_TAGS = new Set([

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -244,7 +244,6 @@ function replayDomTextRangeStyles(el: HTMLElement, html: string, ops: TextRangeS
 type InspectorCtx = {
   slideId: string;
   active: boolean;
-  activate: () => void;
   toggle: () => void;
   cancel: () => void;
   comments: SlideComment[];
@@ -285,14 +284,11 @@ export function InspectorProvider({
   pageIndex: number;
   children: ReactNode;
 }) {
-  const [manualActive, setManualActive] = useState(false);
-  const [heldActive, setHeldActive] = useState(false);
+  const [active, setActive] = useState(false);
   const [selected, setSelected] = useState<SelectedTarget | null>(null);
   const { comments, error, refetch, add, remove } = useComments(slideId);
   const { applyEdit, applyEdits } = useEditor(slideId);
   const history = useHistory();
-  const active = manualActive || heldActive;
-  const manualActiveRef = useRef(manualActive);
 
   const pendingRef = useRef<Map<string, Bucket>>(new Map());
   const instanceCounterRef = useRef(0);
@@ -919,24 +915,15 @@ export function InspectorProvider({
     return () => observer.disconnect();
   }, [selected]);
 
-  const activate = useCallback(() => {
-    manualActiveRef.current = true;
-    setManualActive(true);
+  const toggle = useCallback(() => {
+    setActive((a) => {
+      if (a) setSelected(null);
+      return !a;
+    });
   }, []);
 
-  const toggle = useCallback(() => {
-    setManualActive((a) => {
-      if (a && !heldActive) setSelected(null);
-      const next = !a;
-      manualActiveRef.current = next;
-      return next;
-    });
-  }, [heldActive]);
-
   const cancel = useCallback(() => {
-    manualActiveRef.current = false;
-    setManualActive(false);
-    setHeldActive(false);
+    setActive(false);
     setSelected(null);
   }, []);
 
@@ -960,39 +947,6 @@ export function InspectorProvider({
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [toggle]);
-
-  useEffect(() => {
-    if (import.meta.env.PROD) return;
-
-    const isApplePlatform = /Mac|iPhone|iPad|iPod/.test(
-      `${navigator.platform} ${navigator.userAgent}`,
-    );
-    const holdKey = isApplePlatform ? 'Meta' : 'Control';
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.repeat) return;
-      if (e.target instanceof HTMLElement && e.target.matches('input, textarea')) return;
-      if (e.key !== holdKey) return;
-      setHeldActive(true);
-    };
-
-    const releaseHeld = (e?: KeyboardEvent) => {
-      if (e && e.key !== holdKey) return;
-      setHeldActive(false);
-      if (!manualActiveRef.current) setSelected(null);
-    };
-
-    const onBlur = () => releaseHeld();
-
-    window.addEventListener('keydown', onKeyDown, true);
-    window.addEventListener('keyup', releaseHeld, true);
-    window.addEventListener('blur', onBlur, true);
-    return () => {
-      window.removeEventListener('keydown', onKeyDown, true);
-      window.removeEventListener('keyup', releaseHeld, true);
-      window.removeEventListener('blur', onBlur, true);
-    };
-  }, []);
 
   const openCrop = useCallback((anchor: HTMLImageElement) => {
     const loc = anchor.dataset.slideLoc;
@@ -1019,7 +973,6 @@ export function InspectorProvider({
     () => ({
       slideId,
       active,
-      activate,
       toggle,
       cancel,
       comments,
@@ -1042,7 +995,6 @@ export function InspectorProvider({
     [
       slideId,
       active,
-      activate,
       toggle,
       cancel,
       comments,


### PR DESCRIPTION
Reverts #247.

## Summary

Removes the inspector quick activation gestures added in #247:

- Holding **Command** (macOS) / **Control** (elsewhere) to open the inspector.
- **Double-click** to select an element via the inspector.

The two touched files (`inspect-overlay.tsx`, `inspector-provider.tsx`) are restored exactly to their pre-#247 state. A `patch` changeset is included.

## Validation

- `pnpm check`
- `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Reverted the inspector’s quick-activation gestures, including modifier-key hold behavior and double-click selection changes.

* **Bug Fixes**
  * Simplified inspector activation to use a single toggle shortcut.
  * Improved hover and click handling so inspector UI interactions no longer interfere with selecting elements.
  * Double-click now only opens cropping for image elements, reducing accidental actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->