### PR TITLE
feat(core): stabilize morph transition API

### DIFF
--- a/.changeset/morph-transition.md
+++ b/.changeset/morph-transition.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Stabilize the morph transition API: rename `unstable_SharedElement` to `MorphElement` and the `sharedElements` transition option to `morph`.

--- a/.changeset/shared-element-measure-first.md
+++ b/.changeset/shared-element-measure-first.md
@@ -2,4 +2,4 @@
 "@open-slide/core": patch
 ---
 
-Measure shared-element rects before the enter/exit phases start so transform keyframes no longer offset magic-move targets.
+Measure morph-element rects before the enter/exit phases start so transform keyframes no longer offset morph targets.

--- a/.changeset/shared-element-skill-docs.md
+++ b/.changeset/shared-element-skill-docs.md
@@ -3,4 +3,4 @@
 "@open-slide/cli": patch
 ---
 
-Document shared element transitions (magic move) in the slide-authoring skill.
+Document morph transitions in the slide-authoring skill.

--- a/.changeset/use-is-active-page.md
+++ b/.changeset/use-is-active-page.md
@@ -2,4 +2,4 @@
 "@open-slide/core": minor
 ---
 
-Add unstable_useIsActivePage() so pages can gate entrance animations to the live audience-facing instance.
+Add useIsActivePage() so pages can gate entrance animations to the live audience-facing instance.

--- a/apps/demo/slides/morph-demo/index.tsx
+++ b/apps/demo/slides/morph-demo/index.tsx
@@ -1,7 +1,7 @@
 import {
   type DesignSystem,
+  MorphElement,
   type Page,
-  unstable_SharedElement as SharedElement,
   type SlideMeta,
   type SlideTransition,
 } from '@open-slide/core';
@@ -18,7 +18,7 @@ export const design: DesignSystem = {
 };
 
 export const meta: SlideMeta = {
-  title: 'Magic Move Prototype',
+  title: 'Morph Transition Prototype',
   createdAt: '2026-06-22T17:00:36.438Z',
 };
 
@@ -27,7 +27,7 @@ const EASE = 'cubic-bezier(0.4, 0, 0.2, 1)';
 export const transition: SlideTransition = {
   duration: 1250,
   easing: EASE,
-  sharedElements: {
+  morph: {
     duration: 1250,
     easing: EASE,
   },
@@ -50,7 +50,7 @@ const root: CSSProperties = {
 };
 
 const Title = () => (
-  <SharedElement id="magic-title">
+  <MorphElement id="morph-title">
     <h1
       style={{
         position: 'absolute',
@@ -64,13 +64,13 @@ const Title = () => (
         letterSpacing: 0,
       }}
     >
-      Magic Move
+      Morph
     </h1>
-  </SharedElement>
+  </MorphElement>
 );
 
 const Caption = ({ id, text }: { id: string; text: string }) => (
-  <SharedElement id={`caption-${id}`}>
+  <MorphElement id={`caption-${id}`}>
     <div
       style={{
         position: 'absolute',
@@ -84,7 +84,7 @@ const Caption = ({ id, text }: { id: string; text: string }) => (
     >
       {text}
     </div>
-  </SharedElement>
+  </MorphElement>
 );
 
 const Stage = ({ children }: { children: ReactNode }) => (
@@ -107,7 +107,7 @@ const Dot = ({
   size: number;
   color: string;
 }) => (
-  <SharedElement id={`dot-${id}`}>
+  <MorphElement id={`dot-${id}`}>
     <div
       style={{
         position: 'absolute',
@@ -119,11 +119,11 @@ const Dot = ({
         background: color,
       }}
     />
-  </SharedElement>
+  </MorphElement>
 );
 
 const Ring = ({ left, top, size }: { left: number; top: number; size: number }) => (
-  <SharedElement id="focus-ring">
+  <MorphElement id="focus-ring">
     <div
       style={{
         position: 'absolute',
@@ -136,7 +136,7 @@ const Ring = ({ left, top, size }: { left: number; top: number; size: number }) 
         boxSizing: 'border-box',
       }}
     />
-  </SharedElement>
+  </MorphElement>
 );
 
 const Arrange: Page = () => (

--- a/apps/web/content/docs/primitive/meta.json
+++ b/apps/web/content/docs/primitive/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Primitive",
-  "pages": ["page", "transition", "step", "shared-element"]
+  "pages": ["page", "transition", "step", "morph-element"]
 }

--- a/apps/web/content/docs/primitive/morph-element.mdx
+++ b/apps/web/content/docs/primitive/morph-element.mdx
@@ -1,26 +1,18 @@
 ---
-title: SharedElement
+title: MorphElement
 description: Keynote-style continuity for the same object across pages.
 ---
 
-<Callout type="warn">
-  The shared element API is currently exported as `unstable_SharedElement`.
-  Treat it as experimental and subject to change.
-</Callout>
+`MorphElement` is the primitive for making one visual object move between two
+pages — a Morph Transition (Keynote calls the effect "Magic Move"). Wrap the
+same object on both pages and the runtime morphs it across the cut instead of
+fading it out and back in.
 
-`SharedElement` is the conceptual primitive for making one visual object move
-between two pages. In code today, import `unstable_SharedElement` and alias it
-to the component name you want to use.
-
-```tsx title="slides/magic-move/index.tsx"
-import {
-  unstable_SharedElement as SharedElement,
-  type Page,
-  type SlideTransition,
-} from '@open-slide/core';
+```tsx title="slides/morph/index.tsx"
+import { MorphElement, type Page, type SlideTransition } from '@open-slide/core';
 
 const Token = ({ x, y, size }: { x: number; y: number; size: number }) => (
-  <SharedElement id="token">
+  <MorphElement id="token">
     <div
       style={{
         position: 'absolute',
@@ -32,7 +24,7 @@ const Token = ({ x, y, size }: { x: number; y: number; size: number }) => (
         background: 'var(--osd-accent)',
       }}
     />
-  </SharedElement>
+  </MorphElement>
 );
 
 const Start: Page = () => <Token x={160} y={180} size={180} />;
@@ -40,7 +32,7 @@ const End: Page = () => <Token x={1420} y={720} size={96} />;
 
 export const transition: SlideTransition = {
   duration: 700,
-  sharedElements: {
+  morph: {
     duration: 700,
     easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
   },
@@ -52,7 +44,7 @@ export default [Start, End] satisfies Page[];
 ## Matching Contract
 
 The `id` is the contract. When the outgoing and incoming pages both contain a
-shared element with the same `id`, the runtime measures both DOM nodes, hides
+`MorphElement` with the same `id`, the runtime measures both DOM nodes, hides
 the originals, animates a clone across the 1920 × 1080 canvas, then restores
 the incoming element.
 
@@ -64,22 +56,21 @@ similar objects; unmatched ids are separate objects.
 
 Wrap the same visual object in a new position or size: a logo, diagram node,
 timeline marker, product card, badge, or highlight. Keep changing copy outside
-the shared element. If the content changes while moving, the audience reads it
+the `MorphElement`. If the content changes while moving, the audience reads it
 as one object turning into another, not continuity.
 
-`unstable_SharedElement` works best with a single DOM child. If there is
-exactly one DOM child, the runtime writes the `data-osd-shared-element`
-marker onto that child. Otherwise it wraps the content in a `div`.
+`MorphElement` works best with a single DOM child. If there is exactly one DOM
+child, the runtime writes the `data-osd-morph` marker onto that child.
+Otherwise it wraps the content in a `div`.
 
 ## Transition Required
 
-Shared elements only run when the selected transition enables
-`sharedElements`.
+A Morph Transition only runs when the selected transition enables `morph`.
 
 ```ts
 export const transition: SlideTransition = {
   duration: 600,
-  sharedElements: true,
+  morph: true,
 };
 ```
 

--- a/apps/web/content/docs/primitive/transition.mdx
+++ b/apps/web/content/docs/primitive/transition.mdx
@@ -1,6 +1,6 @@
 ---
 title: Transition
-description: Enter, exit, and shared-element motion between pages.
+description: Enter, exit, and morph motion between pages.
 ---
 
 `SlideTransition` describes what happens when the active `Page` changes. There
@@ -94,15 +94,15 @@ Most decks should keep a single restrained motion family: short duration,
 subtle distance, opacity included, and no different transition vocabulary on
 every page.
 
-## Shared Elements
+## Morph
 
-`SlideTransition.sharedElements` enables [SharedElement](/docs/primitive/shared-element)
+`SlideTransition.morph` enables [MorphElement](/docs/primitive/morph-element)
 matching for objects that should visually continue across two pages.
 
 ```ts
 export const transition: SlideTransition = {
   duration: 600,
-  sharedElements: {
+  morph: {
     duration: 600,
     easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
   },

--- a/apps/web/content/docs/reference/slide-meta.mdx
+++ b/apps/web/content/docs/reference/slide-meta.mdx
@@ -75,15 +75,15 @@ import {
   CANVAS_WIDTH,        // 1920
   CANVAS_HEIGHT,       // 1080
   ImagePlaceholder,    // sized empty placeholder — see /docs/reference/image-placeholder
-  unstable_SharedElement, // match an element across pages — see /docs/reference/slide-transitions
+  MorphElement,        // match an element across pages — see /docs/reference/slide-transitions
 } from '@open-slide/core';
 import type {
-  unstable_SharedElementProps,
+  MorphElementProps,
   Page,
   SlideMeta,
   SlideModule,
   SlideTransition,     // per-page / module-level animations — see /docs/reference/slide-transitions
-  SharedElementTransition,
+  MorphTransition,
   TransitionPhase,
   ImagePlaceholderProps,
 } from '@open-slide/core';

--- a/apps/web/content/docs/reference/slide-transitions.mdx
+++ b/apps/web/content/docs/reference/slide-transitions.mdx
@@ -1,6 +1,6 @@
 ---
 title: SlideTransition
-description: Per-page enter/exit animations and shared element transitions.
+description: Per-page enter/exit animations and morph transitions.
 ---
 
 The framework can run an enter/exit animation between every page change. There
@@ -61,16 +61,16 @@ type SlideTransition = {
   enter?: TransitionPhase;
   /** Plays on the outgoing page. */
   exit?: TransitionPhase;
-  /** Matches unstable_SharedElement pairs and fades unmatched shared elements. */
-  sharedElements?: boolean | SharedElementTransition;
+  /** Matches MorphElement pairs and fades unmatched morph elements. */
+  morph?: boolean | MorphTransition;
 };
 
-type SharedElementTransition = {
-  /** Shared element duration in ms. Falls back to the top-level duration. */
+type MorphTransition = {
+  /** Morph duration in ms. Falls back to the top-level duration. */
   duration?: number;
   /** CSS easing string. Falls back to the top-level easing. */
   easing?: string;
-  /** Delay in ms before shared elements start moving. */
+  /** Delay in ms before the morph starts. */
   delay?: number;
 };
 ```
@@ -125,28 +125,18 @@ Most tasteful tools don't mirror on backward navigation — forward = backward
 reads as more refined. Reach for the direction hook only when the page's motion
 has a literal direction (a horizontal advance, a chapter sweep).
 
-## Shared elements
-
-<Callout type="warn">
-  This feature is currently unstable and subject to change. It is not
-  recommended for production. Try it out and share your feedback on
-  [GitHub](https://github.com/1weiho/open-slide/issues).
-</Callout>
+## Morph
 
 For Keynote-style "Magic Move" continuity, wrap the same visual object on two
-pages with `unstable_SharedElement` and give both instances the same `id`. The transition
+pages with `MorphElement` and give both instances the same `id`. The transition
 layer measures the outgoing and incoming DOM, hides the originals, animates a
 clone across the canvas, then restores the incoming element.
 
 ```tsx
-import {
-  unstable_SharedElement as SharedElement,
-  type Page,
-  type SlideTransition,
-} from '@open-slide/core';
+import { MorphElement, type Page, type SlideTransition } from '@open-slide/core';
 
 const Logo = ({ x, y, size }: { x: number; y: number; size: number }) => (
-  <SharedElement id="logo">
+  <MorphElement id="logo">
     <div
       style={{
         position: 'absolute',
@@ -158,7 +148,7 @@ const Logo = ({ x, y, size }: { x: number; y: number; size: number }) => (
         background: 'var(--osd-accent)',
       }}
     />
-  </SharedElement>
+  </MorphElement>
 );
 
 const Start: Page = () => <Logo x={160} y={180} size={180} />;
@@ -168,7 +158,7 @@ export const transition: SlideTransition = {
   duration: 900,
   enter: { keyframes: [{ opacity: 0.35 }, { opacity: 1 }] },
   exit: { keyframes: [{ opacity: 1 }, { opacity: 0.35 }] },
-  sharedElements: {
+  morph: {
     duration: 900,
     easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
   },
@@ -177,12 +167,12 @@ export const transition: SlideTransition = {
 export default [Start, End];
 ```
 
-Use shared elements only for the same object in a new position or size. If the
-content changes, keep that changing copy outside `unstable_SharedElement` and let it fade
-as normal page content. When `sharedElements` is enabled, marked elements that
-only exist on the outgoing page fade out automatically, and marked elements that
-only exist on the incoming page fade in automatically. The runtime does not
-guess similar objects; the `id` is the contract.
+Morph only the same object in a new position or size. If the content changes,
+keep that changing copy outside `MorphElement` and let it fade as normal page
+content. When `morph` is enabled, marked elements that only exist on the
+outgoing page fade out automatically, and marked elements that only exist on the
+incoming page fade in automatically. The runtime does not guess similar objects;
+the `id` is the contract.
 
 ## Design principles
 

--- a/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slide-authoring
-description: Technical reference for writing or editing open-slide pages — file contract, 1920×1080 canvas, type scale, layout, palette/visual direction, assets, page transitions, and shared-element magic move. Consult this whenever you are about to write or modify any file under `slides/<id>/`, including from inside the `create-slide` or `apply-comments` workflows, or for any ad-hoc slide edit. Triggers on phrases like "edit slide", "tweak this page", "fix the layout", "change the palette", "add a transition", "magic move", "investigate the slide framework", "how do slides work here".
+description: Technical reference for writing or editing open-slide pages — file contract, 1920×1080 canvas, type scale, layout, palette/visual direction, assets, page transitions, and morph transitions. Consult this whenever you are about to write or modify any file under `slides/<id>/`, including from inside the `create-slide` or `apply-comments` workflows, or for any ad-hoc slide edit. Triggers on phrases like "edit slide", "tweak this page", "fix the layout", "change the palette", "add a transition", "morph transition", "investigate the slide framework", "how do slides work here".
 ---
 
 # Authoring open-slide pages
@@ -523,72 +523,70 @@ Most tasteful tools don't mirror on backward navigation. When you genuinely need
 
 If you find yourself reaching for this on every transition, you're probably over-designing. Forward = backward is the more refined default.
 
-### Shared element transitions (magic move)
+### Morph transitions
 
-When the *same visual object* exists on two adjacent pages, the runtime can morph it across the cut — position, size, border-radius, and colors interpolate in one continuous move (Keynote's "Magic Move") — instead of fading out and back in. Two parts opt in:
+When the *same visual object* exists on two adjacent pages, the runtime can morph it across the cut — position, size, border-radius, and colors interpolate in one continuous move (Keynote calls this "Magic Move") — instead of fading out and back in. Two parts opt in:
 
-1. Wrap the object on **both** pages in `unstable_SharedElement` with the **same `id`**.
-2. Enable `sharedElements` on the incoming page's transition.
-
-The component is exported with an `unstable_` prefix — it works and real decks lean on it heavily, but the API surface may still change. Alias it on import.
+1. Wrap the object on **both** pages in `MorphElement` with the **same `id`**.
+2. Enable `morph` on the incoming page's transition.
 
 ```tsx
-import { unstable_SharedElement as SharedElement } from '@open-slide/core';
+import { MorphElement } from '@open-slide/core';
 
 // Morph transition — opacity-only enter/exit keeps all the motion on the clones (see rules).
-const morph: SlideTransition = {
+const morphTransition: SlideTransition = {
   duration: 280,
   exit:  { duration: 224, easing: 'cubic-bezier(0.4, 0, 1, 1)', keyframes: [{ opacity: 1 }, { opacity: 0 }] },
   enter: { duration: 308, delay: 112, easing: 'cubic-bezier(0, 0, 0.2, 1)', keyframes: [{ opacity: 0 }, { opacity: 1 }] },
-  sharedElements: { duration: 868, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
+  morph: { duration: 868, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
 };
 
 const stage: CSSProperties = { width: '100%', height: '100%', position: 'relative', background: '#000000', overflow: 'hidden' };
 
 const Narrow: Page = () => (
   <div style={stage}>
-    <SharedElement id="pill" style={{ position: 'absolute', left: 842, top: 479, width: 236, height: 122, borderRadius: 999, background: '#ffffff' }} />
+    <MorphElement id="pill" style={{ position: 'absolute', left: 842, top: 479, width: 236, height: 122, borderRadius: 999, background: '#ffffff' }} />
   </div>
 );
 const Wide: Page = () => (
   <div style={stage}>
-    <SharedElement id="pill" style={{ position: 'absolute', left: 721, top: 479, width: 478, height: 122, borderRadius: 999, background: '#0a0a0a' }} />
+    <MorphElement id="pill" style={{ position: 'absolute', left: 721, top: 479, width: 478, height: 122, borderRadius: 999, background: '#0a0a0a' }} />
   </div>
 );
 
-Wide.transition = morph;   // forward: Narrow → Wide morphs the pill
-Narrow.transition = morph; // backward: Wide → Narrow morphs it back
+Wide.transition = morphTransition;   // forward: Narrow → Wide morphs the pill
+Narrow.transition = morphTransition; // backward: Wide → Narrow morphs it back
 ```
 
 #### Contract
 
-- `sharedElements: true` inherits the transition's top-level `duration`/`easing`; pass `{ duration?, easing?, delay? }` to time the morph independently of the page cross-fade. Morphs usually read best 2–4× longer than the fade (e.g. 280 ms fade, 868 ms morph).
-- Elements pair by `id` across the cut. A matched pair FLIP-morphs: the runtime measures both rects, clones the outgoing element into an overlay above both pages, hides the originals, and animates transform + border-radius + colors (border widths ride a separate frame so they don't stretch with the box). Keep each `id` unique within a page; don't nest one `SharedElement` inside another.
+- `morph: true` inherits the transition's top-level `duration`/`easing`; pass `{ duration?, easing?, delay? }` to time the morph independently of the page cross-fade. Morphs usually read best 2–4× longer than the fade (e.g. 280 ms fade, 868 ms morph).
+- Elements pair by `id` across the cut. A matched pair FLIP-morphs: the runtime measures both rects, clones the outgoing element into an overlay above both pages, hides the originals, and animates transform + border-radius + colors (border widths ride a separate frame so they don't stretch with the box). Keep each `id` unique within a page; don't nest one `MorphElement` inside another.
 - An `id` present on only one side fades in/out **in place**. This is how "a third box joins the row" reads: carried boxes glide to their new slots, the new one materializes.
-- Colors on the shared node *and its descendants* interpolate too — a label that flips black → white mid-glide just works.
+- Colors on the morph node *and its descendants* interpolate too — a label that flips black → white mid-glide just works.
 - The transition lives on the **incoming** page. For a morph that also plays when stepping backward, assign the same transition object to both pages (as above).
 
 #### Rules — each one earned on a real deck
 
-1. **Prefer opacity-only enter/exit on morphing pages.** Any transition family composes correctly with the morph (shared rects are measured before the phases start), but while clones glide, a transform-bearing enter also slides the rest of the page — two competing motions. Giving the clones all the motion and fading everything else is what makes a magic move read as one confident gesture.
-2. **Shared geometry must be deterministic at mount.** Rects are snapshotted once at the cut. Position shared elements with pixel constants — never with a value measured in an effect after mount (the re-render shifts the target mid-morph and the move jumps). If text inside a shared box grows over time (typewriter etc.), render a hidden full-width spacer so the measured box never changes size.
-3. **No `transform` on the shared node itself.** A percentage translate (`translate(-50%, -50%)`) gets mis-scaled by the morph and lands the clone tens of px off. Put centering/positioning transforms on a plain wrapper `<div>` *around* the `SharedElement`.
-4. **`SharedElement` merges `className`/`style` onto its single host child** (it adds no wrapper when the child is a lone DOM element). A crop box (`overflow: hidden` + fixed width) therefore needs an explicit nested `<div>` — otherwise the box collapses onto the `<img>` inside and squishes it.
-5. **Gate entrance animations behind `unstable_useIsActivePage()`.** During the cut the runtime mounts a *fresh instance* of the outgoing page to snapshot its exit state (and the dev UI mounts every page for thumbnails/overview). If an intro replays there, the snapshot is mid-animation and the morph starts from garbage. The hook returns `true` only for the instance the audience is watching; every other instance (outgoing snapshot, thumbnails, overview, presenter preview, print) should render the final, settled state — no intro, full text.
+1. **Prefer opacity-only enter/exit on morphing pages.** Any transition family composes correctly with the morph (shared rects are measured before the phases start), but while clones glide, a transform-bearing enter also slides the rest of the page — two competing motions. Giving the clones all the motion and fading everything else is what makes a morph read as one confident gesture.
+2. **Morph geometry must be deterministic at mount.** Rects are snapshotted once at the cut. Position morph elements with pixel constants — never with a value measured in an effect after mount (the re-render shifts the target mid-morph and the move jumps). If text inside a morph box grows over time (typewriter etc.), render a hidden full-width spacer so the measured box never changes size.
+3. **No `transform` on the morph node itself.** A percentage translate (`translate(-50%, -50%)`) gets mis-scaled by the morph and lands the clone tens of px off. Put centering/positioning transforms on a plain wrapper `<div>` *around* the `MorphElement`.
+4. **`MorphElement` merges `className`/`style` onto its single host child** (it adds no wrapper when the child is a lone DOM element). A crop box (`overflow: hidden` + fixed width) therefore needs an explicit nested `<div>` — otherwise the box collapses onto the `<img>` inside and squishes it.
+5. **Gate entrance animations behind `useIsActivePage()`.** During the cut the runtime mounts a *fresh instance* of the outgoing page to snapshot its exit state (and the dev UI mounts every page for thumbnails/overview). If an intro replays there, the snapshot is mid-animation and the morph starts from garbage. The hook returns `true` only for the instance the audience is watching; every other instance (outgoing snapshot, thumbnails, overview, presenter preview, print) should render the final, settled state — no intro, full text.
 
    ```tsx
-   import { unstable_useIsActivePage as useIsActivePage } from '@open-slide/core';
+   import { useIsActivePage } from '@open-slide/core';
 
    // Inside the page component:
    const animate = useIsActivePage();
    ```
 
-6. **Clones travel above everything.** The morph overlay sits over both pages, so an incoming element that should appear only when a clone "lands" will otherwise pop early. Give such reveals a delay equal to the morph: `animation: 'osd-fade 0.63s ease-out 0.868s both'` where `0.868s` is `sharedElements.duration`. Keep that number in one shared const so the two can't drift.
+6. **Clones travel above everything.** The morph overlay sits over both pages, so an incoming element that should appear only when a clone "lands" will otherwise pop early. Give such reveals a delay equal to the morph: `animation: 'osd-fade 0.63s ease-out 0.868s both'` where `0.868s` is `morph.duration`. Keep that number in one shared const so the two can't drift.
 7. **A "hold" page is a separate component.** Transitions attach to the incoming page, so to follow a morph cut with a plain cut of the same content, mint a second page component without `.transition` (e.g. `const Flow4Hold: Page = () => <Flow count={4} />`).
 
 #### When to reach for it
 
-Magic move is for **state continuity**: a toggle whose thumb slides to the next option, a card that expands into a detail view, a logo that glides from center stage into the next page's diagram, a row that gains one more box. The object *is the story* across the cut. Don't morph decoration, and don't tag elements "just in case" — every shared id is a promise to the audience that it's the same object. One or two morphing sequences per chapter is plenty; the surrounding pages should cut or fade quietly.
+Morph is for **state continuity**: a toggle whose thumb slides to the next option, a card that expands into a detail view, a logo that glides from center stage into the next page's diagram, a row that gains one more box. The object *is the story* across the cut. Don't morph decoration, and don't tag elements "just in case" — every morph id is a promise to the audience that it's the same object. One or two morphing sequences per chapter is plenty; the surrounding pages should cut or fade quietly.
 
 ### Transition anti-patterns
 
@@ -669,7 +667,7 @@ This applies whenever the *visual element* repeats, not whenever the *data* does
 - [ ] Every `<ImagePlaceholder>` corresponds to a real image the user must supply — not decorative filler. If it could be replaced by typography or layout, it should be.
 - [ ] If a page uses `<Steps>`/`<Step>`, every `<Step>` is a direct child of a `<Steps>`, and the page still reads as complete when jumped to via the overview grid (entering forward builds up; jumping in shows it fully revealed).
 - [ ] If a `SlideTransition` is declared, every page sits in one family — same duration band (140–280 ms), same easing pair, same out-then-in stagger, magnitude under 12 px / 3%. No six-different-vocabularies decks. When in doubt, omit transitions entirely.
-- [ ] If a transition opts into `sharedElements`: every shared `id` is unique per page and stable across the pair, shared geometry is pixel-constant (never measured after mount), no `transform` sits on the shared node, and entrance animations are gated behind `unstable_useIsActivePage()`.
+- [ ] If a transition opts into `morph`: every morph `id` is unique per page and stable across the pair, morph geometry is pixel-constant (never measured after mount), no `transform` sits on the morph node, and entrance animations are gated behind `useIsActivePage()`.
 - [ ] Nothing outside `slides/<id>/` was edited.
 
 ## Anti-patterns

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -78,7 +78,7 @@ export const meta = { title: 'Hello' };
 import {
   CANVAS_WIDTH,   // 1920
   CANVAS_HEIGHT,  // 1080
-  unstable_SharedElement, // match or fade objects across pages for shared element transitions
+  MorphElement,   // match or fade objects across pages for morph transitions
   type Page,
   type SlideMeta,
   type SlideModule,

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slide-authoring
-description: Technical reference for writing or editing open-slide pages — file contract, 1920×1080 canvas, type scale, layout, palette/visual direction, assets, page transitions, and shared-element magic move. Consult this whenever you are about to write or modify any file under `slides/<id>/`, including from inside the `create-slide` or `apply-comments` workflows, or for any ad-hoc slide edit. Triggers on phrases like "edit slide", "tweak this page", "fix the layout", "change the palette", "add a transition", "magic move", "investigate the slide framework", "how do slides work here".
+description: Technical reference for writing or editing open-slide pages — file contract, 1920×1080 canvas, type scale, layout, palette/visual direction, assets, page transitions, and morph transitions. Consult this whenever you are about to write or modify any file under `slides/<id>/`, including from inside the `create-slide` or `apply-comments` workflows, or for any ad-hoc slide edit. Triggers on phrases like "edit slide", "tweak this page", "fix the layout", "change the palette", "add a transition", "morph transition", "investigate the slide framework", "how do slides work here".
 ---
 
 # Authoring open-slide pages
@@ -523,72 +523,70 @@ Most tasteful tools don't mirror on backward navigation. When you genuinely need
 
 If you find yourself reaching for this on every transition, you're probably over-designing. Forward = backward is the more refined default.
 
-### Shared element transitions (magic move)
+### Morph transitions
 
-When the *same visual object* exists on two adjacent pages, the runtime can morph it across the cut — position, size, border-radius, and colors interpolate in one continuous move (Keynote's "Magic Move") — instead of fading out and back in. Two parts opt in:
+When the *same visual object* exists on two adjacent pages, the runtime can morph it across the cut — position, size, border-radius, and colors interpolate in one continuous move (Keynote calls this "Magic Move") — instead of fading out and back in. Two parts opt in:
 
-1. Wrap the object on **both** pages in `unstable_SharedElement` with the **same `id`**.
-2. Enable `sharedElements` on the incoming page's transition.
-
-The component is exported with an `unstable_` prefix — it works and real decks lean on it heavily, but the API surface may still change. Alias it on import.
+1. Wrap the object on **both** pages in `MorphElement` with the **same `id`**.
+2. Enable `morph` on the incoming page's transition.
 
 ```tsx
-import { unstable_SharedElement as SharedElement } from '@open-slide/core';
+import { MorphElement } from '@open-slide/core';
 
 // Morph transition — opacity-only enter/exit keeps all the motion on the clones (see rules).
-const morph: SlideTransition = {
+const morphTransition: SlideTransition = {
   duration: 280,
   exit:  { duration: 224, easing: 'cubic-bezier(0.4, 0, 1, 1)', keyframes: [{ opacity: 1 }, { opacity: 0 }] },
   enter: { duration: 308, delay: 112, easing: 'cubic-bezier(0, 0, 0.2, 1)', keyframes: [{ opacity: 0 }, { opacity: 1 }] },
-  sharedElements: { duration: 868, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
+  morph: { duration: 868, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
 };
 
 const stage: CSSProperties = { width: '100%', height: '100%', position: 'relative', background: '#000000', overflow: 'hidden' };
 
 const Narrow: Page = () => (
   <div style={stage}>
-    <SharedElement id="pill" style={{ position: 'absolute', left: 842, top: 479, width: 236, height: 122, borderRadius: 999, background: '#ffffff' }} />
+    <MorphElement id="pill" style={{ position: 'absolute', left: 842, top: 479, width: 236, height: 122, borderRadius: 999, background: '#ffffff' }} />
   </div>
 );
 const Wide: Page = () => (
   <div style={stage}>
-    <SharedElement id="pill" style={{ position: 'absolute', left: 721, top: 479, width: 478, height: 122, borderRadius: 999, background: '#0a0a0a' }} />
+    <MorphElement id="pill" style={{ position: 'absolute', left: 721, top: 479, width: 478, height: 122, borderRadius: 999, background: '#0a0a0a' }} />
   </div>
 );
 
-Wide.transition = morph;   // forward: Narrow → Wide morphs the pill
-Narrow.transition = morph; // backward: Wide → Narrow morphs it back
+Wide.transition = morphTransition;   // forward: Narrow → Wide morphs the pill
+Narrow.transition = morphTransition; // backward: Wide → Narrow morphs it back
 ```
 
 #### Contract
 
-- `sharedElements: true` inherits the transition's top-level `duration`/`easing`; pass `{ duration?, easing?, delay? }` to time the morph independently of the page cross-fade. Morphs usually read best 2–4× longer than the fade (e.g. 280 ms fade, 868 ms morph).
-- Elements pair by `id` across the cut. A matched pair FLIP-morphs: the runtime measures both rects, clones the outgoing element into an overlay above both pages, hides the originals, and animates transform + border-radius + colors (border widths ride a separate frame so they don't stretch with the box). Keep each `id` unique within a page; don't nest one `SharedElement` inside another.
+- `morph: true` inherits the transition's top-level `duration`/`easing`; pass `{ duration?, easing?, delay? }` to time the morph independently of the page cross-fade. Morphs usually read best 2–4× longer than the fade (e.g. 280 ms fade, 868 ms morph).
+- Elements pair by `id` across the cut. A matched pair FLIP-morphs: the runtime measures both rects, clones the outgoing element into an overlay above both pages, hides the originals, and animates transform + border-radius + colors (border widths ride a separate frame so they don't stretch with the box). Keep each `id` unique within a page; don't nest one `MorphElement` inside another.
 - An `id` present on only one side fades in/out **in place**. This is how "a third box joins the row" reads: carried boxes glide to their new slots, the new one materializes.
-- Colors on the shared node *and its descendants* interpolate too — a label that flips black → white mid-glide just works.
+- Colors on the morph node *and its descendants* interpolate too — a label that flips black → white mid-glide just works.
 - The transition lives on the **incoming** page. For a morph that also plays when stepping backward, assign the same transition object to both pages (as above).
 
 #### Rules — each one earned on a real deck
 
-1. **Prefer opacity-only enter/exit on morphing pages.** Any transition family composes correctly with the morph (shared rects are measured before the phases start), but while clones glide, a transform-bearing enter also slides the rest of the page — two competing motions. Giving the clones all the motion and fading everything else is what makes a magic move read as one confident gesture.
-2. **Shared geometry must be deterministic at mount.** Rects are snapshotted once at the cut. Position shared elements with pixel constants — never with a value measured in an effect after mount (the re-render shifts the target mid-morph and the move jumps). If text inside a shared box grows over time (typewriter etc.), render a hidden full-width spacer so the measured box never changes size.
-3. **No `transform` on the shared node itself.** A percentage translate (`translate(-50%, -50%)`) gets mis-scaled by the morph and lands the clone tens of px off. Put centering/positioning transforms on a plain wrapper `<div>` *around* the `SharedElement`.
-4. **`SharedElement` merges `className`/`style` onto its single host child** (it adds no wrapper when the child is a lone DOM element). A crop box (`overflow: hidden` + fixed width) therefore needs an explicit nested `<div>` — otherwise the box collapses onto the `<img>` inside and squishes it.
-5. **Gate entrance animations behind `unstable_useIsActivePage()`.** During the cut the runtime mounts a *fresh instance* of the outgoing page to snapshot its exit state (and the dev UI mounts every page for thumbnails/overview). If an intro replays there, the snapshot is mid-animation and the morph starts from garbage. The hook returns `true` only for the instance the audience is watching; every other instance (outgoing snapshot, thumbnails, overview, presenter preview, print) should render the final, settled state — no intro, full text.
+1. **Prefer opacity-only enter/exit on morphing pages.** Any transition family composes correctly with the morph (shared rects are measured before the phases start), but while clones glide, a transform-bearing enter also slides the rest of the page — two competing motions. Giving the clones all the motion and fading everything else is what makes a morph read as one confident gesture.
+2. **Morph geometry must be deterministic at mount.** Rects are snapshotted once at the cut. Position morph elements with pixel constants — never with a value measured in an effect after mount (the re-render shifts the target mid-morph and the move jumps). If text inside a morph box grows over time (typewriter etc.), render a hidden full-width spacer so the measured box never changes size.
+3. **No `transform` on the morph node itself.** A percentage translate (`translate(-50%, -50%)`) gets mis-scaled by the morph and lands the clone tens of px off. Put centering/positioning transforms on a plain wrapper `<div>` *around* the `MorphElement`.
+4. **`MorphElement` merges `className`/`style` onto its single host child** (it adds no wrapper when the child is a lone DOM element). A crop box (`overflow: hidden` + fixed width) therefore needs an explicit nested `<div>` — otherwise the box collapses onto the `<img>` inside and squishes it.
+5. **Gate entrance animations behind `useIsActivePage()`.** During the cut the runtime mounts a *fresh instance* of the outgoing page to snapshot its exit state (and the dev UI mounts every page for thumbnails/overview). If an intro replays there, the snapshot is mid-animation and the morph starts from garbage. The hook returns `true` only for the instance the audience is watching; every other instance (outgoing snapshot, thumbnails, overview, presenter preview, print) should render the final, settled state — no intro, full text.
 
    ```tsx
-   import { unstable_useIsActivePage as useIsActivePage } from '@open-slide/core';
+   import { useIsActivePage } from '@open-slide/core';
 
    // Inside the page component:
    const animate = useIsActivePage();
    ```
 
-6. **Clones travel above everything.** The morph overlay sits over both pages, so an incoming element that should appear only when a clone "lands" will otherwise pop early. Give such reveals a delay equal to the morph: `animation: 'osd-fade 0.63s ease-out 0.868s both'` where `0.868s` is `sharedElements.duration`. Keep that number in one shared const so the two can't drift.
+6. **Clones travel above everything.** The morph overlay sits over both pages, so an incoming element that should appear only when a clone "lands" will otherwise pop early. Give such reveals a delay equal to the morph: `animation: 'osd-fade 0.63s ease-out 0.868s both'` where `0.868s` is `morph.duration`. Keep that number in one shared const so the two can't drift.
 7. **A "hold" page is a separate component.** Transitions attach to the incoming page, so to follow a morph cut with a plain cut of the same content, mint a second page component without `.transition` (e.g. `const Flow4Hold: Page = () => <Flow count={4} />`).
 
 #### When to reach for it
 
-Magic move is for **state continuity**: a toggle whose thumb slides to the next option, a card that expands into a detail view, a logo that glides from center stage into the next page's diagram, a row that gains one more box. The object *is the story* across the cut. Don't morph decoration, and don't tag elements "just in case" — every shared id is a promise to the audience that it's the same object. One or two morphing sequences per chapter is plenty; the surrounding pages should cut or fade quietly.
+Morph is for **state continuity**: a toggle whose thumb slides to the next option, a card that expands into a detail view, a logo that glides from center stage into the next page's diagram, a row that gains one more box. The object *is the story* across the cut. Don't morph decoration, and don't tag elements "just in case" — every morph id is a promise to the audience that it's the same object. One or two morphing sequences per chapter is plenty; the surrounding pages should cut or fade quietly.
 
 ### Transition anti-patterns
 
@@ -669,7 +667,7 @@ This applies whenever the *visual element* repeats, not whenever the *data* does
 - [ ] Every `<ImagePlaceholder>` corresponds to a real image the user must supply — not decorative filler. If it could be replaced by typography or layout, it should be.
 - [ ] If a page uses `<Steps>`/`<Step>`, every `<Step>` is a direct child of a `<Steps>`, and the page still reads as complete when jumped to via the overview grid (entering forward builds up; jumping in shows it fully revealed).
 - [ ] If a `SlideTransition` is declared, every page sits in one family — same duration band (140–280 ms), same easing pair, same out-then-in stagger, magnitude under 12 px / 3%. No six-different-vocabularies decks. When in doubt, omit transitions entirely.
-- [ ] If a transition opts into `sharedElements`: every shared `id` is unique per page and stable across the pair, shared geometry is pixel-constant (never measured after mount), no `transform` sits on the shared node, and entrance animations are gated behind `unstable_useIsActivePage()`.
+- [ ] If a transition opts into `morph`: every morph `id` is unique per page and stable across the pair, morph geometry is pixel-constant (never measured after mount), no `transform` sits on the morph node, and entrance animations are gated behind `useIsActivePage()`.
 - [ ] Nothing outside `slides/<id>/` was edited.
 
 ## Anti-patterns

--- a/packages/core/src/app/components/morph-element.tsx
+++ b/packages/core/src/app/components/morph-element.tsx
@@ -7,41 +7,36 @@ import {
   type ReactNode,
 } from 'react';
 
-export type unstable_SharedElementProps = {
+export type MorphElementProps = {
   id: string;
   children: ReactNode;
   className?: string;
   style?: CSSProperties;
 };
 
-type SharedElementChildProps = {
+type MorphElementChildProps = {
   className?: string;
   style?: CSSProperties;
-  'data-osd-shared-element'?: string;
+  'data-osd-morph'?: string;
 };
 
-export function unstable_SharedElement({
-  id,
-  children,
-  className,
-  style,
-}: unstable_SharedElementProps) {
+export function MorphElement({ id, children, className, style }: MorphElementProps) {
   const child = Children.toArray(children)[0] ?? null;
 
   if (
     Children.count(children) === 1 &&
-    isValidElement<SharedElementChildProps>(child) &&
+    isValidElement<MorphElementChildProps>(child) &&
     typeof child.type === 'string'
   ) {
-    return cloneElement(child as ReactElement<SharedElementChildProps>, {
-      'data-osd-shared-element': id,
+    return cloneElement(child as ReactElement<MorphElementChildProps>, {
+      'data-osd-morph': id,
       className: [child.props.className, className].filter(Boolean).join(' ') || undefined,
       style: style ? { ...child.props.style, ...style } : child.props.style,
     });
   }
 
   return (
-    <div className={className} style={style} data-osd-shared-element={id}>
+    <div className={className} style={style} data-osd-morph={id}>
       {children}
     </div>
   );

--- a/packages/core/src/app/components/slide-transition-layer.tsx
+++ b/packages/core/src/app/components/slide-transition-layer.tsx
@@ -8,8 +8,8 @@ import {
   StepHost,
 } from '../lib/step-context';
 import {
+  type MorphTransition,
   resolveTransition,
-  type SharedElementTransition,
   type SlideTransition,
   type TransitionPhase,
 } from '../lib/transition';
@@ -28,9 +28,9 @@ type Props = {
 type Direction = 'forward' | 'backward';
 
 const DEFAULT_EASING = 'cubic-bezier(.4, 0, .2, 1)';
-const SHARED_ELEMENT_SELECTOR = '[data-osd-shared-element]';
+const MORPH_ELEMENT_SELECTOR = '[data-osd-morph]';
 const TEXT_FILL_COLOR_PROPERTY = '-webkit-text-fill-color';
-const SHARED_ELEMENT_VISUAL_PROPERTIES = [
+const MORPH_VISUAL_PROPERTIES = [
   'opacity',
   'color',
   'background-color',
@@ -109,21 +109,21 @@ function runPhase(
   });
 }
 
-type ResolvedSharedElementTransition = Required<SharedElementTransition>;
+type ResolvedMorphTransition = Required<MorphTransition>;
 
-function resolveSharedElementTransition(
-  sharedElements: SlideTransition['sharedElements'],
+function resolveMorphTransition(
+  morph: SlideTransition['morph'],
   fallbackDuration: number,
   fallbackEasing: string,
-): ResolvedSharedElementTransition | null {
-  if (!sharedElements) return null;
-  if (sharedElements === true) {
+): ResolvedMorphTransition | null {
+  if (!morph) return null;
+  if (morph === true) {
     return { duration: fallbackDuration, easing: fallbackEasing, delay: 0 };
   }
   return {
-    duration: sharedElements.duration ?? fallbackDuration,
-    easing: sharedElements.easing ?? fallbackEasing,
-    delay: sharedElements.delay ?? 0,
+    duration: morph.duration ?? fallbackDuration,
+    easing: morph.easing ?? fallbackEasing,
+    delay: morph.delay ?? 0,
   };
 }
 
@@ -165,10 +165,10 @@ function hasUsableRect(rect: LocalRect): boolean {
   return rect.width > 0 && rect.height > 0;
 }
 
-function collectSharedElements(root: HTMLElement): Map<string, HTMLElement> {
+function collectMorphElements(root: HTMLElement): Map<string, HTMLElement> {
   const elements = new Map<string, HTMLElement>();
-  for (const el of root.querySelectorAll<HTMLElement>(SHARED_ELEMENT_SELECTOR)) {
-    const id = el.dataset.osdSharedElement;
+  for (const el of root.querySelectorAll<HTMLElement>(MORPH_ELEMENT_SELECTOR)) {
+    const id = el.dataset.osdMorph;
     if (id && !elements.has(id)) elements.set(id, el);
   }
   return elements;
@@ -214,10 +214,10 @@ function copyComputedStyles(
   }
 }
 
-function cloneSharedElement(source: HTMLElement): HTMLElement {
+function cloneMorphElement(source: HTMLElement): HTMLElement {
   const clone = source.cloneNode(true) as HTMLElement;
   copyComputedStyles(source, clone);
-  clone.removeAttribute('data-osd-shared-element');
+  clone.removeAttribute('data-osd-morph');
   return clone;
 }
 
@@ -251,18 +251,13 @@ function localTransform(styles: CSSStyleDeclaration): string {
   return styles.transform && styles.transform !== 'none' ? styles.transform : '';
 }
 
-function sharedElementTransform(
-  rect: LocalRect,
-  scaleX: number,
-  scaleY: number,
-  local: string,
-): string {
+function morphTransform(rect: LocalRect, scaleX: number, scaleY: number, local: string): string {
   return [`translate(${rect.left}px, ${rect.top}px)`, `scale(${scaleX}, ${scaleY})`, local]
     .filter(Boolean)
     .join(' ');
 }
 
-function sharedElementTranslateTransform(rect: LocalRect, local: string): string {
+function morphTranslateTransform(rect: LocalRect, local: string): string {
   return [`translate(${rect.left}px, ${rect.top}px)`, local].filter(Boolean).join(' ');
 }
 
@@ -276,7 +271,7 @@ function visualStyleKeyframe(
   options: { includeBorderColors?: boolean } = {},
 ): Keyframe {
   const frame: Record<string, string> = {};
-  for (const prop of SHARED_ELEMENT_VISUAL_PROPERTIES) {
+  for (const prop of MORPH_VISUAL_PROPERTIES) {
     if (
       options.includeBorderColors === false &&
       (BORDER_COLOR_PROPERTIES as readonly string[]).includes(prop)
@@ -319,7 +314,7 @@ function borderFrameKeyframe(
     width: `${rect.width}px`,
     height: `${rect.height}px`,
     opacity,
-    transform: sharedElementTranslateTransform(rect, localTransform(styles)),
+    transform: morphTranslateTransform(rect, localTransform(styles)),
     ...radiusKeyframe(styles),
   };
 
@@ -366,7 +361,7 @@ function appendBorderFrame(
 }
 
 function hasVisualStyleChange(from: CSSStyleDeclaration, to: CSSStyleDeclaration): boolean {
-  for (const prop of SHARED_ELEMENT_VISUAL_PROPERTIES) {
+  for (const prop of MORPH_VISUAL_PROPERTIES) {
     if (getStyleProperty(from, prop) !== getStyleProperty(to, prop)) return true;
   }
   return false;
@@ -401,7 +396,7 @@ function appendPositionedClone(
 ): HTMLElement {
   if (!overlay.parentElement) wrapper.appendChild(overlay);
 
-  const clone = cloneSharedElement(source);
+  const clone = cloneMorphElement(source);
   Object.assign(clone.style, {
     position: 'absolute',
     left: '0',
@@ -417,9 +412,7 @@ function appendPositionedClone(
   return clone;
 }
 
-function sharedElementAnimationOptions(
-  phase: ResolvedSharedElementTransition,
-): KeyframeAnimationOptions {
+function morphAnimationOptions(phase: ResolvedMorphTransition): KeyframeAnimationOptions {
   return {
     duration: phase.duration,
     easing: phase.easing,
@@ -432,7 +425,7 @@ function runDescendantVisualStyleTransitions(
   clone: HTMLElement,
   source: HTMLElement,
   target: HTMLElement,
-  phase: ResolvedSharedElementTransition,
+  phase: ResolvedMorphTransition,
 ): Animation[] {
   const animations: Animation[] = [];
   const cloneChildren = clone.querySelectorAll<HTMLElement>('*');
@@ -451,7 +444,7 @@ function runDescendantVisualStyleTransitions(
     animations.push(
       cloneChild.animate(
         [visualStyleKeyframe(sourceStyles), visualStyleKeyframe(targetStyles)],
-        sharedElementAnimationOptions(phase),
+        morphAnimationOptions(phase),
       ),
     );
   }
@@ -459,15 +452,15 @@ function runDescendantVisualStyleTransitions(
   return animations;
 }
 
-function runStationarySharedElementAnimation(
+function runStationaryMorphAnimation(
   clone: HTMLElement,
   rect: LocalRect,
   styles: CSSStyleDeclaration,
   fromOpacity: string,
   toOpacity: string,
-  phase: ResolvedSharedElementTransition,
+  phase: ResolvedMorphTransition,
 ): Animation {
-  const transform = sharedElementTransform(rect, 1, 1, localTransform(styles));
+  const transform = morphTransform(rect, 1, 1, localTransform(styles));
   return clone.animate(
     [
       {
@@ -481,24 +474,24 @@ function runStationarySharedElementAnimation(
         transform,
       },
     ],
-    sharedElementAnimationOptions(phase),
+    morphAnimationOptions(phase),
   );
 }
 
-function runSharedElementTransition(
+function runMorphTransition(
   wrapper: HTMLElement,
   outgoingLayer: HTMLElement,
   incomingLayer: HTMLElement,
-  phase: ResolvedSharedElementTransition,
+  phase: ResolvedMorphTransition,
 ): { animations: Animation[]; cleanup: () => void } {
   const wrapperRect = wrapper.getBoundingClientRect();
   if (wrapperRect.width === 0 || wrapperRect.height === 0) {
     return { animations: [], cleanup: () => {} };
   }
 
-  const incoming = collectSharedElements(incomingLayer);
+  const incoming = collectMorphElements(incomingLayer);
   const overlay = document.createElement('div');
-  overlay.setAttribute('data-osd-shared-layer', '');
+  overlay.setAttribute('data-osd-morph-layer', '');
   Object.assign(overlay.style, {
     position: 'absolute',
     inset: '0',
@@ -508,7 +501,7 @@ function runSharedElementTransition(
 
   const animations: Animation[] = [];
   const restore: Array<() => void> = [];
-  const outgoing = collectSharedElements(outgoingLayer);
+  const outgoing = collectMorphElements(outgoingLayer);
   const handledIncoming = new Set<string>();
 
   for (const [id, source] of outgoing) {
@@ -524,7 +517,7 @@ function runSharedElementTransition(
 
           const targetStyles = getComputedStyle(target);
           animations.push(
-            runStationarySharedElementAnimation(
+            runStationaryMorphAnimation(
               clone,
               to,
               targetStyles,
@@ -544,7 +537,7 @@ function runSharedElementTransition(
 
       const sourceStyles = getComputedStyle(source);
       animations.push(
-        runStationarySharedElementAnimation(
+        runStationaryMorphAnimation(
           clone,
           from,
           sourceStyles,
@@ -563,7 +556,7 @@ function runSharedElementTransition(
 
       const sourceStyles = getComputedStyle(source);
       animations.push(
-        runStationarySharedElementAnimation(
+        runStationaryMorphAnimation(
           clone,
           from,
           sourceStyles,
@@ -587,8 +580,8 @@ function runSharedElementTransition(
     const needsBorderFrame = hasVisibleBorder(sourceStyles) || hasVisibleBorder(targetStyles);
     const scaleX = to.width / from.width;
     const scaleY = to.height / from.height;
-    const fromTransform = sharedElementTransform(from, 1, 1, localTransform(sourceStyles));
-    const toTransform = sharedElementTransform(to, scaleX, scaleY, localTransform(targetStyles));
+    const fromTransform = morphTransform(from, 1, 1, localTransform(sourceStyles));
+    const toTransform = morphTransform(to, scaleX, scaleY, localTransform(targetStyles));
 
     if (needsBorderFrame) {
       hideBorderColors(clone);
@@ -599,7 +592,7 @@ function runSharedElementTransition(
             borderFrameKeyframe(from, sourceStyles, fromOpacity),
             borderFrameKeyframe(to, targetStyles, toOpacity),
           ],
-          sharedElementAnimationOptions(phase),
+          morphAnimationOptions(phase),
         ),
       );
     }
@@ -622,7 +615,7 @@ function runSharedElementTransition(
             transform: toTransform,
           },
         ],
-        sharedElementAnimationOptions(phase),
+        morphAnimationOptions(phase),
       ),
       ...runDescendantVisualStyleTransitions(clone, source, target, phase),
     );
@@ -639,7 +632,7 @@ function runSharedElementTransition(
 
     const targetStyles = getComputedStyle(target);
     animations.push(
-      runStationarySharedElementAnimation(
+      runStationaryMorphAnimation(
         clone,
         to,
         targetStyles,
@@ -733,12 +726,12 @@ export function SlideTransitionLayer({
     const easing = transition.easing ?? DEFAULT_EASING;
     const duration = transition.duration;
 
-    // Shared elements must be measured before the enter/exit phases start:
+    // Morph elements must be measured before the enter/exit phases start:
     // phase keyframes apply immediately (fill: both), so a transform in the
     // enter's first keyframe would offset every measured target rect and land
     // the clones off their true rest positions.
-    const sharedPhase = resolveSharedElementTransition(transition.sharedElements, duration, easing);
-    const shared = sharedPhase ? runSharedElementTransition(wrapper, out, inc, sharedPhase) : null;
+    const morphPhase = resolveMorphTransition(transition.morph, duration, easing);
+    const morphRun = morphPhase ? runMorphTransition(wrapper, out, inc, morphPhase) : null;
 
     const anims: Animation[] = [];
     const exitAnim = runPhase(out, transition.exit, duration, easing);
@@ -747,10 +740,10 @@ export function SlideTransitionLayer({
     if (enterAnim) anims.push(enterAnim);
 
     const cleanups: Array<() => void> = [];
-    if (shared) {
-      anims.push(...shared.animations);
-      cleanups.push(shared.cleanup);
-      if (!exitAnim && shared.animations.length > 0) cleanups.push(hideOriginal(out));
+    if (morphRun) {
+      anims.push(...morphRun.animations);
+      cleanups.push(morphRun.cleanup);
+      if (!exitAnim && morphRun.animations.length > 0) cleanups.push(hideOriginal(out));
     }
     animsRef.current = anims;
 

--- a/packages/core/src/app/lib/step-context.tsx
+++ b/packages/core/src/app/lib/step-context.tsx
@@ -174,11 +174,9 @@ export function StepHost({
 
 // Hostless mounts (thumbnails, overview grid, print/export) are never the
 // audience-facing instance, so no provider means false.
-function useIsActivePage(): boolean {
+export function useIsActivePage(): boolean {
   return useContext(StepHostContext)?.isActivePage ?? false;
 }
-
-export const unstable_useIsActivePage = useIsActivePage;
 
 export type StepsProps = PropsWithChildren;
 

--- a/packages/core/src/app/lib/transition.ts
+++ b/packages/core/src/app/lib/transition.ts
@@ -12,10 +12,10 @@ export type SlideTransition = {
   easing?: string;
   enter?: TransitionPhase;
   exit?: TransitionPhase;
-  sharedElements?: boolean | SharedElementTransition;
+  morph?: boolean | MorphTransition;
 };
 
-export type SharedElementTransition = {
+export type MorphTransition = {
   duration?: number;
   easing?: string;
   delay?: number;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 export type { ImagePlaceholderProps } from './app/components/image-placeholder.tsx';
 export { ImagePlaceholder } from './app/components/image-placeholder.tsx';
-export type { unstable_SharedElementProps } from './app/components/shared-element.tsx';
-export { unstable_SharedElement } from './app/components/shared-element.tsx';
+export type { MorphElementProps } from './app/components/morph-element.tsx';
+export { MorphElement } from './app/components/morph-element.tsx';
 export type {
   DesignFonts,
   DesignPalette,
@@ -13,9 +13,9 @@ export { useSlidePageNumber } from './app/lib/page-context.tsx';
 export type { Page, SlideMeta, SlideModule } from './app/lib/sdk.ts';
 export { CANVAS_HEIGHT, CANVAS_WIDTH } from './app/lib/sdk.ts';
 export type { StepProps, StepsProps } from './app/lib/step-context.tsx';
-export { Step, Steps, unstable_useIsActivePage } from './app/lib/step-context.tsx';
+export { Step, Steps, useIsActivePage } from './app/lib/step-context.tsx';
 export type {
-  SharedElementTransition,
+  MorphTransition,
   SlideTransition,
   TransitionPhase,
 } from './app/lib/transition.ts';


### PR DESCRIPTION
## What & why

Removes the `unstable_` prefixes and unifies the shared-element / magic-move vocabulary under one name. The feature is now **Morph Transition** and the component is **`MorphElement`**. Stabilizing lets decks import the API without an alias, and the single vocabulary removes the "is it shared-element, or magic-move?" confusion across the runtime, docs, and skill.

## Public API changes (`@open-slide/core`)

| Old | New |
| --- | --- |
| `unstable_SharedElement` | `MorphElement` |
| `unstable_SharedElementProps` | `MorphElementProps` |
| `unstable_useIsActivePage` | `useIsActivePage` |
| `SharedElementTransition` (type) | `MorphTransition` |
| `SlideTransition.sharedElements` (option) | `morph` |

## Also updated

- **Runtime internals** — `slide-transition-layer.tsx` helpers (`runMorphTransition`, `collectMorphElements`, …) and the DOM markers `data-osd-shared-element` → `data-osd-morph`, `data-osd-shared-layer` → `data-osd-morph-layer`. Component file renamed `shared-element.tsx` → `morph-element.tsx`.
- **Docs** — `primitive/shared-element.mdx` → `morph-element.mdx` (+ nav), `transition.mdx`, `reference/slide-transitions.mdx` (dropped the "unstable / not for production" callout), `reference/slide-meta.mdx`, core `README`.
- **Skill** — `slide-authoring/SKILL.md` and its CLI-template copy (kept in sync).
- **Demo** — folder `magic-move-demo` → `morph-demo`, now using `MorphElement` / `morph`.
- **Changesets** — new `minor` changeset for the rename; the three pending shared-element/magic-move changesets reworded to Morph terminology.

## Reviewer notes

- **Breaking** for the experimental morph API. No backward-compat aliases were kept — the `unstable_` prefix is removed cleanly. Bumped **minor** to match how `unstable_useIsActivePage` was originally added and the `unstable_`-prefix convention; happy to switch to **major** if preferred given `SharedElement`/`sharedElements` shipped in stable releases.
- "Keynote's Magic Move" is kept only as an *analogy* in prose — our feature is consistently "Morph".
- The demo's on-slide heading text changed "Magic Move" → "Morph" for consistency.

## Verification

- `pnpm typecheck` ✅
- `pnpm check` (Biome) ✅ exit 0
- `pnpm test` ✅ 305/305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the stable `MorphElement` API for matching and animating elements across page transitions.
  * Added `morph` transition configuration with customizable duration, easing, and delay.
  * Added the stable `useIsActivePage()` hook for gating entrance animations.

* **Documentation**
  * Updated guides, references, examples, and authoring guidance to describe morph transitions and usage requirements.
  * Renamed the demo to “Morph Transition Prototype” and updated its examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->