### PR TITLE
refactor(core): split slide-authoring skill into per-primitive reference files

### DIFF
--- a/.changeset/split-authoring-skill-references.md
+++ b/.changeset/split-authoring-skill-references.md
@@ -1,0 +1,6 @@
+---
+"@open-slide/core": patch
+"@open-slide/cli": patch
+---
+
+Split the slide-authoring skill into per-primitive reference files under `references/`.

--- a/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/SKILL.md
@@ -14,6 +14,20 @@ This skill is the **technical reference** for everything that happens inside `sl
 
 When any of those paths reach the point of *writing React code for a page*, this is the source of truth. Do not duplicate the knowledge below into other skills — link here instead.
 
+## Primitive references
+
+Each framework primitive has a full reference file under `references/` in this skill — contract, worked examples, and its own anti-patterns. This file keeps only the always-on rules and a short summary per primitive. **Read the relevant reference file before using a primitive on a page**:
+
+| Primitive | Read before | File |
+| --- | --- | --- |
+| `design` const + `var(--osd-X)` tokens | writing any new slide (default baseline) | `references/design-system.md` |
+| Assets + `<ImagePlaceholder>` | importing images/videos or leaving a placeholder | `references/assets.md` |
+| Webfonts | loading any non-system font | `references/webfonts.md` |
+| `useSlidePageNumber()` | rendering a page-number footer | `references/page-numbers.md` |
+| `<Steps>` / `<Step>` | staging a page's reveal | `references/steps.md` |
+| `SlideTransition` | declaring any enter/exit animation | `references/transitions.md` |
+| `MorphElement` + `morph` | morphing a shared element across pages | `references/morph.md` |
+
 ## Hard rules
 
 - Put the slide under `slides/<kebab-case-id>/`.
@@ -123,23 +137,7 @@ Consult the `frontend-design` skill for deeper aesthetic guidance if the user wa
 
 ## Webfonts
 
-The default is a system font stack — prefer it. When a deck genuinely needs a webfont (a brand font, or CJK / Thai / Arabic where system coverage is poor):
-
-- **Load the stylesheet once, in `<head>` — never inside a per-page component.** Every page is mounted live at the same time (thumbnail rail, overview grid, and the PDF print root), so a `<style>@import>` / `<link>` rendered inside a `Page` registers the whole `@font-face` set once *per page*. Inject it once, idempotently:
-
-  ```tsx
-  const FONT_HREF = 'https://fonts.googleapis.com/css2?family=...&display=swap';
-  if (typeof document !== 'undefined' && !document.getElementById('osd-webfont')) {
-    const link = document.createElement('link');
-    link.id = 'osd-webfont';
-    link.rel = 'stylesheet';
-    link.href = FONT_HREF;
-    document.head.appendChild(link);
-  }
-  ```
-
-- **List only the weights you actually use.** Each extra weight multiplies the number of `@font-face` rules.
-- **CJK fonts are large.** A Google Fonts CJK family registers hundreds of `unicode-range` subset faces (Noto Sans TC ≈ 105 subsets × each weight), and PDF export waits on fonts before printing. If the deck's text is fixed, add `&text=<unique chars>` to the URL to request a tiny single-face subset instead of the full set.
+The default is a system font stack — prefer it. When a deck genuinely needs a webfont (a brand font, or CJK / Thai / Arabic where system coverage is poor), read `references/webfonts.md` first — loading the stylesheet inside a page component registers the whole `@font-face` set once per mounted page, and CJK families need subsetting.
 
 ## Themes
 
@@ -149,47 +147,11 @@ Themes are produced by the `create-theme` skill and are pure documentation: copy
 
 ## Design system (opt-in, per-slide)
 
-A slide can declare its own typed design tokens at the top of `index.tsx`:
+A slide can declare typed design tokens at the top of `index.tsx` — `export const design: DesignSystem = { palette, fonts, typeScale, radius }` — and consume them via `var(--osd-X)` in inline styles. The framework injects the CSS variables at the canvas root, and the dev UI's Design panel can live-tweak them.
 
-```tsx
-import type { DesignSystem, Page } from '@open-slide/core';
+**Default to using it.** Every new slide should declare a `design` const so it stays tweakable from the panel after generation. Only fall back to the local `palette` constants pattern (see starter template) for a one-off slide whose palette is intentionally locked.
 
-export const design: DesignSystem = {
-  palette: { bg: '#f7f5f0', text: '#1a1814', accent: '#6d4cff' },
-  fonts: {
-    display: 'Georgia, "Times New Roman", serif',
-    body: '-apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif',
-  },
-  typeScale: { hero: 168, body: 36 },
-  radius:    12,
-};
-```
-
-`export` it (rather than plain `const`) so the framework can read the object and inject CSS variables at the canvas root automatically.
-
-The shape is intentionally minimal — it only covers what the Design panel can currently tweak. Anything outside this set (heading sizes, spacing, motion, extra palette colors) belongs as plain hard-coded constants in the slide file.
-
-There are **two consumption surfaces**, and you should mix them inside the same slide:
-
-- **`var(--osd-X)` for visual properties (color, font, font-size, radius)** — these get instant updates while the user drags a slider in the Design panel, before any file write.
-  ```tsx
-  <div style={{ background: 'var(--osd-bg)', color: 'var(--osd-text)', borderRadius: 'var(--osd-radius)', fontFamily: 'var(--osd-font-body)', fontSize: 'var(--osd-size-body)' }}>
-  ```
-  Available vars: `--osd-bg`, `--osd-text`, `--osd-accent`, `--osd-font-display`, `--osd-font-body`, `--osd-size-hero`, `--osd-size-body`, `--osd-radius`.
-
-- **Direct `design.X` reads** — when you need a JS number for arithmetic or to label something in the UI. These update via HMR after the panel commits the file, not while dragging.
-  ```tsx
-  <p>{design.typeScale.hero}px</p>
-  ```
-
-The dev UI has a **Design** button in the slide header (next to Inspect). Edits update an in-memory draft and the live-preview overlay; a floating Save / Discard bar at the bottom of the canvas commits or reverts. The const stays the single source of truth — production builds bake the saved values.
-
-**Default to using it.** Every new slide should declare a `design` const so it stays tweakable from the panel after generation — this is the expected baseline. Only fall back to the local `palette` constants pattern (see starter template) for a one-off slide whose palette is intentionally locked and not meant to be re-themed. Both styles can coexist across slides — the panel only operates on the *currently viewed* slide.
-
-Format constraints (for the panel's AST writer):
-- Must be `[export] const design: DesignSystem = { … }` (or `as DesignSystem` / `satisfies DesignSystem`) at module top level.
-- Object initializer must be a literal — no spreads, no helper calls. Plain values only.
-- `DesignSystem` must be imported from `@open-slide/core` (the panel adds the import automatically when creating a fresh block).
+`references/design-system.md` has the full token shape, the two consumption surfaces (`var(--osd-X)` vs direct `design.X` reads), Design panel behavior, and the format constraints the panel's AST writer requires. Read it before writing the const.
 
 ## Starter template
 
@@ -269,336 +231,37 @@ export default [Cover, Content] satisfies Page[];
 
 ## Assets
 
-**Slide-local assets** live under `slides/<id>/assets/` — anything one-off to a single slide. Import them as ES modules:
+Slide-local assets live under `slides/<id>/assets/` and are imported as ES modules (`import hero from './assets/hero.jpg'`). Global assets shared across decks (logos, avatars, recurring icons) live in the project root `assets/` and are imported via the `@assets` alias. Skip the `assets/` folder entirely for pure-text slides.
 
-```tsx
-import hero from './assets/hero.jpg';
-// …
-<img src={hero} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
-```
-
-For URL-only access:
-
-```tsx
-const videoUrl = new URL('./assets/intro.mp4', import.meta.url).href;
-```
-
-**Global assets** — anything reused across decks or themes (company logos, presenter avatars, recurring icons) — live in the project root `assets/` folder. Import them via the `@assets` alias:
-
-```tsx
-import logo from '@assets/logos/acme.svg';
-```
-
-A `themes/*.md` file may name an asset path in its prose (e.g. "use `@assets/logos/acme.svg` in the title slot"); the slide imports it explicitly.
-
-Skip the `assets/` folder entirely for pure-text slides.
+`references/assets.md` covers import forms (module vs `new URL(...)`), the `@assets` alias, and how themes name asset paths.
 
 ## Image placeholders
 
-When a page genuinely needs a real image **the user has to provide** — a product screenshot, a team photo, a chart from their data — leave a typed placeholder instead of inventing a stand-in:
+When a page genuinely needs a real image **the user has to provide** (product screenshot, team photo, chart from their data), leave a typed `<ImagePlaceholder hint="…" />` from `@open-slide/core` instead of inventing a stand-in — the user replaces it via the Assets panel + inspector. **Do not** use placeholders for decoration or generic stock-photo filler; if type, layout, and color can carry the page, do that.
 
-```tsx
-import { ImagePlaceholder } from '@open-slide/core';
-
-<ImagePlaceholder hint="Product hero screenshot" width={1280} height={720} />
-```
-
-The user uploads the real file via the Assets panel, then clicks the placeholder in the inspector and picks "Replace…" — the JSX is rewritten to a real `<img>` with the import added.
-
-**Use a placeholder only when** a specific concrete image is required by the deck's topic. Examples that warrant one: a product-intro deck (product screenshot per feature), an offsite recap (team photo), a case study (customer logo, dashboard screenshot).
-
-**Do not use a placeholder** for decoration, generic "stock photo" filler, hero imagery on a text-heavy slide, or anywhere a typographic / iconographic / illustrative solution would do. If you can carry the page with type, layout, and color — do that. Empty placeholders the user has to fill are friction; only spend that friction when the alternative is worse.
-
-Size the placeholder to the slot it occupies. Pass `width`/`height` when the layout has a fixed image box; omit them when the placeholder fills a flex/grid cell. The `hint` should describe the *content* the user needs ("Q3 revenue chart") not the *role* ("hero image").
+`references/assets.md` has the full usage rules, sizing guidance, and examples of when a placeholder is (and isn't) warranted.
 
 ## Page numbers
 
-If a footer shows the current page (`03 / 12`, `Page 3`, etc.), read it from `useSlidePageNumber()` — **never hardcode** `n` / `TOTAL`. Inserting, reordering, or deleting a page would otherwise force you to retouch every footer.
-
-```tsx
-import { useSlidePageNumber } from '@open-slide/core';
-
-const Footer = () => {
-  const { current, total } = useSlidePageNumber();
-  return (
-    <span>{String(current).padStart(2, '0')} / {String(total).padStart(2, '0')}</span>
-  );
-};
-```
-
-`current` is 1-indexed (matches what readers see) and `total` is the slide's page count. The hook works in every render context (main viewer, thumbnails, overview grid, present mode, presenter window, HTML/PDF export) — the same `<Footer />` JSX is correct everywhere. Call the hook inside a component that's used **per page**; don't try to call it at module top level.
+If a footer shows the current page (`03 / 12`), read it from `useSlidePageNumber()` — **never hardcode** `n` / `TOTAL`. See `references/page-numbers.md` for the hook's contract and where it can be called.
 
 ## Stepped reveals (`<Steps>` / `<Step>`)
 
-Reveal a page one beat at a time instead of showing everything at once. Wrap the deferred parts in `<Step>`, wrap the group in `<Steps>`. Each `→` reveals the next `<Step>`; `→` after the last one advances to the next page. `←` peels the last reveal back. Use it to stage attention — show framing first, then the consequence, then the turn — so the audience reads at the speaker's pace, not ahead.
+Reveal a page one beat at a time: wrap deferred parts in `<Step>`, the group in `<Steps>`; each `→` reveals the next step. Use it when the *order* of ideas is the point — not reflexively on every page. Two rules are load-bearing: `<Step>` must be a **direct child** of `<Steps>` (otherwise it silently renders fully revealed), and a page must still read as complete when jumped to via the overview grid (jumping in shows all steps revealed).
 
-`slides/build-on-reveal/` is the canonical worked example; study it before authoring a stepped page.
-
-```tsx
-import { Step, Steps } from '@open-slide/core';
-
-<Steps>
-  <Step><div style={BULLET_ROW}>An audience reads faster than a presenter speaks.</div></Step>
-  <Step><div style={BULLET_ROW}>Showing every bullet at once invites pre-reading.</div></Step>
-  <Step><div style={BULLET_ROW}>Revealing in time stages attention.</div></Step>
-</Steps>
-```
-
-### Rules
-
-- **`<Step>` must be a *direct* child of `<Steps>`.** A `<Step>` nested deeper (or used without a `<Steps>` parent) renders fully revealed and defers nothing.
-- **Non-`Step` children render immediately.** Put a headline or intro paragraph *inside* `<Steps>` as a plain element and it shows from the start; only the `<Step>` blocks wait. This is the "headline always, body in turn" pattern:
-  ```tsx
-  <Steps>
-    <h2>Not everything has to wait.</h2>{/* visible immediately */}
-    <Step><p>First, set the stage…</p></Step>
-    <Step><p>Then, layer the consequence…</p></Step>
-  </Steps>
-  ```
-- **Multiple `<Steps>` blocks on one page compose in document order.** The first block reveals all its steps before the second begins; `←` unwinds in reverse. Use this for two columns that build left-then-right, each column owning its own `<Steps>`:
-  ```tsx
-  <div style={COL}><Steps><Step>…</Step><Step>…</Step></Steps></div>{/* finishes first */}
-  <div style={COL}><Steps><Step>…</Step><Step>…</Step></Steps></div>{/* then this */}
-  ```
-- **Entry direction decides the starting state — same content, two rhythms.** Entering forward (`→` from the previous page) starts empty and builds up. Jumping in via the overview grid, or arriving backward from a later page, shows the page **fully composed** with every step already revealed. Design the page to read well both ways: a thumbnail or overview jump should look complete, not blank.
-- **`<Step>` fades in over `duration` ms (default 180).** Pass `<Step duration={...}>` to adjust. `prefers-reduced-motion: reduce` collapses it to an instant cut automatically — don't write a fallback.
-
-### When to reach for it
-
-Use stepped reveals when the *order* of ideas is the point — a list whose payoff is the last item, a build-up to a conclusion, a before/after. Don't wrap every page's content in `<Step>` reflexively: a page the audience should take in at a glance (a hero title, a single quote, a diagram) is stronger shown whole. Reveals are timing, not decoration — same restraint as transitions.
+Read `references/steps.md` before authoring a stepped page — it covers composition order across multiple `<Steps>` blocks, the "headline always, body in turn" pattern, and entry-direction behavior. `slides/build-on-reveal/` is the canonical worked example.
 
 ## Page transitions
 
-The framework can run an enter/exit animation between every slide change. There's **no default** — pages snap unless you declare a `SlideTransition`. Snap-swap is a perfectly tasteful default; only opt in when motion adds something.
+The framework can run an enter/exit animation between slide changes, declared as a `SlideTransition` (module-level default, per-page override; the **incoming page wins**). There's **no default** — pages snap unless you opt in, and snap-swap is a perfectly tasteful default. If you do opt in: one motion DNA per deck, 140–280 ms, magnitude under 12 px / 3% scale, opacity always part of it.
 
-`prefers-reduced-motion: reduce` is honored automatically. You don't write a fallback.
+Read `references/transitions.md` before declaring one — it has the full type contract, design principles, a six-member "tasteful family" of ready-to-use transitions sharing one DNA, direction-aware keyframes, and the anti-pattern list.
 
-### Contract
+## Morph transitions
 
-Module-level for the whole deck; per-page to override. The **incoming page wins**: navigating A → B uses `pages[B].transition ?? module.transition`. Its `exit` plays on A, its `enter` plays on B. Going back B → A uses A's transition.
+When the *same visual object* exists on two adjacent pages, wrap it on both pages in `MorphElement` with the same `id` and enable `morph` on the incoming page's transition — position, size, radius, and colors interpolate in one continuous move (Keynote's "Magic Move"). Morph is for **state continuity** (a toggle sliding, a card expanding, a box joining a row); don't morph decoration.
 
-```tsx
-import type { Page, SlideTransition } from '@open-slide/core';
-
-const Cover: Page = () => <section>…</section>;
-const Body:  Page = () => <section>…</section>;
-
-// Module-level default — every page inherits unless it overrides.
-export const transition: SlideTransition = { /* … */ };
-
-// Per-page override.
-Cover.transition = { /* … */ };
-
-export default [Cover, Body];
-```
-
-```ts
-type TransitionPhase = {
-  keyframes: Keyframe[] | PropertyIndexedKeyframes;  // WAAPI keyframes
-  duration?: number;  // ms (falls back to top-level duration)
-  easing?: string;    // CSS easing
-  delay?: number;     // ms — use to overlap exit + enter
-};
-type SlideTransition = {
-  duration: number;          // top-level fallback
-  easing?: string;           // top-level fallback
-  enter?: TransitionPhase;   // runs on incoming page
-  exit?:  TransitionPhase;   // runs on outgoing page
-};
-```
-
-The framework also exposes `--osd-dir` (`1` forward, `-1` backward) and `data-osd-dir` on the wrapper, so a single keyframe can mirror direction without a JS callback.
-
-### Design principles (hold the line)
-
-The single loudest signal of "made in PowerPoint" is six different transitions in one deck. Restraint is the rhythm.
-
-- **Pick one DNA, hold it across the deck.** Same duration band, same easing pair, same out-then-in stagger. Variation lives only in *which property* gets the small nudge — Y, X, opacity, scale, blur.
-- **Duration: 140–280 ms.** Exit 140–180 ms, enter 200–280 ms, enter delayed ~80 ms so they overlap but don't fight. Past 350 ms is video-editor territory; reserve for genuine state changes.
-- **Magnitude ceiling: 12 px or 3% scale.** A 6 px Y-rise reads as "next thought." A 1920 px translateX reads as "different document." Premium tools move barely enough to register.
-- **Opacity is always part of it.** Pure-transform transitions look stiff; pure-opacity transitions are the safest possible default.
-- **Easing: ease-in for exit, ease-out for enter.** `cubic-bezier(0.4, 0, 1, 1)` going out, `cubic-bezier(0, 0, 0.2, 1)` coming in. Never `linear` (feels like a slideshow). Reserve symmetric `ease-in-out` for state-anchored morphs only.
-
-### Tasteful family — six members, one DNA
-
-Use this set as a starting point. Pick one as the deck's house transition; optionally reserve a second for hero/cover slides and a third for genuine section breaks. The CSS-`calc` + `--osd-dir` trick lets a single definition mirror itself on backward navigation when needed.
-
-```tsx
-const EASE_OUT = 'cubic-bezier(0, 0, 0.2, 1)';
-const EASE_IN  = 'cubic-bezier(0.4, 0, 1, 1)';
-
-// RISE — house quiet. 6 px Y. Use as module default.
-export const transition: SlideTransition = {
-  duration: 200,
-  exit:  { duration: 140, easing: EASE_IN,
-           keyframes: [
-             { opacity: 1, transform: 'translateY(0)' },
-             { opacity: 0, transform: 'translateY(-4px)' },
-           ] },
-  enter: { duration: 200, delay: 80, easing: EASE_OUT,
-           keyframes: [
-             { opacity: 0, transform: 'translateY(6px)' },
-             { opacity: 1, transform: 'translateY(0)' },
-           ] },
-};
-
-// DISSOLVE — pure opacity. The quietest possible.
-const dissolve: SlideTransition = {
-  duration: 240,
-  exit:  { duration: 200, easing: EASE_IN,
-           keyframes: [{ opacity: 1 }, { opacity: 0 }] },
-  enter: { duration: 240, delay: 40, easing: EASE_OUT,
-           keyframes: [{ opacity: 0 }, { opacity: 1 }] },
-};
-
-// SETTLE — cover-grade. Rise + a hair of blur on enter only.
-Cover.transition = {
-  duration: 280,
-  exit:  { duration: 160, easing: EASE_IN,
-           keyframes: [
-             { opacity: 1, transform: 'translateY(0)' },
-             { opacity: 0, transform: 'translateY(-6px)' },
-           ] },
-  enter: { duration: 280, delay: 100, easing: EASE_OUT,
-           keyframes: [
-             { opacity: 0, transform: 'translateY(12px)', filter: 'blur(4px)' },
-             { opacity: 1, transform: 'translateY(0)',    filter: 'blur(0)'   },
-           ] },
-};
-
-// BLOOM — scale 0.97 → 1, no translate. Materializes in place.
-const bloom: SlideTransition = {
-  duration: 240,
-  exit:  { duration: 160, easing: EASE_IN,
-           keyframes: [
-             { opacity: 1, transform: 'scale(1)' },
-             { opacity: 0, transform: 'scale(1.01)' },
-           ] },
-  enter: { duration: 240, delay: 80, easing: EASE_OUT,
-           keyframes: [
-             { opacity: 0, transform: 'scale(0.97)' },
-             { opacity: 1, transform: 'scale(1)' },
-           ] },
-};
-
-// FALL — mirrored Rise. Incoming page comes down from above.
-const fall: SlideTransition = {
-  duration: 200,
-  exit:  { duration: 140, easing: EASE_IN,
-           keyframes: [
-             { opacity: 1, transform: 'translateY(0)' },
-             { opacity: 0, transform: 'translateY(4px)' },
-           ] },
-  enter: { duration: 200, delay: 80, easing: EASE_OUT,
-           keyframes: [
-             { opacity: 0, transform: 'translateY(-6px)' },
-             { opacity: 1, transform: 'translateY(0)' },
-           ] },
-};
-
-// BREATH — section break. Exit fully, hold 120 ms, then enter.
-// Reserve for genuine chapter dividers; use at most 1–2× per deck.
-const breath: SlideTransition = {
-  duration: 460,
-  exit:  { duration: 180, easing: EASE_IN,
-           keyframes: [{ opacity: 1 }, { opacity: 0 }] },
-  enter: { duration: 240, delay: 300, easing: EASE_OUT,
-           keyframes: [
-             { opacity: 0, transform: 'translateY(8px)' },
-             { opacity: 1, transform: 'translateY(0)' },
-           ] },
-};
-```
-
-All six share the same DNA — they only differ in which property carries the small nudge. The reader perceives variety; the eye still reads one consistent hand.
-
-### Direction-aware keyframes (use sparingly)
-
-Most tasteful tools don't mirror on backward navigation. When you genuinely need to — e.g. a horizontal slide that should reverse — use `--osd-dir` inside `calc()`:
-
-```tsx
-{ transform: 'translateX(calc(var(--osd-dir, 1) * 8px))' },
-{ transform: 'translateX(0)' },
-```
-
-If you find yourself reaching for this on every transition, you're probably over-designing. Forward = backward is the more refined default.
-
-### Morph transitions
-
-When the *same visual object* exists on two adjacent pages, the runtime can morph it across the cut — position, size, border-radius, and colors interpolate in one continuous move (Keynote calls this "Magic Move") — instead of fading out and back in. Two parts opt in:
-
-1. Wrap the object on **both** pages in `MorphElement` with the **same `id`**.
-2. Enable `morph` on the incoming page's transition.
-
-```tsx
-import { MorphElement } from '@open-slide/core';
-
-// Morph transition — opacity-only enter/exit keeps all the motion on the clones (see rules).
-const morphTransition: SlideTransition = {
-  duration: 280,
-  exit:  { duration: 224, easing: 'cubic-bezier(0.4, 0, 1, 1)', keyframes: [{ opacity: 1 }, { opacity: 0 }] },
-  enter: { duration: 308, delay: 112, easing: 'cubic-bezier(0, 0, 0.2, 1)', keyframes: [{ opacity: 0 }, { opacity: 1 }] },
-  morph: { duration: 868, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
-};
-
-const stage: CSSProperties = { width: '100%', height: '100%', position: 'relative', background: '#000000', overflow: 'hidden' };
-
-const Narrow: Page = () => (
-  <div style={stage}>
-    <MorphElement id="pill" style={{ position: 'absolute', left: 842, top: 479, width: 236, height: 122, borderRadius: 999, background: '#ffffff' }} />
-  </div>
-);
-const Wide: Page = () => (
-  <div style={stage}>
-    <MorphElement id="pill" style={{ position: 'absolute', left: 721, top: 479, width: 478, height: 122, borderRadius: 999, background: '#0a0a0a' }} />
-  </div>
-);
-
-Wide.transition = morphTransition;   // forward: Narrow → Wide morphs the pill
-Narrow.transition = morphTransition; // backward: Wide → Narrow morphs it back
-```
-
-#### Contract
-
-- `morph: true` inherits the transition's top-level `duration`/`easing`; pass `{ duration?, easing?, delay? }` to time the morph independently of the page cross-fade. Morphs usually read best 2–4× longer than the fade (e.g. 280 ms fade, 868 ms morph).
-- Elements pair by `id` across the cut. A matched pair FLIP-morphs: the runtime measures both rects, clones the outgoing element into an overlay above both pages, hides the originals, and animates transform + border-radius + colors (border widths ride a separate frame so they don't stretch with the box). Keep each `id` unique within a page; don't nest one `MorphElement` inside another.
-- An `id` present on only one side fades in/out **in place**. This is how "a third box joins the row" reads: carried boxes glide to their new slots, the new one materializes.
-- Colors on the morph node *and its descendants* interpolate too — a label that flips black → white mid-glide just works.
-- The transition lives on the **incoming** page. For a morph that also plays when stepping backward, assign the same transition object to both pages (as above).
-
-#### Rules — each one earned on a real deck
-
-1. **Prefer opacity-only enter/exit on morphing pages.** Any transition family composes correctly with the morph (shared rects are measured before the phases start), but while clones glide, a transform-bearing enter also slides the rest of the page — two competing motions. Giving the clones all the motion and fading everything else is what makes a morph read as one confident gesture.
-2. **Morph geometry must be deterministic at mount.** Rects are snapshotted once at the cut. Position morph elements with pixel constants — never with a value measured in an effect after mount (the re-render shifts the target mid-morph and the move jumps). If text inside a morph box grows over time (typewriter etc.), render a hidden full-width spacer so the measured box never changes size.
-3. **No `transform` on the morph node itself.** A percentage translate (`translate(-50%, -50%)`) gets mis-scaled by the morph and lands the clone tens of px off. Put centering/positioning transforms on a plain wrapper `<div>` *around* the `MorphElement`.
-4. **`MorphElement` merges `className`/`style` onto its single host child** (it adds no wrapper when the child is a lone DOM element). A crop box (`overflow: hidden` + fixed width) therefore needs an explicit nested `<div>` — otherwise the box collapses onto the `<img>` inside and squishes it.
-5. **Gate entrance animations behind `useIsActivePage()`.** During the cut the runtime mounts a *fresh instance* of the outgoing page to snapshot its exit state (and the dev UI mounts every page for thumbnails/overview). If an intro replays there, the snapshot is mid-animation and the morph starts from garbage. The hook returns `true` only for the instance the audience is watching; every other instance (outgoing snapshot, thumbnails, overview, presenter preview, print) should render the final, settled state — no intro, full text.
-
-   ```tsx
-   import { useIsActivePage } from '@open-slide/core';
-
-   // Inside the page component:
-   const animate = useIsActivePage();
-   ```
-
-6. **Clones travel above everything.** The morph overlay sits over both pages, so an incoming element that should appear only when a clone "lands" will otherwise pop early. Give such reveals a delay equal to the morph: `animation: 'osd-fade 0.63s ease-out 0.868s both'` where `0.868s` is `morph.duration`. Keep that number in one shared const so the two can't drift.
-7. **A "hold" page is a separate component.** Transitions attach to the incoming page, so to follow a morph cut with a plain cut of the same content, mint a second page component without `.transition` (e.g. `const Flow4Hold: Page = () => <Flow count={4} />`).
-
-#### When to reach for it
-
-Morph is for **state continuity**: a toggle whose thumb slides to the next option, a card that expands into a detail view, a logo that glides from center stage into the next page's diagram, a row that gains one more box. The object *is the story* across the cut. Don't morph decoration, and don't tag elements "just in case" — every morph id is a promise to the audience that it's the same object. One or two morphing sequences per chapter is plenty; the surrounding pages should cut or fade quietly.
-
-### Transition anti-patterns
-
-- ❌ Six different transitions across six pages — the single loudest "made in PowerPoint" tell.
-- ❌ `translateX(100%)` slide-from-side — iOS modal / PowerPoint Push; not a slide change.
-- ❌ Aggressive scale-pop (e.g. `0.85 → 1`) + blur — lightbox / photo-viewer vocabulary; implies zooming *into* something.
-- ❌ `clip-path: inset(…)` reveals — After Effects vocabulary; theatrical.
-- ❌ Parallel blur on both layers at once — visual mush; the eye can't fixate.
-- ❌ Duration > 350 ms for a standard slide change — drags.
-- ❌ Translate > 12 px or scale > 3% — reads as rupture, not continuity.
-- ❌ `linear` easing — feels like a slideshow, not a product.
-- ❌ Declaring a transition on every deck. **If you don't have a clear reason, omit it.** Snap-swap is fine.
+Read `references/morph.md` before writing one — the seven rules there (opacity-only enter/exit, deterministic geometry, no `transform` on the morph node, `useIsActivePage()` gating, …) were each earned on a real deck, and violating any of them produces a visibly broken morph.
 
 ## Repeated elements: component, not `map`
 
@@ -684,8 +347,4 @@ This applies whenever the *visual element* repeats, not whenever the *data* does
 - ❌ Writing CSS to a shared file. Inline styles or scoped classnames only.
 - ❌ Creating `README.md` or other prose files inside the slide folder.
 - ❌ Editing `package.json`, `open-slide.config.ts`, or other slides.
-- ❌ Sprinkling `<ImagePlaceholder>` across pages "for visual interest". Placeholders are for content the user owns; they're not stock-photo slots.
-- ❌ Using a placeholder for an icon or decorative shape — those are typography/SVG problems, not asset problems.
-- ❌ Rendering visually repeated elements with `array.map(...)` over a data array. Define a component and instantiate it explicitly per item (`<Card />`, `<Card />`, `<Card />`) so the inspector can edit each independently — a shared `map` body mutates every instance at once.
-- ❌ Wrapping every page's content in `<Step>` reflexively. Stepped reveals are for content whose *order* is the point; a glance-and-get-it page (hero title, single quote, diagram) is stronger shown whole.
-- ❌ A `<Step>` that isn't a direct child of `<Steps>` (nested deeper, or with no `<Steps>` parent). It renders fully revealed and defers nothing — the reveal silently does nothing.
+- ❌ Using a primitive without reading its reference file — each `references/*.md` carries the primitive's own anti-pattern list (placeholder misuse, transition vocabulary, `<Step>` nesting, morph geometry).

--- a/packages/cli/template/.agents/skills/slide-authoring/references/assets.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/references/assets.md
@@ -1,0 +1,52 @@
+# Assets & image placeholders
+
+## Slide-local assets
+
+**Slide-local assets** live under `slides/<id>/assets/` — anything one-off to a single slide. Import them as ES modules:
+
+```tsx
+import hero from './assets/hero.jpg';
+// …
+<img src={hero} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+```
+
+For URL-only access:
+
+```tsx
+const videoUrl = new URL('./assets/intro.mp4', import.meta.url).href;
+```
+
+## Global assets
+
+**Global assets** — anything reused across decks or themes (company logos, presenter avatars, recurring icons) — live in the project root `assets/` folder. Import them via the `@assets` alias:
+
+```tsx
+import logo from '@assets/logos/acme.svg';
+```
+
+A `themes/*.md` file may name an asset path in its prose (e.g. "use `@assets/logos/acme.svg` in the title slot"); the slide imports it explicitly.
+
+Skip the `assets/` folder entirely for pure-text slides.
+
+## Image placeholders (`<ImagePlaceholder>`)
+
+When a page genuinely needs a real image **the user has to provide** — a product screenshot, a team photo, a chart from their data — leave a typed placeholder instead of inventing a stand-in:
+
+```tsx
+import { ImagePlaceholder } from '@open-slide/core';
+
+<ImagePlaceholder hint="Product hero screenshot" width={1280} height={720} />
+```
+
+The user uploads the real file via the Assets panel, then clicks the placeholder in the inspector and picks "Replace…" — the JSX is rewritten to a real `<img>` with the import added.
+
+**Use a placeholder only when** a specific concrete image is required by the deck's topic. Examples that warrant one: a product-intro deck (product screenshot per feature), an offsite recap (team photo), a case study (customer logo, dashboard screenshot).
+
+**Do not use a placeholder** for decoration, generic "stock photo" filler, hero imagery on a text-heavy slide, or anywhere a typographic / iconographic / illustrative solution would do. If you can carry the page with type, layout, and color — do that. Empty placeholders the user has to fill are friction; only spend that friction when the alternative is worse.
+
+Size the placeholder to the slot it occupies. Pass `width`/`height` when the layout has a fixed image box; omit them when the placeholder fills a flex/grid cell. The `hint` should describe the *content* the user needs ("Q3 revenue chart") not the *role* ("hero image").
+
+### Placeholder anti-patterns
+
+- ❌ Sprinkling `<ImagePlaceholder>` across pages "for visual interest". Placeholders are for content the user owns; they're not stock-photo slots.
+- ❌ Using a placeholder for an icon or decorative shape — those are typography/SVG problems, not asset problems.

--- a/packages/cli/template/.agents/skills/slide-authoring/references/design-system.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/references/design-system.md
@@ -1,0 +1,48 @@
+# Design system (`design` const + `var(--osd-X)`)
+
+A slide can declare its own typed design tokens at the top of `index.tsx`:
+
+```tsx
+import type { DesignSystem, Page } from '@open-slide/core';
+
+export const design: DesignSystem = {
+  palette: { bg: '#f7f5f0', text: '#1a1814', accent: '#6d4cff' },
+  fonts: {
+    display: 'Georgia, "Times New Roman", serif',
+    body: '-apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif',
+  },
+  typeScale: { hero: 168, body: 36 },
+  radius:    12,
+};
+```
+
+`export` it (rather than plain `const`) so the framework can read the object and inject CSS variables at the canvas root automatically.
+
+The shape is intentionally minimal — it only covers what the Design panel can currently tweak. Anything outside this set (heading sizes, spacing, motion, extra palette colors) belongs as plain hard-coded constants in the slide file.
+
+## Two consumption surfaces
+
+There are **two consumption surfaces**, and you should mix them inside the same slide:
+
+- **`var(--osd-X)` for visual properties (color, font, font-size, radius)** — these get instant updates while the user drags a slider in the Design panel, before any file write.
+  ```tsx
+  <div style={{ background: 'var(--osd-bg)', color: 'var(--osd-text)', borderRadius: 'var(--osd-radius)', fontFamily: 'var(--osd-font-body)', fontSize: 'var(--osd-size-body)' }}>
+  ```
+  Available vars: `--osd-bg`, `--osd-text`, `--osd-accent`, `--osd-font-display`, `--osd-font-body`, `--osd-size-hero`, `--osd-size-body`, `--osd-radius`.
+
+- **Direct `design.X` reads** — when you need a JS number for arithmetic or to label something in the UI. These update via HMR after the panel commits the file, not while dragging.
+  ```tsx
+  <p>{design.typeScale.hero}px</p>
+  ```
+
+## The Design panel
+
+The dev UI has a **Design** button in the slide header (next to Inspect). Edits update an in-memory draft and the live-preview overlay; a floating Save / Discard bar at the bottom of the canvas commits or reverts. The const stays the single source of truth — production builds bake the saved values.
+
+**Default to using it.** Every new slide should declare a `design` const so it stays tweakable from the panel after generation — this is the expected baseline. Only fall back to the local `palette` constants pattern (see the starter template in `SKILL.md`) for a one-off slide whose palette is intentionally locked and not meant to be re-themed. Both styles can coexist across slides — the panel only operates on the *currently viewed* slide.
+
+## Format constraints (for the panel's AST writer)
+
+- Must be `[export] const design: DesignSystem = { … }` (or `as DesignSystem` / `satisfies DesignSystem`) at module top level.
+- Object initializer must be a literal — no spreads, no helper calls. Plain values only.
+- `DesignSystem` must be imported from `@open-slide/core` (the panel adds the import automatically when creating a fresh block).

--- a/packages/cli/template/.agents/skills/slide-authoring/references/design-system.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/references/design-system.md
@@ -43,6 +43,6 @@ The dev UI has a **Design** button in the slide header (next to Inspect). Edits 
 
 ## Format constraints (for the panel's AST writer)
 
-- Must be `[export] const design: DesignSystem = { … }` (or `as DesignSystem` / `satisfies DesignSystem`) at module top level.
+- Must be `[export] const design: DesignSystem = { … }` (or `as DesignSystem` / `satisfies DesignSystem`) at module top level. The optional `[export]` only describes what the panel's *parser* tolerates — the runtime reads `design` off the module's exports to inject the `--osd-*` vars, so a non-exported const leaves every `var(--osd-X)` unresolved. Always export it.
 - Object initializer must be a literal — no spreads, no helper calls. Plain values only.
 - `DesignSystem` must be imported from `@open-slide/core` (the panel adds the import automatically when creating a fresh block).

--- a/packages/cli/template/.agents/skills/slide-authoring/references/morph.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/references/morph.md
@@ -8,7 +8,8 @@ When the *same visual object* exists on two adjacent pages, the runtime can morp
 2. Enable `morph` on the incoming page's transition.
 
 ```tsx
-import { MorphElement } from '@open-slide/core';
+import { MorphElement, type Page, type SlideTransition } from '@open-slide/core';
+import type { CSSProperties } from 'react';
 
 // Morph transition — opacity-only enter/exit keeps all the motion on the clones (see rules).
 const morphTransition: SlideTransition = {

--- a/packages/cli/template/.agents/skills/slide-authoring/references/morph.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/references/morph.md
@@ -1,0 +1,66 @@
+# Morph transitions (`MorphElement`)
+
+> Morph builds on the `SlideTransition` contract — read `transitions.md` first if you haven't.
+
+When the *same visual object* exists on two adjacent pages, the runtime can morph it across the cut — position, size, border-radius, and colors interpolate in one continuous move (Keynote calls this "Magic Move") — instead of fading out and back in. Two parts opt in:
+
+1. Wrap the object on **both** pages in `MorphElement` with the **same `id`**.
+2. Enable `morph` on the incoming page's transition.
+
+```tsx
+import { MorphElement } from '@open-slide/core';
+
+// Morph transition — opacity-only enter/exit keeps all the motion on the clones (see rules).
+const morphTransition: SlideTransition = {
+  duration: 280,
+  exit:  { duration: 224, easing: 'cubic-bezier(0.4, 0, 1, 1)', keyframes: [{ opacity: 1 }, { opacity: 0 }] },
+  enter: { duration: 308, delay: 112, easing: 'cubic-bezier(0, 0, 0.2, 1)', keyframes: [{ opacity: 0 }, { opacity: 1 }] },
+  morph: { duration: 868, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
+};
+
+const stage: CSSProperties = { width: '100%', height: '100%', position: 'relative', background: '#000000', overflow: 'hidden' };
+
+const Narrow: Page = () => (
+  <div style={stage}>
+    <MorphElement id="pill" style={{ position: 'absolute', left: 842, top: 479, width: 236, height: 122, borderRadius: 999, background: '#ffffff' }} />
+  </div>
+);
+const Wide: Page = () => (
+  <div style={stage}>
+    <MorphElement id="pill" style={{ position: 'absolute', left: 721, top: 479, width: 478, height: 122, borderRadius: 999, background: '#0a0a0a' }} />
+  </div>
+);
+
+Wide.transition = morphTransition;   // forward: Narrow → Wide morphs the pill
+Narrow.transition = morphTransition; // backward: Wide → Narrow morphs it back
+```
+
+## Contract
+
+- `morph: true` inherits the transition's top-level `duration`/`easing`; pass `{ duration?, easing?, delay? }` to time the morph independently of the page cross-fade. Morphs usually read best 2–4× longer than the fade (e.g. 280 ms fade, 868 ms morph).
+- Elements pair by `id` across the cut. A matched pair FLIP-morphs: the runtime measures both rects, clones the outgoing element into an overlay above both pages, hides the originals, and animates transform + border-radius + colors (border widths ride a separate frame so they don't stretch with the box). Keep each `id` unique within a page; don't nest one `MorphElement` inside another.
+- An `id` present on only one side fades in/out **in place**. This is how "a third box joins the row" reads: carried boxes glide to their new slots, the new one materializes.
+- Colors on the morph node *and its descendants* interpolate too — a label that flips black → white mid-glide just works.
+- The transition lives on the **incoming** page. For a morph that also plays when stepping backward, assign the same transition object to both pages (as above).
+
+## Rules — each one earned on a real deck
+
+1. **Prefer opacity-only enter/exit on morphing pages.** Any transition family composes correctly with the morph (shared rects are measured before the phases start), but while clones glide, a transform-bearing enter also slides the rest of the page — two competing motions. Giving the clones all the motion and fading everything else is what makes a morph read as one confident gesture.
+2. **Morph geometry must be deterministic at mount.** Rects are snapshotted once at the cut. Position morph elements with pixel constants — never with a value measured in an effect after mount (the re-render shifts the target mid-morph and the move jumps). If text inside a morph box grows over time (typewriter etc.), render a hidden full-width spacer so the measured box never changes size.
+3. **No `transform` on the morph node itself.** A percentage translate (`translate(-50%, -50%)`) gets mis-scaled by the morph and lands the clone tens of px off. Put centering/positioning transforms on a plain wrapper `<div>` *around* the `MorphElement`.
+4. **`MorphElement` merges `className`/`style` onto its single host child** (it adds no wrapper when the child is a lone DOM element). A crop box (`overflow: hidden` + fixed width) therefore needs an explicit nested `<div>` — otherwise the box collapses onto the `<img>` inside and squishes it.
+5. **Gate entrance animations behind `useIsActivePage()`.** During the cut the runtime mounts a *fresh instance* of the outgoing page to snapshot its exit state (and the dev UI mounts every page for thumbnails/overview). If an intro replays there, the snapshot is mid-animation and the morph starts from garbage. The hook returns `true` only for the instance the audience is watching; every other instance (outgoing snapshot, thumbnails, overview, presenter preview, print) should render the final, settled state — no intro, full text.
+
+   ```tsx
+   import { useIsActivePage } from '@open-slide/core';
+
+   // Inside the page component:
+   const animate = useIsActivePage();
+   ```
+
+6. **Clones travel above everything.** The morph overlay sits over both pages, so an incoming element that should appear only when a clone "lands" will otherwise pop early. Give such reveals a delay equal to the morph: `animation: 'osd-fade 0.63s ease-out 0.868s both'` where `0.868s` is `morph.duration`. Keep that number in one shared const so the two can't drift.
+7. **A "hold" page is a separate component.** Transitions attach to the incoming page, so to follow a morph cut with a plain cut of the same content, mint a second page component without `.transition` (e.g. `const Flow4Hold: Page = () => <Flow count={4} />`).
+
+## When to reach for it
+
+Morph is for **state continuity**: a toggle whose thumb slides to the next option, a card that expands into a detail view, a logo that glides from center stage into the next page's diagram, a row that gains one more box. The object *is the story* across the cut. Don't morph decoration, and don't tag elements "just in case" — every morph id is a promise to the audience that it's the same object. One or two morphing sequences per chapter is plenty; the surrounding pages should cut or fade quietly.

--- a/packages/cli/template/.agents/skills/slide-authoring/references/page-numbers.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/references/page-numbers.md
@@ -1,0 +1,16 @@
+# Page numbers (`useSlidePageNumber`)
+
+If a footer shows the current page (`03 / 12`, `Page 3`, etc.), read it from `useSlidePageNumber()` — **never hardcode** `n` / `TOTAL`. Inserting, reordering, or deleting a page would otherwise force you to retouch every footer.
+
+```tsx
+import { useSlidePageNumber } from '@open-slide/core';
+
+const Footer = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <span>{String(current).padStart(2, '0')} / {String(total).padStart(2, '0')}</span>
+  );
+};
+```
+
+`current` is 1-indexed (matches what readers see) and `total` is the slide's page count. The hook works in every render context (main viewer, thumbnails, overview grid, present mode, presenter window, HTML/PDF export) — the same `<Footer />` JSX is correct everywhere. Call the hook inside a component that's used **per page**; don't try to call it at module top level.

--- a/packages/cli/template/.agents/skills/slide-authoring/references/steps.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/references/steps.md
@@ -1,0 +1,43 @@
+# Stepped reveals (`<Steps>` / `<Step>`)
+
+Reveal a page one beat at a time instead of showing everything at once. Wrap the deferred parts in `<Step>`, wrap the group in `<Steps>`. Each `→` reveals the next `<Step>`; `→` after the last one advances to the next page. `←` peels the last reveal back. Use it to stage attention — show framing first, then the consequence, then the turn — so the audience reads at the speaker's pace, not ahead.
+
+`slides/build-on-reveal/` is the canonical worked example; study it before authoring a stepped page.
+
+```tsx
+import { Step, Steps } from '@open-slide/core';
+
+<Steps>
+  <Step><div style={BULLET_ROW}>An audience reads faster than a presenter speaks.</div></Step>
+  <Step><div style={BULLET_ROW}>Showing every bullet at once invites pre-reading.</div></Step>
+  <Step><div style={BULLET_ROW}>Revealing in time stages attention.</div></Step>
+</Steps>
+```
+
+## Rules
+
+- **`<Step>` must be a *direct* child of `<Steps>`.** A `<Step>` nested deeper (or used without a `<Steps>` parent) renders fully revealed and defers nothing.
+- **Non-`Step` children render immediately.** Put a headline or intro paragraph *inside* `<Steps>` as a plain element and it shows from the start; only the `<Step>` blocks wait. This is the "headline always, body in turn" pattern:
+  ```tsx
+  <Steps>
+    <h2>Not everything has to wait.</h2>{/* visible immediately */}
+    <Step><p>First, set the stage…</p></Step>
+    <Step><p>Then, layer the consequence…</p></Step>
+  </Steps>
+  ```
+- **Multiple `<Steps>` blocks on one page compose in document order.** The first block reveals all its steps before the second begins; `←` unwinds in reverse. Use this for two columns that build left-then-right, each column owning its own `<Steps>`:
+  ```tsx
+  <div style={COL}><Steps><Step>…</Step><Step>…</Step></Steps></div>{/* finishes first */}
+  <div style={COL}><Steps><Step>…</Step><Step>…</Step></Steps></div>{/* then this */}
+  ```
+- **Entry direction decides the starting state — same content, two rhythms.** Entering forward (`→` from the previous page) starts empty and builds up. Jumping in via the overview grid, or arriving backward from a later page, shows the page **fully composed** with every step already revealed. Design the page to read well both ways: a thumbnail or overview jump should look complete, not blank.
+- **`<Step>` fades in over `duration` ms (default 180).** Pass `<Step duration={...}>` to adjust. `prefers-reduced-motion: reduce` collapses it to an instant cut automatically — don't write a fallback.
+
+## When to reach for it
+
+Use stepped reveals when the *order* of ideas is the point — a list whose payoff is the last item, a build-up to a conclusion, a before/after. Don't wrap every page's content in `<Step>` reflexively: a page the audience should take in at a glance (a hero title, a single quote, a diagram) is stronger shown whole. Reveals are timing, not decoration — same restraint as transitions.
+
+## Anti-patterns
+
+- ❌ Wrapping every page's content in `<Step>` reflexively. Stepped reveals are for content whose *order* is the point; a glance-and-get-it page (hero title, single quote, diagram) is stronger shown whole.
+- ❌ A `<Step>` that isn't a direct child of `<Steps>` (nested deeper, or with no `<Steps>` parent). It renders fully revealed and defers nothing — the reveal silently does nothing.

--- a/packages/cli/template/.agents/skills/slide-authoring/references/transitions.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/references/transitions.md
@@ -37,6 +37,12 @@ type SlideTransition = {
   easing?: string;           // top-level fallback
   enter?: TransitionPhase;   // runs on incoming page
   exit?:  TransitionPhase;   // runs on outgoing page
+  morph?: boolean | MorphTransition;  // shared-element morph — see morph.md
+};
+type MorphTransition = {
+  duration?: number;
+  easing?: string;
+  delay?: number;
 };
 ```
 

--- a/packages/cli/template/.agents/skills/slide-authoring/references/transitions.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/references/transitions.md
@@ -1,0 +1,169 @@
+# Page transitions (`SlideTransition`)
+
+The framework can run an enter/exit animation between every slide change. There's **no default** — pages snap unless you declare a `SlideTransition`. Snap-swap is a perfectly tasteful default; only opt in when motion adds something.
+
+`prefers-reduced-motion: reduce` is honored automatically. You don't write a fallback.
+
+(For morphing a shared element across two pages — Keynote's "Magic Move" — see `morph.md`, which builds on the contract here.)
+
+## Contract
+
+Module-level for the whole deck; per-page to override. The **incoming page wins**: navigating A → B uses `pages[B].transition ?? module.transition`. Its `exit` plays on A, its `enter` plays on B. Going back B → A uses A's transition.
+
+```tsx
+import type { Page, SlideTransition } from '@open-slide/core';
+
+const Cover: Page = () => <section>…</section>;
+const Body:  Page = () => <section>…</section>;
+
+// Module-level default — every page inherits unless it overrides.
+export const transition: SlideTransition = { /* … */ };
+
+// Per-page override.
+Cover.transition = { /* … */ };
+
+export default [Cover, Body];
+```
+
+```ts
+type TransitionPhase = {
+  keyframes: Keyframe[] | PropertyIndexedKeyframes;  // WAAPI keyframes
+  duration?: number;  // ms (falls back to top-level duration)
+  easing?: string;    // CSS easing
+  delay?: number;     // ms — use to overlap exit + enter
+};
+type SlideTransition = {
+  duration: number;          // top-level fallback
+  easing?: string;           // top-level fallback
+  enter?: TransitionPhase;   // runs on incoming page
+  exit?:  TransitionPhase;   // runs on outgoing page
+};
+```
+
+The framework also exposes `--osd-dir` (`1` forward, `-1` backward) and `data-osd-dir` on the wrapper, so a single keyframe can mirror direction without a JS callback.
+
+## Design principles (hold the line)
+
+The single loudest signal of "made in PowerPoint" is six different transitions in one deck. Restraint is the rhythm.
+
+- **Pick one DNA, hold it across the deck.** Same duration band, same easing pair, same out-then-in stagger. Variation lives only in *which property* gets the small nudge — Y, X, opacity, scale, blur.
+- **Duration: 140–280 ms.** Exit 140–180 ms, enter 200–280 ms, enter delayed ~80 ms so they overlap but don't fight. Past 350 ms is video-editor territory; reserve for genuine state changes.
+- **Magnitude ceiling: 12 px or 3% scale.** A 6 px Y-rise reads as "next thought." A 1920 px translateX reads as "different document." Premium tools move barely enough to register.
+- **Opacity is always part of it.** Pure-transform transitions look stiff; pure-opacity transitions are the safest possible default.
+- **Easing: ease-in for exit, ease-out for enter.** `cubic-bezier(0.4, 0, 1, 1)` going out, `cubic-bezier(0, 0, 0.2, 1)` coming in. Never `linear` (feels like a slideshow). Reserve symmetric `ease-in-out` for state-anchored morphs only.
+
+## Tasteful family — six members, one DNA
+
+Use this set as a starting point. Pick one as the deck's house transition; optionally reserve a second for hero/cover slides and a third for genuine section breaks. The CSS-`calc` + `--osd-dir` trick lets a single definition mirror itself on backward navigation when needed.
+
+```tsx
+const EASE_OUT = 'cubic-bezier(0, 0, 0.2, 1)';
+const EASE_IN  = 'cubic-bezier(0.4, 0, 1, 1)';
+
+// RISE — house quiet. 6 px Y. Use as module default.
+export const transition: SlideTransition = {
+  duration: 200,
+  exit:  { duration: 140, easing: EASE_IN,
+           keyframes: [
+             { opacity: 1, transform: 'translateY(0)' },
+             { opacity: 0, transform: 'translateY(-4px)' },
+           ] },
+  enter: { duration: 200, delay: 80, easing: EASE_OUT,
+           keyframes: [
+             { opacity: 0, transform: 'translateY(6px)' },
+             { opacity: 1, transform: 'translateY(0)' },
+           ] },
+};
+
+// DISSOLVE — pure opacity. The quietest possible.
+const dissolve: SlideTransition = {
+  duration: 240,
+  exit:  { duration: 200, easing: EASE_IN,
+           keyframes: [{ opacity: 1 }, { opacity: 0 }] },
+  enter: { duration: 240, delay: 40, easing: EASE_OUT,
+           keyframes: [{ opacity: 0 }, { opacity: 1 }] },
+};
+
+// SETTLE — cover-grade. Rise + a hair of blur on enter only.
+Cover.transition = {
+  duration: 280,
+  exit:  { duration: 160, easing: EASE_IN,
+           keyframes: [
+             { opacity: 1, transform: 'translateY(0)' },
+             { opacity: 0, transform: 'translateY(-6px)' },
+           ] },
+  enter: { duration: 280, delay: 100, easing: EASE_OUT,
+           keyframes: [
+             { opacity: 0, transform: 'translateY(12px)', filter: 'blur(4px)' },
+             { opacity: 1, transform: 'translateY(0)',    filter: 'blur(0)'   },
+           ] },
+};
+
+// BLOOM — scale 0.97 → 1, no translate. Materializes in place.
+const bloom: SlideTransition = {
+  duration: 240,
+  exit:  { duration: 160, easing: EASE_IN,
+           keyframes: [
+             { opacity: 1, transform: 'scale(1)' },
+             { opacity: 0, transform: 'scale(1.01)' },
+           ] },
+  enter: { duration: 240, delay: 80, easing: EASE_OUT,
+           keyframes: [
+             { opacity: 0, transform: 'scale(0.97)' },
+             { opacity: 1, transform: 'scale(1)' },
+           ] },
+};
+
+// FALL — mirrored Rise. Incoming page comes down from above.
+const fall: SlideTransition = {
+  duration: 200,
+  exit:  { duration: 140, easing: EASE_IN,
+           keyframes: [
+             { opacity: 1, transform: 'translateY(0)' },
+             { opacity: 0, transform: 'translateY(4px)' },
+           ] },
+  enter: { duration: 200, delay: 80, easing: EASE_OUT,
+           keyframes: [
+             { opacity: 0, transform: 'translateY(-6px)' },
+             { opacity: 1, transform: 'translateY(0)' },
+           ] },
+};
+
+// BREATH — section break. Exit fully, hold 120 ms, then enter.
+// Reserve for genuine chapter dividers; use at most 1–2× per deck.
+const breath: SlideTransition = {
+  duration: 460,
+  exit:  { duration: 180, easing: EASE_IN,
+           keyframes: [{ opacity: 1 }, { opacity: 0 }] },
+  enter: { duration: 240, delay: 300, easing: EASE_OUT,
+           keyframes: [
+             { opacity: 0, transform: 'translateY(8px)' },
+             { opacity: 1, transform: 'translateY(0)' },
+           ] },
+};
+```
+
+All six share the same DNA — they only differ in which property carries the small nudge. The reader perceives variety; the eye still reads one consistent hand.
+
+## Direction-aware keyframes (use sparingly)
+
+Most tasteful tools don't mirror on backward navigation. When you genuinely need to — e.g. a horizontal slide that should reverse — use `--osd-dir` inside `calc()`:
+
+```tsx
+{ transform: 'translateX(calc(var(--osd-dir, 1) * 8px))' },
+{ transform: 'translateX(0)' },
+```
+
+If you find yourself reaching for this on every transition, you're probably over-designing. Forward = backward is the more refined default.
+
+## Anti-patterns
+
+- ❌ Six different transitions across six pages — the single loudest "made in PowerPoint" tell.
+- ❌ `translateX(100%)` slide-from-side — iOS modal / PowerPoint Push; not a slide change.
+- ❌ Aggressive scale-pop (e.g. `0.85 → 1`) + blur — lightbox / photo-viewer vocabulary; implies zooming *into* something.
+- ❌ `clip-path: inset(…)` reveals — After Effects vocabulary; theatrical.
+- ❌ Parallel blur on both layers at once — visual mush; the eye can't fixate.
+- ❌ Duration > 350 ms for a standard slide change — drags.
+- ❌ Translate > 12 px or scale > 3% — reads as rupture, not continuity.
+- ❌ `linear` easing — feels like a slideshow, not a product.
+- ❌ Declaring a transition on every deck. **If you don't have a clear reason, omit it.** Snap-swap is fine.

--- a/packages/cli/template/.agents/skills/slide-authoring/references/webfonts.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/references/webfonts.md
@@ -2,13 +2,14 @@
 
 The default is a system font stack — prefer it. When a deck genuinely needs a webfont (a brand font, or CJK / Thai / Arabic where system coverage is poor):
 
-- **Load the stylesheet once, in `<head>` — never inside a per-page component.** Every page is mounted live at the same time (thumbnail rail, overview grid, and the PDF print root), so a `<style>@import</style>` / `<link>` rendered inside a `Page` registers the whole `@font-face` set once *per page*. Inject it once, idempotently:
+- **Load the stylesheet once, in `<head>` — never inside a per-page component.** Every page is mounted live at the same time (thumbnail rail, overview grid, and the PDF print root), so a `<style>@import</style>` / `<link>` rendered inside a `Page` registers the whole `@font-face` set once *per page*. Inject it once, idempotently. **Key the element id to the slide** (e.g. `osd-webfont-<slide-id>`) — the home page mounts pages from *every* slide at once, so a generic shared id like `osd-webfont` would let the first slide's fonts suppress every other slide's:
 
   ```tsx
   const FONT_HREF = 'https://fonts.googleapis.com/css2?family=...&display=swap';
-  if (typeof document !== 'undefined' && !document.getElementById('osd-webfont')) {
+  const FONT_LINK_ID = 'osd-webfont-q2-roadmap'; // suffix = this slide's folder id
+  if (typeof document !== 'undefined' && !document.getElementById(FONT_LINK_ID)) {
     const link = document.createElement('link');
-    link.id = 'osd-webfont';
+    link.id = FONT_LINK_ID;
     link.rel = 'stylesheet';
     link.href = FONT_HREF;
     document.head.appendChild(link);

--- a/packages/cli/template/.agents/skills/slide-authoring/references/webfonts.md
+++ b/packages/cli/template/.agents/skills/slide-authoring/references/webfonts.md
@@ -1,0 +1,19 @@
+# Webfonts
+
+The default is a system font stack — prefer it. When a deck genuinely needs a webfont (a brand font, or CJK / Thai / Arabic where system coverage is poor):
+
+- **Load the stylesheet once, in `<head>` — never inside a per-page component.** Every page is mounted live at the same time (thumbnail rail, overview grid, and the PDF print root), so a `<style>@import</style>` / `<link>` rendered inside a `Page` registers the whole `@font-face` set once *per page*. Inject it once, idempotently:
+
+  ```tsx
+  const FONT_HREF = 'https://fonts.googleapis.com/css2?family=...&display=swap';
+  if (typeof document !== 'undefined' && !document.getElementById('osd-webfont')) {
+    const link = document.createElement('link');
+    link.id = 'osd-webfont';
+    link.rel = 'stylesheet';
+    link.href = FONT_HREF;
+    document.head.appendChild(link);
+  }
+  ```
+
+- **List only the weights you actually use.** Each extra weight multiplies the number of `@font-face` rules.
+- **CJK fonts are large.** A Google Fonts CJK family registers hundreds of `unicode-range` subset faces (Noto Sans TC ≈ 105 subsets × each weight), and PDF export waits on fonts before printing. If the deck's text is fixed, add `&text=<unique chars>` to the URL to request a tiny single-face subset instead of the full set.

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -14,6 +14,20 @@ This skill is the **technical reference** for everything that happens inside `sl
 
 When any of those paths reach the point of *writing React code for a page*, this is the source of truth. Do not duplicate the knowledge below into other skills — link here instead.
 
+## Primitive references
+
+Each framework primitive has a full reference file under `references/` in this skill — contract, worked examples, and its own anti-patterns. This file keeps only the always-on rules and a short summary per primitive. **Read the relevant reference file before using a primitive on a page**:
+
+| Primitive | Read before | File |
+| --- | --- | --- |
+| `design` const + `var(--osd-X)` tokens | writing any new slide (default baseline) | `references/design-system.md` |
+| Assets + `<ImagePlaceholder>` | importing images/videos or leaving a placeholder | `references/assets.md` |
+| Webfonts | loading any non-system font | `references/webfonts.md` |
+| `useSlidePageNumber()` | rendering a page-number footer | `references/page-numbers.md` |
+| `<Steps>` / `<Step>` | staging a page's reveal | `references/steps.md` |
+| `SlideTransition` | declaring any enter/exit animation | `references/transitions.md` |
+| `MorphElement` + `morph` | morphing a shared element across pages | `references/morph.md` |
+
 ## Hard rules
 
 - Put the slide under `slides/<kebab-case-id>/`.
@@ -123,23 +137,7 @@ Consult the `frontend-design` skill for deeper aesthetic guidance if the user wa
 
 ## Webfonts
 
-The default is a system font stack — prefer it. When a deck genuinely needs a webfont (a brand font, or CJK / Thai / Arabic where system coverage is poor):
-
-- **Load the stylesheet once, in `<head>` — never inside a per-page component.** Every page is mounted live at the same time (thumbnail rail, overview grid, and the PDF print root), so a `<style>@import>` / `<link>` rendered inside a `Page` registers the whole `@font-face` set once *per page*. Inject it once, idempotently:
-
-  ```tsx
-  const FONT_HREF = 'https://fonts.googleapis.com/css2?family=...&display=swap';
-  if (typeof document !== 'undefined' && !document.getElementById('osd-webfont')) {
-    const link = document.createElement('link');
-    link.id = 'osd-webfont';
-    link.rel = 'stylesheet';
-    link.href = FONT_HREF;
-    document.head.appendChild(link);
-  }
-  ```
-
-- **List only the weights you actually use.** Each extra weight multiplies the number of `@font-face` rules.
-- **CJK fonts are large.** A Google Fonts CJK family registers hundreds of `unicode-range` subset faces (Noto Sans TC ≈ 105 subsets × each weight), and PDF export waits on fonts before printing. If the deck's text is fixed, add `&text=<unique chars>` to the URL to request a tiny single-face subset instead of the full set.
+The default is a system font stack — prefer it. When a deck genuinely needs a webfont (a brand font, or CJK / Thai / Arabic where system coverage is poor), read `references/webfonts.md` first — loading the stylesheet inside a page component registers the whole `@font-face` set once per mounted page, and CJK families need subsetting.
 
 ## Themes
 
@@ -149,47 +147,11 @@ Themes are produced by the `create-theme` skill and are pure documentation: copy
 
 ## Design system (opt-in, per-slide)
 
-A slide can declare its own typed design tokens at the top of `index.tsx`:
+A slide can declare typed design tokens at the top of `index.tsx` — `export const design: DesignSystem = { palette, fonts, typeScale, radius }` — and consume them via `var(--osd-X)` in inline styles. The framework injects the CSS variables at the canvas root, and the dev UI's Design panel can live-tweak them.
 
-```tsx
-import type { DesignSystem, Page } from '@open-slide/core';
+**Default to using it.** Every new slide should declare a `design` const so it stays tweakable from the panel after generation. Only fall back to the local `palette` constants pattern (see starter template) for a one-off slide whose palette is intentionally locked.
 
-export const design: DesignSystem = {
-  palette: { bg: '#f7f5f0', text: '#1a1814', accent: '#6d4cff' },
-  fonts: {
-    display: 'Georgia, "Times New Roman", serif',
-    body: '-apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif',
-  },
-  typeScale: { hero: 168, body: 36 },
-  radius:    12,
-};
-```
-
-`export` it (rather than plain `const`) so the framework can read the object and inject CSS variables at the canvas root automatically.
-
-The shape is intentionally minimal — it only covers what the Design panel can currently tweak. Anything outside this set (heading sizes, spacing, motion, extra palette colors) belongs as plain hard-coded constants in the slide file.
-
-There are **two consumption surfaces**, and you should mix them inside the same slide:
-
-- **`var(--osd-X)` for visual properties (color, font, font-size, radius)** — these get instant updates while the user drags a slider in the Design panel, before any file write.
-  ```tsx
-  <div style={{ background: 'var(--osd-bg)', color: 'var(--osd-text)', borderRadius: 'var(--osd-radius)', fontFamily: 'var(--osd-font-body)', fontSize: 'var(--osd-size-body)' }}>
-  ```
-  Available vars: `--osd-bg`, `--osd-text`, `--osd-accent`, `--osd-font-display`, `--osd-font-body`, `--osd-size-hero`, `--osd-size-body`, `--osd-radius`.
-
-- **Direct `design.X` reads** — when you need a JS number for arithmetic or to label something in the UI. These update via HMR after the panel commits the file, not while dragging.
-  ```tsx
-  <p>{design.typeScale.hero}px</p>
-  ```
-
-The dev UI has a **Design** button in the slide header (next to Inspect). Edits update an in-memory draft and the live-preview overlay; a floating Save / Discard bar at the bottom of the canvas commits or reverts. The const stays the single source of truth — production builds bake the saved values.
-
-**Default to using it.** Every new slide should declare a `design` const so it stays tweakable from the panel after generation — this is the expected baseline. Only fall back to the local `palette` constants pattern (see starter template) for a one-off slide whose palette is intentionally locked and not meant to be re-themed. Both styles can coexist across slides — the panel only operates on the *currently viewed* slide.
-
-Format constraints (for the panel's AST writer):
-- Must be `[export] const design: DesignSystem = { … }` (or `as DesignSystem` / `satisfies DesignSystem`) at module top level.
-- Object initializer must be a literal — no spreads, no helper calls. Plain values only.
-- `DesignSystem` must be imported from `@open-slide/core` (the panel adds the import automatically when creating a fresh block).
+`references/design-system.md` has the full token shape, the two consumption surfaces (`var(--osd-X)` vs direct `design.X` reads), Design panel behavior, and the format constraints the panel's AST writer requires. Read it before writing the const.
 
 ## Starter template
 
@@ -269,336 +231,37 @@ export default [Cover, Content] satisfies Page[];
 
 ## Assets
 
-**Slide-local assets** live under `slides/<id>/assets/` — anything one-off to a single slide. Import them as ES modules:
+Slide-local assets live under `slides/<id>/assets/` and are imported as ES modules (`import hero from './assets/hero.jpg'`). Global assets shared across decks (logos, avatars, recurring icons) live in the project root `assets/` and are imported via the `@assets` alias. Skip the `assets/` folder entirely for pure-text slides.
 
-```tsx
-import hero from './assets/hero.jpg';
-// …
-<img src={hero} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
-```
-
-For URL-only access:
-
-```tsx
-const videoUrl = new URL('./assets/intro.mp4', import.meta.url).href;
-```
-
-**Global assets** — anything reused across decks or themes (company logos, presenter avatars, recurring icons) — live in the project root `assets/` folder. Import them via the `@assets` alias:
-
-```tsx
-import logo from '@assets/logos/acme.svg';
-```
-
-A `themes/*.md` file may name an asset path in its prose (e.g. "use `@assets/logos/acme.svg` in the title slot"); the slide imports it explicitly.
-
-Skip the `assets/` folder entirely for pure-text slides.
+`references/assets.md` covers import forms (module vs `new URL(...)`), the `@assets` alias, and how themes name asset paths.
 
 ## Image placeholders
 
-When a page genuinely needs a real image **the user has to provide** — a product screenshot, a team photo, a chart from their data — leave a typed placeholder instead of inventing a stand-in:
+When a page genuinely needs a real image **the user has to provide** (product screenshot, team photo, chart from their data), leave a typed `<ImagePlaceholder hint="…" />` from `@open-slide/core` instead of inventing a stand-in — the user replaces it via the Assets panel + inspector. **Do not** use placeholders for decoration or generic stock-photo filler; if type, layout, and color can carry the page, do that.
 
-```tsx
-import { ImagePlaceholder } from '@open-slide/core';
-
-<ImagePlaceholder hint="Product hero screenshot" width={1280} height={720} />
-```
-
-The user uploads the real file via the Assets panel, then clicks the placeholder in the inspector and picks "Replace…" — the JSX is rewritten to a real `<img>` with the import added.
-
-**Use a placeholder only when** a specific concrete image is required by the deck's topic. Examples that warrant one: a product-intro deck (product screenshot per feature), an offsite recap (team photo), a case study (customer logo, dashboard screenshot).
-
-**Do not use a placeholder** for decoration, generic "stock photo" filler, hero imagery on a text-heavy slide, or anywhere a typographic / iconographic / illustrative solution would do. If you can carry the page with type, layout, and color — do that. Empty placeholders the user has to fill are friction; only spend that friction when the alternative is worse.
-
-Size the placeholder to the slot it occupies. Pass `width`/`height` when the layout has a fixed image box; omit them when the placeholder fills a flex/grid cell. The `hint` should describe the *content* the user needs ("Q3 revenue chart") not the *role* ("hero image").
+`references/assets.md` has the full usage rules, sizing guidance, and examples of when a placeholder is (and isn't) warranted.
 
 ## Page numbers
 
-If a footer shows the current page (`03 / 12`, `Page 3`, etc.), read it from `useSlidePageNumber()` — **never hardcode** `n` / `TOTAL`. Inserting, reordering, or deleting a page would otherwise force you to retouch every footer.
-
-```tsx
-import { useSlidePageNumber } from '@open-slide/core';
-
-const Footer = () => {
-  const { current, total } = useSlidePageNumber();
-  return (
-    <span>{String(current).padStart(2, '0')} / {String(total).padStart(2, '0')}</span>
-  );
-};
-```
-
-`current` is 1-indexed (matches what readers see) and `total` is the slide's page count. The hook works in every render context (main viewer, thumbnails, overview grid, present mode, presenter window, HTML/PDF export) — the same `<Footer />` JSX is correct everywhere. Call the hook inside a component that's used **per page**; don't try to call it at module top level.
+If a footer shows the current page (`03 / 12`), read it from `useSlidePageNumber()` — **never hardcode** `n` / `TOTAL`. See `references/page-numbers.md` for the hook's contract and where it can be called.
 
 ## Stepped reveals (`<Steps>` / `<Step>`)
 
-Reveal a page one beat at a time instead of showing everything at once. Wrap the deferred parts in `<Step>`, wrap the group in `<Steps>`. Each `→` reveals the next `<Step>`; `→` after the last one advances to the next page. `←` peels the last reveal back. Use it to stage attention — show framing first, then the consequence, then the turn — so the audience reads at the speaker's pace, not ahead.
+Reveal a page one beat at a time: wrap deferred parts in `<Step>`, the group in `<Steps>`; each `→` reveals the next step. Use it when the *order* of ideas is the point — not reflexively on every page. Two rules are load-bearing: `<Step>` must be a **direct child** of `<Steps>` (otherwise it silently renders fully revealed), and a page must still read as complete when jumped to via the overview grid (jumping in shows all steps revealed).
 
-`slides/build-on-reveal/` is the canonical worked example; study it before authoring a stepped page.
-
-```tsx
-import { Step, Steps } from '@open-slide/core';
-
-<Steps>
-  <Step><div style={BULLET_ROW}>An audience reads faster than a presenter speaks.</div></Step>
-  <Step><div style={BULLET_ROW}>Showing every bullet at once invites pre-reading.</div></Step>
-  <Step><div style={BULLET_ROW}>Revealing in time stages attention.</div></Step>
-</Steps>
-```
-
-### Rules
-
-- **`<Step>` must be a *direct* child of `<Steps>`.** A `<Step>` nested deeper (or used without a `<Steps>` parent) renders fully revealed and defers nothing.
-- **Non-`Step` children render immediately.** Put a headline or intro paragraph *inside* `<Steps>` as a plain element and it shows from the start; only the `<Step>` blocks wait. This is the "headline always, body in turn" pattern:
-  ```tsx
-  <Steps>
-    <h2>Not everything has to wait.</h2>{/* visible immediately */}
-    <Step><p>First, set the stage…</p></Step>
-    <Step><p>Then, layer the consequence…</p></Step>
-  </Steps>
-  ```
-- **Multiple `<Steps>` blocks on one page compose in document order.** The first block reveals all its steps before the second begins; `←` unwinds in reverse. Use this for two columns that build left-then-right, each column owning its own `<Steps>`:
-  ```tsx
-  <div style={COL}><Steps><Step>…</Step><Step>…</Step></Steps></div>{/* finishes first */}
-  <div style={COL}><Steps><Step>…</Step><Step>…</Step></Steps></div>{/* then this */}
-  ```
-- **Entry direction decides the starting state — same content, two rhythms.** Entering forward (`→` from the previous page) starts empty and builds up. Jumping in via the overview grid, or arriving backward from a later page, shows the page **fully composed** with every step already revealed. Design the page to read well both ways: a thumbnail or overview jump should look complete, not blank.
-- **`<Step>` fades in over `duration` ms (default 180).** Pass `<Step duration={...}>` to adjust. `prefers-reduced-motion: reduce` collapses it to an instant cut automatically — don't write a fallback.
-
-### When to reach for it
-
-Use stepped reveals when the *order* of ideas is the point — a list whose payoff is the last item, a build-up to a conclusion, a before/after. Don't wrap every page's content in `<Step>` reflexively: a page the audience should take in at a glance (a hero title, a single quote, a diagram) is stronger shown whole. Reveals are timing, not decoration — same restraint as transitions.
+Read `references/steps.md` before authoring a stepped page — it covers composition order across multiple `<Steps>` blocks, the "headline always, body in turn" pattern, and entry-direction behavior. `slides/build-on-reveal/` is the canonical worked example.
 
 ## Page transitions
 
-The framework can run an enter/exit animation between every slide change. There's **no default** — pages snap unless you declare a `SlideTransition`. Snap-swap is a perfectly tasteful default; only opt in when motion adds something.
+The framework can run an enter/exit animation between slide changes, declared as a `SlideTransition` (module-level default, per-page override; the **incoming page wins**). There's **no default** — pages snap unless you opt in, and snap-swap is a perfectly tasteful default. If you do opt in: one motion DNA per deck, 140–280 ms, magnitude under 12 px / 3% scale, opacity always part of it.
 
-`prefers-reduced-motion: reduce` is honored automatically. You don't write a fallback.
+Read `references/transitions.md` before declaring one — it has the full type contract, design principles, a six-member "tasteful family" of ready-to-use transitions sharing one DNA, direction-aware keyframes, and the anti-pattern list.
 
-### Contract
+## Morph transitions
 
-Module-level for the whole deck; per-page to override. The **incoming page wins**: navigating A → B uses `pages[B].transition ?? module.transition`. Its `exit` plays on A, its `enter` plays on B. Going back B → A uses A's transition.
+When the *same visual object* exists on two adjacent pages, wrap it on both pages in `MorphElement` with the same `id` and enable `morph` on the incoming page's transition — position, size, radius, and colors interpolate in one continuous move (Keynote's "Magic Move"). Morph is for **state continuity** (a toggle sliding, a card expanding, a box joining a row); don't morph decoration.
 
-```tsx
-import type { Page, SlideTransition } from '@open-slide/core';
-
-const Cover: Page = () => <section>…</section>;
-const Body:  Page = () => <section>…</section>;
-
-// Module-level default — every page inherits unless it overrides.
-export const transition: SlideTransition = { /* … */ };
-
-// Per-page override.
-Cover.transition = { /* … */ };
-
-export default [Cover, Body];
-```
-
-```ts
-type TransitionPhase = {
-  keyframes: Keyframe[] | PropertyIndexedKeyframes;  // WAAPI keyframes
-  duration?: number;  // ms (falls back to top-level duration)
-  easing?: string;    // CSS easing
-  delay?: number;     // ms — use to overlap exit + enter
-};
-type SlideTransition = {
-  duration: number;          // top-level fallback
-  easing?: string;           // top-level fallback
-  enter?: TransitionPhase;   // runs on incoming page
-  exit?:  TransitionPhase;   // runs on outgoing page
-};
-```
-
-The framework also exposes `--osd-dir` (`1` forward, `-1` backward) and `data-osd-dir` on the wrapper, so a single keyframe can mirror direction without a JS callback.
-
-### Design principles (hold the line)
-
-The single loudest signal of "made in PowerPoint" is six different transitions in one deck. Restraint is the rhythm.
-
-- **Pick one DNA, hold it across the deck.** Same duration band, same easing pair, same out-then-in stagger. Variation lives only in *which property* gets the small nudge — Y, X, opacity, scale, blur.
-- **Duration: 140–280 ms.** Exit 140–180 ms, enter 200–280 ms, enter delayed ~80 ms so they overlap but don't fight. Past 350 ms is video-editor territory; reserve for genuine state changes.
-- **Magnitude ceiling: 12 px or 3% scale.** A 6 px Y-rise reads as "next thought." A 1920 px translateX reads as "different document." Premium tools move barely enough to register.
-- **Opacity is always part of it.** Pure-transform transitions look stiff; pure-opacity transitions are the safest possible default.
-- **Easing: ease-in for exit, ease-out for enter.** `cubic-bezier(0.4, 0, 1, 1)` going out, `cubic-bezier(0, 0, 0.2, 1)` coming in. Never `linear` (feels like a slideshow). Reserve symmetric `ease-in-out` for state-anchored morphs only.
-
-### Tasteful family — six members, one DNA
-
-Use this set as a starting point. Pick one as the deck's house transition; optionally reserve a second for hero/cover slides and a third for genuine section breaks. The CSS-`calc` + `--osd-dir` trick lets a single definition mirror itself on backward navigation when needed.
-
-```tsx
-const EASE_OUT = 'cubic-bezier(0, 0, 0.2, 1)';
-const EASE_IN  = 'cubic-bezier(0.4, 0, 1, 1)';
-
-// RISE — house quiet. 6 px Y. Use as module default.
-export const transition: SlideTransition = {
-  duration: 200,
-  exit:  { duration: 140, easing: EASE_IN,
-           keyframes: [
-             { opacity: 1, transform: 'translateY(0)' },
-             { opacity: 0, transform: 'translateY(-4px)' },
-           ] },
-  enter: { duration: 200, delay: 80, easing: EASE_OUT,
-           keyframes: [
-             { opacity: 0, transform: 'translateY(6px)' },
-             { opacity: 1, transform: 'translateY(0)' },
-           ] },
-};
-
-// DISSOLVE — pure opacity. The quietest possible.
-const dissolve: SlideTransition = {
-  duration: 240,
-  exit:  { duration: 200, easing: EASE_IN,
-           keyframes: [{ opacity: 1 }, { opacity: 0 }] },
-  enter: { duration: 240, delay: 40, easing: EASE_OUT,
-           keyframes: [{ opacity: 0 }, { opacity: 1 }] },
-};
-
-// SETTLE — cover-grade. Rise + a hair of blur on enter only.
-Cover.transition = {
-  duration: 280,
-  exit:  { duration: 160, easing: EASE_IN,
-           keyframes: [
-             { opacity: 1, transform: 'translateY(0)' },
-             { opacity: 0, transform: 'translateY(-6px)' },
-           ] },
-  enter: { duration: 280, delay: 100, easing: EASE_OUT,
-           keyframes: [
-             { opacity: 0, transform: 'translateY(12px)', filter: 'blur(4px)' },
-             { opacity: 1, transform: 'translateY(0)',    filter: 'blur(0)'   },
-           ] },
-};
-
-// BLOOM — scale 0.97 → 1, no translate. Materializes in place.
-const bloom: SlideTransition = {
-  duration: 240,
-  exit:  { duration: 160, easing: EASE_IN,
-           keyframes: [
-             { opacity: 1, transform: 'scale(1)' },
-             { opacity: 0, transform: 'scale(1.01)' },
-           ] },
-  enter: { duration: 240, delay: 80, easing: EASE_OUT,
-           keyframes: [
-             { opacity: 0, transform: 'scale(0.97)' },
-             { opacity: 1, transform: 'scale(1)' },
-           ] },
-};
-
-// FALL — mirrored Rise. Incoming page comes down from above.
-const fall: SlideTransition = {
-  duration: 200,
-  exit:  { duration: 140, easing: EASE_IN,
-           keyframes: [
-             { opacity: 1, transform: 'translateY(0)' },
-             { opacity: 0, transform: 'translateY(4px)' },
-           ] },
-  enter: { duration: 200, delay: 80, easing: EASE_OUT,
-           keyframes: [
-             { opacity: 0, transform: 'translateY(-6px)' },
-             { opacity: 1, transform: 'translateY(0)' },
-           ] },
-};
-
-// BREATH — section break. Exit fully, hold 120 ms, then enter.
-// Reserve for genuine chapter dividers; use at most 1–2× per deck.
-const breath: SlideTransition = {
-  duration: 460,
-  exit:  { duration: 180, easing: EASE_IN,
-           keyframes: [{ opacity: 1 }, { opacity: 0 }] },
-  enter: { duration: 240, delay: 300, easing: EASE_OUT,
-           keyframes: [
-             { opacity: 0, transform: 'translateY(8px)' },
-             { opacity: 1, transform: 'translateY(0)' },
-           ] },
-};
-```
-
-All six share the same DNA — they only differ in which property carries the small nudge. The reader perceives variety; the eye still reads one consistent hand.
-
-### Direction-aware keyframes (use sparingly)
-
-Most tasteful tools don't mirror on backward navigation. When you genuinely need to — e.g. a horizontal slide that should reverse — use `--osd-dir` inside `calc()`:
-
-```tsx
-{ transform: 'translateX(calc(var(--osd-dir, 1) * 8px))' },
-{ transform: 'translateX(0)' },
-```
-
-If you find yourself reaching for this on every transition, you're probably over-designing. Forward = backward is the more refined default.
-
-### Morph transitions
-
-When the *same visual object* exists on two adjacent pages, the runtime can morph it across the cut — position, size, border-radius, and colors interpolate in one continuous move (Keynote calls this "Magic Move") — instead of fading out and back in. Two parts opt in:
-
-1. Wrap the object on **both** pages in `MorphElement` with the **same `id`**.
-2. Enable `morph` on the incoming page's transition.
-
-```tsx
-import { MorphElement } from '@open-slide/core';
-
-// Morph transition — opacity-only enter/exit keeps all the motion on the clones (see rules).
-const morphTransition: SlideTransition = {
-  duration: 280,
-  exit:  { duration: 224, easing: 'cubic-bezier(0.4, 0, 1, 1)', keyframes: [{ opacity: 1 }, { opacity: 0 }] },
-  enter: { duration: 308, delay: 112, easing: 'cubic-bezier(0, 0, 0.2, 1)', keyframes: [{ opacity: 0 }, { opacity: 1 }] },
-  morph: { duration: 868, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
-};
-
-const stage: CSSProperties = { width: '100%', height: '100%', position: 'relative', background: '#000000', overflow: 'hidden' };
-
-const Narrow: Page = () => (
-  <div style={stage}>
-    <MorphElement id="pill" style={{ position: 'absolute', left: 842, top: 479, width: 236, height: 122, borderRadius: 999, background: '#ffffff' }} />
-  </div>
-);
-const Wide: Page = () => (
-  <div style={stage}>
-    <MorphElement id="pill" style={{ position: 'absolute', left: 721, top: 479, width: 478, height: 122, borderRadius: 999, background: '#0a0a0a' }} />
-  </div>
-);
-
-Wide.transition = morphTransition;   // forward: Narrow → Wide morphs the pill
-Narrow.transition = morphTransition; // backward: Wide → Narrow morphs it back
-```
-
-#### Contract
-
-- `morph: true` inherits the transition's top-level `duration`/`easing`; pass `{ duration?, easing?, delay? }` to time the morph independently of the page cross-fade. Morphs usually read best 2–4× longer than the fade (e.g. 280 ms fade, 868 ms morph).
-- Elements pair by `id` across the cut. A matched pair FLIP-morphs: the runtime measures both rects, clones the outgoing element into an overlay above both pages, hides the originals, and animates transform + border-radius + colors (border widths ride a separate frame so they don't stretch with the box). Keep each `id` unique within a page; don't nest one `MorphElement` inside another.
-- An `id` present on only one side fades in/out **in place**. This is how "a third box joins the row" reads: carried boxes glide to their new slots, the new one materializes.
-- Colors on the morph node *and its descendants* interpolate too — a label that flips black → white mid-glide just works.
-- The transition lives on the **incoming** page. For a morph that also plays when stepping backward, assign the same transition object to both pages (as above).
-
-#### Rules — each one earned on a real deck
-
-1. **Prefer opacity-only enter/exit on morphing pages.** Any transition family composes correctly with the morph (shared rects are measured before the phases start), but while clones glide, a transform-bearing enter also slides the rest of the page — two competing motions. Giving the clones all the motion and fading everything else is what makes a morph read as one confident gesture.
-2. **Morph geometry must be deterministic at mount.** Rects are snapshotted once at the cut. Position morph elements with pixel constants — never with a value measured in an effect after mount (the re-render shifts the target mid-morph and the move jumps). If text inside a morph box grows over time (typewriter etc.), render a hidden full-width spacer so the measured box never changes size.
-3. **No `transform` on the morph node itself.** A percentage translate (`translate(-50%, -50%)`) gets mis-scaled by the morph and lands the clone tens of px off. Put centering/positioning transforms on a plain wrapper `<div>` *around* the `MorphElement`.
-4. **`MorphElement` merges `className`/`style` onto its single host child** (it adds no wrapper when the child is a lone DOM element). A crop box (`overflow: hidden` + fixed width) therefore needs an explicit nested `<div>` — otherwise the box collapses onto the `<img>` inside and squishes it.
-5. **Gate entrance animations behind `useIsActivePage()`.** During the cut the runtime mounts a *fresh instance* of the outgoing page to snapshot its exit state (and the dev UI mounts every page for thumbnails/overview). If an intro replays there, the snapshot is mid-animation and the morph starts from garbage. The hook returns `true` only for the instance the audience is watching; every other instance (outgoing snapshot, thumbnails, overview, presenter preview, print) should render the final, settled state — no intro, full text.
-
-   ```tsx
-   import { useIsActivePage } from '@open-slide/core';
-
-   // Inside the page component:
-   const animate = useIsActivePage();
-   ```
-
-6. **Clones travel above everything.** The morph overlay sits over both pages, so an incoming element that should appear only when a clone "lands" will otherwise pop early. Give such reveals a delay equal to the morph: `animation: 'osd-fade 0.63s ease-out 0.868s both'` where `0.868s` is `morph.duration`. Keep that number in one shared const so the two can't drift.
-7. **A "hold" page is a separate component.** Transitions attach to the incoming page, so to follow a morph cut with a plain cut of the same content, mint a second page component without `.transition` (e.g. `const Flow4Hold: Page = () => <Flow count={4} />`).
-
-#### When to reach for it
-
-Morph is for **state continuity**: a toggle whose thumb slides to the next option, a card that expands into a detail view, a logo that glides from center stage into the next page's diagram, a row that gains one more box. The object *is the story* across the cut. Don't morph decoration, and don't tag elements "just in case" — every morph id is a promise to the audience that it's the same object. One or two morphing sequences per chapter is plenty; the surrounding pages should cut or fade quietly.
-
-### Transition anti-patterns
-
-- ❌ Six different transitions across six pages — the single loudest "made in PowerPoint" tell.
-- ❌ `translateX(100%)` slide-from-side — iOS modal / PowerPoint Push; not a slide change.
-- ❌ Aggressive scale-pop (e.g. `0.85 → 1`) + blur — lightbox / photo-viewer vocabulary; implies zooming *into* something.
-- ❌ `clip-path: inset(…)` reveals — After Effects vocabulary; theatrical.
-- ❌ Parallel blur on both layers at once — visual mush; the eye can't fixate.
-- ❌ Duration > 350 ms for a standard slide change — drags.
-- ❌ Translate > 12 px or scale > 3% — reads as rupture, not continuity.
-- ❌ `linear` easing — feels like a slideshow, not a product.
-- ❌ Declaring a transition on every deck. **If you don't have a clear reason, omit it.** Snap-swap is fine.
+Read `references/morph.md` before writing one — the seven rules there (opacity-only enter/exit, deterministic geometry, no `transform` on the morph node, `useIsActivePage()` gating, …) were each earned on a real deck, and violating any of them produces a visibly broken morph.
 
 ## Repeated elements: component, not `map`
 
@@ -684,8 +347,4 @@ This applies whenever the *visual element* repeats, not whenever the *data* does
 - ❌ Writing CSS to a shared file. Inline styles or scoped classnames only.
 - ❌ Creating `README.md` or other prose files inside the slide folder.
 - ❌ Editing `package.json`, `open-slide.config.ts`, or other slides.
-- ❌ Sprinkling `<ImagePlaceholder>` across pages "for visual interest". Placeholders are for content the user owns; they're not stock-photo slots.
-- ❌ Using a placeholder for an icon or decorative shape — those are typography/SVG problems, not asset problems.
-- ❌ Rendering visually repeated elements with `array.map(...)` over a data array. Define a component and instantiate it explicitly per item (`<Card />`, `<Card />`, `<Card />`) so the inspector can edit each independently — a shared `map` body mutates every instance at once.
-- ❌ Wrapping every page's content in `<Step>` reflexively. Stepped reveals are for content whose *order* is the point; a glance-and-get-it page (hero title, single quote, diagram) is stronger shown whole.
-- ❌ A `<Step>` that isn't a direct child of `<Steps>` (nested deeper, or with no `<Steps>` parent). It renders fully revealed and defers nothing — the reveal silently does nothing.
+- ❌ Using a primitive without reading its reference file — each `references/*.md` carries the primitive's own anti-pattern list (placeholder misuse, transition vocabulary, `<Step>` nesting, morph geometry).

--- a/packages/core/skills/slide-authoring/references/assets.md
+++ b/packages/core/skills/slide-authoring/references/assets.md
@@ -1,0 +1,52 @@
+# Assets & image placeholders
+
+## Slide-local assets
+
+**Slide-local assets** live under `slides/<id>/assets/` — anything one-off to a single slide. Import them as ES modules:
+
+```tsx
+import hero from './assets/hero.jpg';
+// …
+<img src={hero} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+```
+
+For URL-only access:
+
+```tsx
+const videoUrl = new URL('./assets/intro.mp4', import.meta.url).href;
+```
+
+## Global assets
+
+**Global assets** — anything reused across decks or themes (company logos, presenter avatars, recurring icons) — live in the project root `assets/` folder. Import them via the `@assets` alias:
+
+```tsx
+import logo from '@assets/logos/acme.svg';
+```
+
+A `themes/*.md` file may name an asset path in its prose (e.g. "use `@assets/logos/acme.svg` in the title slot"); the slide imports it explicitly.
+
+Skip the `assets/` folder entirely for pure-text slides.
+
+## Image placeholders (`<ImagePlaceholder>`)
+
+When a page genuinely needs a real image **the user has to provide** — a product screenshot, a team photo, a chart from their data — leave a typed placeholder instead of inventing a stand-in:
+
+```tsx
+import { ImagePlaceholder } from '@open-slide/core';
+
+<ImagePlaceholder hint="Product hero screenshot" width={1280} height={720} />
+```
+
+The user uploads the real file via the Assets panel, then clicks the placeholder in the inspector and picks "Replace…" — the JSX is rewritten to a real `<img>` with the import added.
+
+**Use a placeholder only when** a specific concrete image is required by the deck's topic. Examples that warrant one: a product-intro deck (product screenshot per feature), an offsite recap (team photo), a case study (customer logo, dashboard screenshot).
+
+**Do not use a placeholder** for decoration, generic "stock photo" filler, hero imagery on a text-heavy slide, or anywhere a typographic / iconographic / illustrative solution would do. If you can carry the page with type, layout, and color — do that. Empty placeholders the user has to fill are friction; only spend that friction when the alternative is worse.
+
+Size the placeholder to the slot it occupies. Pass `width`/`height` when the layout has a fixed image box; omit them when the placeholder fills a flex/grid cell. The `hint` should describe the *content* the user needs ("Q3 revenue chart") not the *role* ("hero image").
+
+### Placeholder anti-patterns
+
+- ❌ Sprinkling `<ImagePlaceholder>` across pages "for visual interest". Placeholders are for content the user owns; they're not stock-photo slots.
+- ❌ Using a placeholder for an icon or decorative shape — those are typography/SVG problems, not asset problems.

--- a/packages/core/skills/slide-authoring/references/design-system.md
+++ b/packages/core/skills/slide-authoring/references/design-system.md
@@ -1,0 +1,48 @@
+# Design system (`design` const + `var(--osd-X)`)
+
+A slide can declare its own typed design tokens at the top of `index.tsx`:
+
+```tsx
+import type { DesignSystem, Page } from '@open-slide/core';
+
+export const design: DesignSystem = {
+  palette: { bg: '#f7f5f0', text: '#1a1814', accent: '#6d4cff' },
+  fonts: {
+    display: 'Georgia, "Times New Roman", serif',
+    body: '-apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif',
+  },
+  typeScale: { hero: 168, body: 36 },
+  radius:    12,
+};
+```
+
+`export` it (rather than plain `const`) so the framework can read the object and inject CSS variables at the canvas root automatically.
+
+The shape is intentionally minimal — it only covers what the Design panel can currently tweak. Anything outside this set (heading sizes, spacing, motion, extra palette colors) belongs as plain hard-coded constants in the slide file.
+
+## Two consumption surfaces
+
+There are **two consumption surfaces**, and you should mix them inside the same slide:
+
+- **`var(--osd-X)` for visual properties (color, font, font-size, radius)** — these get instant updates while the user drags a slider in the Design panel, before any file write.
+  ```tsx
+  <div style={{ background: 'var(--osd-bg)', color: 'var(--osd-text)', borderRadius: 'var(--osd-radius)', fontFamily: 'var(--osd-font-body)', fontSize: 'var(--osd-size-body)' }}>
+  ```
+  Available vars: `--osd-bg`, `--osd-text`, `--osd-accent`, `--osd-font-display`, `--osd-font-body`, `--osd-size-hero`, `--osd-size-body`, `--osd-radius`.
+
+- **Direct `design.X` reads** — when you need a JS number for arithmetic or to label something in the UI. These update via HMR after the panel commits the file, not while dragging.
+  ```tsx
+  <p>{design.typeScale.hero}px</p>
+  ```
+
+## The Design panel
+
+The dev UI has a **Design** button in the slide header (next to Inspect). Edits update an in-memory draft and the live-preview overlay; a floating Save / Discard bar at the bottom of the canvas commits or reverts. The const stays the single source of truth — production builds bake the saved values.
+
+**Default to using it.** Every new slide should declare a `design` const so it stays tweakable from the panel after generation — this is the expected baseline. Only fall back to the local `palette` constants pattern (see the starter template in `SKILL.md`) for a one-off slide whose palette is intentionally locked and not meant to be re-themed. Both styles can coexist across slides — the panel only operates on the *currently viewed* slide.
+
+## Format constraints (for the panel's AST writer)
+
+- Must be `[export] const design: DesignSystem = { … }` (or `as DesignSystem` / `satisfies DesignSystem`) at module top level.
+- Object initializer must be a literal — no spreads, no helper calls. Plain values only.
+- `DesignSystem` must be imported from `@open-slide/core` (the panel adds the import automatically when creating a fresh block).

--- a/packages/core/skills/slide-authoring/references/design-system.md
+++ b/packages/core/skills/slide-authoring/references/design-system.md
@@ -43,6 +43,6 @@ The dev UI has a **Design** button in the slide header (next to Inspect). Edits 
 
 ## Format constraints (for the panel's AST writer)
 
-- Must be `[export] const design: DesignSystem = { … }` (or `as DesignSystem` / `satisfies DesignSystem`) at module top level.
+- Must be `[export] const design: DesignSystem = { … }` (or `as DesignSystem` / `satisfies DesignSystem`) at module top level. The optional `[export]` only describes what the panel's *parser* tolerates — the runtime reads `design` off the module's exports to inject the `--osd-*` vars, so a non-exported const leaves every `var(--osd-X)` unresolved. Always export it.
 - Object initializer must be a literal — no spreads, no helper calls. Plain values only.
 - `DesignSystem` must be imported from `@open-slide/core` (the panel adds the import automatically when creating a fresh block).

--- a/packages/core/skills/slide-authoring/references/morph.md
+++ b/packages/core/skills/slide-authoring/references/morph.md
@@ -8,7 +8,8 @@ When the *same visual object* exists on two adjacent pages, the runtime can morp
 2. Enable `morph` on the incoming page's transition.
 
 ```tsx
-import { MorphElement } from '@open-slide/core';
+import { MorphElement, type Page, type SlideTransition } from '@open-slide/core';
+import type { CSSProperties } from 'react';
 
 // Morph transition — opacity-only enter/exit keeps all the motion on the clones (see rules).
 const morphTransition: SlideTransition = {

--- a/packages/core/skills/slide-authoring/references/morph.md
+++ b/packages/core/skills/slide-authoring/references/morph.md
@@ -1,0 +1,66 @@
+# Morph transitions (`MorphElement`)
+
+> Morph builds on the `SlideTransition` contract — read `transitions.md` first if you haven't.
+
+When the *same visual object* exists on two adjacent pages, the runtime can morph it across the cut — position, size, border-radius, and colors interpolate in one continuous move (Keynote calls this "Magic Move") — instead of fading out and back in. Two parts opt in:
+
+1. Wrap the object on **both** pages in `MorphElement` with the **same `id`**.
+2. Enable `morph` on the incoming page's transition.
+
+```tsx
+import { MorphElement } from '@open-slide/core';
+
+// Morph transition — opacity-only enter/exit keeps all the motion on the clones (see rules).
+const morphTransition: SlideTransition = {
+  duration: 280,
+  exit:  { duration: 224, easing: 'cubic-bezier(0.4, 0, 1, 1)', keyframes: [{ opacity: 1 }, { opacity: 0 }] },
+  enter: { duration: 308, delay: 112, easing: 'cubic-bezier(0, 0, 0.2, 1)', keyframes: [{ opacity: 0 }, { opacity: 1 }] },
+  morph: { duration: 868, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
+};
+
+const stage: CSSProperties = { width: '100%', height: '100%', position: 'relative', background: '#000000', overflow: 'hidden' };
+
+const Narrow: Page = () => (
+  <div style={stage}>
+    <MorphElement id="pill" style={{ position: 'absolute', left: 842, top: 479, width: 236, height: 122, borderRadius: 999, background: '#ffffff' }} />
+  </div>
+);
+const Wide: Page = () => (
+  <div style={stage}>
+    <MorphElement id="pill" style={{ position: 'absolute', left: 721, top: 479, width: 478, height: 122, borderRadius: 999, background: '#0a0a0a' }} />
+  </div>
+);
+
+Wide.transition = morphTransition;   // forward: Narrow → Wide morphs the pill
+Narrow.transition = morphTransition; // backward: Wide → Narrow morphs it back
+```
+
+## Contract
+
+- `morph: true` inherits the transition's top-level `duration`/`easing`; pass `{ duration?, easing?, delay? }` to time the morph independently of the page cross-fade. Morphs usually read best 2–4× longer than the fade (e.g. 280 ms fade, 868 ms morph).
+- Elements pair by `id` across the cut. A matched pair FLIP-morphs: the runtime measures both rects, clones the outgoing element into an overlay above both pages, hides the originals, and animates transform + border-radius + colors (border widths ride a separate frame so they don't stretch with the box). Keep each `id` unique within a page; don't nest one `MorphElement` inside another.
+- An `id` present on only one side fades in/out **in place**. This is how "a third box joins the row" reads: carried boxes glide to their new slots, the new one materializes.
+- Colors on the morph node *and its descendants* interpolate too — a label that flips black → white mid-glide just works.
+- The transition lives on the **incoming** page. For a morph that also plays when stepping backward, assign the same transition object to both pages (as above).
+
+## Rules — each one earned on a real deck
+
+1. **Prefer opacity-only enter/exit on morphing pages.** Any transition family composes correctly with the morph (shared rects are measured before the phases start), but while clones glide, a transform-bearing enter also slides the rest of the page — two competing motions. Giving the clones all the motion and fading everything else is what makes a morph read as one confident gesture.
+2. **Morph geometry must be deterministic at mount.** Rects are snapshotted once at the cut. Position morph elements with pixel constants — never with a value measured in an effect after mount (the re-render shifts the target mid-morph and the move jumps). If text inside a morph box grows over time (typewriter etc.), render a hidden full-width spacer so the measured box never changes size.
+3. **No `transform` on the morph node itself.** A percentage translate (`translate(-50%, -50%)`) gets mis-scaled by the morph and lands the clone tens of px off. Put centering/positioning transforms on a plain wrapper `<div>` *around* the `MorphElement`.
+4. **`MorphElement` merges `className`/`style` onto its single host child** (it adds no wrapper when the child is a lone DOM element). A crop box (`overflow: hidden` + fixed width) therefore needs an explicit nested `<div>` — otherwise the box collapses onto the `<img>` inside and squishes it.
+5. **Gate entrance animations behind `useIsActivePage()`.** During the cut the runtime mounts a *fresh instance* of the outgoing page to snapshot its exit state (and the dev UI mounts every page for thumbnails/overview). If an intro replays there, the snapshot is mid-animation and the morph starts from garbage. The hook returns `true` only for the instance the audience is watching; every other instance (outgoing snapshot, thumbnails, overview, presenter preview, print) should render the final, settled state — no intro, full text.
+
+   ```tsx
+   import { useIsActivePage } from '@open-slide/core';
+
+   // Inside the page component:
+   const animate = useIsActivePage();
+   ```
+
+6. **Clones travel above everything.** The morph overlay sits over both pages, so an incoming element that should appear only when a clone "lands" will otherwise pop early. Give such reveals a delay equal to the morph: `animation: 'osd-fade 0.63s ease-out 0.868s both'` where `0.868s` is `morph.duration`. Keep that number in one shared const so the two can't drift.
+7. **A "hold" page is a separate component.** Transitions attach to the incoming page, so to follow a morph cut with a plain cut of the same content, mint a second page component without `.transition` (e.g. `const Flow4Hold: Page = () => <Flow count={4} />`).
+
+## When to reach for it
+
+Morph is for **state continuity**: a toggle whose thumb slides to the next option, a card that expands into a detail view, a logo that glides from center stage into the next page's diagram, a row that gains one more box. The object *is the story* across the cut. Don't morph decoration, and don't tag elements "just in case" — every morph id is a promise to the audience that it's the same object. One or two morphing sequences per chapter is plenty; the surrounding pages should cut or fade quietly.

--- a/packages/core/skills/slide-authoring/references/page-numbers.md
+++ b/packages/core/skills/slide-authoring/references/page-numbers.md
@@ -1,0 +1,16 @@
+# Page numbers (`useSlidePageNumber`)
+
+If a footer shows the current page (`03 / 12`, `Page 3`, etc.), read it from `useSlidePageNumber()` — **never hardcode** `n` / `TOTAL`. Inserting, reordering, or deleting a page would otherwise force you to retouch every footer.
+
+```tsx
+import { useSlidePageNumber } from '@open-slide/core';
+
+const Footer = () => {
+  const { current, total } = useSlidePageNumber();
+  return (
+    <span>{String(current).padStart(2, '0')} / {String(total).padStart(2, '0')}</span>
+  );
+};
+```
+
+`current` is 1-indexed (matches what readers see) and `total` is the slide's page count. The hook works in every render context (main viewer, thumbnails, overview grid, present mode, presenter window, HTML/PDF export) — the same `<Footer />` JSX is correct everywhere. Call the hook inside a component that's used **per page**; don't try to call it at module top level.

--- a/packages/core/skills/slide-authoring/references/steps.md
+++ b/packages/core/skills/slide-authoring/references/steps.md
@@ -1,0 +1,43 @@
+# Stepped reveals (`<Steps>` / `<Step>`)
+
+Reveal a page one beat at a time instead of showing everything at once. Wrap the deferred parts in `<Step>`, wrap the group in `<Steps>`. Each `→` reveals the next `<Step>`; `→` after the last one advances to the next page. `←` peels the last reveal back. Use it to stage attention — show framing first, then the consequence, then the turn — so the audience reads at the speaker's pace, not ahead.
+
+`slides/build-on-reveal/` is the canonical worked example; study it before authoring a stepped page.
+
+```tsx
+import { Step, Steps } from '@open-slide/core';
+
+<Steps>
+  <Step><div style={BULLET_ROW}>An audience reads faster than a presenter speaks.</div></Step>
+  <Step><div style={BULLET_ROW}>Showing every bullet at once invites pre-reading.</div></Step>
+  <Step><div style={BULLET_ROW}>Revealing in time stages attention.</div></Step>
+</Steps>
+```
+
+## Rules
+
+- **`<Step>` must be a *direct* child of `<Steps>`.** A `<Step>` nested deeper (or used without a `<Steps>` parent) renders fully revealed and defers nothing.
+- **Non-`Step` children render immediately.** Put a headline or intro paragraph *inside* `<Steps>` as a plain element and it shows from the start; only the `<Step>` blocks wait. This is the "headline always, body in turn" pattern:
+  ```tsx
+  <Steps>
+    <h2>Not everything has to wait.</h2>{/* visible immediately */}
+    <Step><p>First, set the stage…</p></Step>
+    <Step><p>Then, layer the consequence…</p></Step>
+  </Steps>
+  ```
+- **Multiple `<Steps>` blocks on one page compose in document order.** The first block reveals all its steps before the second begins; `←` unwinds in reverse. Use this for two columns that build left-then-right, each column owning its own `<Steps>`:
+  ```tsx
+  <div style={COL}><Steps><Step>…</Step><Step>…</Step></Steps></div>{/* finishes first */}
+  <div style={COL}><Steps><Step>…</Step><Step>…</Step></Steps></div>{/* then this */}
+  ```
+- **Entry direction decides the starting state — same content, two rhythms.** Entering forward (`→` from the previous page) starts empty and builds up. Jumping in via the overview grid, or arriving backward from a later page, shows the page **fully composed** with every step already revealed. Design the page to read well both ways: a thumbnail or overview jump should look complete, not blank.
+- **`<Step>` fades in over `duration` ms (default 180).** Pass `<Step duration={...}>` to adjust. `prefers-reduced-motion: reduce` collapses it to an instant cut automatically — don't write a fallback.
+
+## When to reach for it
+
+Use stepped reveals when the *order* of ideas is the point — a list whose payoff is the last item, a build-up to a conclusion, a before/after. Don't wrap every page's content in `<Step>` reflexively: a page the audience should take in at a glance (a hero title, a single quote, a diagram) is stronger shown whole. Reveals are timing, not decoration — same restraint as transitions.
+
+## Anti-patterns
+
+- ❌ Wrapping every page's content in `<Step>` reflexively. Stepped reveals are for content whose *order* is the point; a glance-and-get-it page (hero title, single quote, diagram) is stronger shown whole.
+- ❌ A `<Step>` that isn't a direct child of `<Steps>` (nested deeper, or with no `<Steps>` parent). It renders fully revealed and defers nothing — the reveal silently does nothing.

--- a/packages/core/skills/slide-authoring/references/transitions.md
+++ b/packages/core/skills/slide-authoring/references/transitions.md
@@ -37,6 +37,12 @@ type SlideTransition = {
   easing?: string;           // top-level fallback
   enter?: TransitionPhase;   // runs on incoming page
   exit?:  TransitionPhase;   // runs on outgoing page
+  morph?: boolean | MorphTransition;  // shared-element morph — see morph.md
+};
+type MorphTransition = {
+  duration?: number;
+  easing?: string;
+  delay?: number;
 };
 ```
 

--- a/packages/core/skills/slide-authoring/references/transitions.md
+++ b/packages/core/skills/slide-authoring/references/transitions.md
@@ -1,0 +1,169 @@
+# Page transitions (`SlideTransition`)
+
+The framework can run an enter/exit animation between every slide change. There's **no default** — pages snap unless you declare a `SlideTransition`. Snap-swap is a perfectly tasteful default; only opt in when motion adds something.
+
+`prefers-reduced-motion: reduce` is honored automatically. You don't write a fallback.
+
+(For morphing a shared element across two pages — Keynote's "Magic Move" — see `morph.md`, which builds on the contract here.)
+
+## Contract
+
+Module-level for the whole deck; per-page to override. The **incoming page wins**: navigating A → B uses `pages[B].transition ?? module.transition`. Its `exit` plays on A, its `enter` plays on B. Going back B → A uses A's transition.
+
+```tsx
+import type { Page, SlideTransition } from '@open-slide/core';
+
+const Cover: Page = () => <section>…</section>;
+const Body:  Page = () => <section>…</section>;
+
+// Module-level default — every page inherits unless it overrides.
+export const transition: SlideTransition = { /* … */ };
+
+// Per-page override.
+Cover.transition = { /* … */ };
+
+export default [Cover, Body];
+```
+
+```ts
+type TransitionPhase = {
+  keyframes: Keyframe[] | PropertyIndexedKeyframes;  // WAAPI keyframes
+  duration?: number;  // ms (falls back to top-level duration)
+  easing?: string;    // CSS easing
+  delay?: number;     // ms — use to overlap exit + enter
+};
+type SlideTransition = {
+  duration: number;          // top-level fallback
+  easing?: string;           // top-level fallback
+  enter?: TransitionPhase;   // runs on incoming page
+  exit?:  TransitionPhase;   // runs on outgoing page
+};
+```
+
+The framework also exposes `--osd-dir` (`1` forward, `-1` backward) and `data-osd-dir` on the wrapper, so a single keyframe can mirror direction without a JS callback.
+
+## Design principles (hold the line)
+
+The single loudest signal of "made in PowerPoint" is six different transitions in one deck. Restraint is the rhythm.
+
+- **Pick one DNA, hold it across the deck.** Same duration band, same easing pair, same out-then-in stagger. Variation lives only in *which property* gets the small nudge — Y, X, opacity, scale, blur.
+- **Duration: 140–280 ms.** Exit 140–180 ms, enter 200–280 ms, enter delayed ~80 ms so they overlap but don't fight. Past 350 ms is video-editor territory; reserve for genuine state changes.
+- **Magnitude ceiling: 12 px or 3% scale.** A 6 px Y-rise reads as "next thought." A 1920 px translateX reads as "different document." Premium tools move barely enough to register.
+- **Opacity is always part of it.** Pure-transform transitions look stiff; pure-opacity transitions are the safest possible default.
+- **Easing: ease-in for exit, ease-out for enter.** `cubic-bezier(0.4, 0, 1, 1)` going out, `cubic-bezier(0, 0, 0.2, 1)` coming in. Never `linear` (feels like a slideshow). Reserve symmetric `ease-in-out` for state-anchored morphs only.
+
+## Tasteful family — six members, one DNA
+
+Use this set as a starting point. Pick one as the deck's house transition; optionally reserve a second for hero/cover slides and a third for genuine section breaks. The CSS-`calc` + `--osd-dir` trick lets a single definition mirror itself on backward navigation when needed.
+
+```tsx
+const EASE_OUT = 'cubic-bezier(0, 0, 0.2, 1)';
+const EASE_IN  = 'cubic-bezier(0.4, 0, 1, 1)';
+
+// RISE — house quiet. 6 px Y. Use as module default.
+export const transition: SlideTransition = {
+  duration: 200,
+  exit:  { duration: 140, easing: EASE_IN,
+           keyframes: [
+             { opacity: 1, transform: 'translateY(0)' },
+             { opacity: 0, transform: 'translateY(-4px)' },
+           ] },
+  enter: { duration: 200, delay: 80, easing: EASE_OUT,
+           keyframes: [
+             { opacity: 0, transform: 'translateY(6px)' },
+             { opacity: 1, transform: 'translateY(0)' },
+           ] },
+};
+
+// DISSOLVE — pure opacity. The quietest possible.
+const dissolve: SlideTransition = {
+  duration: 240,
+  exit:  { duration: 200, easing: EASE_IN,
+           keyframes: [{ opacity: 1 }, { opacity: 0 }] },
+  enter: { duration: 240, delay: 40, easing: EASE_OUT,
+           keyframes: [{ opacity: 0 }, { opacity: 1 }] },
+};
+
+// SETTLE — cover-grade. Rise + a hair of blur on enter only.
+Cover.transition = {
+  duration: 280,
+  exit:  { duration: 160, easing: EASE_IN,
+           keyframes: [
+             { opacity: 1, transform: 'translateY(0)' },
+             { opacity: 0, transform: 'translateY(-6px)' },
+           ] },
+  enter: { duration: 280, delay: 100, easing: EASE_OUT,
+           keyframes: [
+             { opacity: 0, transform: 'translateY(12px)', filter: 'blur(4px)' },
+             { opacity: 1, transform: 'translateY(0)',    filter: 'blur(0)'   },
+           ] },
+};
+
+// BLOOM — scale 0.97 → 1, no translate. Materializes in place.
+const bloom: SlideTransition = {
+  duration: 240,
+  exit:  { duration: 160, easing: EASE_IN,
+           keyframes: [
+             { opacity: 1, transform: 'scale(1)' },
+             { opacity: 0, transform: 'scale(1.01)' },
+           ] },
+  enter: { duration: 240, delay: 80, easing: EASE_OUT,
+           keyframes: [
+             { opacity: 0, transform: 'scale(0.97)' },
+             { opacity: 1, transform: 'scale(1)' },
+           ] },
+};
+
+// FALL — mirrored Rise. Incoming page comes down from above.
+const fall: SlideTransition = {
+  duration: 200,
+  exit:  { duration: 140, easing: EASE_IN,
+           keyframes: [
+             { opacity: 1, transform: 'translateY(0)' },
+             { opacity: 0, transform: 'translateY(4px)' },
+           ] },
+  enter: { duration: 200, delay: 80, easing: EASE_OUT,
+           keyframes: [
+             { opacity: 0, transform: 'translateY(-6px)' },
+             { opacity: 1, transform: 'translateY(0)' },
+           ] },
+};
+
+// BREATH — section break. Exit fully, hold 120 ms, then enter.
+// Reserve for genuine chapter dividers; use at most 1–2× per deck.
+const breath: SlideTransition = {
+  duration: 460,
+  exit:  { duration: 180, easing: EASE_IN,
+           keyframes: [{ opacity: 1 }, { opacity: 0 }] },
+  enter: { duration: 240, delay: 300, easing: EASE_OUT,
+           keyframes: [
+             { opacity: 0, transform: 'translateY(8px)' },
+             { opacity: 1, transform: 'translateY(0)' },
+           ] },
+};
+```
+
+All six share the same DNA — they only differ in which property carries the small nudge. The reader perceives variety; the eye still reads one consistent hand.
+
+## Direction-aware keyframes (use sparingly)
+
+Most tasteful tools don't mirror on backward navigation. When you genuinely need to — e.g. a horizontal slide that should reverse — use `--osd-dir` inside `calc()`:
+
+```tsx
+{ transform: 'translateX(calc(var(--osd-dir, 1) * 8px))' },
+{ transform: 'translateX(0)' },
+```
+
+If you find yourself reaching for this on every transition, you're probably over-designing. Forward = backward is the more refined default.
+
+## Anti-patterns
+
+- ❌ Six different transitions across six pages — the single loudest "made in PowerPoint" tell.
+- ❌ `translateX(100%)` slide-from-side — iOS modal / PowerPoint Push; not a slide change.
+- ❌ Aggressive scale-pop (e.g. `0.85 → 1`) + blur — lightbox / photo-viewer vocabulary; implies zooming *into* something.
+- ❌ `clip-path: inset(…)` reveals — After Effects vocabulary; theatrical.
+- ❌ Parallel blur on both layers at once — visual mush; the eye can't fixate.
+- ❌ Duration > 350 ms for a standard slide change — drags.
+- ❌ Translate > 12 px or scale > 3% — reads as rupture, not continuity.
+- ❌ `linear` easing — feels like a slideshow, not a product.
+- ❌ Declaring a transition on every deck. **If you don't have a clear reason, omit it.** Snap-swap is fine.

--- a/packages/core/skills/slide-authoring/references/webfonts.md
+++ b/packages/core/skills/slide-authoring/references/webfonts.md
@@ -2,13 +2,14 @@
 
 The default is a system font stack — prefer it. When a deck genuinely needs a webfont (a brand font, or CJK / Thai / Arabic where system coverage is poor):
 
-- **Load the stylesheet once, in `<head>` — never inside a per-page component.** Every page is mounted live at the same time (thumbnail rail, overview grid, and the PDF print root), so a `<style>@import</style>` / `<link>` rendered inside a `Page` registers the whole `@font-face` set once *per page*. Inject it once, idempotently:
+- **Load the stylesheet once, in `<head>` — never inside a per-page component.** Every page is mounted live at the same time (thumbnail rail, overview grid, and the PDF print root), so a `<style>@import</style>` / `<link>` rendered inside a `Page` registers the whole `@font-face` set once *per page*. Inject it once, idempotently. **Key the element id to the slide** (e.g. `osd-webfont-<slide-id>`) — the home page mounts pages from *every* slide at once, so a generic shared id like `osd-webfont` would let the first slide's fonts suppress every other slide's:
 
   ```tsx
   const FONT_HREF = 'https://fonts.googleapis.com/css2?family=...&display=swap';
-  if (typeof document !== 'undefined' && !document.getElementById('osd-webfont')) {
+  const FONT_LINK_ID = 'osd-webfont-q2-roadmap'; // suffix = this slide's folder id
+  if (typeof document !== 'undefined' && !document.getElementById(FONT_LINK_ID)) {
     const link = document.createElement('link');
-    link.id = 'osd-webfont';
+    link.id = FONT_LINK_ID;
     link.rel = 'stylesheet';
     link.href = FONT_HREF;
     document.head.appendChild(link);

--- a/packages/core/skills/slide-authoring/references/webfonts.md
+++ b/packages/core/skills/slide-authoring/references/webfonts.md
@@ -1,0 +1,19 @@
+# Webfonts
+
+The default is a system font stack — prefer it. When a deck genuinely needs a webfont (a brand font, or CJK / Thai / Arabic where system coverage is poor):
+
+- **Load the stylesheet once, in `<head>` — never inside a per-page component.** Every page is mounted live at the same time (thumbnail rail, overview grid, and the PDF print root), so a `<style>@import</style>` / `<link>` rendered inside a `Page` registers the whole `@font-face` set once *per page*. Inject it once, idempotently:
+
+  ```tsx
+  const FONT_HREF = 'https://fonts.googleapis.com/css2?family=...&display=swap';
+  if (typeof document !== 'undefined' && !document.getElementById('osd-webfont')) {
+    const link = document.createElement('link');
+    link.id = 'osd-webfont';
+    link.rel = 'stylesheet';
+    link.href = FONT_HREF;
+    document.head.appendChild(link);
+  }
+  ```
+
+- **List only the weights you actually use.** Each extra weight multiplies the number of `@font-face` rules.
+- **CJK fonts are large.** A Google Fonts CJK family registers hundreds of `unicode-range` subset faces (Noto Sans TC ≈ 105 subsets × each weight), and PDF export waits on fonts before printing. If the deck's text is fixed, add `&text=<unique chars>` to the URL to request a tiny single-face subset instead of the full set.


### PR DESCRIPTION
## What changed

The `slide-authoring` SKILL.md had grown to ~690 lines. This splits each framework primitive's documentation into a dedicated file under `references/`, keeping SKILL.md to the always-on core plus a short summary and pointer per primitive:

| Reference | Covers |
| --- | --- |
| `references/design-system.md` | `design` const, `var(--osd-X)` tokens, Design panel, AST-writer format constraints |
| `references/assets.md` | slide-local / `@assets` imports, `<ImagePlaceholder>` usage rules |
| `references/webfonts.md` | one-shot stylesheet injection, CJK subsetting |
| `references/page-numbers.md` | `useSlidePageNumber()` |
| `references/steps.md` | `<Steps>` / `<Step>` rules and timing |
| `references/transitions.md` | `SlideTransition` contract, tasteful family, anti-patterns |
| `references/morph.md` | `MorphElement` contract and the seven morph rules |

SKILL.md retains the hard rules, file contract, canvas/vertical-budget math, visual direction, starter template, repeated-elements rule, and the full self-review checklist, plus an index table mapping each primitive to its reference file.

## Why

- Progressive disclosure: most slide edits touch one or two primitives; loading 200 lines of transition docs for a text tweak wastes context.
- Each primitive now has room to grow richer examples and details in its own file without bloating the always-loaded SKILL.md.

## Notes for review

- Content was moved verbatim, not rewritten — the diff is large but mechanical.
- Each primitive's most load-bearing rule stays inline in SKILL.md (e.g. `<Step>` must be a direct child, page numbers never hardcoded, no default transition), so an agent that skips the reference still avoids the worst failure modes.
- Section headings cross-referenced by other skills (`Design system`, `Image placeholders`, `Self-review before finishing`) are preserved.
- `packages/cli/template` was re-mirrored via `sync-template-skills.mjs`; `diff -rq` against `packages/core/skills` is clean.
- Changeset included: patch for `@open-slide/core` and `@open-slide/cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Slide authoring guidance is reorganized into dedicated per-primitive reference topics (design system, assets/image placeholders, webfonts, page numbers, stepped reveals, transitions, and morph effects), with the main guide streamlined and cross-linked.
  * Added clearer authoring rules and “anti-patterns” for each primitive, including morph continuity guidance and transition behavior/timing expectations.

* **Chores**
  * Released patch versions of the core and CLI.
  * Updated authoring metadata to reflect the split reference layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->