### PR TITLE
fix: apply deck transitions in the read-only build

### DIFF
--- a/.changeset/published-slide-transitions.md
+++ b/.changeset/published-slide-transitions.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Play a deck's exported `transition` in the read-only build (`showSlideUi: false`) instead of swapping pages instantly.

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -386,6 +386,7 @@ export function Slide() {
       <Player
         pages={pages}
         design={slide.design}
+        transition={slide.transition}
         index={index}
         onIndexChange={goTo}
         onExit={() => {}}


### PR DESCRIPTION
## Summary

A deck that exports a `transition` animates page changes in the dev editor and in present mode, but swaps pages instantly in the read-only build (`build.showSlideUi: false`).

## Root cause

`routes/slide.tsx` renders `<Player>` on two paths. The present-mode path forwards `transition={slide.transition}`; the read-only path does not:

```tsx
if (!showSlideUi) {
  return (
    <Player
      pages={pages}
      design={slide.design}
      // no transition prop
      index={index}
      onIndexChange={goTo}
      onExit={() => {}}
      allowExit={false}
    />
  );
}
```

With no `transition`, `SlideTransitionLayer` resolves nothing to run and updates `current` immediately, so no enter/exit animation plays.

## Reproduction

`open-slide.config.ts`

```ts
import type { OpenSlideConfig } from '@open-slide/core';

export default { build: { showSlideUi: false } } satisfies OpenSlideConfig;
```

`slides/fade-repro/index.tsx`

```tsx
import type { Page, SlideTransition } from '@open-slide/core';

export const transition: SlideTransition = {
  duration: 220,
  exit: { duration: 150, keyframes: [{ opacity: 1 }, { opacity: 0 }] },
  enter: { duration: 220, delay: 70, keyframes: [{ opacity: 0 }, { opacity: 1 }] },
};

const page = (label: string): Page => () => (
  <div style={{ width: 1920, height: 1080, display: 'grid', placeItems: 'center', fontSize: 120 }}>
    {label}
  </div>
);

export default [page('One'), page('Two')] satisfies Page[];
```

```bash
open-slide build && open-slide preview
```

Navigate between the two pages:

- **Before:** instant swap; `document.getAnimations()` is empty during the change.
- **After:** the fade plays; `document.getAnimations()` reports the enter/exit animations, then settles.

## Fix

```diff
   if (!showSlideUi) {
     return (
       <Player
         pages={pages}
         design={slide.design}
+        transition={slide.transition}
         index={index}
         onIndexChange={goTo}
         onExit={() => {}}
         allowExit={false}
       />
     );
   }
```

This mirrors the present-mode path, which already forwards `slide.transition`.

## Notes

- `SlideTransitionLayer` still receives `disabled={prefersReducedMotion}` on this path, so reduced-motion users are unaffected.