### PR TITLE
fix(core): remediate verified React Doctor findings

### DIFF
--- a/.changeset/quiet-lamps-listen.md
+++ b/.changeset/quiet-lamps-listen.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Fix stale callback reads and add accessible labels across editor controls.

--- a/packages/core/src/app/components/asset-view.tsx
+++ b/packages/core/src/app/components/asset-view.tsx
@@ -1126,6 +1126,7 @@ function RenameAsset({
         </div>
         <input
           ref={inputRef}
+          aria-label={t.common.rename}
           value={value}
           disabled={saving}
           onChange={(event) => setValue(event.target.value)}
@@ -1176,6 +1177,7 @@ function RenameAsset({
       <div className="border-t bg-card px-2 py-2">
         <input
           ref={inputRef}
+          aria-label={t.common.rename}
           value={value}
           disabled={saving}
           onChange={(e) => setValue(e.target.value)}
@@ -1400,7 +1402,7 @@ function LogoSearchDialog({
       clearTimeout(timer);
       ctrl.abort();
     };
-  }, [query, retryToken]);
+  }, [query, retryToken, t.asset.toastSearchFailed]);
 
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>

--- a/packages/core/src/app/components/history-provider.tsx
+++ b/packages/core/src/app/components/history-provider.tsx
@@ -3,6 +3,7 @@ import {
   type ReactNode,
   useCallback,
   useContext,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -25,6 +26,11 @@ type HistoryCtx = {
   isSuppressed: () => boolean;
 };
 
+type HistoryState = {
+  past: HistoryEntry[];
+  future: HistoryEntry[];
+};
+
 const COALESCE_WINDOW_MS = 500;
 
 const Ctx = createContext<HistoryCtx | null>(null);
@@ -36,84 +42,92 @@ export function useHistory(): HistoryCtx {
 }
 
 export function HistoryProvider({ children }: { children: ReactNode }) {
-  const [past, setPast] = useState<HistoryEntry[]>([]);
-  const [future, setFuture] = useState<HistoryEntry[]>([]);
+  const [history, setHistory] = useState<HistoryState>({ past: [], future: [] });
+  const historyRef = useRef(history);
   // Set while invoking an entry's undo/redo so providers can skip
   // re-recording the resulting state mutation.
   const suppressedRef = useRef(false);
 
+  useLayoutEffect(() => {
+    historyRef.current = history;
+  }, [history]);
+
   const record = useCallback((entry: Omit<HistoryEntry, 'ts'>) => {
     if (suppressedRef.current) return;
     const ts = Date.now();
-    setPast((prev) => {
-      const top = prev.at(-1);
-      if (
+    setHistory((current) => {
+      const { past } = current;
+      const top = past.at(-1);
+      const nextPast =
         top &&
         entry.coalesceKey !== undefined &&
         top.coalesceKey === entry.coalesceKey &&
         ts - top.ts < COALESCE_WINDOW_MS
-      ) {
-        const merged: HistoryEntry = {
-          undo: top.undo,
-          redo: entry.redo,
-          coalesceKey: entry.coalesceKey,
-          ts,
-        };
-        return [...prev.slice(0, -1), merged];
-      }
-      return [...prev, { ...entry, ts }];
+          ? [
+              ...past.slice(0, -1),
+              {
+                undo: top.undo,
+                redo: entry.redo,
+                coalesceKey: entry.coalesceKey,
+                ts,
+              },
+            ]
+          : [...past, { ...entry, ts }];
+      return { past: nextPast, future: [] };
     });
-    setFuture([]);
   }, []);
 
   const undo = useCallback(() => {
-    setPast((prev) => {
-      const top = prev.at(-1);
-      if (!top) return prev;
-      suppressedRef.current = true;
-      try {
-        top.undo();
-      } finally {
-        suppressedRef.current = false;
-      }
-      setFuture((f) => [...f, top]);
-      return prev.slice(0, -1);
-    });
+    const { past } = historyRef.current;
+    const top = past.at(-1);
+    if (!top) return;
+    suppressedRef.current = true;
+    try {
+      top.undo();
+    } finally {
+      suppressedRef.current = false;
+    }
+    setHistory((current) =>
+      current.past.at(-1) === top
+        ? { past: current.past.slice(0, -1), future: [...current.future, top] }
+        : current,
+    );
   }, []);
 
   const redo = useCallback(() => {
-    setFuture((prev) => {
-      const top = prev.at(-1);
-      if (!top) return prev;
-      suppressedRef.current = true;
-      try {
-        top.redo();
-      } finally {
-        suppressedRef.current = false;
-      }
-      setPast((p) => [...p, top]);
-      return prev.slice(0, -1);
-    });
+    const { future } = historyRef.current;
+    const top = future.at(-1);
+    if (!top) return;
+    suppressedRef.current = true;
+    try {
+      top.redo();
+    } finally {
+      suppressedRef.current = false;
+    }
+    setHistory((current) =>
+      current.future.at(-1) === top
+        ? { past: [...current.past, top], future: current.future.slice(0, -1) }
+        : current,
+    );
   }, []);
 
   const clear = useCallback(() => {
-    setPast([]);
-    setFuture([]);
+    setHistory({ past: [], future: [] });
   }, []);
 
   const isSuppressed = useCallback(() => suppressedRef.current, []);
 
   const value = useMemo<HistoryCtx>(
     () => ({
-      canUndo: past.length > 0,
-      canRedo: future.length > 0,
+      canUndo: history.past.length > 0,
+      canRedo: history.future.length > 0,
       record,
       undo,
       redo,
       clear,
       isSuppressed,
     }),
-    [past.length, future.length, record, undo, redo, clear, isSuppressed],
+    [history.past.length, history.future.length, record, undo, redo, clear, isSuppressed],
   );
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;

--- a/packages/core/src/app/components/inspector/comment-widget.tsx
+++ b/packages/core/src/app/components/inspector/comment-widget.tsx
@@ -33,6 +33,7 @@ export function CommentWidget() {
             </span>
             <button
               type="button"
+              aria-label={t.common.close}
               className="text-muted-foreground hover:text-foreground"
               onClick={() => setOpen(false)}
             >
@@ -60,6 +61,7 @@ export function CommentWidget() {
                     </div>
                     <button
                       type="button"
+                      aria-label={t.inspector.commentDeleteAria}
                       onClick={() => remove(c.id)}
                       className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-red-600"
                       title={t.inspector.commentDeleteAria}

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -453,6 +453,7 @@ function FontSizeField({
         className="flex-1"
       />
       <NumberField
+        ariaLabel={t.inspector.sizeLabel}
         value={Math.round(snapshot.fontSize)}
         onChange={set}
         min={1}
@@ -572,7 +573,14 @@ function LineHeightField({
         onValueChange={(next) => set((Array.isArray(next) ? next[0] : next) ?? v)}
         className="flex-1"
       />
-      <NumberField value={round2(v)} onChange={set} step={0.05} min={0.5} max={5} />
+      <NumberField
+        ariaLabel={t.inspector.lineHeightLabel}
+        value={round2(v)}
+        onChange={set}
+        step={0.05}
+        min={0.5}
+        max={5}
+      />
     </Field>
   );
 }
@@ -607,6 +615,7 @@ function LetterSpacingField({
         className="flex-1"
       />
       <NumberField
+        ariaLabel={t.inspector.trackingLabel}
         value={round2(snapshot.letterSpacing)}
         onChange={set}
         step={0.1}
@@ -689,7 +698,9 @@ function ColorField({
   return (
     <Field label={label}>
       <label className="relative inline-flex size-8 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md border bg-background shadow-xs">
+        <span className="sr-only">{label}</span>
         <span
+          aria-hidden
           className="size-5 rounded-sm"
           style={{
             backgroundColor: dim ? 'transparent' : value,

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -820,7 +820,9 @@ export function InspectorProvider({
   // surfaced via toast inside `commitEdits`; the catch here only
   // swallows the rethrown rejection.
   const commitRef = useRef(commitEdits);
-  commitRef.current = commitEdits;
+  useEffect(() => {
+    commitRef.current = commitEdits;
+  }, [commitEdits]);
   useEffect(() => {
     if (!active) commitRef.current().catch(() => {});
   }, [active]);
@@ -905,7 +907,11 @@ export function InspectorProvider({
         `[data-slide-loc="${selected.line}:${selected.column}"]`,
       );
       if (next && next !== selected.anchor) {
-        setSelected({ ...selected, anchor: next });
+        setSelected((current) =>
+          current?.line === selected.line && current.column === selected.column
+            ? { ...current, anchor: next }
+            : current,
+        );
       }
     };
 
@@ -916,11 +922,10 @@ export function InspectorProvider({
   }, [selected]);
 
   const toggle = useCallback(() => {
-    setActive((a) => {
-      if (a) setSelected(null);
-      return !a;
-    });
-  }, []);
+    const next = !active;
+    if (!next) setSelected(null);
+    setActive(next);
+  }, [active]);
 
   const cancel = useCallback(() => {
     setActive(false);

--- a/packages/core/src/app/components/panel/panel-fields.tsx
+++ b/packages/core/src/app/components/panel/panel-fields.tsx
@@ -28,6 +28,7 @@ export function NumberField({
   max,
   step = 1,
   suffix,
+  ariaLabel,
 }: {
   value: number;
   onChange: (n: number) => void;
@@ -35,11 +36,13 @@ export function NumberField({
   max?: number;
   step?: number;
   suffix?: string;
+  ariaLabel: string;
 }) {
   return (
     <div className="flex h-7 shrink-0 items-center rounded-[5px] border border-border bg-background pr-1.5 transition-colors focus-within:border-foreground/40 focus-within:ring-2 focus-within:ring-ring/30">
       <input
         type="number"
+        aria-label={ariaLabel}
         value={value}
         onChange={(e) => {
           const n = Number(e.target.value);

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -85,7 +85,9 @@ export function Player({
   // latest value without re-binding — exits from window mode must not call
   // onExit, but exits initiated by the browser (Esc in fullscreen) must.
   const windowedRef = useRef(windowed);
-  windowedRef.current = windowed;
+  useEffect(() => {
+    windowedRef.current = windowed;
+  }, [windowed]);
 
   const canPrev = index > 0;
   const canNext = index < pages.length - 1;
@@ -238,7 +240,9 @@ export function Player({
     [index, pages.length, blackout, startedAt, stepAggregate],
   );
   const presenterStateRef = useRef(presenterState);
-  presenterStateRef.current = presenterState;
+  useEffect(() => {
+    presenterStateRef.current = presenterState;
+  }, [presenterState]);
 
   const handlePresenterCommand = useCallback(
     (msg: PresenterCommand, send: (m: PresenterCommand) => void) => {

--- a/packages/core/src/app/components/present/use-presenter-channel.ts
+++ b/packages/core/src/app/components/present/use-presenter-channel.ts
@@ -27,7 +27,9 @@ const SUPPORTED = typeof window !== 'undefined' && typeof BroadcastChannel !== '
 // closed one behind that throws on the next send().
 export function usePresenterChannel(slideId: string, onMessage?: Handler) {
   const onMessageRef = useRef(onMessage);
-  onMessageRef.current = onMessage;
+  useEffect(() => {
+    onMessageRef.current = onMessage;
+  }, [onMessage]);
 
   const channelRef = useRef<BroadcastChannel | null>(null);
   const [available, setAvailable] = useState(false);

--- a/packages/core/src/app/components/sidebar/folder-item.tsx
+++ b/packages/core/src/app/components/sidebar/folder-item.tsx
@@ -202,6 +202,7 @@ export function FolderItem({
 
       {renaming && row.kind === 'folder' ? (
         <input
+          aria-label={t.home.folderName}
           value={draftName}
           onChange={(e) => setDraftName(e.target.value)}
           onBlur={commitRename}

--- a/packages/core/src/app/components/sidebar/sidebar.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar.tsx
@@ -61,7 +61,7 @@ export function Sidebar({
     if (!ids.includes(fromId) || !ids.includes(toId)) return;
     const next = ids.filter((id) => id !== fromId);
     next.splice(next.indexOf(toId) + (before ? 0 : 1), 0, fromId);
-    if (next.every((id, i) => id === ids[i])) return;
+    if (next.length === ids.length && next.every((id, i) => id === ids[i])) return;
     onReorder(next);
   };
   const [creating, setCreating] = useState(false);

--- a/packages/core/src/app/components/sidebar/sidebar.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar.tsx
@@ -1,5 +1,5 @@
 import { Plus } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { LanguageToggle } from '@/components/language-toggle';
 import { ThemeToggle } from '@/components/theme-toggle';
@@ -86,15 +86,17 @@ export function Sidebar({
   }, [creating]);
 
   const stateRef = useRef({ name: newName, icon: newIcon, iconOpen });
-  stateRef.current = { name: newName, icon: newIcon, iconOpen };
+  useEffect(() => {
+    stateRef.current = { name: newName, icon: newIcon, iconOpen };
+  }, [newName, newIcon, iconOpen]);
 
-  const exitCreate = () => {
+  const exitCreate = useCallback(() => {
     setCreating(false);
     setNewName('');
     setIconOpen(false);
-  };
+  }, []);
 
-  const commitCreate = async () => {
+  const commitCreate = useCallback(async () => {
     const trimmed = stateRef.current.name.trim();
     const icon = stateRef.current.icon;
     if (!trimmed) {
@@ -108,9 +110,13 @@ export function Sidebar({
     } catch {
       toast.error(t.home.toastFolderCreateFailed);
     }
-  };
+  }, [exitCreate, onCreate, t]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: commitCreate reads latest state via stateRef
+  const commitCreateRef = useRef(commitCreate);
+  useEffect(() => {
+    commitCreateRef.current = commitCreate;
+  }, [commitCreate]);
+
   useEffect(() => {
     if (!creating) return;
     const onDown = (e: MouseEvent) => {
@@ -119,7 +125,7 @@ export function Sidebar({
       if (!target) return;
       if (target.closest('[data-folder-create]')) return;
       if (target.closest('[data-slot="popover-content"]')) return;
-      commitCreate();
+      commitCreateRef.current();
     };
     document.addEventListener('mousedown', onDown);
     return () => document.removeEventListener('mousedown', onDown);

--- a/packages/core/src/app/components/slide-preload-layer.tsx
+++ b/packages/core/src/app/components/slide-preload-layer.tsx
@@ -97,7 +97,9 @@ export function SlidePreloadLayer({ pages, index, design, includeCurrent = false
   }
 
   const onDoneRef = useRef(onDone);
-  onDoneRef.current = onDone;
+  useEffect(() => {
+    onDoneRef.current = onDone;
+  }, [onDone]);
   useEffect(() => {
     if (done) onDoneRef.current?.();
   }, [done]);

--- a/packages/core/src/app/components/slide-transition-layer.tsx
+++ b/packages/core/src/app/components/slide-transition-layer.tsx
@@ -684,7 +684,9 @@ export function SlideTransitionLayer({
   const animsRef = useRef<Animation[]>([]);
   const cleanupRef = useRef<(() => void) | null>(null);
   const currentRef = useRef(current);
-  currentRef.current = current;
+  useEffect(() => {
+    currentRef.current = current;
+  }, [current]);
 
   useEffect(() => {
     if (index === currentRef.current) return;

--- a/packages/core/src/app/components/style-panel/design-provider.tsx
+++ b/packages/core/src/app/components/style-panel/design-provider.tsx
@@ -48,7 +48,9 @@ export function DesignProvider({ slideId, children }: { slideId: string; childre
   const [committing, setCommitting] = useState(false);
   const history = useHistory();
   const draftRef = useRef<DesignSystem | null>(null);
-  draftRef.current = draft;
+  useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
 
   useEffect(() => {
     if (design) setDraft(clone(design));

--- a/packages/core/src/app/components/style-panel/style-panel.tsx
+++ b/packages/core/src/app/components/style-panel/style-panel.tsx
@@ -233,7 +233,8 @@ function ColorField({
   return (
     <Field label={label}>
       <label className="relative inline-flex size-8 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md border bg-background shadow-xs">
-        <span className="size-5 rounded-sm" style={{ backgroundColor: value }} />
+        <span className="sr-only">{label}</span>
+        <span aria-hidden className="size-5 rounded-sm" style={{ backgroundColor: value }} />
         <input
           type="color"
           value={normalizeHex(value)}
@@ -330,6 +331,7 @@ function SliderField({
         className="flex-1"
       />
       <NumberField
+        ariaLabel={label}
         value={value}
         onChange={onChange}
         min={min}

--- a/packages/core/src/app/components/style-panel/use-design.ts
+++ b/packages/core/src/app/components/style-panel/use-design.ts
@@ -22,7 +22,9 @@ export function useDesign(slideId: string): UseDesignReturn {
     loaded: false,
   });
   const slideIdRef = useRef(slideId);
-  slideIdRef.current = slideId;
+  useEffect(() => {
+    slideIdRef.current = slideId;
+  }, [slideId]);
 
   const refresh = useCallback(async () => {
     const id = slideIdRef.current;

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -610,6 +610,11 @@ function VirtualThumbList({
     );
   }, [current, onCurrentPositionChange, pages.length, rowHeight]);
 
+  const onScrollInteractionRef = useRef(onScrollInteraction);
+  useEffect(() => {
+    onScrollInteractionRef.current = onScrollInteraction;
+  }, [onScrollInteraction]);
+
   useEffect(() => {
     const root = rootRef.current;
     if (!root) return;
@@ -625,25 +630,26 @@ function VirtualThumbList({
       frame = requestAnimationFrame(updateRange);
     };
     const resizeObserver = new ResizeObserver(scheduleUpdate);
+    const handleScrollInteraction = () => onScrollInteractionRef.current();
 
     viewport.addEventListener('scroll', scheduleUpdate, { passive: true });
-    scrollArea?.addEventListener('wheel', onScrollInteraction, { passive: true });
-    scrollArea?.addEventListener('touchstart', onScrollInteraction, { passive: true });
-    scrollArea?.addEventListener('pointerdown', onScrollInteraction, { passive: true });
+    scrollArea?.addEventListener('wheel', handleScrollInteraction, { passive: true });
+    scrollArea?.addEventListener('touchstart', handleScrollInteraction, { passive: true });
+    scrollArea?.addEventListener('pointerdown', handleScrollInteraction, { passive: true });
     resizeObserver.observe(viewport);
     scheduleUpdate();
 
     return () => {
       cancelAnimationFrame(frame);
       viewport.removeEventListener('scroll', scheduleUpdate);
-      scrollArea?.removeEventListener('wheel', onScrollInteraction);
-      scrollArea?.removeEventListener('touchstart', onScrollInteraction);
-      scrollArea?.removeEventListener('pointerdown', onScrollInteraction);
+      scrollArea?.removeEventListener('wheel', handleScrollInteraction);
+      scrollArea?.removeEventListener('touchstart', handleScrollInteraction);
+      scrollArea?.removeEventListener('pointerdown', handleScrollInteraction);
       resizeObserver.disconnect();
       if (viewportRef.current === viewport) viewportRef.current = null;
       onScrollElementsChange(null, null);
     };
-  }, [onScrollElementsChange, onScrollInteraction, updateRange]);
+  }, [onScrollElementsChange, updateRange]);
 
   useEffect(() => {
     const viewport = viewportRef.current;

--- a/packages/core/src/app/lib/inspector/use-notes.ts
+++ b/packages/core/src/app/lib/inspector/use-notes.ts
@@ -44,7 +44,9 @@ export function useNotes(slideId: string, index: number, initial: string | undef
   const inflightRef = useRef<AbortController | null>(null);
   const targetRef = useRef<Target>({ slideId, index });
   const valueRef = useRef(value);
-  valueRef.current = value;
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
 
   const cancelTimer = useCallback(() => {
     if (timerRef.current != null) {

--- a/packages/core/src/app/lib/step-context.tsx
+++ b/packages/core/src/app/lib/step-context.tsx
@@ -75,9 +75,11 @@ export function StepHost({
   const registrationsRef = useRef<Tracked[]>([]);
 
   const onAggregateChangeRef = useRef(onAggregateChange);
-  onAggregateChangeRef.current = onAggregateChange;
   const controlledRevealedRef = useRef(controlledRevealed);
-  controlledRevealedRef.current = controlledRevealed;
+  useLayoutEffect(() => {
+    onAggregateChangeRef.current = onAggregateChange;
+    controlledRevealedRef.current = controlledRevealed;
+  }, [onAggregateChange, controlledRevealed]);
 
   const composite = useMemo<StepController>(
     () => ({

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -69,6 +69,14 @@ function useSortPref(): [SortKey, (next: SortKey) => void] {
 
 const TITLE_COLLATOR = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
 
+function SortFieldIcon({ sortKey, className }: { sortKey: SortKey; className?: string }) {
+  return sortKey === 'title-asc' || sortKey === 'title-desc' ? (
+    <ArrowDownAZ className={className} aria-hidden />
+  ) : (
+    <Clock className={className} aria-hidden />
+  );
+}
+
 export function Home() {
   const {
     manifest,
@@ -90,11 +98,10 @@ export function Home() {
   const isDraft = selectedId === DRAFT_ID;
   const selectedFolder =
     isAll || isDraft ? null : (manifest.folders.find((f) => f.id === selectedId) ?? null);
-  const visibleSlides = isAll
-    ? slideIds
-    : isDraft
-      ? draftSlides
-      : (slidesByFolder[selectedId] ?? []);
+  const visibleSlides = useMemo(
+    () => (isAll ? slideIds : isDraft ? draftSlides : (slidesByFolder[selectedId] ?? [])),
+    [isAll, isDraft, draftSlides, slidesByFolder, selectedId],
+  );
 
   const title = selectedFolder?.name ?? (isAll ? t.home.slides : t.home.draft);
   const headerIcon = selectedFolder?.icon ?? {
@@ -283,12 +290,6 @@ function SortControl({ value, onChange }: { value: SortKey; onChange: (next: Sor
     'title-asc': t.home.sortByTitleAsc,
     'title-desc': t.home.sortByTitleDesc,
   };
-  const FieldIcon = ({ k, className }: { k: SortKey; className?: string }) =>
-    k === 'title-asc' || k === 'title-desc' ? (
-      <ArrowDownAZ className={className} aria-hidden />
-    ) : (
-      <Clock className={className} aria-hidden />
-    );
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -298,7 +299,7 @@ function SortControl({ value, onChange }: { value: SortKey; onChange: (next: Sor
             aria-label={`${t.home.sortLabel}: ${labels[value]}`}
             className="flex h-8 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-[6px] border border-border bg-background pl-2 pr-1.5 text-[12.5px] font-medium text-foreground outline-none hover:bg-muted focus-visible:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring/30"
           >
-            <FieldIcon k={value} className="size-3.5 text-muted-foreground" />
+            <SortFieldIcon sortKey={value} className="size-3.5 text-muted-foreground" />
             <span>{labels[value]}</span>
             <ChevronDown className="size-3 text-muted-foreground" aria-hidden />
           </button>
@@ -313,7 +314,7 @@ function SortControl({ value, onChange }: { value: SortKey; onChange: (next: Sor
               onClick={() => onChange(key)}
               className={cn(active && 'bg-muted text-foreground')}
             >
-              <FieldIcon k={key} className="size-3.5 text-muted-foreground" />
+              <SortFieldIcon sortKey={key} className="size-3.5 text-muted-foreground" />
               <span>{labels[key]}</span>
             </DropdownMenuItem>
           );

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -1098,6 +1098,7 @@ function InlineTitleEditor({
           </span>
           <input
             ref={inputRef}
+            aria-label={t.slide.renameSlide}
             size={1}
             value={value}
             disabled={saving}


### PR DESCRIPTION
## Summary

Central draft PR for React Doctor triage and verified core fixes.

Baseline: React Doctor v0.7.7 reported 139 diagnostics in `packages/core` (47 errors, 92 warnings). After the verified fixes it reports 107 diagnostics (32 errors, 75 warnings): 32 total findings removed, including 15 errors and 9 of 11 accessibility warnings.

## Triage

| Rule | Count | Decision | Confidence / evidence |
| --- | ---: | --- | --- |
| `advanced-event-handler-refs` | 1 | Fixed | High; thumbnail scroll subscription rebinds when the handler changes. |
| `async-await-in-loop` | 8 | No change | High; uploads, DOM rendering/capture, polling, and filesystem scans are intentionally sequential or order-sensitive. |
| `control-has-associated-label` | 7 | Fixed | High; seven inputs/icon buttons lack accessible names. |
| `dangerous-html-sink` | 2 | No change | High; both values are trusted DOM snapshots captured by the inspector and restored locally. |
| `effect-needs-cleanup` | 5 | False positive | High; every Vite HMR subscription already removes the same handler with `hot.off`. |
| `exhaustive-deps` | 10 | Fixed 3 / no change 7 | High; fix one localized message dependency, one unstable derived array, and one callback subscription. The remaining values are compile-time `import.meta.env.DEV` constants or intentional open-transition behavior. |
| `js-batch-dom-css` | 2 | No change | Medium; export code reads each element's computed values before mutating it; a broader two-pass rewrite is low-value and behavior-sensitive. |
| `js-combine-iterations` | 3 | No change | High; small collections and clearer filter/map pipelines. |
| `js-length-check-first` | 1 | Fixed | High; cheap, behavior-preserving early exit. |
| `js-set-map-lookups` | 1 | False positive | High; this is one `DOMStringList.includes` check per drag event, not repeated lookup in a loop. |
| `jsx-no-constructed-context-values` | 1 | No change | High; generated shadcn UI is explicitly out of scope for manual edits. |
| `label-has-associated-control` | 2 | Fixed | High; hidden color inputs need explicit accessible names. |
| `no-adjust-state-on-prop-change` | 2 | Defer | Medium; transition state is intentionally coordinated after page changes; changing it alters animation semantics. |
| `no-array-index-as-key` | 3 | No change | High; page positions are the stable identity and the existing source records that invariant. |
| `no-chain-state-updates` | 2 | Defer | Medium; mobile chrome and inline editing coordinate multiple related states; needs a separate behavior review. |
| `no-effect-chain` | 2 | No change | High; inspector close animation and overview focus intentionally run after committed DOM changes. |
| `no-event-handler` | 1 | Defer | Medium; inline editor reset semantics are tied to prop and editing transitions. |
| `no-fetch-in-effect` | 3 | No change | High; this is a client-only Vite app and each request has cancellation or stale-result guards. |
| `no-giant-component` | 4 | Defer | High; architectural decomposition is not a bug fix and should be reviewed separately. |
| `no-impure-state-updater` | 30 | Fixed 3 / false positive 27 | High; two history callbacks and inspector toggle perform real nested work; the other sites are ordinary setters misclassified as updater callbacks. |
| `no-inline-exhaustive-style` | 3 | No change | High; styles are dynamic visual data in the image placeholder. |
| `no-json-parse-stringify-clone` | 2 | No change | High; design documents are deliberately JSON-only and serialization enforces that boundary. |
| `no-mirror-prop-effect` | 2 | No change | High; both drafts intentionally preserve IME or partial hex input. |
| `no-nested-component-definition` | 1 | Fixed | High; move stateless sort icon selection to module scope. |
| `no-pass-live-state-to-parent` | 1 | Defer | Medium; moving title ownership changes the home-card data flow. |
| `no-permanent-will-change` | 1 | False positive | High; the laser node only exists while the continuously moving tool is active. |
| `no-prop-callback-in-effect` | 2 | Defer | Medium; preload completion and title resolution are explicit post-commit notifications. |
| `no-ref-current-in-render` | 12 | Fixed | High; synchronize latest-value refs in effects/layout effects so render stays pure. |
| `no-reset-all-state-on-prop-change` | 2 | Defer | Medium; theme/demo and dialog resets need parent-key ownership decisions. |
| `no-tiny-text` | 1 | No change | Medium; intentional canvas annotation, a product typography choice. |
| `no-unstable-nested-components` | 1 | Fixed | High; duplicate report for the nested sort icon component. |
| `no-vulnerable-react-server-components` | 1 | Out of scope | High; Next 16.2.4 is in the `apps/web` importer, not the core dependency graph. |
| `only-export-components` | 8 | No change | High; library helpers/variants and generated shadcn exports intentionally share modules. |
| `prefer-html-dialog` | 1 | Defer | High; the present-mode overlay needs fullscreen-aware focus/portal design before replacement. |
| `rendering-hydration-no-flicker` | 1 | No change | High; mounted gating is the documented next-themes hydration pattern. |
| `rerender-functional-setstate` | 1 | Fixed | High; functional update avoids a stale selection closure. |
| `unused-dependency` | 1 | False positive | High; `use-sync-external-store` is intentionally direct so Vite can prebundle Base UI's shim under pnpm. |
| `unused-file` | 8 | False positive / no change | High; six CLI files are build entrypoints and two UI files are generated shadcn artifacts. |

## Verification

- `npx --yes react-doctor@latest . --verbose --scope changed`: no issues after each fix batch.
- `npx --yes react-doctor@latest . --verbose`: 139 → 107 diagnostics; errors 47 → 32; warnings 92 → 75; score 0 → 16.
- `pnpm check`: passed with the existing `request-guard.ts` optional-chain warning.
- `./packages/core/node_modules/.bin/tsc --noEmit -p packages/core/tsconfig.json`: passed.
- `./node_modules/.bin/tsdown` in `packages/core`: passed with the existing virtual-module externalization warning.
- `./node_modules/.bin/vitest run`: 20 files and 300 tests passed.

## Fix commits

- `39778a7` — keep lifecycle callbacks pure.
- `8dfdc13` — improve editor accessibility and stability.
