### PR TITLE
chore: bump UI redesign and Base UI migration changesets to minor

### DIFF
--- a/.changeset/base-ui-migration.md
+++ b/.changeset/base-ui-migration.md
@@ -1,5 +1,5 @@
 ---
-'@open-slide/core': patch
+'@open-slide/core': minor
 ---
 
 Migrate the internal UI primitives from Radix UI to Base UI (`@base-ui/react`), dropping the `radix-ui` dependency.

--- a/.changeset/neat-planes-shave.md
+++ b/.changeset/neat-planes-shave.md
@@ -1,5 +1,5 @@
 ---
-'@open-slide/core': patch
+'@open-slide/core': minor
 ---
 
 Retone the app UI to a neutral SaaS palette: flat pure-gray surfaces, crisper labels, refreshed folder colors.


### PR DESCRIPTION
Bumps the two pending `@open-slide/core` changesets from `patch` to `minor`:

- `neat-planes-shave.md` — UI redesign (retone to neutral SaaS palette)
- `base-ui-migration.md` — Radix UI → Base UI migration

Both introduce user-facing changes to the app UI / internal primitives that warrant a minor bump rather than patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the upcoming `@open-slide/core` release classification from patch to minor.
  * Migrated internal UI primitives to Base UI.
  * Removed the previous Radix UI dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->