### PR TITLE
feat(web): elevate landing page with engineered-grid visual system

### DIFF
--- a/apps/web/app/(home)/landing.css
+++ b/apps/web/app/(home)/landing.css
@@ -85,6 +85,64 @@ html.dark .os-landing {
   background: var(--color-rule);
 }
 
+/* Shared frame width — the page-long vertical rails and every crosshair
+   marker align to this box, so all the "engineering grid" lines meet. */
+.os-landing .frame-w {
+  width: min(100% - 40px, 1360px);
+  margin-inline: auto;
+}
+
+.os-landing .stripes {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    var(--color-rule-soft) 0,
+    var(--color-rule-soft) 1px,
+    transparent 1px,
+    transparent 9px
+  );
+}
+
+.os-landing .dot-grid {
+  background-image: radial-gradient(
+    color-mix(in oklab, var(--color-text) 16%, transparent) 1px,
+    transparent 1.5px
+  );
+  background-size: 24px 24px;
+  -webkit-mask-image: radial-gradient(110% 84% at 50% 0%, #000 0%, transparent 70%);
+  mask-image: radial-gradient(110% 84% at 50% 0%, #000 0%, transparent 70%);
+}
+
+.os-landing .bloom {
+  background: radial-gradient(
+    56% 44% at 66% -12%,
+    color-mix(in oklab, var(--color-accent) 7%, transparent),
+    transparent 70%
+  );
+}
+html.dark .os-landing .bloom {
+  background: radial-gradient(
+    56% 44% at 66% -12%,
+    color-mix(in oklab, var(--color-accent) 11%, transparent),
+    transparent 70%
+  );
+}
+
+@supports (background-clip: text) or (-webkit-background-clip: text) {
+  .os-landing .text-sheen {
+    background-image: linear-gradient(
+      180deg,
+      var(--color-text) 45%,
+      color-mix(in oklab, var(--color-text) 62%, transparent)
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+  .os-landing .text-sheen .accent-fill {
+    -webkit-text-fill-color: var(--color-accent);
+  }
+}
+
 .os-landing .edge {
   box-shadow: var(--shadow-edge);
 }

--- a/apps/web/app/(home)/layout.tsx
+++ b/apps/web/app/(home)/layout.tsx
@@ -1,5 +1,12 @@
 import './landing.css';
 
 export default function Layout({ children }: LayoutProps<'/'>) {
-  return <div className="os-landing flex-1 flex flex-col">{children}</div>;
+  return (
+    <div className="os-landing relative flex-1 flex flex-col">
+      <div aria-hidden className="pointer-events-none absolute inset-0 hidden sm:block">
+        <div className="frame-w h-full border-x border-[color:var(--color-rule-soft)]" />
+      </div>
+      {children}
+    </div>
+  );
 }

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -3,6 +3,7 @@ import { Anatomy } from '@/components/landing/anatomy';
 import { Assets } from '@/components/landing/assets';
 import { FAQ, faqs } from '@/components/landing/faq';
 import { Footer } from '@/components/landing/footer';
+import { StripeBand } from '@/components/landing/frame';
 import { GetStarted } from '@/components/landing/get-started';
 import { Hero } from '@/components/landing/hero';
 import { HowItWorks } from '@/components/landing/how-it-works';
@@ -120,12 +121,14 @@ export default async function HomePage() {
       <main className="relative flex-1">
         <Hero />
         <LiveDemo />
+        <StripeBand />
         <HowItWorks />
         <Anatomy />
         <Inspector />
         <Assets />
         <Agents />
         <FAQ />
+        <StripeBand />
         <GetStarted />
       </main>
       <Footer />

--- a/apps/web/components/landing/agents.tsx
+++ b/apps/web/components/landing/agents.tsx
@@ -21,7 +21,7 @@ export function Agents() {
 
   return (
     <section id="agents" className="relative overflow-hidden">
-      <div className="border-y border-[color:var(--color-rule)] bg-[color:var(--color-panel)]">
+      <div className="border-t border-[color:var(--color-rule)] bg-[color:var(--color-panel)]">
         <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-10 sm:py-12">
           <h2 className="font-[family-name:var(--font-sans)] text-[18px] sm:text-[20px] text-[color:var(--color-text-soft)] font-normal">
             Bring your own agent. Anything that edits React works.

--- a/apps/web/components/landing/anatomy.tsx
+++ b/apps/web/components/landing/anatomy.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { SectionRule } from './frame';
 
 type Variant = {
   word: string;
@@ -67,6 +68,7 @@ export function Anatomy() {
 
   return (
     <section id="anatomy" className="relative">
+      <SectionRule />
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
         <h2 className="text-[32px] sm:text-[44px] lg:text-[60px] leading-[1.1] sm:leading-[1.05] tracking-[-0.035em] font-medium max-w-[820px] mb-14 sm:mb-20">
           A slide is a file.

--- a/apps/web/components/landing/assets.tsx
+++ b/apps/web/components/landing/assets.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { SectionRule } from './frame';
 
 type AssetMock = { name: string; size: string; logo: string; themed?: boolean };
 
@@ -50,7 +51,7 @@ const callouts: { eyebrow: string; title: string; body: ReactNode }[] = [
 export function Assets() {
   return (
     <section id="assets" className="relative">
-      <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-[color:var(--color-rule)]" />
+      <SectionRule />
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
         <h2 className="text-[32px] sm:text-[44px] lg:text-[60px] leading-[1.1] sm:leading-[1.05] tracking-[-0.035em] font-medium max-w-[820px] mb-14 sm:mb-20">
           Drop in images.

--- a/apps/web/components/landing/faq.tsx
+++ b/apps/web/components/landing/faq.tsx
@@ -1,4 +1,5 @@
 import { FaqItem } from './faq-item';
+import { SectionRule } from './frame';
 
 export type QA = { q: string; a: string };
 
@@ -32,7 +33,7 @@ export const faqs: QA[] = [
 export function FAQ() {
   return (
     <section id="faq" className="relative">
-      <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-[color:var(--color-rule)]" />
+      <SectionRule />
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
         <h2 className="text-[32px] sm:text-[44px] lg:text-[60px] leading-[1.1] sm:leading-[1.05] tracking-[-0.035em] font-medium max-w-[820px] mb-14 sm:mb-20">
           Questions, <span className="text-[color:var(--color-muted)]">answered.</span>

--- a/apps/web/components/landing/frame.tsx
+++ b/apps/web/components/landing/frame.tsx
@@ -1,0 +1,28 @@
+export function SectionRule() {
+  return (
+    <div aria-hidden className="pointer-events-none absolute inset-x-0 top-0 z-[1]">
+      <div className="hair" />
+      <div className="frame-w relative hidden sm:block">
+        <CrossMark className="absolute -top-[6px] -left-[5px]" />
+        <CrossMark className="absolute -top-[6px] -right-[5px]" />
+      </div>
+    </div>
+  );
+}
+
+export function StripeBand() {
+  return (
+    <div
+      aria-hidden
+      className="stripes h-10 border-y border-[color:var(--color-rule-soft)] sm:h-14"
+    />
+  );
+}
+
+function CrossMark({ className }: { className?: string }) {
+  return (
+    <svg aria-hidden width="11" height="11" viewBox="0 0 11 11" fill="none" className={className}>
+      <path d="M5.5 0v11M0 5.5h11" stroke="var(--color-dim)" strokeWidth="1" />
+    </svg>
+  );
+}

--- a/apps/web/components/landing/get-started.tsx
+++ b/apps/web/components/landing/get-started.tsx
@@ -1,15 +1,18 @@
+import Link from 'next/link';
 import { CopyCommand } from './copy-command';
 
 export function GetStarted() {
   return (
     <section id="install" className="relative overflow-hidden">
-      <div aria-hidden className="hair absolute inset-x-0 top-0" />
+      <div aria-hidden className="bloom absolute inset-0" />
       <div className="relative mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-24 sm:py-36 lg:py-48">
         <div className="flex flex-col gap-10 sm:gap-14 max-w-[820px]">
-          <h2 className="text-[36px] sm:text-[52px] lg:text-[76px] leading-[1.05] sm:leading-[1.0] tracking-[-0.04em] font-medium">
+          <h2 className="text-sheen text-[36px] sm:text-[52px] lg:text-[76px] leading-[1.05] sm:leading-[1.0] tracking-[-0.04em] font-medium">
             Author a deck
             <br />
-            <span className="text-[color:var(--color-accent)]">in the next minute.</span>
+            <span className="accent-fill text-[color:var(--color-accent)]">
+              in the next minute.
+            </span>
           </h2>
 
           <p className="max-w-[560px] text-[18px] leading-[1.65] text-[color:var(--color-text-soft)]">
@@ -18,6 +21,18 @@ export function GetStarted() {
 
           <div className="flex flex-wrap items-center gap-4">
             <CopyCommand command="npx @open-slide/cli init" />
+            <Link
+              href="/docs"
+              className="group inline-flex h-[48px] sm:h-[52px] items-center gap-2 px-2 text-[14px] font-medium text-[color:var(--color-muted)] transition-colors hover:text-[color:var(--color-text)]"
+            >
+              Read the docs
+              <span
+                aria-hidden
+                className="transition-transform duration-200 group-hover:translate-x-0.5"
+              >
+                →
+              </span>
+            </Link>
           </div>
         </div>
       </div>

--- a/apps/web/components/landing/hero.tsx
+++ b/apps/web/components/landing/hero.tsx
@@ -3,28 +3,52 @@ import { HeroSetup } from './hero-setup';
 export function Hero() {
   return (
     <section className="relative overflow-hidden">
-      <div aria-hidden className="hair absolute inset-x-0 top-0" />
+      <div aria-hidden className="dot-grid absolute inset-0" />
+      <div aria-hidden className="bloom absolute inset-0" />
 
-      <div className="relative mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 pt-20 sm:pt-32 lg:pt-44 pb-20 sm:pb-32">
+      <div className="relative mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 pt-16 sm:pt-24 lg:pt-32 pb-20 sm:pb-32">
         <div className="flex flex-col gap-10 sm:gap-14 max-w-[920px]">
-          <h1
-            className="text-[42px] sm:text-[68px] lg:text-[92px] leading-[1.05] sm:leading-[1.0] tracking-[-0.045em] font-medium text-[color:var(--color-text)] rise"
-            style={{ animationDelay: '80ms' }}
-          >
-            The slide framework
-            <br />
-            built for <span className="text-[color:var(--color-accent)]">agents</span>.
-          </h1>
+          <div className="flex flex-col items-start gap-6 sm:gap-8">
+            <a
+              href="https://github.com/1weiho/open-slide"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group inline-flex items-center gap-2.5 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)]/70 py-1.5 pl-3.5 pr-3 text-[13px] font-medium text-[color:var(--color-text-soft)] backdrop-blur transition-colors hover:border-[color:var(--color-dim)] hover:text-[color:var(--color-text)] rise"
+              style={{ animationDelay: '40ms' }}
+            >
+              <span
+                aria-hidden
+                className="h-1.5 w-1.5 rounded-full bg-[color:var(--color-accent)]"
+              />
+              Open source, MIT licensed
+              <span
+                aria-hidden
+                className="text-[color:var(--color-muted)] transition-transform duration-200 group-hover:translate-x-0.5"
+              >
+                →
+              </span>
+            </a>
+
+            <h1
+              className="text-sheen text-[42px] sm:text-[68px] lg:text-[92px] leading-[1.05] sm:leading-[1.0] tracking-[-0.045em] font-medium text-[color:var(--color-text)] rise"
+              style={{ animationDelay: '120ms' }}
+            >
+              The slide framework
+              <br />
+              built for <span className="accent-fill text-[color:var(--color-accent)]">agents</span>
+              .
+            </h1>
+          </div>
 
           <p
             className="max-w-[600px] text-[18px] sm:text-[20px] leading-[1.6] text-[color:var(--color-text-soft)] rise"
-            style={{ animationDelay: '200ms' }}
+            style={{ animationDelay: '240ms' }}
           >
             A React-first slide framework. Every page is arbitrary code on a 1920×1080 canvas. No
             layout to fight. Design anything you can imagine.
           </p>
 
-          <div className="w-full rise" style={{ animationDelay: '320ms' }}>
+          <div className="w-full rise" style={{ animationDelay: '360ms' }}>
             <HeroSetup />
           </div>
         </div>

--- a/apps/web/components/landing/hero.tsx
+++ b/apps/web/components/landing/hero.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { HeroSetup } from './hero-setup';
 
 export function Hero() {
@@ -9,10 +10,8 @@ export function Hero() {
       <div className="relative mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 pt-16 sm:pt-24 lg:pt-32 pb-20 sm:pb-32">
         <div className="flex flex-col gap-10 sm:gap-14 max-w-[920px]">
           <div className="flex flex-col items-start gap-6 sm:gap-8">
-            <a
-              href="https://github.com/1weiho/open-slide"
-              target="_blank"
-              rel="noopener noreferrer"
+            <Link
+              href="/docs/primitive/morph-element"
               className="group inline-flex items-center gap-2.5 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)]/70 py-1.5 pl-3.5 pr-3 text-[13px] font-medium text-[color:var(--color-text-soft)] backdrop-blur transition-colors hover:border-[color:var(--color-dim)] hover:text-[color:var(--color-text)] rise"
               style={{ animationDelay: '40ms' }}
             >
@@ -20,14 +19,14 @@ export function Hero() {
                 aria-hidden
                 className="h-1.5 w-1.5 rounded-full bg-[color:var(--color-accent)]"
               />
-              Open source, MIT licensed
+              Introducing Morph Transition
               <span
                 aria-hidden
                 className="text-[color:var(--color-muted)] transition-transform duration-200 group-hover:translate-x-0.5"
               >
                 →
               </span>
-            </a>
+            </Link>
 
             <h1
               className="text-sheen text-[42px] sm:text-[68px] lg:text-[92px] leading-[1.05] sm:leading-[1.0] tracking-[-0.045em] font-medium text-[color:var(--color-text)] rise"

--- a/apps/web/components/landing/how-it-works.tsx
+++ b/apps/web/components/landing/how-it-works.tsx
@@ -92,7 +92,6 @@ function AgentRow() {
 export function HowItWorks() {
   return (
     <section id="how-it-works" className="relative">
-      <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-[color:var(--color-rule)]" />
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
         <h2 className="text-[32px] sm:text-[44px] lg:text-[60px] leading-[1.1] sm:leading-[1.05] tracking-[-0.035em] font-medium max-w-[820px] mb-14 sm:mb-20">
           Slides as code.

--- a/apps/web/components/landing/inspector.tsx
+++ b/apps/web/components/landing/inspector.tsx
@@ -9,11 +9,12 @@ import {
   useTransform,
 } from 'motion/react';
 import { type ReactNode, useEffect, useRef } from 'react';
+import { SectionRule } from './frame';
 
 export function Inspector() {
   return (
     <section id="inspector" className="relative">
-      <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-[color:var(--color-rule)]" />
+      <SectionRule />
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-20 sm:py-32 lg:py-40">
         <h2 className="text-[32px] sm:text-[44px] lg:text-[60px] leading-[1.1] sm:leading-[1.05] tracking-[-0.035em] font-medium max-w-[860px] mb-14 sm:mb-20">
           Talk to the agent.

--- a/apps/web/components/landing/nav.tsx
+++ b/apps/web/components/landing/nav.tsx
@@ -59,6 +59,12 @@ export function Nav({ githubStars }: { githubStars?: string | null }) {
             ) : null}
           </a>
           <ThemeToggle />
+          <Link
+            href="/docs"
+            className="hidden sm:inline-flex h-8 items-center rounded-full bg-[color:var(--color-text)] px-3.5 text-[13px] font-medium text-[color:var(--color-ink)] transition-opacity hover:opacity-80"
+          >
+            Get started
+          </Link>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## What

Raises the visual craft of the landing page to a top-tier minimal-SaaS level, without changing the existing palette (zero-chroma neutrals + vermillion) or content.

- **Page-long vertical rails** aligned to the content column, so the whole page reads as one engineered frame
- **Crosshair `+` markers** where each section rule intersects the rails
- **Diagonal-stripe divider bands** between the demo and "Slides as code", and before the closing CTA
- **Hero**: dot-grid backdrop with a radial fade, a soft accent bloom, an "Open source, MIT licensed" announcement pill, and a vertical gradient sheen on the headline
- **Nav**: inverted "Get started" pill button
- **Closing CTA**: same bloom + sheen treatment, plus a secondary "Read the docs →" link next to the copy command

All decorative layers are `aria-hidden`, pointer-transparent, and theme-aware (light/dark verified).

## Notes

- `apps/web` only — no changeset needed
- `pnpm check` and web `types:check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Get started” and “Read the docs” calls to action on the landing page.
  - Introduced a striped band in the main content and refreshed section framing/dividers for a more cohesive landing layout.
- **Style**
  - Updated landing visuals with dot-grid, bloom/radial gradients, diagonal stripes, and improved section border treatment.
  - Refreshed hero typography/layout and animation timing, including dark-mode handling and text sheen effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->