### PR TITLE
feat(core): add allowedHosts to open-slide.config.ts

### DIFF
--- a/.changeset/allowed-hosts-config.md
+++ b/.changeset/allowed-hosts-config.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Add `allowedHosts` to `open-slide.config.ts` so proxied domains (Coder, Codespaces, reverse proxies) can reach the dev and preview servers.

--- a/apps/web/content/docs/cli/dev.mdx
+++ b/apps/web/content/docs/cli/dev.mdx
@@ -49,3 +49,8 @@ const config: OpenSlideConfig = {
 
 export default config;
 ```
+
+Accessing the dev server through a proxied domain (Coder, Codespaces, a
+reverse proxy) and hitting `Blocked request. This host is not allowed.`?
+Set [`allowedHosts`](/docs/reference/config#remote-ide--proxied-dev-server)
+in the config.

--- a/apps/web/content/docs/reference/config.mdx
+++ b/apps/web/content/docs/reference/config.mdx
@@ -43,6 +43,11 @@ export default config;
       default: 'first free port from 5173 upward',
       description: 'Dev server port.',
     },
+    allowedHosts: {
+      type: 'string[] | true',
+      default: "Vite's default host check",
+      description: 'Hostnames the dev/preview server responds to. `true` allows any host.',
+    },
     build: {
       type: 'OpenSlideBuildConfig',
       default: 'all toggles on',
@@ -103,6 +108,25 @@ const config: OpenSlideConfig = {
 
 The value is passed straight to Vite's `base` and to React Router's
 `basename`, so client-side navigation matches the deployed path.
+
+### Remote IDE / proxied dev server
+
+Cloud workspaces (Coder, Codespaces, Gitpod, …) reach the dev server through
+a generated domain, so Vite blocks the request with
+`Blocked request. This host (…) is not allowed.` Allow your workspace domain
+— a leading dot matches every subdomain:
+
+```ts
+const config: OpenSlideConfig = {
+  allowedHosts: ['.my-workspace.example.com'],
+};
+```
+
+Or set `allowedHosts: true` to accept any host. Only do this on a trusted
+network — it disables Vite's DNS-rebinding protection. The value is passed
+straight to Vite's
+[`server.allowedHosts`](https://vite.dev/config/server-options#server-allowedhosts)
+and also applies to `open-slide preview`.
 
 ### Organizing many decks
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -12,6 +12,7 @@ export type OpenSlideConfig = {
   themesDir?: string;
   assetsDir?: string;
   port?: number;
+  allowedHosts?: string[] | true;
   /**
    * @deprecated Pick the UI language from the language switcher in the slide UI
    * instead. When set, this only seeds the initial language until the user

--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -113,6 +113,7 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
     },
     server: {
       port: config.port ?? 5173,
+      ...(config.allowedHosts !== undefined ? { allowedHosts: config.allowedHosts } : {}),
       fs: { allow: [APP_ROOT, userCwd, slidesAbs, themesAbs, assetsAbs] },
     },
     build: {


### PR DESCRIPTION
Closes #334

## What

Adds `allowedHosts` to `open-slide.config.ts`, passed straight to Vite's `server.allowedHosts`:

```ts
const config: OpenSlideConfig = {
  allowedHosts: ['.my-workspace.example.com'], // or `true` to allow any host
};
```

Remote IDEs (Coder, Codespaces, Gitpod, …) reach the dev server through a generated proxy domain, and Vite blocks those requests with `Blocked request. This host is not allowed.` Since open-slide owns the Vite config, users had no way to allow their domain.

## Why a config field instead of the proposed CLI flag

The issue proposed `--allow-all-hosts`. A config field covers the same need with two upsides: the workspace domain is a property of the environment, so it belongs in the config rather than on every invocation, and `string[]` lets users allow just their own domain instead of disabling host checking entirely (`true` still works for that). Happy to add the flag on top if you'd prefer both.

No change when the field is unset — Vite's default protection stays as is. `open-slide preview` picks it up too, since Vite's `preview.allowedHosts` defaults to `server.allowedHosts`.

Docs updated: schema + a "Remote IDE / proxied dev server" recipe in the config reference, and a pointer from the `dev` CLI page.

## Testing

Verified end-to-end against the demo app (curl with a spoofed `Host` header):

| Config | Coder-style host | Other host | localhost |
| --- | --- | --- | --- |
| unset (baseline) | 403 Blocked | 403 | 200 |
| `allowedHosts: true` | 200 | 200 | 200 |
| `allowedHosts: ['.domain.tld']` | 200 | 403 | 200 |

`pnpm typecheck`, `pnpm check`, and `pnpm test` (305 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `allowedHosts` configuration for development and preview servers.
  * Supports specifying permitted hostnames or allowing all hosts.
  * Improved compatibility with reverse proxies and remote development environments.

* **Documentation**
  * Added guidance for resolving blocked-host errors.
  * Included examples for hostname patterns and unrestricted host access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->