### PR TITLE
feat(core): add adjustable speaker notes text size in presenter view

### DIFF
--- a/.changeset/presenter-notes-font-size.md
+++ b/.changeset/presenter-notes-font-size.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Add adjustable speaker notes text size in presenter view, persisted across sessions.

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -1,4 +1,12 @@
-import { ChevronLeft, ChevronRight, RotateCcw, Square, Sun } from 'lucide-react';
+import {
+  AArrowDown,
+  AArrowUp,
+  ChevronLeft,
+  ChevronRight,
+  RotateCcw,
+  Square,
+  Sun,
+} from 'lucide-react';
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
@@ -221,22 +229,7 @@ export function Presenter() {
             </div>
           </div>
 
-          <div className="flex min-h-0 flex-1 flex-col gap-2">
-            <SectionLabel>{t.presenter.speakerNotes}</SectionLabel>
-            <div className="min-h-0 flex-1 overflow-y-auto rounded-[6px] border border-border bg-card p-3 text-[13.5px] leading-relaxed whitespace-pre-wrap text-card-foreground">
-              {note?.trim() ? (
-                note
-              ) : (
-                <span className="text-muted-foreground">
-                  {t.presenter.noNotesPrefix}
-                  <code className="rounded-[3px] bg-muted px-1 py-0.5 font-mono text-[12px]">
-                    export const notes = […]
-                  </code>
-                  {t.presenter.noNotesSuffix}
-                </span>
-              )}
-            </div>
-          </div>
+          <SpeakerNotes note={note} />
 
           <PresenterJumpControl total={total} current={index} onJump={goTo} />
         </aside>
@@ -347,6 +340,71 @@ function PresenterBottomBar({
         </Button>
       </div>
     </footer>
+  );
+}
+
+const NOTES_FONT_SIZES = [11, 12, 13.5, 15, 17, 20, 24, 28];
+const NOTES_FONT_SIZE_DEFAULT_INDEX = 2;
+const NOTES_FONT_SIZE_STORAGE_KEY = 'open-slide:presenter-notes-font-size';
+
+function SpeakerNotes({ note }: { note: string | undefined }) {
+  const t = useLocale();
+  const [sizeIndex, setSizeIndex] = useState(() => {
+    if (typeof window === 'undefined') return NOTES_FONT_SIZE_DEFAULT_INDEX;
+    const stored = Number(window.localStorage.getItem(NOTES_FONT_SIZE_STORAGE_KEY));
+    return NOTES_FONT_SIZES.includes(stored)
+      ? NOTES_FONT_SIZES.indexOf(stored)
+      : NOTES_FONT_SIZE_DEFAULT_INDEX;
+  });
+
+  useEffect(() => {
+    window.localStorage.setItem(NOTES_FONT_SIZE_STORAGE_KEY, String(NOTES_FONT_SIZES[sizeIndex]));
+  }, [sizeIndex]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <SectionLabel>{t.presenter.speakerNotes}</SectionLabel>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => setSizeIndex((i) => Math.max(0, i - 1))}
+            disabled={sizeIndex === 0}
+            title={t.presenter.notesTextSmaller}
+            aria-label={t.presenter.notesTextSmaller}
+          >
+            <AArrowDown className="size-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => setSizeIndex((i) => Math.min(NOTES_FONT_SIZES.length - 1, i + 1))}
+            disabled={sizeIndex === NOTES_FONT_SIZES.length - 1}
+            title={t.presenter.notesTextLarger}
+            aria-label={t.presenter.notesTextLarger}
+          >
+            <AArrowUp className="size-4" />
+          </Button>
+        </div>
+      </div>
+      <div
+        className="min-h-0 flex-1 overflow-y-auto rounded-[6px] border border-border bg-card p-3 leading-relaxed whitespace-pre-wrap text-card-foreground"
+        style={{ fontSize: NOTES_FONT_SIZES[sizeIndex] }}
+      >
+        {note?.trim() ? (
+          note
+        ) : (
+          <span className="text-muted-foreground">
+            {t.presenter.noNotesPrefix}
+            <code className="rounded-[3px] bg-muted px-1 py-0.5 font-mono text-[0.9em]">
+              export const notes = […]
+            </code>
+            {t.presenter.noNotesSuffix}
+          </span>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -147,6 +147,8 @@ export const en: Locale = {
     lastSlide: 'Last slide',
     endOfDeck: 'End of deck',
     speakerNotes: 'Speaker notes',
+    notesTextSmaller: 'Make notes text smaller',
+    notesTextLarger: 'Make notes text larger',
     noNotesPrefix: 'No speaker notes for this slide. Add ',
     noNotesSuffix: ' to your slide module to see notes here.',
     blackScreen: 'Black screen',

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -148,6 +148,8 @@ export const ja: Locale = {
     lastSlide: '最後のスライド',
     endOfDeck: 'デッキの終わり',
     speakerNotes: '発表者ノート',
+    notesTextSmaller: 'ノートの文字を小さく',
+    notesTextLarger: 'ノートの文字を大きく',
     noNotesPrefix: 'このスライドには発表者ノートがありません。スライドモジュールに ',
     noNotesSuffix: ' を追加するとここに表示されます。',
     blackScreen: '黒い画面',

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -147,6 +147,8 @@ export type Locale = {
     lastSlide: string;
     endOfDeck: string;
     speakerNotes: string;
+    notesTextSmaller: string;
+    notesTextLarger: string;
     noNotesPrefix: string;
     noNotesSuffix: string;
     blackScreen: string;

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -145,6 +145,8 @@ export const zhCN: Locale = {
     lastSlide: '最后一张',
     endOfDeck: '演示结束',
     speakerNotes: '演讲备注',
+    notesTextSmaller: '缩小备注文字',
+    notesTextLarger: '放大备注文字',
     noNotesPrefix: '该幻灯片没有演讲备注。在你的幻灯片模块中添加 ',
     noNotesSuffix: ' 即可在此查看备注。',
     blackScreen: '黑屏',

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -145,6 +145,8 @@ export const zhTW: Locale = {
     lastSlide: '最後一張',
     endOfDeck: '簡報結束',
     speakerNotes: '演講備忘',
+    notesTextSmaller: '縮小備忘文字',
+    notesTextLarger: '放大備忘文字',
     noNotesPrefix: '此投影片沒有演講備忘。在你的投影片模組中加入 ',
     noNotesSuffix: ' 即可在此查看備忘。',
     blackScreen: '黑屏',


### PR DESCRIPTION
## Summary

Adds font size controls to the speaker notes panel in presenter view, so presenters can bump the notes text up (or down) to a comfortable reading size.

- `AArrowDown` / `AArrowUp` ghost buttons in the SPEAKER NOTES header step through 8 sizes (11–28px, default 13.5px)
- Buttons disable at the min/max bounds
- The chosen size persists in `localStorage` across sessions; invalid stored values fall back to the default
- The no-notes placeholder (including the inline `export const notes = […]` code chunk) scales proportionally via `em` units
- New locale strings (`notesTextSmaller` / `notesTextLarger`) added to en, ja, zh-CN, zh-TW

## Testing

- Verified in the demo app presenter view: sizing up/down, bound disabling, persistence across reload, corrupted `localStorage` value falling back to default, and placeholder rendering at max size
- `pnpm typecheck` and `pnpm check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adjustable speaker notes text sizing in presenter view.
  * Notes text size can be increased or decreased and is remembered between sessions.
  * Added localized controls for changing notes size in English, Japanese, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->