### PR TITLE
fix: keep <Steps> reveals working in the read-only build

### DIFF
--- a/.changeset/steps-reveal-published-build.md
+++ b/.changeset/steps-reveal-published-build.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Reveal `<Steps>` one at a time in the read-only build (`showSlideUi: false`) instead of skipping straight to the next slide on Space/Arrow.

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -244,7 +244,10 @@ export function Slide() {
   );
 
   useEffect(() => {
-    if (playMode) return;
+    // When showSlideUi is false the read-only <Player> is rendered and owns
+    // keyboard navigation (including step-aware advance/retreat). Attaching this
+    // page-nav handler too would race it and skip <Steps> reveals, so bail out.
+    if (playMode || !showSlideUi) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.target instanceof HTMLElement && e.target.matches('input, textarea')) return;
       // Letter shortcuts only fire bare so browser combos (Cmd/Ctrl-P, ⌘F…) stay intact.


### PR DESCRIPTION
## Summary

In the read-only build (`build.showSlideUi: false`), pressing <kbd>Space</kbd>/<kbd>→</kbd> on a page with `<Steps>` skips the reveal and jumps straight to the next slide. Stepping works in the dev editor and in present mode — only the deployed read-only viewer is affected.

## Root cause

`routes/slide.tsx` has three render paths, with different owners of keyboard navigation:

| Condition | Renders | Who handles keys |
| --- | --- | --- |
| `!showSlideUi` | read-only `<Player>` | the Player (step-aware) |
| `playMode` | `<Player controls>` | the Player (step-aware) |
| otherwise | editor inline view (no Player) | `Slide()`'s own keydown handler |

That handler is registered in a `useEffect`, guarded only by `if (playMode) return`. Because hooks run **before** the early `return <Player .../>` branches, the effect still executes on the read-only path and attaches a second global `keydown` listener. On <kbd>Space</kbd> both fire:

- the Player's handler calls `stepController.advance()` → would reveal the next step;
- `slide.tsx`'s handler calls `goTo(index + 1)` → changes the page.

The page change wins, so `<Steps>` never advances. Dev was unaffected because it forces `showSlideUi: true` (the editor path, where this handler is the intended navigator), and present mode was already excluded by the `playMode` guard.

## Reproduction

`open-slide.config.ts`

```ts
import type { OpenSlideConfig } from '@open-slide/core';

export default { build: { showSlideUi: false } } satisfies OpenSlideConfig;
```

`slides/steps-repro/index.tsx`

```tsx
import { Step, Steps, type Page } from '@open-slide/core';

const StepsPage: Page = () => (
  <div style={{ width: 1920, height: 1080, display: 'flex', flexDirection: 'column', gap: 24, justifyContent: 'center', padding: 120 }}>
    <div>Row 1</div>
    <Steps>
      <Step><div>Row 2</div></Step>
      <Step><div>Row 3</div></Step>
    </Steps>
  </div>
);

const Next: Page = () => (
  <div style={{ width: 1920, height: 1080, display: 'grid', placeItems: 'center' }}>Next slide</div>
);

export default [StepsPage, Next] satisfies Page[];
```

```bash
open-slide build && open-slide preview
```

Open the Steps page and press <kbd>Space</kbd>:

- **Before:** jumps to "Next slide"; Row 2 / Row 3 never appear.
- **After:** reveals Row 2, then Row 3, and only then advances to "Next slide".

## Fix

```diff
   useEffect(() => {
-    if (playMode) return;
+    // When showSlideUi is false the read-only <Player> is rendered and owns
+    // keyboard navigation (including step-aware advance/retreat). Attaching this
+    // page-nav handler too would race it and skip <Steps> reveals, so bail out.
+    if (playMode || !showSlideUi) return;
     const onKey = (e: KeyboardEvent) => {
```

The handler now attaches only in the editor inline view (`!playMode && showSlideUi`), where it is the sole navigator.

## Notes

- No behavior change in dev/editor (`showSlideUi` forced `true`) or present mode (already excluded by `playMode`).
- The extra shortcuts this handler owns (`o`, `f`, `Enter`, `p`) were already inert in the read-only build, since the `!showSlideUi` return short-circuits before `playMode` is ever consulted — so nothing is lost by bailing there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved step navigation in the read-only viewer so steps now reveal one at a time instead of jumping ahead when using keyboard controls.
  * Prevented an extra keyboard handler from being attached in read-only mode, avoiding conflicts with built-in navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->