### PR TITLE
feat(web): restyle landing and docs to match core's neutral SaaS design

### DIFF
--- a/apps/web/app/(home)/landing.css
+++ b/apps/web/app/(home)/landing.css
@@ -30,7 +30,7 @@
     0 16px 40px -12px oklch(0 0 0 / 0.06);
 
   --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-jetbrains-mono);
+  --font-mono: var(--font-geist-mono);
 
   background: var(--color-ink);
   color: var(--color-text);

--- a/apps/web/app/(home)/landing.css
+++ b/apps/web/app/(home)/landing.css
@@ -1,32 +1,34 @@
 /* open-slide landing styles — scoped to .os-landing so they don't bleed
    into the rest of the docs site (which uses fumadocs-ui's defaults).
 
-   Palette mirrors packages/core: warm paper + ink, single vermillion
-   accent. Brand consistency is the whole point — same identity across
-   the marketing surface, the docs, and the editor itself. */
+   Palette mirrors packages/core/src/app/styles.css: a pure zero-chroma
+   neutral ramp — clean white surfaces, hairline borders — with vermillion
+   as the single accent. Brand consistency is the whole point: same
+   identity across the marketing surface, the docs, and the editor. */
 
 .os-landing {
-  /* Dark mode is the default — warm near-black ink, paper text. */
-  --color-ink: oklch(0.155 0.005 70);
-  --color-paper: oklch(0.945 0.005 80);
-  --color-panel: oklch(0.195 0.006 70);
-  --color-panel-hi: oklch(0.245 0.006 70);
-  --color-rule: oklch(1 0 0 / 0.1);
-  --color-rule-soft: oklch(1 0 0 / 0.06);
-  --color-text: oklch(0.945 0.005 80);
-  --color-text-soft: oklch(0.86 0.006 78);
-  --color-muted: oklch(0.68 0.008 75);
-  --color-dim: oklch(0.42 0.008 70);
+  --color-ink: oklch(0.99 0 0);
+  --color-panel: oklch(1 0 0);
+  --color-panel-hi: oklch(0.97 0 0);
+  --color-rule: oklch(0.92 0 0);
+  --color-rule-soft: oklch(0.945 0 0);
+  --color-text: oklch(0.145 0 0);
+  --color-text-soft: oklch(0.35 0 0);
+  --color-muted: oklch(0.5 0 0);
+  --color-dim: oklch(0.72 0 0);
 
   /* Vermillion — single accent across the brand. Mirrors core's
-     --brand and --brand-soft tokens. */
-  --color-accent: oklch(0.66 0.19 28);
-  --color-accent-soft: oklch(0.76 0.14 28);
-  --color-accent-deep: oklch(0.555 0.185 28);
-  --color-warm: oklch(0.78 0.14 60);
-  --color-mint: oklch(0.7 0.14 160);
+     --brand token; restraint is the point. */
+  --color-accent: oklch(0.6 0.2 25);
+  --color-accent-soft: oklch(0.54 0.16 25);
+  --color-warm: oklch(0.55 0.12 75);
+  --color-mint: oklch(0.55 0.12 160);
 
-  --font-display: var(--font-instrument-serif);
+  --shadow-edge: 0 0 0 0.5px oklch(0 0 0 / 0.06), 0 1px 0 oklch(0 0 0 / 0.025);
+  --shadow-floating:
+    0 1px 1px oklch(0 0 0 / 0.03), 0 4px 16px -2px oklch(0 0 0 / 0.05),
+    0 16px 40px -12px oklch(0 0 0 / 0.06);
+
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-jetbrains-mono);
 
@@ -35,45 +37,47 @@
   font-family: var(--font-sans);
   letter-spacing: -0.005em;
   font-feature-settings: "ss01", "cv11", "calt";
-  text-rendering: geometricPrecision;
+  text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-html.light .os-landing {
-  /* Light mode — core's warm paper + ink. */
-  --color-ink: oklch(0.985 0.004 75);
-  --color-paper: oklch(0.2 0.012 60);
-  --color-panel: oklch(1 0 0);
-  --color-panel-hi: oklch(0.96 0.006 75);
-  --color-rule: oklch(0.86 0.008 70);
-  --color-rule-soft: oklch(0.91 0.008 70);
-  --color-text: oklch(0.2 0.012 60);
-  --color-text-soft: oklch(0.32 0.012 60);
-  --color-muted: oklch(0.485 0.012 60);
-  --color-dim: oklch(0.72 0.008 70);
+html.dark .os-landing {
+  --color-ink: oklch(0.145 0 0);
+  --color-panel: oklch(0.19 0 0);
+  --color-panel-hi: oklch(0.24 0 0);
+  --color-rule: oklch(1 0 0 / 0.1);
+  --color-rule-soft: oklch(1 0 0 / 0.06);
+  --color-text: oklch(0.93 0 0);
+  --color-text-soft: oklch(0.8 0 0);
+  --color-muted: oklch(0.68 0 0);
+  --color-dim: oklch(0.45 0 0);
 
-  --color-accent: oklch(0.555 0.185 28);
-  --color-accent-soft: oklch(0.66 0.16 28);
-  --color-accent-deep: oklch(0.46 0.18 28);
-  --color-warm: oklch(0.6 0.14 60);
-  --color-mint: oklch(0.5 0.13 160);
+  --color-accent: oklch(0.63 0.2 25);
+  --color-accent-soft: oklch(0.74 0.14 25);
+  --color-warm: oklch(0.75 0.12 75);
+  --color-mint: oklch(0.72 0.12 160);
+
+  --shadow-edge: 0 0 0 0.5px oklch(0 0 0 / 0.2);
+  --shadow-floating: 0 1px 1px oklch(0 0 0 / 0.2), 0 8px 24px -8px oklch(0 0 0 / 0.35);
 }
 
 .os-landing ::selection {
-  background: color-mix(in oklab, var(--color-accent) 30%, transparent);
+  background: color-mix(in oklab, var(--color-accent) 20%, transparent);
   color: var(--color-text);
 }
 
 /* ————————————————————————— utilities ————————————————————————— */
 
+/* Eyebrow label — mirrors core's .eyebrow: tracked-out small caps in
+   muted ink, one typographic gesture for every section label. */
 .os-landing .caption {
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
   font-size: 11px;
-  letter-spacing: 0.18em;
+  font-weight: 500;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-muted);
-  font-weight: 500;
 }
 
 .os-landing .hair {
@@ -81,46 +85,12 @@ html.light .os-landing {
   background: var(--color-rule);
 }
 
-.os-landing .tick::before {
-  content: "";
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  margin-right: 10px;
-  border-left: 1px solid var(--color-accent);
-  border-top: 1px solid var(--color-accent);
-  transform: translateY(1px);
+.os-landing .edge {
+  box-shadow: var(--shadow-edge);
 }
 
-.os-landing .brackets::before {
-  content: "‹";
-  margin-right: 6px;
-  color: var(--color-muted);
-}
-.os-landing .brackets::after {
-  content: "›";
-  margin-left: 6px;
-  color: var(--color-muted);
-}
-
-.os-landing .noise::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' seed='7'/><feColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
-  opacity: 0.35;
-  mix-blend-mode: overlay;
-  pointer-events: none;
-  z-index: 0;
-}
-
-.os-landing .specimen {
-  background-image: radial-gradient(
-    circle at 1px 1px,
-    color-mix(in oklab, var(--color-text) 12%, transparent) 1px,
-    transparent 0
-  );
-  background-size: 16px 16px;
+.os-landing .floating {
+  box-shadow: var(--shadow-floating);
 }
 
 @keyframes os-marquee {
@@ -186,7 +156,7 @@ html.light .os-landing {
 
 @keyframes os-codePulse {
   0% {
-    background-color: color-mix(in oklab, var(--color-accent) 32%, transparent);
+    background-color: color-mix(in oklab, var(--color-accent) 22%, transparent);
   }
   100% {
     background-color: transparent;
@@ -223,29 +193,30 @@ html.light .os-landing {
   }
 }
 
-.os-landing .logo-light {
+.os-landing .logo-dark {
   display: none;
 }
-html.light .os-landing .logo-dark {
-  display: none;
-}
-html.light .os-landing .logo-light {
+html.dark .os-landing .logo-dark {
   display: inline-block;
+}
+html.dark .os-landing .logo-light {
+  display: none;
 }
 
 .os-landing .agent-mono {
-  filter: brightness(0) invert(1);
-}
-html.light .os-landing .agent-mono {
   filter: brightness(0);
   opacity: 0.7;
 }
+html.dark .os-landing .agent-mono {
+  filter: brightness(0) invert(1);
+  opacity: 1;
+}
 
 .os-landing .vercel-oss-badge {
-  filter: invert(1) brightness(1.08);
-}
-html.light .os-landing .vercel-oss-badge {
   filter: none;
+}
+html.dark .os-landing .vercel-oss-badge {
+  filter: invert(1) brightness(1.08);
 }
 
 .os-landing :where(a, button, [role="button"]):focus-visible {

--- a/apps/web/app/global.css
+++ b/apps/web/app/global.css
@@ -56,6 +56,12 @@
   --color-fd-muted-foreground: oklch(0.72 0 0);
 }
 
+/* Unlayered so it beats Tailwind's @layer theme — routes every monospace
+   surface (font-mono utilities, preflight code/pre) through Geist Mono. */
+:root {
+  --font-mono: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
 html {
   scrollbar-gutter: stable;
 }

--- a/apps/web/app/global.css
+++ b/apps/web/app/global.css
@@ -4,55 +4,56 @@
 
 /* ─────────────────────────────────────────────────────────────────────────
    Brand override — align Fumadocs UI with packages/core's design language.
-   Warm paper + ink palette, vermillion as the single accent. Matches the
-   tokens defined in packages/core/src/app/styles.css so the marketing
-   site, the docs, and the editor share one visual identity.
+   Pure zero-chroma neutral ramp on clean white, hairline borders, and
+   vermillion as the single accent. Matches the tokens defined in
+   packages/core/src/app/styles.css so the marketing site, the docs, and
+   the editor share one visual identity.
    ───────────────────────────────────────────────────────────────────── */
 
 @theme {
-  --color-fd-background: oklch(0.985 0.004 75);
-  --color-fd-foreground: oklch(0.2 0.012 60);
-  --color-fd-muted: oklch(0.955 0.008 75);
-  --color-fd-muted-foreground: oklch(0.485 0.012 60);
-  --color-fd-popover: oklch(0.998 0.002 75);
-  --color-fd-popover-foreground: oklch(0.2 0.012 60);
+  --color-fd-background: oklch(0.99 0 0);
+  --color-fd-foreground: oklch(0.145 0 0);
+  --color-fd-muted: oklch(0.955 0 0);
+  --color-fd-muted-foreground: oklch(0.5 0 0);
+  --color-fd-popover: oklch(1 0 0);
+  --color-fd-popover-foreground: oklch(0.145 0 0);
   --color-fd-card: oklch(1 0 0);
-  --color-fd-card-foreground: oklch(0.2 0.012 60);
-  --color-fd-border: oklch(0.86 0.008 70);
-  --color-fd-primary: oklch(0.555 0.185 28);
-  --color-fd-primary-foreground: oklch(0.985 0.004 75);
-  --color-fd-secondary: oklch(0.96 0.006 75);
-  --color-fd-secondary-foreground: oklch(0.215 0.012 60);
-  --color-fd-accent: oklch(0.945 0.012 75);
-  --color-fd-accent-foreground: oklch(0.215 0.012 60);
-  --color-fd-ring: oklch(0.555 0.185 28);
+  --color-fd-card-foreground: oklch(0.145 0 0);
+  --color-fd-border: oklch(0.92 0 0);
+  --color-fd-primary: oklch(0.6 0.2 25);
+  --color-fd-primary-foreground: oklch(0.985 0 0);
+  --color-fd-secondary: oklch(0.96 0 0);
+  --color-fd-secondary-foreground: oklch(0.185 0 0);
+  --color-fd-accent: oklch(0.945 0 0);
+  --color-fd-accent-foreground: oklch(0.185 0 0);
+  --color-fd-ring: oklch(0.6 0.2 25);
   --color-fd-overlay: oklch(0 0 0 / 0.18);
 }
 
 .dark {
-  --color-fd-background: oklch(0.155 0.005 70);
-  --color-fd-foreground: oklch(0.945 0.005 80);
-  --color-fd-muted: oklch(0.235 0.006 70);
-  --color-fd-muted-foreground: oklch(0.68 0.008 75);
-  --color-fd-popover: oklch(0.21 0.006 70);
-  --color-fd-popover-foreground: oklch(0.945 0.005 80);
-  --color-fd-card: oklch(0.195 0.006 70);
-  --color-fd-card-foreground: oklch(0.945 0.005 80);
+  --color-fd-background: oklch(0.145 0 0);
+  --color-fd-foreground: oklch(0.93 0 0);
+  --color-fd-muted: oklch(0.23 0 0);
+  --color-fd-muted-foreground: oklch(0.68 0 0);
+  --color-fd-popover: oklch(0.205 0 0);
+  --color-fd-popover-foreground: oklch(0.93 0 0);
+  --color-fd-card: oklch(0.19 0 0);
+  --color-fd-card-foreground: oklch(0.93 0 0);
   --color-fd-border: oklch(1 0 0 / 0.1);
-  --color-fd-primary: oklch(0.66 0.19 28);
-  --color-fd-primary-foreground: oklch(0.155 0.005 70);
-  --color-fd-secondary: oklch(0.245 0.006 70);
-  --color-fd-secondary-foreground: oklch(0.945 0.005 80);
-  --color-fd-accent: oklch(0.27 0.008 70);
-  --color-fd-accent-foreground: oklch(0.945 0.005 80);
-  --color-fd-ring: oklch(0.66 0.19 28);
+  --color-fd-primary: oklch(0.63 0.2 25);
+  --color-fd-primary-foreground: oklch(0.985 0 0);
+  --color-fd-secondary: oklch(0.24 0 0);
+  --color-fd-secondary-foreground: oklch(0.93 0 0);
+  --color-fd-accent: oklch(0.265 0 0);
+  --color-fd-accent-foreground: oklch(0.93 0 0);
+  --color-fd-ring: oklch(0.63 0.19 25);
   --color-fd-overlay: oklch(0 0 0 / 0.2);
 }
 
 .dark #nd-sidebar {
-  --color-fd-muted: oklch(0.21 0.006 70);
-  --color-fd-secondary: oklch(0.245 0.006 70);
-  --color-fd-muted-foreground: oklch(0.72 0.008 75);
+  --color-fd-muted: oklch(0.205 0 0);
+  --color-fd-secondary: oklch(0.24 0 0);
+  --color-fd-muted-foreground: oklch(0.72 0 0);
 }
 
 html {
@@ -67,6 +68,6 @@ html > body[data-scroll-locked] {
 }
 
 ::selection {
-  background: oklch(0.555 0.185 28 / 0.18);
+  background: oklch(0.6 0.2 25 / 0.15);
   color: var(--color-fd-foreground);
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,7 +1,7 @@
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import './global.css';
 import type { Metadata, Viewport } from 'next';
-import { Geist, JetBrains_Mono } from 'next/font/google';
+import { Geist, Geist_Mono } from 'next/font/google';
 import { appName, gitConfig, siteUrl } from '@/lib/shared';
 
 const geist = Geist({
@@ -10,8 +10,8 @@ const geist = Geist({
   display: 'swap',
 });
 
-const jetbrains = JetBrains_Mono({
-  variable: '--font-jetbrains-mono',
+const geistMono = Geist_Mono({
+  variable: '--font-geist-mono',
   subsets: ['latin'],
   display: 'swap',
 });
@@ -104,7 +104,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
     <html
       lang="en"
       suppressHydrationWarning
-      className={`${geist.className} ${geist.variable} ${jetbrains.variable}`}
+      className={`${geist.className} ${geist.variable} ${geistMono.variable}`}
     >
       <body className="flex flex-col min-h-screen">
         <RootProvider>{children}</RootProvider>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,7 +1,7 @@
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import './global.css';
 import type { Metadata, Viewport } from 'next';
-import { Geist, Instrument_Serif, JetBrains_Mono } from 'next/font/google';
+import { Geist, JetBrains_Mono } from 'next/font/google';
 import { appName, gitConfig, siteUrl } from '@/lib/shared';
 
 const geist = Geist({
@@ -13,14 +13,6 @@ const geist = Geist({
 const jetbrains = JetBrains_Mono({
   variable: '--font-jetbrains-mono',
   subsets: ['latin'],
-  display: 'swap',
-});
-
-const instrument = Instrument_Serif({
-  variable: '--font-instrument-serif',
-  subsets: ['latin'],
-  weight: '400',
-  style: ['normal', 'italic'],
   display: 'swap',
 });
 
@@ -102,8 +94,8 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#F7F4EC' },
-    { media: '(prefers-color-scheme: dark)', color: '#1A1814' },
+    { media: '(prefers-color-scheme: light)', color: '#FCFCFC' },
+    { media: '(prefers-color-scheme: dark)', color: '#0A0A0A' },
   ],
 };
 
@@ -112,7 +104,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
     <html
       lang="en"
       suppressHydrationWarning
-      className={`${geist.className} ${geist.variable} ${jetbrains.variable} ${instrument.variable}`}
+      className={`${geist.className} ${geist.variable} ${jetbrains.variable}`}
     >
       <body className="flex flex-col min-h-screen">
         <RootProvider>{children}</RootProvider>

--- a/apps/web/app/og/docs/[...slug]/route.tsx
+++ b/apps/web/app/og/docs/[...slug]/route.tsx
@@ -35,7 +35,7 @@ export async function GET(_req: Request, { params }: RouteContext<'/og/docs/[...
   const [geistRegular, geistMedium, mono, logoBuffer] = await Promise.all([
     loadGoogleFont('Geist', 400),
     loadGoogleFont('Geist', 500),
-    loadGoogleFont('JetBrains Mono', 500),
+    loadGoogleFont('Geist Mono', 500),
     readFile(path.join(process.cwd(), 'public/open-slide.png')),
   ]);
   const logoSrc = `data:image/png;base64,${logoBuffer.toString('base64')}`;
@@ -52,7 +52,7 @@ export async function GET(_req: Request, { params }: RouteContext<'/og/docs/[...
       fonts: [
         { name: 'Geist', data: geistRegular, weight: 400, style: 'normal' },
         { name: 'Geist', data: geistMedium, weight: 500, style: 'normal' },
-        { name: 'JetBrains Mono', data: mono, weight: 500, style: 'normal' },
+        { name: 'Geist Mono', data: mono, weight: 500, style: 'normal' },
       ],
     },
   );
@@ -101,7 +101,7 @@ function Frame({
         <img src={logoSrc} width={48} height={48} alt="" style={{ borderRadius: 8 }} />
         <div
           style={{
-            fontFamily: 'JetBrains Mono',
+            fontFamily: 'Geist Mono',
             fontSize: 18,
             letterSpacing: '0.08em',
             textTransform: 'uppercase',
@@ -179,7 +179,7 @@ function Frame({
           marginTop: 'auto',
           paddingTop: 24,
           borderTop: `1px solid ${RULE}`,
-          fontFamily: 'JetBrains Mono',
+          fontFamily: 'Geist Mono',
           fontSize: 18,
           color: MUTED,
         }}

--- a/apps/web/app/og/docs/[...slug]/route.tsx
+++ b/apps/web/app/og/docs/[...slug]/route.tsx
@@ -7,13 +7,13 @@ import { getPageImage, source } from '@/lib/source';
 
 export const revalidate = false;
 
-// Mirrors apps/web/app/(home)/landing.css.
-const PAPER = '#F7F4EC';
-const INK = '#1A1814';
-const INK_SOFT = '#3A352E';
-const MUTED = '#6E665B';
-const RULE = '#D9D2C3';
-const ACCENT = '#C2410C';
+// Mirrors apps/web/app/(home)/landing.css — clean neutral surface, vermillion accent.
+const PAPER = '#FCFCFC';
+const INK = '#0A0A0A';
+const INK_SOFT = '#3A3A3A';
+const MUTED = '#636363';
+const RULE = '#E4E4E4';
+const ACCENT = '#DE3B3D';
 
 async function loadGoogleFont(family: string, weight: number, italic = false) {
   const ital = italic ? 'ital,' : '';
@@ -77,10 +77,6 @@ function Frame({
         width: '100%',
         height: '100%',
         backgroundColor: PAPER,
-        backgroundImage:
-          // subtle dot grid — mirrors `.specimen` in landing.css
-          `radial-gradient(circle at 1px 1px, rgba(26,24,20,0.06) 1px, transparent 0)`,
-        backgroundSize: '20px 20px',
         fontFamily: 'Geist',
         color: INK,
         padding: '72px 80px',
@@ -107,7 +103,7 @@ function Frame({
           style={{
             fontFamily: 'JetBrains Mono',
             fontSize: 18,
-            letterSpacing: '0.18em',
+            letterSpacing: '0.08em',
             textTransform: 'uppercase',
             color: MUTED,
             display: 'flex',

--- a/apps/web/components/landing/anatomy.tsx
+++ b/apps/web/components/landing/anatomy.tsx
@@ -12,7 +12,7 @@ type Variant = {
 const variants: Variant[] = [
   {
     word: 'deck',
-    accent: '#d56b48',
+    accent: '#de3b3d',
     label: '01',
     subtitle: 'A React slide, rendered live.',
   },
@@ -68,21 +68,17 @@ export function Anatomy() {
   return (
     <section id="anatomy" className="relative">
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
-        <h2 className="text-[32px] sm:text-[44px] lg:text-[64px] leading-[1.1] sm:leading-[1.05] tracking-[-0.03em] max-w-[820px] mb-14 sm:mb-20">
-          <span className="font-[family-name:var(--font-sans)] font-medium">
-            A slide is a file.
-          </span>
+        <h2 className="text-[32px] sm:text-[44px] lg:text-[60px] leading-[1.1] sm:leading-[1.05] tracking-[-0.035em] font-medium max-w-[820px] mb-14 sm:mb-20">
+          A slide is a file.
           <br />
-          <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-muted)]">
-            Just React, nothing else.
-          </span>
+          <span className="text-[color:var(--color-muted)]">Just React, nothing else.</span>
         </h2>
 
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-12 items-start">
           {/* code pane */}
           <div className="lg:col-span-7">
-            <div className="relative rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] overflow-hidden">
-              <div className="flex items-center justify-between px-4 sm:px-5 h-10 sm:h-11 border-b border-[color:var(--color-rule)] font-[family-name:var(--font-mono)] text-[12px] text-[color:var(--color-muted)]">
+            <div className="floating relative rounded-[8px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] overflow-hidden">
+              <div className="flex items-center justify-between px-4 sm:px-5 h-10 sm:h-11 border-b border-[color:var(--color-rule-soft)] font-[family-name:var(--font-mono)] text-[12px] text-[color:var(--color-muted)]">
                 <div className="flex items-center gap-3">
                   <span
                     className="h-2.5 w-2.5 rounded-full transition-colors duration-500"
@@ -90,7 +86,7 @@ export function Anatomy() {
                   />
                   <span>slides/hello/index.tsx</span>
                 </div>
-                <span className="tracking-[0.14em] uppercase">tsx · {lines.length} lines</span>
+                <span className="tracking-[0.08em] uppercase">tsx · {lines.length} lines</span>
               </div>
               <pre className="p-4 sm:p-6 text-[12px] sm:text-[13.5px] leading-[1.65] sm:leading-[1.75] overflow-x-auto font-[family-name:var(--font-mono)]">
                 <code>
@@ -114,8 +110,8 @@ export function Anatomy() {
 
           {/* preview pane */}
           <div className="lg:col-span-5">
-            <div className="relative rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] p-4 sm:p-5">
-              <div className="flex items-center justify-between font-[family-name:var(--font-mono)] text-[11px] tracking-[0.14em] uppercase text-[color:var(--color-muted)] mb-4">
+            <div className="floating relative rounded-[8px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] p-4 sm:p-5">
+              <div className="flex items-center justify-between font-[family-name:var(--font-mono)] text-[11px] tracking-[0.08em] uppercase text-[color:var(--color-muted)] mb-4">
                 <span>rendered output</span>
                 <span className="flex items-center gap-2">
                   <span
@@ -197,9 +193,9 @@ function SlidePreview({ variant, index }: { variant: Variant; index: number }) {
         <h1
           className="text-center"
           style={{
-            fontFamily: 'var(--font-display), serif',
-            fontStyle: 'italic',
-            fontSize: '10cqw',
+            fontFamily: 'var(--font-sans), system-ui, sans-serif',
+            fontWeight: 600,
+            fontSize: '9.5cqw',
             lineHeight: 0.98,
             letterSpacing: '-0.04em',
           }}
@@ -210,6 +206,7 @@ function SlidePreview({ variant, index }: { variant: Variant; index: number }) {
             className="inline-block"
             style={{
               color: accent,
+              fontStyle: 'italic',
               transition: 'color 600ms ease',
               animation: 'textReveal 650ms cubic-bezier(0.2,0.7,0.2,1) both',
             }}

--- a/apps/web/components/landing/assets.tsx
+++ b/apps/web/components/landing/assets.tsx
@@ -52,12 +52,10 @@ export function Assets() {
     <section id="assets" className="relative">
       <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-[color:var(--color-rule)]" />
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
-        <h2 className="text-[32px] sm:text-[44px] lg:text-[64px] leading-[1.1] sm:leading-[1.05] tracking-[-0.03em] max-w-[820px] mb-14 sm:mb-20">
-          <span className="font-[family-name:var(--font-sans)] font-medium">Drop in images.</span>
+        <h2 className="text-[32px] sm:text-[44px] lg:text-[60px] leading-[1.1] sm:leading-[1.05] tracking-[-0.035em] font-medium max-w-[820px] mb-14 sm:mb-20">
+          Drop in images.
           <br />
-          <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-warm)]">
-            Pull in logos.
-          </span>
+          <span className="text-[color:var(--color-muted)]">Pull in logos.</span>
         </h2>
 
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-12 items-start">
@@ -67,11 +65,11 @@ export function Assets() {
           </div>
 
           {/* side callouts */}
-          <div className="lg:col-span-4 flex flex-col gap-px bg-[color:var(--color-rule)] border border-[color:var(--color-rule)] rounded-[6px] overflow-hidden">
+          <div className="floating lg:col-span-4 flex flex-col gap-px bg-[color:var(--color-rule)] border border-[color:var(--color-rule)] rounded-[8px] overflow-hidden">
             {callouts.map((c) => (
               <div
                 key={c.eyebrow}
-                className="bg-[color:var(--color-ink)] p-6 sm:p-7 lg:p-8 flex flex-col gap-3"
+                className="bg-[color:var(--color-panel)] p-6 sm:p-7 lg:p-8 flex flex-col gap-3"
               >
                 <span className="caption">{c.eyebrow}</span>
                 <h3 className="text-[22px] lg:text-[24px] font-medium tracking-[-0.025em] leading-[1.2]">
@@ -91,9 +89,9 @@ export function Assets() {
 
 function AssetManagerMock() {
   return (
-    <div className="relative rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] overflow-hidden">
+    <div className="floating relative rounded-[8px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] overflow-hidden">
       {/* window header */}
-      <div className="flex items-center px-4 sm:px-5 h-10 sm:h-11 border-b border-[color:var(--color-rule)] font-[family-name:var(--font-mono)] text-[12px] text-[color:var(--color-muted)]">
+      <div className="flex items-center px-4 sm:px-5 h-10 sm:h-11 border-b border-[color:var(--color-rule-soft)] font-[family-name:var(--font-mono)] text-[12px] text-[color:var(--color-muted)]">
         <div className="flex items-center gap-2">
           <span className="size-[10px] rounded-full bg-[#ff5f56]" />
           <span className="size-[10px] rounded-full bg-[#ffbd2e]" />
@@ -132,7 +130,7 @@ function AssetManagerMock() {
         </div>
 
         {/* svgl Logo Search dialog */}
-        <div className="absolute right-3 sm:right-5 bottom-3 sm:bottom-5 w-[80%] sm:w-[64%] max-w-[420px] rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)] shadow-[0_10px_28px_-14px_rgba(0,0,0,0.35)] p-4">
+        <div className="floating absolute right-3 sm:right-5 bottom-3 sm:bottom-5 w-[80%] sm:w-[64%] max-w-[420px] rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] p-4">
           <div className="flex items-center justify-between mb-3 font-[family-name:var(--font-mono)] text-[11px] text-[color:var(--color-muted)]">
             <span>Search svgl</span>
             <span className="text-[color:var(--color-dim)]">✕</span>

--- a/apps/web/components/landing/copy-command.tsx
+++ b/apps/web/components/landing/copy-command.tsx
@@ -25,11 +25,7 @@ export function CopyCommand({ command, size = 'lg' }: { command: string; size?: 
     <button
       type="button"
       onClick={onCopy}
-      style={{
-        boxShadow:
-          '0 0 0 1px color-mix(in oklab, var(--color-accent) 15%, transparent), 0 20px 80px -20px color-mix(in oklab, var(--color-accent) 35%, transparent)',
-      }}
-      className={`group relative inline-flex items-center gap-3 ${height} ${pad} rounded-[6px] border border-[color:var(--color-accent)]/40 bg-[color:var(--color-panel)] text-[color:var(--color-text)] font-[family-name:var(--font-mono)] ${text} hover:border-[color:var(--color-accent)] transition`}
+      className={`group floating relative inline-flex items-center gap-3 ${height} ${pad} rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] text-[color:var(--color-text)] font-[family-name:var(--font-mono)] ${text} hover:border-[color:var(--color-accent)]/50 transition`}
     >
       <span aria-hidden className="text-[color:var(--color-accent)]">
         $

--- a/apps/web/components/landing/demo-slide/index.tsx
+++ b/apps/web/components/landing/demo-slide/index.tsx
@@ -40,7 +40,7 @@ const palette = {
 
 const font = {
   sans: '"Inter", "SF Pro Display", system-ui, -apple-system, sans-serif',
-  mono: '"JetBrains Mono", "SF Mono", ui-monospace, Menlo, monospace',
+  mono: 'var(--font-geist-mono), "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace',
 };
 
 const fill = {

--- a/apps/web/components/landing/faq.tsx
+++ b/apps/web/components/landing/faq.tsx
@@ -34,14 +34,11 @@ export function FAQ() {
     <section id="faq" className="relative">
       <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-[color:var(--color-rule)]" />
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
-        <h2 className="text-[32px] sm:text-[44px] lg:text-[64px] leading-[1.1] sm:leading-[1.05] tracking-[-0.03em] max-w-[820px] mb-14 sm:mb-20">
-          <span className="font-[family-name:var(--font-sans)] font-medium">Questions,</span>{' '}
-          <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-accent)]">
-            answered.
-          </span>
+        <h2 className="text-[32px] sm:text-[44px] lg:text-[60px] leading-[1.1] sm:leading-[1.05] tracking-[-0.035em] font-medium max-w-[820px] mb-14 sm:mb-20">
+          Questions, <span className="text-[color:var(--color-muted)]">answered.</span>
         </h2>
 
-        <dl className="max-w-[860px]">
+        <dl className="max-w-[860px] border-y border-[color:var(--color-rule-soft)] divide-y divide-[color:var(--color-rule-soft)]">
           {faqs.map((item, idx) => (
             <FaqItem key={item.q} item={item} index={idx} />
           ))}

--- a/apps/web/components/landing/footer.tsx
+++ b/apps/web/components/landing/footer.tsx
@@ -3,10 +3,10 @@ import { VercelOssBadge } from './vercel-oss-badge';
 
 export function Footer() {
   return (
-    <footer className="border-t border-[color:var(--color-rule)] bg-[color:var(--color-panel)]/60">
+    <footer className="border-t border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)]/50">
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-10 sm:py-14 grid grid-cols-12 gap-x-6 gap-y-10">
         <div className="col-span-12 lg:col-span-4 flex flex-col gap-4">
-          <div className="flex items-center gap-3 font-[family-name:var(--font-mono)] text-[13px]">
+          <div className="flex items-center gap-2.5 text-[14px] font-medium">
             <Image
               src="/open-slide.png"
               alt=""
@@ -49,7 +49,7 @@ export function Footer() {
       </div>
 
       <div className="border-t border-[color:var(--color-rule)]">
-        <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-5 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-0 font-[family-name:var(--font-mono)] text-[11px] tracking-[0.18em] uppercase text-[color:var(--color-muted)]">
+        <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-5 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-0 text-[13px] text-[color:var(--color-muted)]">
           <VercelOssBadge imageClassName="h-4 sm:h-5" />
           <span>
             Crafted with 🤍 by{' '}

--- a/apps/web/components/landing/get-started.tsx
+++ b/apps/web/components/landing/get-started.tsx
@@ -6,12 +6,10 @@ export function GetStarted() {
       <div aria-hidden className="hair absolute inset-x-0 top-0" />
       <div className="relative mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-24 sm:py-36 lg:py-48">
         <div className="flex flex-col gap-10 sm:gap-14 max-w-[820px]">
-          <h2 className="text-[36px] sm:text-[52px] lg:text-[80px] leading-[1.05] sm:leading-[1.0] tracking-[-0.035em]">
-            <span className="font-[family-name:var(--font-sans)] font-medium">Author a deck</span>
+          <h2 className="text-[36px] sm:text-[52px] lg:text-[76px] leading-[1.05] sm:leading-[1.0] tracking-[-0.04em] font-medium">
+            Author a deck
             <br />
-            <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-accent)]">
-              in the next minute.
-            </span>
+            <span className="text-[color:var(--color-accent)]">in the next minute.</span>
           </h2>
 
           <p className="max-w-[560px] text-[18px] leading-[1.65] text-[color:var(--color-text-soft)]">

--- a/apps/web/components/landing/hero-setup.tsx
+++ b/apps/web/components/landing/hero-setup.tsx
@@ -101,7 +101,7 @@ export function HeroSetup() {
         type="button"
         aria-label={option.copyLabel}
         onClick={copySetup}
-        className="group flex h-[58px] w-[337px] max-w-full items-center gap-3 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-5 text-left shadow-[0_18px_70px_-36px_color-mix(in_oklab,var(--color-accent)_55%,transparent)] transition-[border-color,background-color,box-shadow] duration-200 hover:border-[color:var(--color-accent)]/50 hover:bg-[color:var(--color-panel-hi)] hover:shadow-[0_22px_80px_-34px_color-mix(in_oklab,var(--color-accent)_65%,transparent)] sm:h-[68px] sm:px-7"
+        className="group floating flex h-[58px] w-[337px] max-w-full items-center gap-3 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-5 text-left transition-[border-color,background-color] duration-200 hover:border-[color:var(--color-accent)]/50 sm:h-[68px] sm:px-7"
       >
         <span className="relative h-[20px] min-w-0 flex-1 overflow-hidden sm:h-[22px]">
           <AnimatePresence initial={false} custom={direction}>

--- a/apps/web/components/landing/hero.tsx
+++ b/apps/web/components/landing/hero.tsx
@@ -8,16 +8,12 @@ export function Hero() {
       <div className="relative mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 pt-20 sm:pt-32 lg:pt-44 pb-20 sm:pb-32">
         <div className="flex flex-col gap-10 sm:gap-14 max-w-[920px]">
           <h1
-            className="text-[44px] sm:text-[72px] lg:text-[100px] leading-[1.05] sm:leading-[0.98] tracking-[-0.035em] rise"
+            className="text-[42px] sm:text-[68px] lg:text-[92px] leading-[1.05] sm:leading-[1.0] tracking-[-0.045em] font-medium text-[color:var(--color-text)] rise"
             style={{ animationDelay: '80ms' }}
           >
-            <span className="font-[family-name:var(--font-sans)] font-medium text-[color:var(--color-text)]">
-              The slide framework
-            </span>
+            The slide framework
             <br />
-            <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-paper)]">
-              built for <span className="text-[color:var(--color-accent)]">agents</span>.
-            </span>
+            built for <span className="text-[color:var(--color-accent)]">agents</span>.
           </h1>
 
           <p

--- a/apps/web/components/landing/how-it-works.tsx
+++ b/apps/web/components/landing/how-it-works.tsx
@@ -82,7 +82,7 @@ function AgentRow() {
       {agents.map(([file, name]) => (
         <img key={file} src={`/assets/${file}`} alt={name} className={cls} />
       ))}
-      <span className="text-[10px] tracking-[0.1em] uppercase text-[color:var(--color-muted)]">
+      <span className="text-[10px] tracking-[0.08em] uppercase text-[color:var(--color-muted)]">
         ...
       </span>
     </span>
@@ -94,21 +94,19 @@ export function HowItWorks() {
     <section id="how-it-works" className="relative">
       <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-[color:var(--color-rule)]" />
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
-        <h2 className="text-[32px] sm:text-[44px] lg:text-[64px] leading-[1.1] sm:leading-[1.05] tracking-[-0.03em] max-w-[820px] mb-14 sm:mb-20">
-          <span className="font-[family-name:var(--font-sans)] font-medium">Slides as code.</span>
+        <h2 className="text-[32px] sm:text-[44px] lg:text-[60px] leading-[1.1] sm:leading-[1.05] tracking-[-0.035em] font-medium max-w-[820px] mb-14 sm:mb-20">
+          Slides as code.
           <br />
-          <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-accent)]">
-            Crafted by agents.
-          </span>
+          <span className="text-[color:var(--color-muted)]">Crafted by agents.</span>
         </h2>
 
-        <ol className="grid grid-cols-1 md:grid-cols-3 gap-px bg-[color:var(--color-rule)] border border-[color:var(--color-rule)] rounded-[6px] overflow-hidden">
+        <ol className="floating grid grid-cols-1 md:grid-cols-3 gap-px bg-[color:var(--color-rule)] border border-[color:var(--color-rule)] rounded-[8px] overflow-hidden">
           {steps.map((s) => (
             <li
               key={s.num}
-              className="group relative p-8 sm:p-10 lg:p-12 bg-[color:var(--color-ink)] flex flex-col gap-7 transition-colors hover:bg-[color:var(--color-panel)]"
+              className="group relative p-8 sm:p-10 lg:p-12 bg-[color:var(--color-panel)] flex flex-col gap-7"
             >
-              <span className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.18em] uppercase text-[color:var(--color-muted)]">
+              <span className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.08em] uppercase text-[color:var(--color-muted)]">
                 {s.num} · {s.kicker}
               </span>
 
@@ -121,14 +119,14 @@ export function HowItWorks() {
                 </p>
               </div>
 
-              <div className="rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)] p-4 font-[family-name:var(--font-mono)] text-[13px]">
+              <div className="rounded-[6px] border border-[color:var(--color-rule-soft)] bg-[color:var(--color-panel-hi)] p-4 font-[family-name:var(--font-mono)] text-[13px]">
                 <div className="flex items-center gap-2">
                   <span className="text-[color:var(--color-accent)]">{s.code.prompt}</span>
                   <span className="text-[color:var(--color-text)] truncate">
                     {renderLine(s.code.line)}
                   </span>
                 </div>
-                <div className="mt-3 text-[11px] tracking-[0.1em] uppercase text-[color:var(--color-muted)]">
+                <div className="mt-3 text-[11px] tracking-[0.08em] uppercase text-[color:var(--color-muted)]">
                   {s.code.tail}
                 </div>
               </div>

--- a/apps/web/components/landing/inline-slide-player.tsx
+++ b/apps/web/components/landing/inline-slide-player.tsx
@@ -91,7 +91,7 @@ export function InlineSlidePlayer({ index, onIndexChange }: Props) {
 
       <div
         aria-hidden
-        className="pointer-events-none absolute bottom-3 right-3 font-[family-name:var(--font-mono)] text-[11px] tracking-[0.18em] uppercase text-[color:var(--color-muted)]/90 bg-[color:var(--color-ink)]/60 backdrop-blur-sm px-2 py-1 rounded"
+        className="pointer-events-none absolute bottom-3 right-3 font-[family-name:var(--font-mono)] text-[11px] tracking-[0.08em] text-[color:var(--color-muted)] bg-[color:var(--color-panel)]/75 backdrop-blur-sm px-2 py-1 rounded-[4px]"
       >
         {String(index + 1).padStart(2, '0')} / {String(count).padStart(2, '0')}
       </div>

--- a/apps/web/components/landing/inspector.tsx
+++ b/apps/web/components/landing/inspector.tsx
@@ -15,17 +15,13 @@ export function Inspector() {
     <section id="inspector" className="relative">
       <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-[color:var(--color-rule)]" />
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
-        <h2 className="text-[32px] sm:text-[44px] lg:text-[64px] leading-[1.1] sm:leading-[1.05] tracking-[-0.03em] max-w-[860px] mb-14 sm:mb-20">
-          <span className="font-[family-name:var(--font-sans)] font-medium">
-            Talk to the agent.
-          </span>
+        <h2 className="text-[32px] sm:text-[44px] lg:text-[60px] leading-[1.1] sm:leading-[1.05] tracking-[-0.035em] font-medium max-w-[860px] mb-14 sm:mb-20">
+          Talk to the agent.
           <br />
-          <span className="font-[family-name:var(--font-display)] italic text-[color:var(--color-accent)]">
-            Or just tap the canvas.
-          </span>
+          <span className="text-[color:var(--color-muted)]">Or just tap the canvas.</span>
         </h2>
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-px bg-[color:var(--color-rule)] border border-[color:var(--color-rule)] rounded-[6px] overflow-hidden">
+        <div className="floating grid grid-cols-1 lg:grid-cols-2 gap-px bg-[color:var(--color-rule)] border border-[color:var(--color-rule)] rounded-[8px] overflow-hidden">
           <FeatureCell
             num="01"
             kicker="agent applies"
@@ -72,8 +68,8 @@ function FeatureCell({
   visual: ReactNode;
 }) {
   return (
-    <div className="group relative bg-[color:var(--color-ink)] flex flex-col gap-10 p-8 sm:p-10 lg:p-12 transition-colors hover:bg-[color:var(--color-panel)]">
-      <span className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.18em] uppercase text-[color:var(--color-muted)]">
+    <div className="group relative bg-[color:var(--color-panel)] flex flex-col gap-10 p-8 sm:p-10 lg:p-12">
+      <span className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.08em] uppercase text-[color:var(--color-muted)]">
         {num} · {kicker}
       </span>
 
@@ -226,7 +222,7 @@ function AgentApplyVisual() {
 
           {/* "Agent applying..." status pill — appears after submit, fades before style change settles */}
           <motion.div
-            className="absolute right-[1.5cqw] bottom-[1.5cqw] inline-flex items-center gap-[0.55cqw] rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)] font-[family-name:var(--font-sans)] text-[color:var(--color-text)] shadow-[0_8px_24px_-12px_rgba(0,0,0,0.35)]"
+            className="absolute right-[1.5cqw] bottom-[1.5cqw] inline-flex items-center gap-[0.55cqw] rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)] font-[family-name:var(--font-sans)] text-[color:var(--color-text)] shadow-[0_8px_24px_-12px_rgba(0,0,0,0.18)]"
             style={{ padding: '0.55cqw 0.9cqw', fontSize: '1.05cqw' }}
             animate={
               active
@@ -476,7 +472,7 @@ function VisualEditorVisual() {
           {/* SaveBar — matches core/SaveCard layout */}
           <div className="absolute left-1/2 -translate-x-1/2" style={{ bottom: '3cqw' }}>
             <div
-              className="inline-flex items-center gap-[0.4cqw] whitespace-nowrap rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)]/95 backdrop-blur-md shadow-[0_8px_24px_-12px_rgba(0,0,0,0.35)]"
+              className="inline-flex items-center gap-[0.4cqw] whitespace-nowrap rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)]/95 backdrop-blur-md shadow-[0_8px_24px_-12px_rgba(0,0,0,0.18)]"
               style={{ padding: '0.35cqw 0.35cqw 0.35cqw 0.5cqw' }}
             >
               <SaveBarIconBtn glyph={<UndoGlyph />} />
@@ -604,7 +600,7 @@ function VisualEditorVisual() {
           <PanelSection label="Color">
             <PanelRow label="Text">
               <PanelSwatch color="var(--color-accent)" />
-              <PanelInput value="#D56B48" mono uppercase />
+              <PanelInput value="#DE3B3D" mono uppercase />
             </PanelRow>
           </PanelSection>
         </div>

--- a/apps/web/components/landing/live-demo.tsx
+++ b/apps/web/components/landing/live-demo.tsx
@@ -36,13 +36,13 @@ export function LiveDemo() {
           Live demo
         </h2>
         <div
-          className="relative block w-full overflow-hidden rounded-[8px] border border-[color:var(--color-rule)] bg-black"
+          className="floating relative block w-full overflow-hidden rounded-[8px] border border-[color:var(--color-rule)] bg-black"
           style={{ aspectRatio: '16 / 9' }}
         >
           <InlineSlidePlayer index={index} onIndexChange={setIndex} />
         </div>
 
-        <div className="mt-6 flex items-center justify-between font-[family-name:var(--font-mono)] text-[11px] tracking-[0.12em] uppercase text-[color:var(--color-muted)]">
+        <div className="mt-6 flex items-center justify-between text-[13px] font-medium text-[color:var(--color-muted)]">
           <a
             href="https://demo.open-slide.dev/"
             target="_blank"
@@ -54,7 +54,7 @@ export function LiveDemo() {
             <span aria-hidden>↗</span>
           </a>
           <span className="flex items-center gap-3">
-            <span className="text-[color:var(--color-text-soft)]">
+            <span className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.08em] text-[color:var(--color-text-soft)]">
               {String(index + 1).padStart(2, '0')} / {String(count).padStart(2, '0')}
             </span>
             <button

--- a/apps/web/components/landing/nav.tsx
+++ b/apps/web/components/landing/nav.tsx
@@ -7,11 +7,11 @@ import { ThemeToggle } from './theme-toggle';
 
 export function Nav({ githubStars }: { githubStars?: string | null }) {
   return (
-    <header className="sticky top-0 z-40 bg-[color:var(--color-ink)]/80 backdrop-blur-md border-b border-[color:var(--color-rule-soft)]">
-      <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 h-16 flex items-center justify-between">
+    <header className="sticky top-0 z-40 bg-[color:var(--color-ink)]/85 backdrop-blur-md border-b border-[color:var(--color-rule-soft)]">
+      <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 h-14 flex items-center justify-between">
         <Link
           href="/"
-          className="flex items-center gap-3 font-[family-name:var(--font-mono)] text-[13px] tracking-[0.04em]"
+          className="flex items-center gap-2.5 text-[14px] font-medium tracking-[-0.01em]"
         >
           <Image
             src="/open-slide.png"
@@ -24,7 +24,7 @@ export function Nav({ githubStars }: { githubStars?: string | null }) {
           <span className="text-[color:var(--color-text)]">open-slide</span>
         </Link>
 
-        <nav className="flex items-center gap-8 font-[family-name:var(--font-mono)] text-[12px] tracking-[0.08em] uppercase">
+        <nav className="flex items-center gap-6 text-[13.5px] font-medium">
           <Link
             href="/docs"
             className="hidden md:inline text-[color:var(--color-muted)] hover:text-[color:var(--color-text)] transition-colors"
@@ -38,7 +38,7 @@ export function Nav({ githubStars }: { githubStars?: string | null }) {
             onClick={() => posthog.capture('nav_external_link_clicked', { label: 'demo' })}
             className="hidden md:inline text-[color:var(--color-muted)] hover:text-[color:var(--color-text)] transition-colors"
           >
-            Demo ↗
+            Demo
           </a>
           <a
             href="https://github.com/1weiho/open-slide"
@@ -47,11 +47,11 @@ export function Nav({ githubStars }: { githubStars?: string | null }) {
             onClick={() => posthog.capture('nav_external_link_clicked', { label: 'github' })}
             className="hidden md:inline-flex items-center gap-2 text-[color:var(--color-muted)] hover:text-[color:var(--color-text)] transition-colors"
           >
-            <span>GitHub ↗</span>
+            <span>GitHub</span>
             {githubStars ? (
               <span
                 aria-label={`${githubStars} GitHub stars`}
-                className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-rule-soft)] px-2 py-[2px] text-[10px] tracking-[0.06em] text-[color:var(--color-text)]"
+                className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10.5px] text-[color:var(--color-text)]"
               >
                 <span aria-hidden>★</span>
                 {githubStars}


### PR DESCRIPTION
Retone the marketing site and docs from the warm paper/ink editorial
palette to the clean zero-chroma neutral ramp used by packages/core:
white surfaces, hairline borders, Geist headings (Instrument Serif
removed), and vermillion as the single accent.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HPrUAPdKuZWY3ziTf7t5bF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refreshed the landing page theme with a cleaner neutral palette, vermillion accent, updated shadows, and revised selection/hover visuals.
  * Restyled multiple landing components (hero, nav, buttons, cards, previews, FAQ, footer, slide counter, and the inline demo player).
* **Typography / Branding**
  * Switched monospace styling to Geist Mono across the landing experience and the documentation OG graphics.
  * Updated key heading and emphasis layouts for a more consistent typographic hierarchy.
* **Dark Mode**
  * Improved dark-mode rendering for logos/badges and tuned related visuals/animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->