### PR TITLE
fix(core): pre-bundle Base UI use-sync-external-store shim

### DIFF
--- a/.changeset/pre-bundle-use-sync-external-store.md
+++ b/.changeset/pre-bundle-use-sync-external-store.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Pre-bundle the Base UI `use-sync-external-store` shim so the dev server no longer throws a missing `useSyncExternalStore` export.

--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -82,6 +82,12 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
         'next-themes',
         'react-router-dom',
         '@base-ui/react',
+        '@base-ui/utils',
+        // @base-ui/utils reaches for the CommonJS use-sync-external-store shim
+        // (React 17 fallback). Left un-optimized, its named `useSyncExternalStore`
+        // export fails ESM interop in the browser — pre-bundle it to fix that.
+        'use-sync-external-store/shim',
+        'use-sync-external-store/shim/with-selector',
         'lucide-react',
         'clsx',
         'tailwind-merge',


### PR DESCRIPTION
## What

Adds the `use-sync-external-store/shim` subpaths and `@base-ui/utils` to `optimizeDeps.include` in the Vite config the dev/build CLI generates.

## Why

The Base UI migration pulled in `@base-ui/utils/store/useStore.mjs`, which imports the **CommonJS** `use-sync-external-store/shim` (Base UI's React 17 fallback). When Vite serves that shim un-bundled, its named `useSyncExternalStore` export fails ESM interop in the browser:

```
Uncaught SyntaxError: The requested module '.../use-sync-external-store/shim/index.js'
does not provide an export named 'useSyncExternalStore' (at useStore.mjs:4:10)
```

Pre-bundling the shim forces esbuild to convert it into proper ESM with the named export intact — the canonical Vite fix for this class of CJS-interop error.

## Notes for reviewers

- The two `use-sync-external-store/shim*` entries are the minimal fix. `@base-ui/utils` is added deliberately so Vite keeps the store as a single shared optimized chunk, avoiding duplicate store instances (which would break Base UI's reactivity).
- Repros only against the built/published package in a consumer app (e.g. a fresh sandbox); clear `node_modules/.vite` there to force a re-optimize when verifying.
- Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a development-server issue that could cause errors when loading external-store functionality.
  * Improved browser compatibility and module loading for Base UI utilities and related React shims.

* **Chores**
  * Added a patch release entry for the core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->