### PR TITLE
fix(core): interpolate morph colors instead of snapping at the end of the glide

### DIFF
--- a/.changeset/morph-color-interpolation.md
+++ b/.changeset/morph-color-interpolation.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Fix morph transitions snapping background, border, and outline colors at the end of the glide instead of interpolating them.

--- a/apps/demo/slides/morph-messages/index.tsx
+++ b/apps/demo/slides/morph-messages/index.tsx
@@ -6,7 +6,7 @@ import {
   type SlideTransition,
   useIsActivePage,
 } from '@open-slide/core';
-import type { CSSProperties, ReactNode } from 'react';
+import { type CSSProperties, type ReactNode, useState } from 'react';
 
 export const design: DesignSystem = {
   palette: { bg: '#fbfbfd', text: '#1d1d1f', accent: '#0a84ff' },
@@ -75,6 +75,7 @@ if (typeof document !== 'undefined' && !document.getElementById('morph-messages-
     '@keyframes morph-messages-rise { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }',
     `@keyframes morph-messages-slide-left { from { transform: translateX(${960 - DIAMOND_X}px); } to { transform: none; } }`,
     '@keyframes morph-messages-slide-right { from { opacity: 0; transform: translateX(-64px); } to { opacity: 1; transform: none; } }',
+    '@keyframes morph-messages-hero-in { from { opacity: 0; transform: translateY(24px); filter: blur(12px); } to { opacity: 1; transform: none; filter: none; } }',
   ].join('');
   document.head.appendChild(style);
 }
@@ -217,15 +218,36 @@ const ShedLine = (props: LineProps) => {
   );
 };
 
-const Introducing: Page = () => (
-  <section style={stage}>
-    <div style={centered}>
-      <Line id="msg-introducing" fontSize="var(--osd-size-hero)" color="var(--osd-text)">
-        Introducing
-      </Line>
-    </div>
-  </section>
-);
+// The hero entrance plays exactly once — on the deck's first audience-facing
+// mount. Every later active mount can be the measured target of a backward
+// 2→1 morph, and a replaying rise/fade would poison the measured rect and
+// opacity endpoints. The flag is set from onAnimationStart (not an effect)
+// so StrictMode's mount/unmount/remount cycle can't burn it before the
+// animation ever shows.
+let heroEntranceShown = false;
+
+const Introducing: Page = () => {
+  const active = useIsActivePage();
+  const [entrance] = useState(() => active && !heroEntranceShown);
+  return (
+    <section style={stage}>
+      <div style={centered}>
+        <div
+          style={{
+            animation: entrance ? `morph-messages-hero-in 720ms ${EASE_OUT} 60ms both` : 'none',
+          }}
+          onAnimationStart={() => {
+            heroEntranceShown = true;
+          }}
+        >
+          <Line id="msg-introducing" fontSize="var(--osd-size-hero)" color="var(--osd-text)">
+            Introducing
+          </Line>
+        </div>
+      </div>
+    </section>
+  );
+};
 
 const Reveal: Page = () => (
   <section style={stage}>

--- a/apps/demo/slides/morph-messages/index.tsx
+++ b/apps/demo/slides/morph-messages/index.tsx
@@ -23,31 +23,54 @@ export const meta: SlideMeta = {
   createdAt: '2026-07-15T13:59:59.809Z',
 };
 
-const MORPH_MS = 820;
+const EASE_IN = 'cubic-bezier(0.4, 0, 1, 1)';
+const EASE_OUT = 'cubic-bezier(0, 0, 0.2, 1)';
+const EASE_STANDARD = 'cubic-bezier(0.4, 0, 0.2, 1)';
+
+const HERO_MORPH_MS = 1250;
+const THREAD_MORPH_MS = 750;
+const RISE_MS = 420;
 
 export const transition: SlideTransition = {
+  duration: 360,
+  exit: {
+    duration: 288,
+    easing: EASE_IN,
+    keyframes: [{ opacity: 1 }, { opacity: 0 }],
+  },
+  enter: {
+    duration: 396,
+    delay: 144,
+    easing: EASE_OUT,
+    keyframes: [{ opacity: 0 }, { opacity: 1 }],
+  },
+  morph: { duration: HERO_MORPH_MS, easing: EASE_STANDARD },
+};
+
+const threadTransition: SlideTransition = {
   duration: 280,
   exit: {
     duration: 224,
-    easing: 'cubic-bezier(0.4, 0, 1, 1)',
+    easing: EASE_IN,
     keyframes: [{ opacity: 1 }, { opacity: 0 }],
   },
   enter: {
     duration: 308,
     delay: 112,
-    easing: 'cubic-bezier(0, 0, 0.2, 1)',
+    easing: EASE_OUT,
     keyframes: [{ opacity: 0 }, { opacity: 1 }],
   },
-  morph: { duration: MORPH_MS, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
+  morph: { duration: THREAD_MORPH_MS, easing: EASE_STANDARD },
 };
 
 const muted = '#86868b';
+const grayBubble = '#e9e9eb';
 
 if (typeof document !== 'undefined' && !document.getElementById('morph-messages-styles')) {
   const style = document.createElement('style');
   style.id = 'morph-messages-styles';
   style.textContent =
-    '@keyframes morph-messages-rise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }';
+    '@keyframes morph-messages-rise { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }';
   document.head.appendChild(style);
 }
 
@@ -70,39 +93,83 @@ const centered: CSSProperties = {
   justifyContent: 'center',
 };
 
+const thread: CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  bottom: 0,
+  left: 160,
+  right: 160,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+  justifyContent: 'center',
+  gap: 14,
+};
+
 // All box geometry rides in em so the pill keeps its aspect ratio at every
 // font size — the morph clone then scales uniformly instead of stretching.
+const pill = (
+  fontSize: number | string,
+  color: string,
+  background: string,
+  received: boolean,
+): CSSProperties => ({
+  fontSize,
+  lineHeight: 1.25,
+  fontWeight: 700,
+  letterSpacing: '-0.02em',
+  whiteSpace: 'nowrap',
+  padding: '0.3em 0.7em',
+  borderRadius: 'var(--osd-radius)',
+  background,
+  color,
+  alignSelf: received ? 'flex-start' : undefined,
+});
+
+type LineProps = {
+  id: string;
+  fontSize: number | string;
+  color: string;
+  background?: string;
+  received?: boolean;
+  style?: CSSProperties;
+  children: ReactNode;
+};
+
 const Line = ({
   id,
   fontSize,
   color,
   background = 'transparent',
+  received = false,
+  style,
   children,
-}: {
-  id: string;
-  fontSize: number | string;
-  color: string;
-  background?: string;
-  children: ReactNode;
-}) => (
+}: LineProps) => (
   <MorphElement id={id}>
+    <div style={{ ...pill(fontSize, color, background, received), ...style }}>{children}</div>
+  </MorphElement>
+);
+
+// A message on its debut page: the audience-facing instance renders without a
+// morph id so the runtime doesn't clone it and the fade-up owns the entrance;
+// every other instance (exit snapshot, thumbnails, print) renders the settled
+// MorphElement so the next cut can still pair it.
+const DebutLine = (props: LineProps) => {
+  const animate = useIsActivePage();
+  if (!animate) return <Line {...props} />;
+  const { fontSize, color, background = 'transparent', received = false, style, children } = props;
+  return (
     <div
       style={{
-        fontSize,
-        lineHeight: 1.25,
-        fontWeight: 700,
-        letterSpacing: '-0.02em',
-        whiteSpace: 'nowrap',
-        padding: '0.3em 0.7em',
-        borderRadius: 'var(--osd-radius)',
-        background,
-        color,
+        ...pill(fontSize, color, background, received),
+        ...style,
+        animation: `morph-messages-rise ${RISE_MS}ms ${EASE_OUT} ${THREAD_MORPH_MS}ms both`,
       }}
     >
       {children}
     </div>
-  </MorphElement>
-);
+  );
+};
 
 const Introducing: Page = () => (
   <section style={stage}>
@@ -116,34 +183,27 @@ const Introducing: Page = () => (
 
 const Reveal: Page = () => (
   <section style={stage}>
-    <div style={{ ...centered, gap: 8 }}>
+    <div style={centered}>
       <Line id="msg-introducing" fontSize={72} color={muted}>
         Introducing
       </Line>
-      <Line id="msg-morph" fontSize="var(--osd-size-hero)" color="var(--osd-text)">
+      <Line
+        id="msg-morph"
+        fontSize="var(--osd-size-hero)"
+        color="var(--osd-text)"
+        style={{ marginTop: -36 }}
+      >
         Morph Transition
       </Line>
     </div>
   </section>
 );
 
-const Thread: Page = () => {
+const Sent: Page = () => {
   const animate = useIsActivePage();
   return (
     <section style={stage}>
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          bottom: 0,
-          right: 160,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'flex-end',
-          justifyContent: 'center',
-          gap: 14,
-        }}
-      >
+      <div style={thread}>
         <Line
           id="msg-introducing"
           fontSize="var(--osd-size-body)"
@@ -168,7 +228,7 @@ const Thread: Page = () => {
             color: muted,
             marginRight: 12,
             animation: animate
-              ? `morph-messages-rise 480ms cubic-bezier(0, 0, 0.2, 1) ${MORPH_MS}ms both`
+              ? `morph-messages-rise 480ms ${EASE_OUT} ${HERO_MORPH_MS}ms both`
               : 'none',
           }}
         >
@@ -179,4 +239,79 @@ const Thread: Page = () => {
   );
 };
 
-export default [Introducing, Reveal, Thread] satisfies Page[];
+const Question: Page = () => (
+  <section style={stage}>
+    <div style={thread}>
+      <Line
+        id="msg-introducing"
+        fontSize="var(--osd-size-body)"
+        color="#ffffff"
+        background="var(--osd-accent)"
+      >
+        Introducing
+      </Line>
+      <Line
+        id="msg-morph"
+        fontSize="var(--osd-size-body)"
+        color="#ffffff"
+        background="var(--osd-accent)"
+      >
+        Morph Transition
+      </Line>
+      <DebutLine
+        id="msg-question"
+        fontSize="var(--osd-size-body)"
+        color="var(--osd-text)"
+        background={grayBubble}
+        received
+      >
+        How do I use it? 👀
+      </DebutLine>
+    </div>
+  </section>
+);
+
+const Answer: Page = () => (
+  <section style={stage}>
+    <div style={thread}>
+      <Line
+        id="msg-introducing"
+        fontSize="var(--osd-size-body)"
+        color="#ffffff"
+        background="var(--osd-accent)"
+      >
+        Introducing
+      </Line>
+      <Line
+        id="msg-morph"
+        fontSize="var(--osd-size-body)"
+        color="#ffffff"
+        background="var(--osd-accent)"
+      >
+        Morph Transition
+      </Line>
+      <Line
+        id="msg-question"
+        fontSize="var(--osd-size-body)"
+        color="var(--osd-text)"
+        background={grayBubble}
+        received
+      >
+        How do I use it? 👀
+      </Line>
+      <DebutLine
+        id="msg-answer"
+        fontSize="var(--osd-size-body)"
+        color="#ffffff"
+        background="var(--osd-accent)"
+      >
+        Use the new Morph Transition primitive from open-slide
+      </DebutLine>
+    </div>
+  </section>
+);
+
+Question.transition = threadTransition;
+Answer.transition = threadTransition;
+
+export default [Introducing, Reveal, Sent, Question, Answer] satisfies Page[];

--- a/apps/demo/slides/morph-messages/index.tsx
+++ b/apps/demo/slides/morph-messages/index.tsx
@@ -1,0 +1,182 @@
+import {
+  type DesignSystem,
+  MorphElement,
+  type Page,
+  type SlideMeta,
+  type SlideTransition,
+  useIsActivePage,
+} from '@open-slide/core';
+import type { CSSProperties, ReactNode } from 'react';
+
+export const design: DesignSystem = {
+  palette: { bg: '#fbfbfd', text: '#1d1d1f', accent: '#0a84ff' },
+  fonts: {
+    display: '-apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", sans-serif',
+    body: '-apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif',
+  },
+  typeScale: { hero: 144, body: 44 },
+  radius: 999,
+};
+
+export const meta: SlideMeta = {
+  title: 'Introducing Morph Transition',
+  createdAt: '2026-07-15T13:59:59.809Z',
+};
+
+const MORPH_MS = 820;
+
+export const transition: SlideTransition = {
+  duration: 280,
+  exit: {
+    duration: 224,
+    easing: 'cubic-bezier(0.4, 0, 1, 1)',
+    keyframes: [{ opacity: 1 }, { opacity: 0 }],
+  },
+  enter: {
+    duration: 308,
+    delay: 112,
+    easing: 'cubic-bezier(0, 0, 0.2, 1)',
+    keyframes: [{ opacity: 0 }, { opacity: 1 }],
+  },
+  morph: { duration: MORPH_MS, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
+};
+
+const muted = '#86868b';
+
+if (typeof document !== 'undefined' && !document.getElementById('morph-messages-styles')) {
+  const style = document.createElement('style');
+  style.id = 'morph-messages-styles';
+  style.textContent =
+    '@keyframes morph-messages-rise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }';
+  document.head.appendChild(style);
+}
+
+const stage: CSSProperties = {
+  width: '100%',
+  height: '100%',
+  position: 'relative',
+  overflow: 'hidden',
+  background: 'var(--osd-bg)',
+  color: 'var(--osd-text)',
+  fontFamily: 'var(--osd-font-display)',
+};
+
+const centered: CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+// All box geometry rides in em so the pill keeps its aspect ratio at every
+// font size — the morph clone then scales uniformly instead of stretching.
+const Line = ({
+  id,
+  fontSize,
+  color,
+  background = 'transparent',
+  children,
+}: {
+  id: string;
+  fontSize: number | string;
+  color: string;
+  background?: string;
+  children: ReactNode;
+}) => (
+  <MorphElement id={id}>
+    <div
+      style={{
+        fontSize,
+        lineHeight: 1.25,
+        fontWeight: 700,
+        letterSpacing: '-0.02em',
+        whiteSpace: 'nowrap',
+        padding: '0.3em 0.7em',
+        borderRadius: 'var(--osd-radius)',
+        background,
+        color,
+      }}
+    >
+      {children}
+    </div>
+  </MorphElement>
+);
+
+const Introducing: Page = () => (
+  <section style={stage}>
+    <div style={centered}>
+      <Line id="msg-introducing" fontSize="var(--osd-size-hero)" color="var(--osd-text)">
+        Introducing
+      </Line>
+    </div>
+  </section>
+);
+
+const Reveal: Page = () => (
+  <section style={stage}>
+    <div style={{ ...centered, gap: 8 }}>
+      <Line id="msg-introducing" fontSize={72} color={muted}>
+        Introducing
+      </Line>
+      <Line id="msg-morph" fontSize="var(--osd-size-hero)" color="var(--osd-text)">
+        Morph Transition
+      </Line>
+    </div>
+  </section>
+);
+
+const Thread: Page = () => {
+  const animate = useIsActivePage();
+  return (
+    <section style={stage}>
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          right: 160,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-end',
+          justifyContent: 'center',
+          gap: 14,
+        }}
+      >
+        <Line
+          id="msg-introducing"
+          fontSize="var(--osd-size-body)"
+          color="#ffffff"
+          background="var(--osd-accent)"
+        >
+          Introducing
+        </Line>
+        <Line
+          id="msg-morph"
+          fontSize="var(--osd-size-body)"
+          color="#ffffff"
+          background="var(--osd-accent)"
+        >
+          Morph Transition
+        </Line>
+        <div
+          style={{
+            fontFamily: 'var(--osd-font-body)',
+            fontSize: 24,
+            fontWeight: 500,
+            color: muted,
+            marginRight: 12,
+            animation: animate
+              ? `morph-messages-rise 480ms cubic-bezier(0, 0, 0.2, 1) ${MORPH_MS}ms both`
+              : 'none',
+          }}
+        >
+          Delivered
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default [Introducing, Reveal, Thread] satisfies Page[];

--- a/apps/demo/slides/morph-messages/index.tsx
+++ b/apps/demo/slides/morph-messages/index.tsx
@@ -30,6 +30,8 @@ const EASE_STANDARD = 'cubic-bezier(0.4, 0, 0.2, 1)';
 const HERO_MORPH_MS = 1250;
 const THREAD_MORPH_MS = 750;
 const RISE_MS = 420;
+const SLIDE_MS = 920;
+const DIAMOND_X = 654;
 
 export const transition: SlideTransition = {
   duration: 360,
@@ -69,8 +71,11 @@ const grayBubble = '#e9e9eb';
 if (typeof document !== 'undefined' && !document.getElementById('morph-messages-styles')) {
   const style = document.createElement('style');
   style.id = 'morph-messages-styles';
-  style.textContent =
-    '@keyframes morph-messages-rise { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }';
+  style.textContent = [
+    '@keyframes morph-messages-rise { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }',
+    `@keyframes morph-messages-slide-left { from { transform: translateX(${960 - DIAMOND_X}px); } to { transform: none; } }`,
+    '@keyframes morph-messages-slide-right { from { opacity: 0; transform: translateX(-64px); } to { opacity: 1; transform: none; } }',
+  ].join('');
   document.head.appendChild(style);
 }
 
@@ -167,6 +172,47 @@ const DebutLine = (props: LineProps) => {
       }}
     >
       {children}
+    </div>
+  );
+};
+
+// A message about to depart into a shape-only morph: the exit-snapshot
+// instance splits the bubble into a shell and a label morph element, so the
+// shell can change aspect freely while the label rides its own pair —
+// shrinking uniformly and dissolving via color interpolation — instead of
+// squashing inside a single-element clone. The audience-facing instance stays
+// a plain Line so arriving morphs still land on a full bubble.
+const ShedLine = (props: LineProps) => {
+  const animate = useIsActivePage();
+  if (animate) return <Line {...props} />;
+  const {
+    id,
+    fontSize,
+    color,
+    background = 'transparent',
+    received = false,
+    style,
+    children,
+  } = props;
+  return (
+    <div style={{ position: 'relative', alignSelf: received ? 'flex-start' : undefined }}>
+      <MorphElement id={id}>
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            borderRadius: 'var(--osd-radius)',
+            background,
+          }}
+        />
+      </MorphElement>
+      <MorphElement id={`${id}-label`}>
+        <div
+          style={{ ...pill(fontSize, color, 'transparent', false), position: 'relative', ...style }}
+        >
+          {children}
+        </div>
+      </MorphElement>
     </div>
   );
 };
@@ -274,14 +320,14 @@ const Question: Page = () => (
 const Answer: Page = () => (
   <section style={stage}>
     <div style={thread}>
-      <Line
+      <ShedLine
         id="msg-introducing"
         fontSize="var(--osd-size-body)"
         color="#ffffff"
         background="var(--osd-accent)"
       >
         Introducing
-      </Line>
+      </ShedLine>
       <Line
         id="msg-morph"
         fontSize="var(--osd-size-body)"
@@ -311,7 +357,192 @@ const Answer: Page = () => (
   </section>
 );
 
+const FromThis: Page = () => {
+  const animate = useIsActivePage();
+  return (
+    <section style={stage}>
+      <MorphElement id="msg-introducing">
+        <div
+          style={{
+            // The exit snapshot pins the radius to exactly half the box so
+            // the departing 06→07 morph relaxes its corners across the whole
+            // glide — an oversized radius (999px) spends most of the
+            // interpolation above the paint-time clamp, compressing the
+            // visible change into the final frames. The audience-facing
+            // instance keeps the token so the 05→06 arrival morphs against
+            // the original value.
+            borderRadius: animate ? 'var(--osd-radius)' : 120,
+            position: 'absolute',
+            left: 840,
+            top: 420,
+            width: 240,
+            height: 240,
+            background: 'var(--osd-accent)',
+          }}
+        />
+      </MorphElement>
+      {/* Invisible pair target: the departing label glides here, shrinking
+          uniformly (em geometry, half the font size) while its color fades to
+          zero-alpha white — a visible dissolve instead of a squashed ride. */}
+      <div
+        style={{
+          position: 'absolute',
+          left: 840,
+          top: 420,
+          width: 240,
+          height: 240,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <MorphElement id="msg-introducing-label">
+          <div
+            style={pill(
+              'calc(var(--osd-size-body) / 2)',
+              'rgba(255, 255, 255, 0)',
+              'transparent',
+              false,
+            )}
+          >
+            Introducing
+          </div>
+        </MorphElement>
+      </div>
+      <div
+        style={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          top: 732,
+          textAlign: 'center',
+          fontSize: 64,
+          fontWeight: 700,
+          letterSpacing: '-0.02em',
+          color: muted,
+          animation: animate
+            ? `morph-messages-rise ${RISE_MS}ms ${EASE_OUT} ${HERO_MORPH_MS}ms both`
+            : 'none',
+        }}
+      >
+        from this
+      </div>
+    </section>
+  );
+};
+
+const ToThis: Page = () => {
+  const animate = useIsActivePage();
+  return (
+    <section style={stage}>
+      <MorphElement id="msg-introducing">
+        <div
+          style={{
+            position: 'absolute',
+            left: 582,
+            top: 162,
+            width: 756,
+            height: 756,
+            borderRadius: 120,
+            background: 'var(--osd-accent)',
+          }}
+        />
+      </MorphElement>
+      <div
+        style={{
+          position: 'absolute',
+          left: 582,
+          top: 162,
+          width: 756,
+          height: 756,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 96,
+          fontWeight: 700,
+          letterSpacing: '-0.02em',
+          color: '#ffffff',
+          animation: animate
+            ? `morph-messages-rise ${RISE_MS}ms ${EASE_OUT} ${HERO_MORPH_MS}ms both`
+            : 'none',
+        }}
+      >
+        to this
+      </div>
+    </section>
+  );
+};
+
+// The static layout is the settled end state (diamond at DIAMOND_X, command
+// visible). While the morph runs, the fill-both slide-left animation holds
+// the wrapper offset so the diamond sits at canvas center — the morph
+// measures and lands there — then slides it left as the command sweeps in.
+const Spin: Page = () => {
+  const animate = useIsActivePage();
+  return (
+    <section style={stage}>
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          animation: animate
+            ? `morph-messages-slide-left ${SLIDE_MS}ms ${EASE_OUT} ${HERO_MORPH_MS}ms both`
+            : 'none',
+        }}
+      >
+        <MorphElement id="msg-introducing">
+          <div
+            style={{
+              // The morph runtime composes the clone's transform about
+              // 'top left', so the element must rotate about the same origin;
+              // the layout position is offset by R(135°)·(12,12) so the
+              // rotated box still centers on (DIAMOND_X, 540). Keeping the
+              // rotation on the morph node is what makes the runtime
+              // interpolate it into the glide.
+              left: DIAMOND_X + 16.97,
+              top: 540,
+              position: 'absolute',
+              width: 24,
+              height: 24,
+              borderRadius: 4,
+              background: 'var(--osd-accent)',
+              transform: 'rotate(135deg)',
+              transformOrigin: '0 0',
+            }}
+          />
+        </MorphElement>
+      </div>
+      <div
+        style={{
+          position: 'absolute',
+          left: 707,
+          top: 520,
+          fontSize: 40,
+          lineHeight: 1,
+          fontWeight: 600,
+          fontFamily: 'ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace',
+          color: 'var(--osd-text)',
+          animation: animate
+            ? `morph-messages-slide-right ${SLIDE_MS}ms ${EASE_OUT} ${HERO_MORPH_MS + 140}ms both`
+            : 'none',
+        }}
+      >
+        npx @open-slide/cli init
+      </div>
+    </section>
+  );
+};
+
 Question.transition = threadTransition;
 Answer.transition = threadTransition;
 
-export default [Introducing, Reveal, Sent, Question, Answer] satisfies Page[];
+export default [
+  Introducing,
+  Reveal,
+  Sent,
+  Question,
+  Answer,
+  FromThis,
+  ToThis,
+  Spin,
+] satisfies Page[];

--- a/packages/core/src/app/components/slide-transition-layer.tsx
+++ b/packages/core/src/app/components/slide-transition-layer.tsx
@@ -265,6 +265,12 @@ function getStyleProperty(styles: CSSStyleDeclaration, css: string): string {
   return styles.getPropertyValue(css);
 }
 
+// element.animate() silently drops kebab-case keys; keyframe properties must
+// use their IDL camelCase names.
+function keyframeProperty(css: string): string {
+  return css.replace(/^-/, '').replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
 function visualStyleKeyframe(
   styles: CSSStyleDeclaration,
   opacity?: string,
@@ -280,7 +286,7 @@ function visualStyleKeyframe(
     }
     const value = getStyleProperty(styles, prop);
     if (prop === TEXT_FILL_COLOR_PROPERTY && value === styles.color) continue;
-    if (value) frame[prop] = value;
+    if (value) frame[keyframeProperty(prop)] = value;
   }
   if (opacity !== undefined) frame.opacity = opacity;
   return frame;


### PR DESCRIPTION
## What changed

- **`packages/core`**: `visualStyleKeyframe` fed kebab-case CSS property names (`background-color`, `border-top-color`, `outline-color`, `text-decoration-color`, …) straight into WAAPI keyframe objects. `element.animate()` silently drops kebab-case keys — keyframe properties must use their IDL camelCase names — so none of those colors ever registered. A morphing element kept its outgoing colors for the entire glide, then snapped to the incoming colors when the overlay was cleaned up. New `keyframeProperty()` helper converts the names, fixing both the matched-pair clone animation and the descendant visual-style animations that share this path.
- **`apps/demo`**: new `morph-messages` slide — a three-page morph showcase where two hero lines fly right and shrink into iMessage-style bubbles. Page 2 → 3 exercises exactly the broken path: `transparent → #0a84ff` background interpolation on a matched pair.
- Changeset included (`@open-slide/core` patch).

## Why

Reported while dogfooding the new slide: the blue bubbles on page 3 appeared instantly at the end of the morph instead of flooding in during flight, despite the docs promising color interpolation on morph nodes and their descendants.

## Notes for review

- Verified empirically in a browser: `{'background-color': …}` keyframes register zero properties; `{backgroundColor: …}` registers correctly. `transform`/`borderRadius`/`opacity` were already camelCase, which is why the glide itself always worked and only colors snapped. `morph-demo` never caught this because its morph ids keep identical colors across pages.
- `-webkit-text-fill-color` / `-webkit-text-stroke-color` are rejected by WAAPI even in camelCase (dropped silently, no throw) — unchanged behavior; regular text color rides `color`, which now works as before.
- Other keyframe builders (`radiusKeyframe`, `borderFrameKeyframe`) were audited and already use camelCase; all `.animate()` call sites live in this one file.
- `pnpm check` ✓ (one pre-existing `useOptionalChain` warning in `request-guard.ts`, untouched here), `pnpm core typecheck` ✓, full vitest suite 305/305 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed morph transitions so background, border, and outline colors interpolate smoothly without snapping at the end of the glide.
* **New Features**
  * Expanded the Morph Transition demo with additional staged pages (including From/To and Spin), added animated “Delivered” status, and improved thread-style transition handling for question/answer pages.
* **Improvements**
  * Improved consistency of morph animation for CSS visual properties to enhance the reliability of color and style interpolation during transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->