### PR TITLE
feat(core): add offscreen current slide return control

### DIFF
--- a/.changeset/calm-rivers-return.md
+++ b/.changeset/calm-rivers-return.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Show an edge control to return to the current slide when its thumbnail is out of view.

--- a/packages/core/src/app/components/thumbnail-rail-scroll.test.ts
+++ b/packages/core/src/app/components/thumbnail-rail-scroll.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getCenteredThumbnailScrollTop,
+  getThumbnailOffscreenDirection,
+} from './thumbnail-rail-scroll';
+
+describe('getThumbnailOffscreenDirection', () => {
+  const visibleBounds = { visibleTop: 40, visibleBottom: 540 };
+
+  it('reports a thumbnail fully above the visible area', () => {
+    expect(getThumbnailOffscreenDirection({ itemTop: -80, itemBottom: 40, ...visibleBounds })).toBe(
+      'above',
+    );
+  });
+
+  it('reports a thumbnail fully below the visible area', () => {
+    expect(
+      getThumbnailOffscreenDirection({ itemTop: 540, itemBottom: 660, ...visibleBounds }),
+    ).toBe('below');
+  });
+
+  it('keeps the control hidden while a thumbnail is fully visible', () => {
+    expect(
+      getThumbnailOffscreenDirection({ itemTop: 120, itemBottom: 240, ...visibleBounds }),
+    ).toBeNull();
+  });
+
+  it('keeps the control hidden while either edge remains visible', () => {
+    expect(
+      getThumbnailOffscreenDirection({ itemTop: 20, itemBottom: 80, ...visibleBounds }),
+    ).toBeNull();
+    expect(
+      getThumbnailOffscreenDirection({ itemTop: 500, itemBottom: 580, ...visibleBounds }),
+    ).toBeNull();
+  });
+});
+
+describe('getCenteredThumbnailScrollTop', () => {
+  it('centers the thumbnail inside the unobscured viewport', () => {
+    expect(
+      getCenteredThumbnailScrollTop({
+        itemTop: 1040,
+        itemHeight: 120,
+        viewportHeight: 600,
+        topInset: 40,
+      }),
+    ).toBe(780);
+  });
+
+  it('does not scroll before the start of the list', () => {
+    expect(
+      getCenteredThumbnailScrollTop({
+        itemTop: 40,
+        itemHeight: 120,
+        viewportHeight: 600,
+        topInset: 40,
+      }),
+    ).toBe(0);
+  });
+});

--- a/packages/core/src/app/components/thumbnail-rail-scroll.ts
+++ b/packages/core/src/app/components/thumbnail-rail-scroll.ts
@@ -1,0 +1,33 @@
+export type ThumbnailOffscreenDirection = 'above' | 'below' | null;
+
+export function getThumbnailOffscreenDirection({
+  itemTop,
+  itemBottom,
+  visibleTop,
+  visibleBottom,
+}: {
+  itemTop: number;
+  itemBottom: number;
+  visibleTop: number;
+  visibleBottom: number;
+}): ThumbnailOffscreenDirection {
+  if (itemBottom <= visibleTop) return 'above';
+  if (itemTop >= visibleBottom) return 'below';
+  return null;
+}
+
+export function getCenteredThumbnailScrollTop({
+  itemTop,
+  itemHeight,
+  viewportHeight,
+  topInset,
+}: {
+  itemTop: number;
+  itemHeight: number;
+  viewportHeight: number;
+  topInset: number;
+}): number {
+  const visibleHeight = Math.max(0, viewportHeight - topInset);
+  const centerOffset = Math.max(0, (visibleHeight - itemHeight) / 2);
+  return Math.max(0, itemTop - topInset - centerOffset);
+}

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -15,8 +15,18 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Copy, Grid2x2, ListOrdered, type LucideIcon, Sparkles, Trash2 } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronUp,
+  Copy,
+  Grid2x2,
+  ListOrdered,
+  type LucideIcon,
+  Sparkles,
+  Trash2,
+} from 'lucide-react';
 import { Fragment, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
 import {
   ContextMenu,
   ContextMenuContent,
@@ -34,6 +44,11 @@ import type { Page } from '../lib/sdk';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
 import type { SlideTransition } from '../lib/transition';
 import { SlideCanvas } from './slide-canvas';
+import {
+  getCenteredThumbnailScrollTop,
+  getThumbnailOffscreenDirection,
+  type ThumbnailOffscreenDirection,
+} from './thumbnail-rail-scroll';
 
 type Orientation = 'vertical' | 'horizontal';
 
@@ -84,18 +99,23 @@ export function ThumbnailRail({
   onOverview,
 }: Props) {
   const activeRef = useRef<HTMLButtonElement | null>(null);
+  const virtualListRef = useRef<HTMLDivElement | null>(null);
+  const verticalViewportRef = useRef<HTMLElement | null>(null);
+  const focusCurrentAfterScrollRef = useRef(false);
+  const [currentPosition, setCurrentPosition] = useState<ThumbnailOffscreenDirection>(null);
   const t = useLocale();
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `current` triggers re-scroll on selection change
-  useEffect(() => {
-    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const setVerticalScrollElements = useCallback(
+    (viewport: HTMLElement | null, root: HTMLDivElement | null) => {
+      verticalViewportRef.current = viewport;
+      virtualListRef.current = root;
+    },
+    [],
+  );
 
-    activeRef.current?.scrollIntoView({
-      block: 'nearest',
-      inline: 'nearest',
-      behavior: reduceMotion ? 'auto' : 'smooth',
-    });
-  }, [current]);
+  const cancelPendingFocus = useCallback(() => {
+    focusCurrentAfterScrollRef.current = false;
+  }, []);
 
   const thumbWidth =
     width != null
@@ -104,6 +124,52 @@ export function ThumbnailRail({
   const scale = thumbWidth / CANVAS_WIDTH;
   const height = CANVAS_HEIGHT * scale;
   const rowHeight = height + VERTICAL_THUMB_PADDING_Y + VERTICAL_THUMB_GAP;
+
+  const scrollToCurrent = useCallback(
+    (focusCurrent: boolean) => {
+      const viewport = verticalViewportRef.current;
+      const root = virtualListRef.current;
+      if (!viewport || !root || pages.length <= 0) return;
+
+      focusCurrentAfterScrollRef.current = focusCurrent;
+      const clampedCurrent = Math.min(Math.max(current, 0), pages.length - 1);
+      const topInset = root.offsetTop;
+      const itemTop = topInset + clampedCurrent * rowHeight;
+      viewport.scrollTo({
+        top: getCenteredThumbnailScrollTop({
+          itemTop,
+          itemHeight: rowHeight,
+          viewportHeight: viewport.clientHeight,
+          topInset,
+        }),
+        behavior: scrollBehavior(),
+      });
+    },
+    [current, pages.length, rowHeight],
+  );
+
+  useEffect(() => {
+    if (currentPosition !== null || !focusCurrentAfterScrollRef.current) return;
+    let frame = 0;
+    let attempts = 0;
+    const focusCurrent = () => {
+      if (!focusCurrentAfterScrollRef.current) return;
+      const active = activeRef.current;
+      if (active) {
+        active.focus({ preventScroll: true });
+        focusCurrentAfterScrollRef.current = false;
+        return;
+      }
+      attempts += 1;
+      if (attempts < 4) {
+        frame = requestAnimationFrame(focusCurrent);
+      } else {
+        focusCurrentAfterScrollRef.current = false;
+      }
+    };
+    frame = requestAnimationFrame(focusCurrent);
+    return () => cancelAnimationFrame(frame);
+  }, [currentPosition]);
 
   const renderThumb = useCallback(
     (PageComp: Page, i: number) => {
@@ -138,7 +204,7 @@ export function ThumbnailRail({
           ref={active ? activeRef : undefined}
           onClick={() => onSelect(i)}
           aria-label={format(t.thumbnailRail.goToPageAria, { n: i + 1 })}
-          aria-current={active ? 'true' : undefined}
+          aria-current={active ? 'page' : undefined}
           className={thumbButtonClass(active)}
         >
           {inner}
@@ -233,36 +299,102 @@ export function ThumbnailRail({
         current={current}
         rowHeight={rowHeight}
         activeRef={activeRef}
+        onScrollElementsChange={setVerticalScrollElements}
+        onScrollInteraction={cancelPendingFocus}
+        onCurrentPositionChange={setCurrentPosition}
         renderThumb={renderThumb}
       />
     </aside>
   );
 
-  if (!onReorder) {
-    return (
-      <TooltipProvider delayDuration={200}>
-        <ScrollArea className="h-full border-r border-hairline bg-sidebar [&_[data-slot=scroll-area-scrollbar]]:z-20">
-          {list}
-        </ScrollArea>
-      </TooltipProvider>
-    );
-  }
+  const scrollAreaContents = onReorder ? (
+    <SortableRail pages={pages} onReorder={onReorder} onSelect={onSelect}>
+      {list}
+    </SortableRail>
+  ) : (
+    list
+  );
 
   return (
     <TooltipProvider delayDuration={200}>
-      <ScrollArea className="h-full border-r border-hairline bg-sidebar [&_[data-slot=scroll-area-scrollbar]]:z-20">
-        <SortableRail pages={pages} onReorder={onReorder} onSelect={onSelect}>
-          {list}
-        </SortableRail>
-      </ScrollArea>
+      <div className="relative h-full">
+        <ScrollArea className="h-full border-r border-hairline bg-sidebar [&_[data-slot=scroll-area-scrollbar]]:z-20">
+          {scrollAreaContents}
+        </ScrollArea>
+        {currentPosition && (
+          <CurrentThumbnailButton
+            direction={currentPosition}
+            label={format(
+              currentPosition === 'above'
+                ? t.thumbnailRail.scrollUpToCurrentPage
+                : t.thumbnailRail.scrollDownToCurrentPage,
+              { n: current + 1 },
+            )}
+            onActivate={scrollToCurrent}
+          />
+        )}
+      </div>
     </TooltipProvider>
+  );
+}
+
+function CurrentThumbnailButton({
+  direction,
+  label,
+  onActivate,
+}: {
+  direction: Exclude<ThumbnailOffscreenDirection, null>;
+  label: string;
+  onActivate: (focusCurrent: boolean) => void;
+}) {
+  const Icon = direction === 'above' ? ChevronUp : ChevronDown;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          aria-label={label}
+          onClick={(event) => onActivate(event.detail === 0)}
+          onKeyDown={(event) => {
+            if (event.key === ' ') {
+              event.preventDefault();
+              event.stopPropagation();
+              return;
+            }
+            if (event.key !== 'Enter') return;
+            event.preventDefault();
+            event.stopPropagation();
+            onActivate(true);
+          }}
+          onKeyUp={(event) => {
+            if (event.key !== ' ') return;
+            event.preventDefault();
+            event.stopPropagation();
+            onActivate(true);
+          }}
+          className={cn(
+            'pointer-events-auto absolute left-1/2 z-30 -translate-x-1/2 bg-card/95 shadow-floating backdrop-blur-sm',
+            'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-95 motion-safe:duration-150',
+            direction === 'above' ? 'top-10' : 'bottom-3',
+          )}
+        >
+          <Icon className="size-3.5" strokeWidth={1.75} aria-hidden />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side={direction === 'above' ? 'bottom' : 'top'} sideOffset={6}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
 function thumbButtonClass(active: boolean): string {
   return cn(
-    'group/thumb flex w-full items-start gap-2.5 rounded-[6px] p-1.5 text-left motion-safe:transition-colors',
+    'group/thumb flex w-full items-start gap-2.5 rounded-[6px] p-1.5 text-left outline-none motion-safe:transition-colors',
     'hover:bg-muted/60',
+    'focus-visible:ring-1 focus-visible:ring-brand focus-visible:ring-offset-1 focus-visible:ring-offset-sidebar',
     active && 'bg-muted',
   );
 }
@@ -362,7 +494,7 @@ function HorizontalVirtualThumbList({
         ref={active ? activeRef : undefined}
         onClick={() => onSelect(i)}
         aria-label={format(t.thumbnailRail.goToPageAria, { n: i + 1 })}
-        aria-current={active ? 'true' : undefined}
+        aria-current={active ? 'page' : undefined}
         className={cn('group/thumb relative flex shrink-0 flex-col items-center gap-1.5')}
       >
         <span
@@ -432,12 +564,18 @@ function VirtualThumbList({
   current,
   rowHeight,
   activeRef,
+  onScrollElementsChange,
+  onScrollInteraction,
+  onCurrentPositionChange,
   renderThumb,
 }: {
   pages: Page[];
   current: number;
   rowHeight: number;
   activeRef: React.MutableRefObject<HTMLButtonElement | null>;
+  onScrollElementsChange: (viewport: HTMLElement | null, root: HTMLDivElement | null) => void;
+  onScrollInteraction: () => void;
+  onCurrentPositionChange: (position: ThumbnailOffscreenDirection) => void;
   renderThumb: (page: Page, index: number) => React.ReactNode;
 }) {
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -450,14 +588,32 @@ function VirtualThumbList({
     if (!viewport || !root) return;
     const scrollTop = Math.max(0, viewport.scrollTop - root.offsetTop);
     setRange(getVisibleRange(scrollTop, pages.length, viewport.clientHeight, rowHeight));
-  }, [pages.length, rowHeight]);
+
+    if (pages.length <= 0) {
+      onCurrentPositionChange(null);
+      return;
+    }
+
+    const clampedCurrent = Math.min(Math.max(current, 0), pages.length - 1);
+    const itemTop = root.offsetTop + clampedCurrent * rowHeight;
+    onCurrentPositionChange(
+      getThumbnailOffscreenDirection({
+        itemTop,
+        itemBottom: itemTop + rowHeight,
+        visibleTop: viewport.scrollTop + root.offsetTop,
+        visibleBottom: viewport.scrollTop + viewport.clientHeight,
+      }),
+    );
+  }, [current, onCurrentPositionChange, pages.length, rowHeight]);
 
   useEffect(() => {
     const root = rootRef.current;
     if (!root) return;
     const viewport = root.closest('[data-slot="scroll-area-viewport"]') as HTMLElement | null;
     if (!viewport) return;
+    const scrollArea = viewport.parentElement;
     viewportRef.current = viewport;
+    onScrollElementsChange(viewport, root);
 
     let frame = 0;
     const scheduleUpdate = () => {
@@ -467,29 +623,38 @@ function VirtualThumbList({
     const resizeObserver = new ResizeObserver(scheduleUpdate);
 
     viewport.addEventListener('scroll', scheduleUpdate, { passive: true });
+    scrollArea?.addEventListener('wheel', onScrollInteraction, { passive: true });
+    scrollArea?.addEventListener('touchstart', onScrollInteraction, { passive: true });
+    scrollArea?.addEventListener('pointerdown', onScrollInteraction, { passive: true });
     resizeObserver.observe(viewport);
     scheduleUpdate();
 
     return () => {
       cancelAnimationFrame(frame);
       viewport.removeEventListener('scroll', scheduleUpdate);
+      scrollArea?.removeEventListener('wheel', onScrollInteraction);
+      scrollArea?.removeEventListener('touchstart', onScrollInteraction);
+      scrollArea?.removeEventListener('pointerdown', onScrollInteraction);
       resizeObserver.disconnect();
       if (viewportRef.current === viewport) viewportRef.current = null;
+      onScrollElementsChange(null, null);
     };
-  }, [updateRange]);
+  }, [onScrollElementsChange, onScrollInteraction, updateRange]);
 
   useEffect(() => {
     const viewport = viewportRef.current;
     const root = rootRef.current;
     if (!viewport || !root) return;
 
-    const top = root.offsetTop + current * rowHeight;
+    if (pages.length <= 0) return;
+    const clampedCurrent = Math.min(Math.max(current, 0), pages.length - 1);
+    const top = root.offsetTop + clampedCurrent * rowHeight;
     const bottom = top + rowHeight;
-    const viewportTop = viewport.scrollTop;
-    const viewportBottom = viewportTop + viewport.clientHeight;
+    const viewportTop = viewport.scrollTop + root.offsetTop;
+    const viewportBottom = viewport.scrollTop + viewport.clientHeight;
 
     if (top < viewportTop) {
-      viewport.scrollTo({ top, behavior: scrollBehavior() });
+      viewport.scrollTo({ top: top - root.offsetTop, behavior: scrollBehavior() });
     } else if (bottom > viewportBottom) {
       viewport.scrollTo({ top: bottom - viewport.clientHeight, behavior: scrollBehavior() });
     } else {
@@ -499,7 +664,7 @@ function VirtualThumbList({
         behavior: scrollBehavior(),
       });
     }
-  }, [activeRef, current, rowHeight]);
+  }, [activeRef, current, pages.length, rowHeight]);
 
   const visibleRange = clampVisibleRange(range, current, pages.length);
   const visible = [];
@@ -786,7 +951,7 @@ function SortableThumb({
       type="button"
       onClick={onSelect}
       aria-label={ariaLabel}
-      aria-current={active ? 'true' : undefined}
+      aria-current={active ? 'page' : undefined}
       style={{
         transform: CSS.Transform.toString(yOnlyTransform),
         transition,

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -355,6 +355,8 @@ export const en: Locale = {
     transitionIndicator: 'Has slide transition',
     stepsIndicator: 'Has step-by-step reveals',
     overviewAria: 'Slide overview (O)',
+    scrollUpToCurrentPage: 'Scroll up to current page {n}',
+    scrollDownToCurrentPage: 'Scroll down to current page {n}',
   },
 
   pdfToast: {

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -360,6 +360,8 @@ export const ja: Locale = {
     transitionIndicator: 'スライドトランジションあり',
     stepsIndicator: 'ステップ表示あり',
     overviewAria: 'スライド一覧 (O)',
+    scrollUpToCurrentPage: '上にスクロールして現在のページ {n} へ移動',
+    scrollDownToCurrentPage: '下にスクロールして現在のページ {n} へ移動',
   },
 
   pdfToast: {

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -376,6 +376,10 @@ export type Locale = {
     transitionIndicator: string;
     stepsIndicator: string;
     overviewAria: string;
+    /** template: "Scroll up to current page {n}" */
+    scrollUpToCurrentPage: string;
+    /** template: "Scroll down to current page {n}" */
+    scrollDownToCurrentPage: string;
   };
 
   pdfToast: {

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -353,6 +353,8 @@ export const zhCN: Locale = {
     transitionIndicator: '有换页转场',
     stepsIndicator: '有逐步揭示',
     overviewAria: '幻灯片总览 (O)',
+    scrollUpToCurrentPage: '向上滚动至当前第 {n} 页',
+    scrollDownToCurrentPage: '向下滚动至当前第 {n} 页',
   },
 
   pdfToast: {

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -353,6 +353,8 @@ export const zhTW: Locale = {
     transitionIndicator: '有換頁轉場',
     stepsIndicator: '有逐步揭示',
     overviewAria: '投影片總覽 (O)',
+    scrollUpToCurrentPage: '向上捲動至目前的第 {n} 頁',
+    scrollDownToCurrentPage: '向下捲動至目前的第 {n} 頁',
   },
 
   pdfToast: {


### PR DESCRIPTION
## Summary

- Show a directional edge control when the current slide thumbnail is outside the vertical rail viewport.
- Center the current thumbnail when the control is activated and preserve keyboard focus when appropriate.
- Add localized accessibility labels and unit tests for thumbnail visibility and scroll geometry.

## Why

In long decks, it is easy to scroll the thumbnail rail far away from the current slide. Returning to it previously required searching through the list manually.

## User impact

Users can immediately jump back to the current slide from either direction without changing slides or losing their place in the deck.

## Testing

- `./node_modules/.bin/biome check .`
- `./node_modules/.bin/vitest run` (279 tests)
- `./packages/core/node_modules/.bin/tsc -p packages/core/tsconfig.json --noEmit`
- `./node_modules/.bin/tsdown` from `packages/core`
- Browser QA at 1280×720 for above/below states, pointer activation, keyboard activation, and focus handoff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a floating control that returns you to the current page when its thumbnail is outside the visible rail.
  * Improved scrolling and focus behavior when selecting pages, including virtualized thumbnail lists.
  * Enhanced accessibility indicators for the active page.

* **Documentation**
  * Added localized labels for scrolling up or down to the current page in English, Japanese, Simplified Chinese, and Traditional Chinese.

* **Tests**
  * Added coverage for thumbnail visibility detection and centered scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->