### PR TITLE
fix(core): resolve use-sync-external-store shim under pnpm

### DIFF
--- a/.changeset/fix-use-sync-external-store-resolve.md
+++ b/.changeset/fix-use-sync-external-store-resolve.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Declare `use-sync-external-store` as a direct dependency so Vite can resolve and pre-bundle the Base UI shim under pnpm, fixing the missing `useSyncExternalStore` export at runtime.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -92,6 +92,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
     "tw-animate-css": "^1.4.0",
+    "use-sync-external-store": "^1.6.0",
     "vite": "^5.4.10"
   },
   "devDependencies": {

--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -82,10 +82,10 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
         'next-themes',
         'react-router-dom',
         '@base-ui/react',
-        '@base-ui/utils',
         // @base-ui/utils reaches for the CommonJS use-sync-external-store shim
         // (React 17 fallback). Left un-optimized, its named `useSyncExternalStore`
         // export fails ESM interop in the browser — pre-bundle it to fix that.
+        // (@base-ui/utils itself has no "." export, so we can't list it here.)
         'use-sync-external-store/shim',
         'use-sync-external-store/shim/with-selector',
         'lucide-react',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      use-sync-external-store:
+        specifier: ^1.6.0
+        version: 1.6.0(react@18.3.1)
       vite:
         specifier: ^5.4.10
         version: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)


### PR DESCRIPTION
## What

Follow-up to #306. Makes `use-sync-external-store` a direct dependency of `@open-slide/core` and drops the invalid `@base-ui/utils` entry from `optimizeDeps.include`.

## Why

#306 (released in 1.15.1) didn't actually fix the runtime error and introduced a new crash:

- `@base-ui/utils` has no `.` export, so listing it in `optimizeDeps.include` crashed dev startup: `Failed to resolve entry for package "@base-ui/utils" … Missing "." specifier`.
- Under pnpm's strict `node_modules`, `use-sync-external-store` is nested beneath `@base-ui/utils` and **isn't resolvable as a bare specifier from the app root**. Vite logged `Failed to resolve dependency: use-sync-external-store/shim, present in 'optimizeDeps.include'` and never pre-bundled it — so the original `does not provide an export named 'useSyncExternalStore'` error persisted.

Declaring `use-sync-external-store` (`^1.6.0`, the range Base UI itself uses) as a direct dependency makes it resolvable from the app root, so `optimizeDeps.include` pre-bundles the CJS shim into proper ESM. It's already in the tree transitively, so there's no real install-size change.

## Verification (local, against the workspace-linked demo)

Reproduced and confirmed the fix without publishing:

- Dev server starts clean — no `Failed to resolve` warning, no crash.
- App renders fully (Base UI menus, dialogs, locale/theme toggles all mount).
- **Zero console errors** — the `useSyncExternalStore` SyntaxError is gone.
- `use-sync-external-store_shim.js` now appears in `.vite/deps/` (pre-bundled).

## Notes for reviewers

- Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a runtime issue that could prevent `useSyncExternalStore` from loading correctly in Vite environments using pnpm.
  * Improved dependency pre-bundling for more reliable application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->