### PR TITLE
feat(core): improve shared element transition (magic move) support

### DIFF
--- a/.changeset/shared-element-measure-first.md
+++ b/.changeset/shared-element-measure-first.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Measure shared-element rects before the enter/exit phases start so transform keyframes no longer offset magic-move targets.

--- a/.changeset/shared-element-skill-docs.md
+++ b/.changeset/shared-element-skill-docs.md
@@ -1,0 +1,6 @@
+---
+"@open-slide/core": patch
+"@open-slide/cli": patch
+---
+
+Document shared element transitions (magic move) in the slide-authoring skill.

--- a/.changeset/use-is-active-page.md
+++ b/.changeset/use-is-active-page.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Add unstable_useIsActivePage() so pages can gate entrance animations to the live audience-facing instance.

--- a/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slide-authoring
-description: Technical reference for writing or editing open-slide pages — file contract, 1920×1080 canvas, type scale, layout, palette/visual direction, and assets. Consult this whenever you are about to write or modify any file under `slides/<id>/`, including from inside the `create-slide` or `apply-comments` workflows, or for any ad-hoc slide edit. Triggers on phrases like "edit slide", "tweak this page", "fix the layout", "change the palette", "investigate the slide framework", "how do slides work here".
+description: Technical reference for writing or editing open-slide pages — file contract, 1920×1080 canvas, type scale, layout, palette/visual direction, assets, page transitions, and shared-element magic move. Consult this whenever you are about to write or modify any file under `slides/<id>/`, including from inside the `create-slide` or `apply-comments` workflows, or for any ad-hoc slide edit. Triggers on phrases like "edit slide", "tweak this page", "fix the layout", "change the palette", "add a transition", "magic move", "investigate the slide framework", "how do slides work here".
 ---
 
 # Authoring open-slide pages
@@ -523,6 +523,73 @@ Most tasteful tools don't mirror on backward navigation. When you genuinely need
 
 If you find yourself reaching for this on every transition, you're probably over-designing. Forward = backward is the more refined default.
 
+### Shared element transitions (magic move)
+
+When the *same visual object* exists on two adjacent pages, the runtime can morph it across the cut — position, size, border-radius, and colors interpolate in one continuous move (Keynote's "Magic Move") — instead of fading out and back in. Two parts opt in:
+
+1. Wrap the object on **both** pages in `unstable_SharedElement` with the **same `id`**.
+2. Enable `sharedElements` on the incoming page's transition.
+
+The component is exported with an `unstable_` prefix — it works and real decks lean on it heavily, but the API surface may still change. Alias it on import.
+
+```tsx
+import { unstable_SharedElement as SharedElement } from '@open-slide/core';
+
+// Morph transition — opacity-only enter/exit keeps all the motion on the clones (see rules).
+const morph: SlideTransition = {
+  duration: 280,
+  exit:  { duration: 224, easing: 'cubic-bezier(0.4, 0, 1, 1)', keyframes: [{ opacity: 1 }, { opacity: 0 }] },
+  enter: { duration: 308, delay: 112, easing: 'cubic-bezier(0, 0, 0.2, 1)', keyframes: [{ opacity: 0 }, { opacity: 1 }] },
+  sharedElements: { duration: 868, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
+};
+
+const stage: CSSProperties = { width: '100%', height: '100%', position: 'relative', background: '#000000', overflow: 'hidden' };
+
+const Narrow: Page = () => (
+  <div style={stage}>
+    <SharedElement id="pill" style={{ position: 'absolute', left: 842, top: 479, width: 236, height: 122, borderRadius: 999, background: '#ffffff' }} />
+  </div>
+);
+const Wide: Page = () => (
+  <div style={stage}>
+    <SharedElement id="pill" style={{ position: 'absolute', left: 721, top: 479, width: 478, height: 122, borderRadius: 999, background: '#0a0a0a' }} />
+  </div>
+);
+
+Wide.transition = morph;   // forward: Narrow → Wide morphs the pill
+Narrow.transition = morph; // backward: Wide → Narrow morphs it back
+```
+
+#### Contract
+
+- `sharedElements: true` inherits the transition's top-level `duration`/`easing`; pass `{ duration?, easing?, delay? }` to time the morph independently of the page cross-fade. Morphs usually read best 2–4× longer than the fade (e.g. 280 ms fade, 868 ms morph).
+- Elements pair by `id` across the cut. A matched pair FLIP-morphs: the runtime measures both rects, clones the outgoing element into an overlay above both pages, hides the originals, and animates transform + border-radius + colors (border widths ride a separate frame so they don't stretch with the box). Keep each `id` unique within a page; don't nest one `SharedElement` inside another.
+- An `id` present on only one side fades in/out **in place**. This is how "a third box joins the row" reads: carried boxes glide to their new slots, the new one materializes.
+- Colors on the shared node *and its descendants* interpolate too — a label that flips black → white mid-glide just works.
+- The transition lives on the **incoming** page. For a morph that also plays when stepping backward, assign the same transition object to both pages (as above).
+
+#### Rules — each one earned on a real deck
+
+1. **Prefer opacity-only enter/exit on morphing pages.** Any transition family composes correctly with the morph (shared rects are measured before the phases start), but while clones glide, a transform-bearing enter also slides the rest of the page — two competing motions. Giving the clones all the motion and fading everything else is what makes a magic move read as one confident gesture.
+2. **Shared geometry must be deterministic at mount.** Rects are snapshotted once at the cut. Position shared elements with pixel constants — never with a value measured in an effect after mount (the re-render shifts the target mid-morph and the move jumps). If text inside a shared box grows over time (typewriter etc.), render a hidden full-width spacer so the measured box never changes size.
+3. **No `transform` on the shared node itself.** A percentage translate (`translate(-50%, -50%)`) gets mis-scaled by the morph and lands the clone tens of px off. Put centering/positioning transforms on a plain wrapper `<div>` *around* the `SharedElement`.
+4. **`SharedElement` merges `className`/`style` onto its single host child** (it adds no wrapper when the child is a lone DOM element). A crop box (`overflow: hidden` + fixed width) therefore needs an explicit nested `<div>` — otherwise the box collapses onto the `<img>` inside and squishes it.
+5. **Gate entrance animations behind `unstable_useIsActivePage()`.** During the cut the runtime mounts a *fresh instance* of the outgoing page to snapshot its exit state (and the dev UI mounts every page for thumbnails/overview). If an intro replays there, the snapshot is mid-animation and the morph starts from garbage. The hook returns `true` only for the instance the audience is watching; every other instance (outgoing snapshot, thumbnails, overview, presenter preview, print) should render the final, settled state — no intro, full text.
+
+   ```tsx
+   import { unstable_useIsActivePage as useIsActivePage } from '@open-slide/core';
+
+   // Inside the page component:
+   const animate = useIsActivePage();
+   ```
+
+6. **Clones travel above everything.** The morph overlay sits over both pages, so an incoming element that should appear only when a clone "lands" will otherwise pop early. Give such reveals a delay equal to the morph: `animation: 'osd-fade 0.63s ease-out 0.868s both'` where `0.868s` is `sharedElements.duration`. Keep that number in one shared const so the two can't drift.
+7. **A "hold" page is a separate component.** Transitions attach to the incoming page, so to follow a morph cut with a plain cut of the same content, mint a second page component without `.transition` (e.g. `const Flow4Hold: Page = () => <Flow count={4} />`).
+
+#### When to reach for it
+
+Magic move is for **state continuity**: a toggle whose thumb slides to the next option, a card that expands into a detail view, a logo that glides from center stage into the next page's diagram, a row that gains one more box. The object *is the story* across the cut. Don't morph decoration, and don't tag elements "just in case" — every shared id is a promise to the audience that it's the same object. One or two morphing sequences per chapter is plenty; the surrounding pages should cut or fade quietly.
+
 ### Transition anti-patterns
 
 - ❌ Six different transitions across six pages — the single loudest "made in PowerPoint" tell.
@@ -602,6 +669,7 @@ This applies whenever the *visual element* repeats, not whenever the *data* does
 - [ ] Every `<ImagePlaceholder>` corresponds to a real image the user must supply — not decorative filler. If it could be replaced by typography or layout, it should be.
 - [ ] If a page uses `<Steps>`/`<Step>`, every `<Step>` is a direct child of a `<Steps>`, and the page still reads as complete when jumped to via the overview grid (entering forward builds up; jumping in shows it fully revealed).
 - [ ] If a `SlideTransition` is declared, every page sits in one family — same duration band (140–280 ms), same easing pair, same out-then-in stagger, magnitude under 12 px / 3%. No six-different-vocabularies decks. When in doubt, omit transitions entirely.
+- [ ] If a transition opts into `sharedElements`: every shared `id` is unique per page and stable across the pair, shared geometry is pixel-constant (never measured after mount), no `transform` sits on the shared node, and entrance animations are gated behind `unstable_useIsActivePage()`.
 - [ ] Nothing outside `slides/<id>/` was edited.
 
 ## Anti-patterns

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slide-authoring
-description: Technical reference for writing or editing open-slide pages — file contract, 1920×1080 canvas, type scale, layout, palette/visual direction, and assets. Consult this whenever you are about to write or modify any file under `slides/<id>/`, including from inside the `create-slide` or `apply-comments` workflows, or for any ad-hoc slide edit. Triggers on phrases like "edit slide", "tweak this page", "fix the layout", "change the palette", "investigate the slide framework", "how do slides work here".
+description: Technical reference for writing or editing open-slide pages — file contract, 1920×1080 canvas, type scale, layout, palette/visual direction, assets, page transitions, and shared-element magic move. Consult this whenever you are about to write or modify any file under `slides/<id>/`, including from inside the `create-slide` or `apply-comments` workflows, or for any ad-hoc slide edit. Triggers on phrases like "edit slide", "tweak this page", "fix the layout", "change the palette", "add a transition", "magic move", "investigate the slide framework", "how do slides work here".
 ---
 
 # Authoring open-slide pages
@@ -523,6 +523,73 @@ Most tasteful tools don't mirror on backward navigation. When you genuinely need
 
 If you find yourself reaching for this on every transition, you're probably over-designing. Forward = backward is the more refined default.
 
+### Shared element transitions (magic move)
+
+When the *same visual object* exists on two adjacent pages, the runtime can morph it across the cut — position, size, border-radius, and colors interpolate in one continuous move (Keynote's "Magic Move") — instead of fading out and back in. Two parts opt in:
+
+1. Wrap the object on **both** pages in `unstable_SharedElement` with the **same `id`**.
+2. Enable `sharedElements` on the incoming page's transition.
+
+The component is exported with an `unstable_` prefix — it works and real decks lean on it heavily, but the API surface may still change. Alias it on import.
+
+```tsx
+import { unstable_SharedElement as SharedElement } from '@open-slide/core';
+
+// Morph transition — opacity-only enter/exit keeps all the motion on the clones (see rules).
+const morph: SlideTransition = {
+  duration: 280,
+  exit:  { duration: 224, easing: 'cubic-bezier(0.4, 0, 1, 1)', keyframes: [{ opacity: 1 }, { opacity: 0 }] },
+  enter: { duration: 308, delay: 112, easing: 'cubic-bezier(0, 0, 0.2, 1)', keyframes: [{ opacity: 0 }, { opacity: 1 }] },
+  sharedElements: { duration: 868, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
+};
+
+const stage: CSSProperties = { width: '100%', height: '100%', position: 'relative', background: '#000000', overflow: 'hidden' };
+
+const Narrow: Page = () => (
+  <div style={stage}>
+    <SharedElement id="pill" style={{ position: 'absolute', left: 842, top: 479, width: 236, height: 122, borderRadius: 999, background: '#ffffff' }} />
+  </div>
+);
+const Wide: Page = () => (
+  <div style={stage}>
+    <SharedElement id="pill" style={{ position: 'absolute', left: 721, top: 479, width: 478, height: 122, borderRadius: 999, background: '#0a0a0a' }} />
+  </div>
+);
+
+Wide.transition = morph;   // forward: Narrow → Wide morphs the pill
+Narrow.transition = morph; // backward: Wide → Narrow morphs it back
+```
+
+#### Contract
+
+- `sharedElements: true` inherits the transition's top-level `duration`/`easing`; pass `{ duration?, easing?, delay? }` to time the morph independently of the page cross-fade. Morphs usually read best 2–4× longer than the fade (e.g. 280 ms fade, 868 ms morph).
+- Elements pair by `id` across the cut. A matched pair FLIP-morphs: the runtime measures both rects, clones the outgoing element into an overlay above both pages, hides the originals, and animates transform + border-radius + colors (border widths ride a separate frame so they don't stretch with the box). Keep each `id` unique within a page; don't nest one `SharedElement` inside another.
+- An `id` present on only one side fades in/out **in place**. This is how "a third box joins the row" reads: carried boxes glide to their new slots, the new one materializes.
+- Colors on the shared node *and its descendants* interpolate too — a label that flips black → white mid-glide just works.
+- The transition lives on the **incoming** page. For a morph that also plays when stepping backward, assign the same transition object to both pages (as above).
+
+#### Rules — each one earned on a real deck
+
+1. **Prefer opacity-only enter/exit on morphing pages.** Any transition family composes correctly with the morph (shared rects are measured before the phases start), but while clones glide, a transform-bearing enter also slides the rest of the page — two competing motions. Giving the clones all the motion and fading everything else is what makes a magic move read as one confident gesture.
+2. **Shared geometry must be deterministic at mount.** Rects are snapshotted once at the cut. Position shared elements with pixel constants — never with a value measured in an effect after mount (the re-render shifts the target mid-morph and the move jumps). If text inside a shared box grows over time (typewriter etc.), render a hidden full-width spacer so the measured box never changes size.
+3. **No `transform` on the shared node itself.** A percentage translate (`translate(-50%, -50%)`) gets mis-scaled by the morph and lands the clone tens of px off. Put centering/positioning transforms on a plain wrapper `<div>` *around* the `SharedElement`.
+4. **`SharedElement` merges `className`/`style` onto its single host child** (it adds no wrapper when the child is a lone DOM element). A crop box (`overflow: hidden` + fixed width) therefore needs an explicit nested `<div>` — otherwise the box collapses onto the `<img>` inside and squishes it.
+5. **Gate entrance animations behind `unstable_useIsActivePage()`.** During the cut the runtime mounts a *fresh instance* of the outgoing page to snapshot its exit state (and the dev UI mounts every page for thumbnails/overview). If an intro replays there, the snapshot is mid-animation and the morph starts from garbage. The hook returns `true` only for the instance the audience is watching; every other instance (outgoing snapshot, thumbnails, overview, presenter preview, print) should render the final, settled state — no intro, full text.
+
+   ```tsx
+   import { unstable_useIsActivePage as useIsActivePage } from '@open-slide/core';
+
+   // Inside the page component:
+   const animate = useIsActivePage();
+   ```
+
+6. **Clones travel above everything.** The morph overlay sits over both pages, so an incoming element that should appear only when a clone "lands" will otherwise pop early. Give such reveals a delay equal to the morph: `animation: 'osd-fade 0.63s ease-out 0.868s both'` where `0.868s` is `sharedElements.duration`. Keep that number in one shared const so the two can't drift.
+7. **A "hold" page is a separate component.** Transitions attach to the incoming page, so to follow a morph cut with a plain cut of the same content, mint a second page component without `.transition` (e.g. `const Flow4Hold: Page = () => <Flow count={4} />`).
+
+#### When to reach for it
+
+Magic move is for **state continuity**: a toggle whose thumb slides to the next option, a card that expands into a detail view, a logo that glides from center stage into the next page's diagram, a row that gains one more box. The object *is the story* across the cut. Don't morph decoration, and don't tag elements "just in case" — every shared id is a promise to the audience that it's the same object. One or two morphing sequences per chapter is plenty; the surrounding pages should cut or fade quietly.
+
 ### Transition anti-patterns
 
 - ❌ Six different transitions across six pages — the single loudest "made in PowerPoint" tell.
@@ -602,6 +669,7 @@ This applies whenever the *visual element* repeats, not whenever the *data* does
 - [ ] Every `<ImagePlaceholder>` corresponds to a real image the user must supply — not decorative filler. If it could be replaced by typography or layout, it should be.
 - [ ] If a page uses `<Steps>`/`<Step>`, every `<Step>` is a direct child of a `<Steps>`, and the page still reads as complete when jumped to via the overview grid (entering forward builds up; jumping in shows it fully revealed).
 - [ ] If a `SlideTransition` is declared, every page sits in one family — same duration band (140–280 ms), same easing pair, same out-then-in stagger, magnitude under 12 px / 3%. No six-different-vocabularies decks. When in doubt, omit transitions entirely.
+- [ ] If a transition opts into `sharedElements`: every shared `id` is unique per page and stable across the pair, shared geometry is pixel-constant (never measured after mount), no `transform` sits on the shared node, and entrance animations are gated behind `unstable_useIsActivePage()`.
 - [ ] Nothing outside `slides/<id>/` was edited.
 
 ## Anti-patterns

--- a/packages/core/src/app/components/slide-transition-layer.tsx
+++ b/packages/core/src/app/components/slide-transition-layer.tsx
@@ -733,6 +733,13 @@ export function SlideTransitionLayer({
     const easing = transition.easing ?? DEFAULT_EASING;
     const duration = transition.duration;
 
+    // Shared elements must be measured before the enter/exit phases start:
+    // phase keyframes apply immediately (fill: both), so a transform in the
+    // enter's first keyframe would offset every measured target rect and land
+    // the clones off their true rest positions.
+    const sharedPhase = resolveSharedElementTransition(transition.sharedElements, duration, easing);
+    const shared = sharedPhase ? runSharedElementTransition(wrapper, out, inc, sharedPhase) : null;
+
     const anims: Animation[] = [];
     const exitAnim = runPhase(out, transition.exit, duration, easing);
     const enterAnim = runPhase(inc, transition.enter, duration, easing);
@@ -740,9 +747,7 @@ export function SlideTransitionLayer({
     if (enterAnim) anims.push(enterAnim);
 
     const cleanups: Array<() => void> = [];
-    const sharedPhase = resolveSharedElementTransition(transition.sharedElements, duration, easing);
-    if (sharedPhase) {
-      const shared = runSharedElementTransition(wrapper, out, inc, sharedPhase);
+    if (shared) {
       anims.push(...shared.animations);
       cleanups.push(shared.cleanup);
       if (!exitAnim && shared.animations.length > 0) cleanups.push(hideOriginal(out));

--- a/packages/core/src/app/lib/step-context.tsx
+++ b/packages/core/src/app/lib/step-context.tsx
@@ -41,6 +41,7 @@ type StepHostContextValue = {
   reportRevealed: (id: object, revealed: number) => void;
   entryDirection: EntryDirection;
   controlled: boolean;
+  isActivePage: boolean;
 };
 
 const GLOBAL_KEY = '__open_slide_step_host_context__';
@@ -163,12 +164,21 @@ export function StepHost({
       },
       entryDirection,
       controlled: controlledRevealed != null,
+      isActivePage,
     }),
-    [entryDirection, controlledRevealed, distributeControlled, notifyAggregate],
+    [entryDirection, controlledRevealed, distributeControlled, notifyAggregate, isActivePage],
   );
 
   return <StepHostContext.Provider value={value}>{children}</StepHostContext.Provider>;
 }
+
+// Hostless mounts (thumbnails, overview grid, print/export) are never the
+// audience-facing instance, so no provider means false.
+function useIsActivePage(): boolean {
+  return useContext(StepHostContext)?.isActivePage ?? false;
+}
+
+export const unstable_useIsActivePage = useIsActivePage;
 
 export type StepsProps = PropsWithChildren;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,7 +13,7 @@ export { useSlidePageNumber } from './app/lib/page-context.tsx';
 export type { Page, SlideMeta, SlideModule } from './app/lib/sdk.ts';
 export { CANVAS_HEIGHT, CANVAS_WIDTH } from './app/lib/sdk.ts';
 export type { StepProps, StepsProps } from './app/lib/step-context.tsx';
-export { Step, Steps } from './app/lib/step-context.tsx';
+export { Step, Steps, unstable_useIsActivePage } from './app/lib/step-context.tsx';
 export type {
   SharedElementTransition,
   SlideTransition,


### PR DESCRIPTION
## Summary

Deep-dive into the shared element transition (magic move) implementation, driven by the hacks a real 190-page keynote deck had to make. Two framework fixes plus full skill documentation:

- **Measure shared-element rects before the enter/exit phases start** ([slide-transition-layer.tsx](https://github.com/1weiho/open-slide/blob/shared-element-magic-move/packages/core/src/app/components/slide-transition-layer.tsx)). Phase keyframes apply immediately (`fill: 'both'`), so a `translateY` in the enter's first keyframe used to offset every measured target rect — clones landed a few px off and snapped at morph end, forcing authors into pure-opacity transitions on every morphing page. Measuring first removes that constraint; `sharedElements` now composes with any transition family.
- **Add `unstable_useIsActivePage()`** ([step-context.tsx](https://github.com/1weiho/open-slide/blob/shared-element-magic-move/packages/core/src/app/lib/step-context.tsx)). The runtime mounts a fresh instance of the outgoing page to snapshot its exit state, and the dev UI mounts every page for thumbnails/overview/presenter/print — decks had to parse `?p=` from the URL to keep typewriters, connector draws, and audio from replaying there (wrong in thumbnails of the current page, the presenter window, and print). The hook reads the `isActivePage` flag `StepHost` already threads through; hostless mounts default to `false` so they render the settled final state.
- **Document shared element transitions in the `slide-authoring` skill** (core copy + CLI template copy kept in sync): opt-in contract, FLIP semantics (id pairing, in-place fades for unmatched ids, bidirectional morphs), seven authoring rules (deterministic geometry, no transform on the shared node, single-child style merge, morph-timed reveals, hold pages…), and taste guidance on when to reach for a magic move.

## Changesets

- `@open-slide/core` **minor** — new public API `unstable_useIsActivePage()`
- `@open-slide/core` **patch** — measurement-order fix
- `@open-slide/core` + `@open-slide/cli` **patch** — skill docs

## Testing

- `pnpm typecheck` and `pnpm test` (305 tests) pass; biome clean on changed files.
- The measurement reorder stays within the same synchronous layout effect (all animations still start in the same frame before paint), so existing opacity-only decks are unaffected.
- No WAAPI test harness exists for the transition layer; runtime verification is easiest by giving a morphing page a transform-bearing enter — before this fix the clones land offset and snap, after it they land flush.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `unstable_useIsActivePage()` to identify the live audience-facing page and control entrance animations.
  - Improved shared-element (“magic move”) transitions by measuring elements before enter and exit animations begin.

- **Documentation**
  - Added guidance and review requirements for configuring shared-element transitions, including matching IDs, stable geometry, and animation gating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->