### PR TITLE
Fix slide content bleeding through the asset loading screen

### DIFF
--- a/.changeset/preload-layer-opacity.md
+++ b/.changeset/preload-layer-opacity.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Fix slide content bleeding through the asset loading screen when pages contain revealed steps.

--- a/packages/core/src/app/components/slide-preload-layer.tsx
+++ b/packages/core/src/app/components/slide-preload-layer.tsx
@@ -145,6 +145,11 @@ export function SlidePreloadLayer({ pages, index, design, includeCurrent = false
         inset: 0,
         overflow: 'hidden',
         visibility: 'hidden',
+        // Descendants can override inherited visibility back to visible —
+        // <Step> does exactly that on revealed steps. Group opacity can't be
+        // overridden from inside, and an opacity<1 ancestor also becomes the
+        // containing block for position:fixed content, so nothing escapes.
+        opacity: 0,
         pointerEvents: 'none',
         ...(design ? designToCssVars(design) : {}),
       }}


### PR DESCRIPTION
Follow-up to #287. Decks whose pages use `<Steps>` painted their revealed step content on top of the "Loading assets" screen while the hidden preload layer warmed the deck.

## Root cause

CSS `visibility` is inherited but overridable: a descendant can set `visibility: visible` and punch through an ancestor's `visibility: hidden`. The `<Step>` component does exactly that — revealed steps carry inline `visibility: 'visible'` — so any step content inside the preload layer became visible over the loader.

## Fix

Add `opacity: 0` to the preload layer root. Group opacity can't be overridden by descendants, layout still runs (so fonts and images keep preloading), and an `opacity < 1` ancestor also becomes the containing block for `position: fixed` descendants, so nothing inside the layer can paint. The existing `visibility: hidden` stays as a second line of defense.

## Verification

Against a production build, with a Steps + image deck and image responses artificially delayed to hold the gate open:

- Mid-gate DOM probe: revealed `<Step>` elements inside the layer compute `visibility: visible` (40/40 on the `steps-in-motion` deck) — the bleed vector is real and active
- Mid-gate screenshot: loader renders clean — hairline + "Loading assets" only, no deck content
- Gate still completes and the slide UI appears; fonts/images preloading behavior unchanged (biome + 273 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZjVgYekH8jzboyXwoy6DG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZjVgYekH8jzboyXwoy6DG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented slide content from showing through the asset loading screen on pages with revealed steps.
  * Improved the hidden preloading layer so content stays fully concealed while loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->