### PR TITLE
Preload upcoming slide assets to eliminate font flashes and image pop-in

### DIFF
--- a/.changeset/slide-asset-preload.md
+++ b/.changeset/slide-asset-preload.md
@@ -2,4 +2,4 @@
 '@open-slide/core': patch
 ---
 
-Preload upcoming pages' images and fonts in a hidden layer during present and presenter modes, eliminating font flashes and image pop-in when navigating slides.
+Preload every page's images and fonts behind the deck loading screen — slides and presenter views first render with all assets cached, eliminating font flashes and image pop-in during playback.

--- a/.changeset/slide-asset-preload.md
+++ b/.changeset/slide-asset-preload.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Preload upcoming pages' images and fonts in a hidden layer during present and presenter modes, eliminating font flashes and image pop-in when navigating slides.

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -24,7 +24,6 @@ import {
 } from './present/use-presenter-channel';
 import { useTouchSwipe } from './present/use-touch-swipe';
 import { SlideCanvas } from './slide-canvas';
-import { SlidePreloadLayer } from './slide-preload-layer';
 import { SlideTransitionLayer } from './slide-transition-layer';
 
 const IDLE_HIDE_MS = 2000;
@@ -414,8 +413,6 @@ export function Player({
           onStepAggregateChange={handleAggregateChange}
         />
       </SlideCanvas>
-
-      <SlidePreloadLayer pages={pages} index={index} design={design} />
 
       {controls && (
         <div data-osd-chrome style={{ display: 'contents' }}>

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -24,6 +24,7 @@ import {
 } from './present/use-presenter-channel';
 import { useTouchSwipe } from './present/use-touch-swipe';
 import { SlideCanvas } from './slide-canvas';
+import { SlidePreloadLayer } from './slide-preload-layer';
 import { SlideTransitionLayer } from './slide-transition-layer';
 
 const IDLE_HIDE_MS = 2000;
@@ -413,6 +414,8 @@ export function Player({
           onStepAggregateChange={handleAggregateChange}
         />
       </SlideCanvas>
+
+      <SlidePreloadLayer pages={pages} index={index} design={design} />
 
       {controls && (
         <div data-osd-chrome style={{ display: 'contents' }}>

--- a/packages/core/src/app/components/slide-preload-layer.tsx
+++ b/packages/core/src/app/components/slide-preload-layer.tsx
@@ -11,7 +11,22 @@ type Props = {
   pages: Page[];
   index: number;
   design?: DesignSystem;
+  /** Also warm the page at `index` — for use while no page is live yet. */
+  includeCurrent?: boolean;
+  onDone?: () => void;
 };
+
+// Per-document registry so a deck gates the UI on its first open only —
+// revisits within the same tab skip straight to the slides.
+const warmedDecks = new Set<string>();
+
+export function isDeckWarmed(slideId: string): boolean {
+  return warmedDecks.has(slideId);
+}
+
+export function markDeckWarmed(slideId: string): void {
+  warmedDecks.add(slideId);
+}
 
 function nextFrame(): Promise<void> {
   return new Promise((resolve) => requestAnimationFrame(() => resolve()));
@@ -36,12 +51,12 @@ function saveDataEnabled(): boolean {
   return connection?.saveData === true;
 }
 
-// Nearest upcoming pages first, wrapping around, skipping the live page.
-function computeWarmupOrder(pages: Page[], index: number): number[] {
+// Nearest upcoming pages first, wrapping around.
+function computeWarmupOrder(pages: Page[], index: number, includeCurrent: boolean): number[] {
   if (saveDataEnabled()) return [];
   const start = Math.max(0, Math.min(pages.length - 1, index));
   const result: number[] = [];
-  for (let step = 1; step < pages.length; step++) {
+  for (let step = includeCurrent ? 0 : 1; step < pages.length; step++) {
     result.push((start + step) % pages.length);
   }
   return result;
@@ -58,26 +73,34 @@ function computeWarmupOrder(pages: Page[], index: number): number[] {
  * boxes trigger background-image loads), and the whole layer unmounts once
  * fonts and images have settled — by then everything sits in the HTTP cache.
  */
-export function SlidePreloadLayer({ pages, index, design }: Props) {
+export function SlidePreloadLayer({ pages, index, design, includeCurrent = false, onDone }: Props) {
   // Warm-up order is captured on mount, not on every index change — later
   // navigation must not restart the sequence. But the deck itself can change
   // under a reused component instance (a client-side slide switch keeps this
   // route mounted, and the editor mutates `pages` on reorder/add/delete), so
   // recompute from scratch whenever the `pages` identity changes.
   const [deck, setDeck] = useState(pages);
-  const [order, setOrder] = useState<number[]>(() => computeWarmupOrder(pages, index));
+  const [order, setOrder] = useState<number[]>(() =>
+    computeWarmupOrder(pages, index, includeCurrent),
+  );
   const [mountedCount, setMountedCount] = useState(0);
   const [done, setDone] = useState(order.length === 0);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const controllerRef = useRef<StepController | null>(null);
 
   if (deck !== pages) {
-    const nextOrder = computeWarmupOrder(pages, index);
+    const nextOrder = computeWarmupOrder(pages, index, includeCurrent);
     setDeck(pages);
     setOrder(nextOrder);
     setMountedCount(0);
     setDone(nextOrder.length === 0);
   }
+
+  const onDoneRef = useRef(onDone);
+  onDoneRef.current = onDone;
+  useEffect(() => {
+    if (done) onDoneRef.current?.();
+  }, [done]);
 
   useEffect(() => {
     if (done || mountedCount >= order.length) return;

--- a/packages/core/src/app/components/slide-preload-layer.tsx
+++ b/packages/core/src/app/components/slide-preload-layer.tsx
@@ -36,6 +36,17 @@ function saveDataEnabled(): boolean {
   return connection?.saveData === true;
 }
 
+// Nearest upcoming pages first, wrapping around, skipping the live page.
+function computeWarmupOrder(pages: Page[], index: number): number[] {
+  if (saveDataEnabled()) return [];
+  const start = Math.max(0, Math.min(pages.length - 1, index));
+  const result: number[] = [];
+  for (let step = 1; step < pages.length; step++) {
+    result.push((start + step) % pages.length);
+  }
+  return result;
+}
+
 /**
  * Mounts every non-visible page of the deck in a hidden layer so the browser
  * fetches their images and font faces before the audience navigates to them —
@@ -48,21 +59,25 @@ function saveDataEnabled(): boolean {
  * fonts and images have settled — by then everything sits in the HTTP cache.
  */
 export function SlidePreloadLayer({ pages, index, design }: Props) {
-  // Snapshot the warm-up order once: nearest upcoming pages first, wrapping
-  // around, skipping the live page. Later index changes must not restart it.
-  const [order] = useState<number[]>(() => {
-    if (saveDataEnabled()) return [];
-    const start = Math.max(0, Math.min(pages.length - 1, index));
-    const result: number[] = [];
-    for (let step = 1; step < pages.length; step++) {
-      result.push((start + step) % pages.length);
-    }
-    return result;
-  });
+  // Warm-up order is captured on mount, not on every index change — later
+  // navigation must not restart the sequence. But the deck itself can change
+  // under a reused component instance (a client-side slide switch keeps this
+  // route mounted, and the editor mutates `pages` on reorder/add/delete), so
+  // recompute from scratch whenever the `pages` identity changes.
+  const [deck, setDeck] = useState(pages);
+  const [order, setOrder] = useState<number[]>(() => computeWarmupOrder(pages, index));
   const [mountedCount, setMountedCount] = useState(0);
   const [done, setDone] = useState(order.length === 0);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const controllerRef = useRef<StepController | null>(null);
+
+  if (deck !== pages) {
+    const nextOrder = computeWarmupOrder(pages, index);
+    setDeck(pages);
+    setOrder(nextOrder);
+    setMountedCount(0);
+    setDone(nextOrder.length === 0);
+  }
 
   useEffect(() => {
     if (done || mountedCount >= order.length) return;

--- a/packages/core/src/app/components/slide-preload-layer.tsx
+++ b/packages/core/src/app/components/slide-preload-layer.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState } from 'react';
+import { type DesignSystem, designToCssVars } from '../lib/design';
+import { SlidePageProvider } from '../lib/page-context';
+import { CANVAS_HEIGHT, CANVAS_WIDTH, type Page } from '../lib/sdk';
+import { type StepController, StepHost } from '../lib/step-context';
+
+const PAGES_PER_FRAME = 2;
+const SETTLE_TIMEOUT_MS = 15_000;
+
+type Props = {
+  pages: Page[];
+  index: number;
+  design?: DesignSystem;
+};
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function waitForImages(root: HTMLElement): Promise<unknown> {
+  const pending = Array.from(root.querySelectorAll('img'))
+    .filter((img) => !img.complete)
+    .map(
+      (img) =>
+        new Promise<void>((resolve) => {
+          img.addEventListener('load', () => resolve(), { once: true });
+          img.addEventListener('error', () => resolve(), { once: true });
+        }),
+    );
+  return Promise.all(pending);
+}
+
+function saveDataEnabled(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const connection = (navigator as Navigator & { connection?: { saveData?: boolean } }).connection;
+  return connection?.saveData === true;
+}
+
+/**
+ * Mounts every non-visible page of the deck in a hidden layer so the browser
+ * fetches their images and font faces before the audience navigates to them —
+ * without this, each page's assets only start downloading on entry, which
+ * shows up as font flashes and image pop-in mid-presentation.
+ *
+ * Pages mount a few per frame to keep the first slide's paint smooth, stay
+ * `visibility: hidden` (layout still runs, so text triggers font loads and
+ * boxes trigger background-image loads), and the whole layer unmounts once
+ * fonts and images have settled — by then everything sits in the HTTP cache.
+ */
+export function SlidePreloadLayer({ pages, index, design }: Props) {
+  // Snapshot the warm-up order once: nearest upcoming pages first, wrapping
+  // around, skipping the live page. Later index changes must not restart it.
+  const [order] = useState<number[]>(() => {
+    if (saveDataEnabled()) return [];
+    const start = Math.max(0, Math.min(pages.length - 1, index));
+    const result: number[] = [];
+    for (let step = 1; step < pages.length; step++) {
+      result.push((start + step) % pages.length);
+    }
+    return result;
+  });
+  const [mountedCount, setMountedCount] = useState(0);
+  const [done, setDone] = useState(order.length === 0);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const controllerRef = useRef<StepController | null>(null);
+
+  useEffect(() => {
+    if (done || mountedCount >= order.length) return;
+    const raf = requestAnimationFrame(() => {
+      setMountedCount((n) => Math.min(order.length, n + PAGES_PER_FRAME));
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [done, mountedCount, order.length]);
+
+  useEffect(() => {
+    if (done || mountedCount < order.length) return;
+    let cancelled = false;
+    const settle = async () => {
+      // Two frames of layout so newly mounted text has kicked off its font
+      // requests before `document.fonts.ready` takes a snapshot.
+      await nextFrame();
+      await nextFrame();
+      const root = rootRef.current;
+      await Promise.all([
+        'fonts' in document ? document.fonts.ready : Promise.resolve(),
+        root ? waitForImages(root) : Promise.resolve(),
+      ]);
+    };
+    const timeout = new Promise<void>((resolve) => setTimeout(resolve, SETTLE_TIMEOUT_MS));
+    Promise.race([settle(), timeout]).then(() => {
+      if (!cancelled) setDone(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [done, mountedCount, order.length]);
+
+  if (done) return null;
+
+  return (
+    <div
+      ref={rootRef}
+      aria-hidden
+      data-osd-freeze-motion=""
+      style={{
+        position: 'absolute',
+        inset: 0,
+        overflow: 'hidden',
+        visibility: 'hidden',
+        pointerEvents: 'none',
+        ...(design ? designToCssVars(design) : {}),
+      }}
+    >
+      {order.slice(0, mountedCount).map((pageIndex) => {
+        const PageComponent = pages[pageIndex];
+        if (!PageComponent) return null;
+        return (
+          <div
+            key={pageIndex}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: CANVAS_WIDTH,
+              height: CANVAS_HEIGHT,
+            }}
+          >
+            <SlidePageProvider index={pageIndex} total={pages.length}>
+              <StepHost
+                isActivePage={false}
+                entryDirection="backward"
+                controllerRef={controllerRef}
+              >
+                <PageComponent />
+              </StepHost>
+            </SlidePageProvider>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -9,7 +9,7 @@ import {
   usePresenterChannel,
 } from '../components/present/use-presenter-channel';
 import { SlideCanvas } from '../components/slide-canvas';
-import { SlidePreloadLayer } from '../components/slide-preload-layer';
+import { isDeckWarmed, markDeckWarmed, SlidePreloadLayer } from '../components/slide-preload-layer';
 import { SlidePageProvider } from '../lib/page-context';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
 import { type StepController, StepHost } from '../lib/step-context';
@@ -29,6 +29,11 @@ export function Presenter() {
   const [hasProjection, setHasProjection] = useState(false);
   const requestedRef = useRef(false);
   const t = useLocale();
+  const [, setWarmedTick] = useState(0);
+  const handleAssetsWarmed = useCallback(() => {
+    markDeckWarmed(slideId);
+    setWarmedTick((n) => n + 1);
+  }, [slideId]);
 
   const channel = usePresenterChannel(slideId, (msg) => {
     if (msg.type === 'state') {
@@ -131,9 +136,33 @@ export function Presenter() {
   const CurrentPage = pages[index];
   const NextPage = hasNext ? pages[nextPageIndex] : null;
 
+  // Hold the loader while a hidden layer warms the whole deck's images and
+  // fonts, so the previews first paint with every asset already in cache.
+  if (!isDeckWarmed(slideId)) {
+    return (
+      <div className="dark grid h-dvh place-items-center bg-background text-muted-foreground">
+        <div className="flex flex-col items-center gap-4">
+          <div className="relative h-px w-56 overflow-hidden bg-border">
+            <span
+              aria-hidden
+              className="line-loader-bar absolute inset-y-[-0.5px] left-0 w-1/4 bg-foreground"
+            />
+          </div>
+          <div className="text-[11.5px]">{t.presenter.loadingAssets}</div>
+        </div>
+        <SlidePreloadLayer
+          pages={pages}
+          index={index}
+          design={slide.design}
+          includeCurrent
+          onDone={handleAssetsWarmed}
+        />
+      </div>
+    );
+  }
+
   return (
-    <div className="dark relative flex h-dvh w-screen flex-col overflow-hidden bg-background text-foreground">
-      <SlidePreloadLayer pages={pages} index={index} design={slide.design} />
+    <div className="dark flex h-dvh w-screen flex-col overflow-hidden bg-background text-foreground">
       <PresenterTopBar
         index={index}
         total={total}

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -9,6 +9,7 @@ import {
   usePresenterChannel,
 } from '../components/present/use-presenter-channel';
 import { SlideCanvas } from '../components/slide-canvas';
+import { SlidePreloadLayer } from '../components/slide-preload-layer';
 import { SlidePageProvider } from '../lib/page-context';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
 import { type StepController, StepHost } from '../lib/step-context';
@@ -131,7 +132,8 @@ export function Presenter() {
   const NextPage = hasNext ? pages[nextPageIndex] : null;
 
   return (
-    <div className="dark flex h-dvh w-screen flex-col overflow-hidden bg-background text-foreground">
+    <div className="dark relative flex h-dvh w-screen flex-col overflow-hidden bg-background text-foreground">
+      <SlidePreloadLayer pages={pages} index={index} design={slide.design} />
       <PresenterTopBar
         index={index}
         total={total}

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -55,6 +55,7 @@ import { PdfProgressToast } from '../components/pdf-progress-toast';
 import { openPresenterWindow, Player } from '../components/player';
 import { PptxProgressToast } from '../components/pptx-progress-toast';
 import { SlideCanvas } from '../components/slide-canvas';
+import { isDeckWarmed, markDeckWarmed, SlidePreloadLayer } from '../components/slide-preload-layer';
 import { SlideTransitionLayer } from '../components/slide-transition-layer';
 import { type ThumbnailActions, ThumbnailRail } from '../components/thumbnail-rail';
 import { exportSlideAsHtml } from '../lib/export-html';
@@ -77,6 +78,11 @@ export function Slide() {
   const linkCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [designOpen, setDesignOpen] = useState(false);
   const [overviewOpen, setOverviewOpen] = useState(false);
+  const [, setWarmedTick] = useState(0);
+  const handleAssetsWarmed = useCallback(() => {
+    markDeckWarmed(slideId);
+    setWarmedTick((n) => n + 1);
+  }, [slideId]);
 
   useEffect(() => {
     return () => {
@@ -343,6 +349,34 @@ export function Slide() {
           </code>
           {t.slide.emptyHintSuffix}
         </p>
+      </div>
+    );
+  }
+
+  // Hold the loader while a hidden layer warms the whole deck's images and
+  // fonts, so the slide UI first paints with every asset already in cache.
+  if (view !== 'assets' && !isDeckWarmed(slideId)) {
+    return (
+      <div className="grid min-h-dvh place-items-center px-8 text-muted-foreground">
+        <div className="flex flex-col items-center gap-4">
+          <div className="relative h-px w-56 overflow-hidden bg-hairline">
+            <span
+              aria-hidden
+              className="line-loader-bar absolute inset-y-[-0.5px] left-0 w-1/4 bg-foreground"
+            />
+          </div>
+          <div className="flex flex-wrap items-baseline justify-center gap-x-2 text-[11.5px]">
+            <span className="eyebrow">{t.slide.loadingAssetsEyebrow}</span>
+            <span className="font-mono">{slideId}</span>
+          </div>
+        </div>
+        <SlidePreloadLayer
+          pages={pages}
+          index={index}
+          design={slide.design}
+          includeCurrent
+          onDone={handleAssetsWarmed}
+        />
       </div>
     );
   }

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -131,6 +131,7 @@ export const en: Locale = {
     assetsTab: 'Assets',
     renameSlide: 'Rename slide',
     loadingEyebrow: 'Loading',
+    loadingAssetsEyebrow: 'Loading assets',
     emptyEyebrow: 'Empty',
     nothingToShow: 'Nothing to show.',
     emptyHintPrefix: '',
@@ -160,6 +161,7 @@ export const en: Locale = {
     elapsed: 'Elapsed',
     jump: 'Jump',
     loadingSlide: 'Loading {slideId}…',
+    loadingAssets: 'Loading assets…',
   },
 
   present: {

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -132,6 +132,7 @@ export const ja: Locale = {
     assetsTab: 'アセット',
     renameSlide: 'スライドの名前を変更',
     loadingEyebrow: '読み込み中',
+    loadingAssetsEyebrow: 'アセットを読み込み中',
     emptyEyebrow: '空',
     nothingToShow: '表示する内容がありません。',
     emptyHintPrefix: '',
@@ -161,6 +162,7 @@ export const ja: Locale = {
     elapsed: '経過時間',
     jump: 'ジャンプ',
     loadingSlide: '{slideId} を読み込み中…',
+    loadingAssets: 'アセットを読み込み中…',
   },
 
   present: {

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -131,6 +131,7 @@ export type Locale = {
     assetsTab: string;
     renameSlide: string;
     loadingEyebrow: string;
+    loadingAssetsEyebrow: string;
     emptyEyebrow: string;
     nothingToShow: string;
     emptyHintPrefix: string;
@@ -161,6 +162,7 @@ export type Locale = {
     jump: string;
     /** template: "Loading {slideId}…" */
     loadingSlide: string;
+    loadingAssets: string;
   };
 
   present: {

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -129,6 +129,7 @@ export const zhCN: Locale = {
     assetsTab: '素材',
     renameSlide: '重命名幻灯片',
     loadingEyebrow: '加载中',
+    loadingAssetsEyebrow: '加载资源中',
     emptyEyebrow: '空白',
     nothingToShow: '没有可显示的内容。',
     emptyHintPrefix: '',
@@ -158,6 +159,7 @@ export const zhCN: Locale = {
     elapsed: '已用时',
     jump: '跳至',
     loadingSlide: '正在加载 {slideId}…',
+    loadingAssets: '正在加载资源…',
   },
 
   present: {

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -129,6 +129,7 @@ export const zhTW: Locale = {
     assetsTab: '素材',
     renameSlide: '重新命名投影片',
     loadingEyebrow: '載入中',
+    loadingAssetsEyebrow: '載入資源中',
     emptyEyebrow: '空白',
     nothingToShow: '沒有可顯示的內容。',
     emptyHintPrefix: '',
@@ -158,6 +159,7 @@ export const zhTW: Locale = {
     elapsed: '已耗時',
     jump: '跳至',
     loadingSlide: '正在載入 {slideId}…',
+    loadingAssets: '正在載入資源…',
   },
 
   present: {


### PR DESCRIPTION
Adds a hidden preload layer that mounts non-visible pages during present and presenter modes, allowing the browser to fetch their images and font faces before navigation. This eliminates font flashes and image pop-in when the audience navigates to upcoming slides.

## Changes

- **New component `SlidePreloadLayer`**: Mounts pages in a hidden layer (`visibility: hidden`) to trigger asset downloads without blocking the active slide's paint. Pages mount a few per frame to keep the first slide smooth, and the layer unmounts once fonts and images have settled into the HTTP cache.
  - Respects the `Save-Data` header and skips preloading if enabled
  - Waits for `document.fonts.ready` and all images to load before unmounting
  - Includes a 15-second timeout to prevent indefinite waiting
  
- **Integration**: Added `SlidePreloadLayer` to both `Presenter` and `Player` components, passing the current page index and design system so preloading starts from the next upcoming page and wraps around the deck.

## Implementation details

- Pages are mounted in order of proximity (nearest upcoming first, wrapping around), skipping the currently active page
- Uses `requestAnimationFrame` to batch mounting (2 pages per frame) and avoid layout thrashing
- Waits for two frames after mounting before checking font readiness, ensuring newly mounted text has kicked off font requests
- Layer is positioned absolutely and marked `aria-hidden` with `pointer-events: none` to keep it invisible and non-interactive

https://claude.ai/code/session_01EZjVgYekH8jzboyXwoy6DG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slides and presenter view now preload assets before showing the main UI, helping reduce font flashes and image pop-in.
  * A warm-up state is now tracked per deck so previously loaded decks can open faster within the same tab.

* **Bug Fixes**
  * Improved loading behavior when navigating slides, with a clearer loading screen until assets are ready.

* **Localization**
  * Added new loading messages in English, Japanese, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->