### PR TITLE
feat(core): retone app UI to a neutral SaaS palette

### DIFF
--- a/.changeset/neat-planes-shave.md
+++ b/.changeset/neat-planes-shave.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Retone the app UI to a neutral SaaS palette: flat pure-gray surfaces, crisper labels, refreshed folder colors.

--- a/packages/core/src/app/components/asset-view.tsx
+++ b/packages/core/src/app/components/asset-view.tsx
@@ -804,7 +804,7 @@ function AssetListHeader({
 }) {
   const t = useLocale();
   return (
-    <div className="hidden items-center gap-3 px-2 pb-1 text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/70 sm:flex">
+    <div className="hidden items-center gap-3 px-2 pb-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground/70 sm:flex">
       <SortableColumnHeader
         label={t.asset.nameColumn}
         sortKey="name"

--- a/packages/core/src/app/components/overview-grid.tsx
+++ b/packages/core/src/app/components/overview-grid.tsx
@@ -225,7 +225,7 @@ function OverviewThumb({
         className={cn(
           'relative w-full overflow-hidden rounded-[4px] ring-1 transition-shadow',
           styles.thumbSurface,
-          isFocused ? 'ring-2 ring-[var(--brand,#ef4444)]' : styles.thumbRing,
+          isFocused ? 'ring-2 ring-[var(--brand,#e5484d)]' : styles.thumbRing,
         )}
         style={{ height: THUMB_H }}
       >
@@ -243,7 +243,7 @@ function OverviewThumb({
         {isCurrent && (
           <span
             aria-hidden
-            className="pointer-events-none absolute top-1.5 right-1.5 rounded-[3px] bg-[var(--brand,#ef4444)] px-1.5 py-0.5 font-mono text-[9.5px] tracking-[0.06em] uppercase text-white"
+            className="pointer-events-none absolute top-1.5 right-1.5 rounded-[3px] bg-[var(--brand,#e5484d)] px-1.5 py-0.5 font-mono text-[9.5px] tracking-[0.06em] uppercase text-white"
           >
             {t.present.nowBadge}
           </span>

--- a/packages/core/src/app/components/present/control-bar.tsx
+++ b/packages/core/src/app/components/present/control-bar.tsx
@@ -272,7 +272,7 @@ function BarButton({
             'inline-flex size-8 items-center justify-center rounded-full transition-colors',
             'hover:bg-white/12 focus-visible:bg-white/12 focus-visible:outline-none',
             'disabled:pointer-events-none disabled:opacity-30',
-            active && 'bg-[var(--brand,#ef4444)]/85 text-white hover:bg-[var(--brand,#ef4444)]',
+            active && 'bg-[var(--brand,#e5484d)]/85 text-white hover:bg-[var(--brand,#e5484d)]',
           )}
         >
           {children}

--- a/packages/core/src/app/components/present/progress-bar.tsx
+++ b/packages/core/src/app/components/present/progress-bar.tsx
@@ -18,7 +18,7 @@ export function PresentProgressBar({ index, total, visible }: Props) {
       )}
     >
       <div
-        className="h-full w-full origin-left bg-[var(--brand,#ef4444)] transition-transform duration-200 ease-out"
+        className="h-full w-full origin-left bg-[var(--brand,#e5484d)] transition-transform duration-200 ease-out"
         style={{ transform: `scaleX(${pct})` }}
       />
     </div>

--- a/packages/core/src/app/components/sidebar/icon-picker.tsx
+++ b/packages/core/src/app/components/sidebar/icon-picker.tsx
@@ -4,14 +4,14 @@ import type { FolderIcon } from '@/lib/sdk';
 import { useLocale } from '@/lib/use-locale';
 
 export const PRESET_COLORS = [
-  '#c0392b', // vermillion
-  '#b8743e', // ochre
-  '#6f7a3a', // olive
-  '#2f6a4f', // forest
-  '#3a5a7c', // ink blue
-  '#6b4675', // plum
-  '#a3543b', // terracotta
-  '#3a3a3a', // graphite
+  '#e5484d', // red
+  '#f76b15', // orange
+  '#ffb224', // amber
+  '#30a46c', // green
+  '#12a594', // teal
+  '#0091ff', // blue
+  '#6e56cf', // violet
+  '#60646c', // gray
 ];
 
 export function IconPicker({

--- a/packages/core/src/app/components/sidebar/sidebar.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar.tsx
@@ -126,7 +126,7 @@ export function Sidebar({
   }, [creating]);
 
   return (
-    <aside className="paper relative flex h-full w-[16.5rem] shrink-0 flex-col border-r border-hairline bg-sidebar text-sidebar-foreground">
+    <aside className="relative flex h-full w-[16.5rem] shrink-0 flex-col border-r border-hairline bg-sidebar text-sidebar-foreground">
       <div className="flex items-center justify-between px-4 pt-5 pb-4">
         <h1 className="font-heading text-lg font-bold tracking-tight">{t.home.appTitle}</h1>
         <div className="-mr-1.5 flex items-center">

--- a/packages/core/src/app/components/style-panel/style-panel.tsx
+++ b/packages/core/src/app/components/style-panel/style-panel.tsx
@@ -85,8 +85,8 @@ export function DesignPanel({ open, onClose }: DesignPanelProps) {
       }
       banner={
         warning && (
-          <div className="flex gap-2 border-b border-hairline bg-[oklch(0.97_0.04_85)] px-3 py-2 text-[11px] leading-relaxed text-[oklch(0.35_0.08_45)] dark:bg-[oklch(0.25_0.04_60)] dark:text-[oklch(0.85_0.08_85)]">
-            <span aria-hidden className="mt-0.5 size-1.5 shrink-0 rounded-full bg-brand" />
+          <div className="flex gap-2 border-b border-hairline bg-amber-500/10 px-3 py-2 text-[11px] leading-relaxed text-amber-800 dark:bg-amber-400/10 dark:text-amber-200">
+            <span aria-hidden className="mt-0.5 size-1.5 shrink-0 rounded-full bg-amber-500" />
             <span>{warning}</span>
           </div>
         )

--- a/packages/core/src/app/components/themes/theme-detail.tsx
+++ b/packages/core/src/app/components/themes/theme-detail.tsx
@@ -102,7 +102,7 @@ export function ThemeDetail({ themeId, onBack }: { themeId: string; onBack: () =
               {!theme.hasDemo ? (
                 <NoDemoLargeState />
               ) : !demo ? (
-                <div className="grid h-full w-full place-items-center text-[11px] tracking-[0.16em] uppercase text-muted-foreground/60">
+                <div className="grid h-full w-full place-items-center text-[11px] tracking-[0.08em] uppercase text-muted-foreground/60">
                   {t.common.loading}
                 </div>
               ) : Current ? (
@@ -236,7 +236,7 @@ function ThemeSlideCard({ id }: { id: string }) {
             </SlideCanvas>
           </div>
         ) : (
-          <div className="grid h-full w-full place-items-center text-[10px] tracking-[0.16em] uppercase text-muted-foreground/60">
+          <div className="grid h-full w-full place-items-center text-[10px] tracking-[0.08em] uppercase text-muted-foreground/60">
             {t.common.loading}
           </div>
         )}

--- a/packages/core/src/app/components/themes/themes-gallery.tsx
+++ b/packages/core/src/app/components/themes/themes-gallery.tsx
@@ -68,7 +68,7 @@ function ThemePreview({ theme }: { theme: Theme }) {
   }
   if (!demo) {
     return (
-      <div className="grid h-full w-full place-items-center text-[10px] tracking-[0.16em] uppercase text-muted-foreground/60">
+      <div className="grid h-full w-full place-items-center text-[10px] tracking-[0.08em] uppercase text-muted-foreground/60">
         {t.common.loading}
       </div>
     );

--- a/packages/core/src/app/routes/home-shell.tsx
+++ b/packages/core/src/app/routes/home-shell.tsx
@@ -170,7 +170,7 @@ export function HomeShell() {
         />
       </div>
 
-      <div className="paper relative flex min-w-0 flex-1 flex-col overflow-y-auto bg-canvas">
+      <div className="relative flex min-w-0 flex-1 flex-col overflow-y-auto bg-canvas">
         <div className="flex items-center justify-between border-b border-hairline bg-sidebar px-4 py-3 md:hidden">
           <h1 className="font-heading text-lg font-bold tracking-tight">{t.home.appTitle}</h1>
           <div className="-mr-1.5 flex items-center gap-0.5">

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -518,7 +518,7 @@ function SlideCard({
                 </SlideCanvas>
               </div>
             ) : (
-              <div className="grid h-full w-full place-items-center text-[10px] tracking-[0.16em] uppercase text-muted-foreground/60">
+              <div className="grid h-full w-full place-items-center text-[10px] tracking-[0.08em] uppercase text-muted-foreground/60">
                 {tCard.common.loading}
               </div>
             )}

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -187,7 +187,7 @@ export function Presenter() {
               <div
                 aria-hidden
                 className={cn(
-                  'pointer-events-none absolute inset-0 grid place-items-center text-[11px] tracking-[0.16em] uppercase',
+                  'pointer-events-none absolute inset-0 grid place-items-center text-[11px] tracking-[0.08em] uppercase',
                   blackout === 'black' ? 'bg-black text-white/35' : 'bg-white text-black/35',
                 )}
               >

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -746,7 +746,7 @@ export function Slide() {
                     ref={slideViewportRef}
                     data-inspector-root
                     data-slide-id={slideId}
-                    className="paper relative min-h-0 min-w-0 flex-1 bg-canvas p-2 md:p-10"
+                    className="relative min-h-0 min-w-0 flex-1 bg-canvas p-2 md:p-10"
                   >
                     <SlideViewportNavigation
                       targetRef={slideViewportRef}

--- a/packages/core/src/app/styles.css
+++ b/packages/core/src/app/styles.css
@@ -68,100 +68,101 @@
 }
 
 :root {
-  /* Warm paper, ink foreground. Not pure white / pure black — those read as
-     "default browser"; the slight warmth gives the surface a quiet voice. */
-  --background: oklch(0.985 0.004 75);
-  --foreground: oklch(0.2 0.012 60);
-  --canvas: oklch(0.974 0.005 75);
+  /* Pure neutral ramp — zero chroma, flat surfaces, hairline borders.
+     Near-white background with white cards floating on a slightly
+     recessed canvas. */
+  --background: oklch(0.99 0 0);
+  --foreground: oklch(0.145 0 0);
+  --canvas: oklch(0.975 0 0);
 
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.2 0.012 60);
-  --popover: oklch(0.998 0.002 75);
-  --popover-foreground: oklch(0.2 0.012 60);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
 
-  --primary: oklch(0.215 0.012 60);
-  --primary-foreground: oklch(0.985 0.004 75);
-  --secondary: oklch(0.96 0.006 75);
-  --secondary-foreground: oklch(0.215 0.012 60);
-  --muted: oklch(0.955 0.008 75);
-  --muted-foreground: oklch(0.485 0.012 60);
-  --accent: oklch(0.945 0.012 75);
-  --accent-foreground: oklch(0.215 0.012 60);
-  --destructive: oklch(0.55 0.21 27);
+  --primary: oklch(0.185 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.96 0 0);
+  --secondary-foreground: oklch(0.185 0 0);
+  --muted: oklch(0.955 0 0);
+  --muted-foreground: oklch(0.5 0 0);
+  --accent: oklch(0.945 0 0);
+  --accent-foreground: oklch(0.185 0 0);
+  --destructive: oklch(0.58 0.22 27);
 
-  --border: oklch(0.895 0.008 70);
-  --hairline: oklch(0.86 0.008 70);
-  --input: oklch(0.91 0.008 70);
-  --ring: oklch(0.55 0.18 28);
+  --border: oklch(0.92 0 0);
+  --hairline: oklch(0.885 0 0);
+  --input: oklch(0.92 0 0);
+  --ring: oklch(0.6 0.2 25);
 
-  /* Vermillion — refined editorial red. Single accent across the app;
-     restraint is the point. */
-  --brand: oklch(0.555 0.185 28);
-  --brand-foreground: oklch(0.985 0.004 75);
-  --brand-soft: oklch(0.555 0.185 28 / 0.1);
+  /* Vermillion — the single signature accent on an otherwise neutral
+     surface; restraint is the point. */
+  --brand: oklch(0.6 0.2 25);
+  --brand-foreground: oklch(0.985 0 0);
+  --brand-soft: oklch(0.6 0.2 25 / 0.1);
 
-  --chart-1: oklch(0.555 0.185 28);
-  --chart-2: oklch(0.55 0.1 60);
-  --chart-3: oklch(0.45 0.06 245);
-  --chart-4: oklch(0.55 0.12 160);
-  --chart-5: oklch(0.4 0.04 60);
+  --chart-1: oklch(0.6 0.2 25);
+  --chart-2: oklch(0.55 0.16 250);
+  --chart-3: oklch(0.55 0.15 285);
+  --chart-4: oklch(0.6 0.13 160);
+  --chart-5: oklch(0.5 0 0);
 
   /* Tight, considered radius — drops the trendy 10px squish for 6px crisp. */
   --radius: 0.375rem;
 
-  --sidebar: oklch(0.972 0.005 75);
-  --sidebar-foreground: oklch(0.215 0.012 60);
-  --sidebar-primary: oklch(0.215 0.012 60);
-  --sidebar-primary-foreground: oklch(0.985 0.004 75);
-  --sidebar-accent: oklch(0.94 0.01 75);
-  --sidebar-accent-foreground: oklch(0.215 0.012 60);
-  --sidebar-border: oklch(0.895 0.008 70);
-  --sidebar-ring: oklch(0.55 0.18 28);
+  --sidebar: oklch(0.98 0 0);
+  --sidebar-foreground: oklch(0.185 0 0);
+  --sidebar-primary: oklch(0.185 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.94 0 0);
+  --sidebar-accent-foreground: oklch(0.185 0 0);
+  --sidebar-border: oklch(0.905 0 0);
+  --sidebar-ring: oklch(0.6 0.2 25);
 }
 
 .dark {
-  --background: oklch(0.155 0.005 70);
-  --foreground: oklch(0.945 0.005 80);
-  --canvas: oklch(0.135 0.005 70);
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.93 0 0);
+  --canvas: oklch(0.125 0 0);
 
-  --card: oklch(0.195 0.006 70);
-  --card-foreground: oklch(0.945 0.005 80);
-  --popover: oklch(0.21 0.006 70);
-  --popover-foreground: oklch(0.945 0.005 80);
+  --card: oklch(0.19 0 0);
+  --card-foreground: oklch(0.93 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.93 0 0);
 
-  --primary: oklch(0.94 0.005 80);
-  --primary-foreground: oklch(0.18 0.008 70);
-  --secondary: oklch(0.245 0.006 70);
-  --secondary-foreground: oklch(0.945 0.005 80);
-  --muted: oklch(0.235 0.006 70);
-  --muted-foreground: oklch(0.68 0.008 75);
-  --accent: oklch(0.27 0.008 70);
-  --accent-foreground: oklch(0.945 0.005 80);
-  --destructive: oklch(0.68 0.2 25);
+  --primary: oklch(0.925 0 0);
+  --primary-foreground: oklch(0.17 0 0);
+  --secondary: oklch(0.24 0 0);
+  --secondary-foreground: oklch(0.93 0 0);
+  --muted: oklch(0.23 0 0);
+  --muted-foreground: oklch(0.68 0 0);
+  --accent: oklch(0.265 0 0);
+  --accent-foreground: oklch(0.93 0 0);
+  --destructive: oklch(0.66 0.2 25);
 
   --border: oklch(1 0 0 / 0.1);
-  --hairline: oklch(1 0 0 / 0.06);
-  --input: oklch(1 0 0 / 0.13);
-  --ring: oklch(0.62 0.18 28);
+  --hairline: oklch(1 0 0 / 0.07);
+  --input: oklch(1 0 0 / 0.14);
+  --ring: oklch(0.63 0.19 25);
 
-  --brand: oklch(0.66 0.19 28);
-  --brand-foreground: oklch(0.155 0.005 70);
-  --brand-soft: oklch(0.66 0.19 28 / 0.18);
+  --brand: oklch(0.63 0.2 25);
+  --brand-foreground: oklch(0.985 0 0);
+  --brand-soft: oklch(0.63 0.2 25 / 0.16);
 
-  --chart-1: oklch(0.66 0.19 28);
-  --chart-2: oklch(0.7 0.1 60);
-  --chart-3: oklch(0.65 0.08 245);
-  --chart-4: oklch(0.65 0.12 160);
-  --chart-5: oklch(0.6 0.04 60);
+  --chart-1: oklch(0.63 0.2 25);
+  --chart-2: oklch(0.65 0.15 250);
+  --chart-3: oklch(0.65 0.14 285);
+  --chart-4: oklch(0.7 0.13 160);
+  --chart-5: oklch(0.65 0 0);
 
-  --sidebar: oklch(0.18 0.006 70);
-  --sidebar-foreground: oklch(0.945 0.005 80);
-  --sidebar-primary: oklch(0.94 0.005 80);
-  --sidebar-primary-foreground: oklch(0.18 0.008 70);
-  --sidebar-accent: oklch(0.265 0.008 70);
-  --sidebar-accent-foreground: oklch(0.945 0.005 80);
+  --sidebar: oklch(0.17 0 0);
+  --sidebar-foreground: oklch(0.93 0 0);
+  --sidebar-primary: oklch(0.925 0 0);
+  --sidebar-primary-foreground: oklch(0.17 0 0);
+  --sidebar-accent: oklch(0.26 0 0);
+  --sidebar-accent-foreground: oklch(0.93 0 0);
   --sidebar-border: oklch(1 0 0 / 0.1);
-  --sidebar-ring: oklch(0.62 0.18 28);
+  --sidebar-ring: oklch(0.63 0.19 25);
 }
 
 /* Tabular numerics — pages, counts, hex values, slider readouts.
@@ -209,8 +210,8 @@
    * label across the app. Tracked-out small caps in muted ink.
    */
   .eyebrow {
-    @apply font-sans text-[10px] font-semibold uppercase text-muted-foreground;
-    letter-spacing: 0.14em;
+    @apply font-sans text-[11px] font-medium uppercase text-muted-foreground;
+    letter-spacing: 0.08em;
   }
 
   /* Hairline divider — 0.5px on retina, snaps to 1px elsewhere. */
@@ -218,34 +219,9 @@
     background: var(--hairline);
   }
 
-  /* Subtle paper texture for "studio" surfaces (sidebar, gallery bg).
-     Pure-CSS noise via SVG; cheap, dark-mode aware via mix-blend. */
-  .paper {
-    position: relative;
-    isolation: isolate;
-  }
-  .paper::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='3'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.55 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
-    opacity: 0.025;
-    pointer-events: none;
-    z-index: 0;
-    mix-blend-mode: multiply;
-  }
-  .dark .paper::before {
-    opacity: 0.05;
-    mix-blend-mode: screen;
-  }
-  .paper > * {
-    position: relative;
-    z-index: 1;
-  }
-
   /* Numeric folio-style page count. */
   .folio {
-    @apply nums font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground;
+    @apply nums font-mono text-[10.5px] tracking-[0.08em] text-muted-foreground;
   }
 }
 


### PR DESCRIPTION
## What changed

Retones the entire core runtime UI (viewer, editor, present mode, sidebar, panels) from the warm paper + editorial look to a flat, pure-neutral surface system in the spirit of modern SaaS products.

- **Design tokens (`styles.css`)** — the bulk of the change:
  - All surface/border/text tokens move from warm-tinted hues to zero-chroma neutrals, in both light and dark mode. Light: near-white background, white cards on a slightly recessed canvas. Dark: `#0a0a0a` near-black.
  - Brand stays vermillion (kept for identity with the logo/marketing site) but tuned brighter and cleaner (`oklch(0.6 0.2 25)` ≈ `#e5484d`). Brand buttons now use white text in dark mode.
  - The SVG paper-noise texture (`.paper`) is removed — surfaces are flat.
  - `.eyebrow` / `.folio` label tracking collapses from 0.14–0.16em to 0.08em (dashboard feel instead of print).
  - Chart colors move to a cool modern set.
- **Components**:
  - `paper` class removed from sidebar, home shell, and editor canvas.
  - Folder preset colors refreshed from muted editorial tones to a saturated modern set.
  - `var(--brand,#ef4444)` fallbacks updated to `#e5484d`.
  - Style-panel warning banner switches from custom warm oklch values to a standard amber alpha treatment.
  - Loading-placeholder tracking unified at 0.08em.

## Why

The previous warm palette read as editorial/print; the goal is the crisp, professional feel of modern SaaS dashboards while keeping the product's red brand identity.

## Notes for review

- `components/ui` (shadcn-generated) is untouched — it picks up the new tokens automatically.
- Functional colors are intentionally unchanged: laser pointer red, success-green check, inspector's blue selection outline, present-mode black-glass control bar.
- Biome + typecheck pass; the single biome warning in `src/http` is pre-existing and unrelated.
- Changeset included (`@open-slide/core` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed the app’s visual palette with neutral gray surfaces, updated dark-mode colors, and refined semantic accents.
  * Updated brand reds and preset icon colors across thumbnails, presentation controls, progress indicators, and folder icons.
  * Improved typography for headers, labels, folios, loading states, and presentation overlays with clearer sizing and spacing.
  * Simplified canvas and sidebar surfaces for a cleaner layout.
  * Updated warning banners with a clearer amber treatment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->