### PR TITLE
feat(web): render Vercel OSS badge as a component

### DIFF
--- a/apps/web/app/(home)/landing.css
+++ b/apps/web/app/(home)/landing.css
@@ -357,13 +357,6 @@ html.dark .os-landing .agent-mono {
   opacity: 1;
 }
 
-.os-landing .vercel-oss-badge {
-  filter: none;
-}
-html.dark .os-landing .vercel-oss-badge {
-  filter: invert(1) brightness(1.08);
-}
-
 .os-landing :where(a, button, [role="button"]):focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 3px;

--- a/apps/web/components/landing/footer.tsx
+++ b/apps/web/components/landing/footer.tsx
@@ -50,7 +50,7 @@ export function Footer() {
 
       <div className="border-t border-[color:var(--color-rule)]">
         <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 py-5 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-0 text-[13px] text-[color:var(--color-muted)]">
-          <VercelOssBadge imageClassName="h-4 sm:h-5" />
+          <VercelOssBadge />
           <span>
             Crafted with 🤍 by{' '}
             <a

--- a/apps/web/components/landing/vercel-oss-badge.tsx
+++ b/apps/web/components/landing/vercel-oss-badge.tsx
@@ -1,24 +1,25 @@
 import { cn } from '@/lib/cn';
 
-export function VercelOssBadge({
-  className,
-  imageClassName,
-}: {
-  className?: string;
-  imageClassName?: string;
-}) {
+export function VercelOssBadge({ className }: { className?: string }) {
   return (
     <a
       href="https://vercel.com/open-source-program"
       target="_blank"
       rel="noopener noreferrer"
-      className={cn('block w-fit opacity-75 transition-opacity hover:opacity-100', className)}
+      aria-label="Vercel OSS Program"
+      className={cn(
+        'flex w-fit items-center gap-2.5 opacity-75 transition-opacity hover:opacity-100',
+        className,
+      )}
     >
-      <img
-        alt="Vercel OSS Program"
-        src="https://vercel.com/oss/program-badge-2026.svg"
-        className={cn('vercel-oss-badge w-auto', imageClassName)}
-      />
+      <img src="/assets/vercel-light.svg" alt="" className="logo-light h-3.5 w-auto" />
+      <img src="/assets/vercel-dark.svg" alt="" className="logo-dark h-3.5 w-auto" />
+      <span className="font-[family-name:var(--font-mono)] text-[10px] leading-[1.45] uppercase tracking-[0.06em] text-[color:var(--color-text)]">
+        <span className="block">
+          Vercel Inc. <span className="text-[color:var(--color-muted)]">{'//'}</span> 2026
+        </span>
+        <span className="block">Open Source Software Program</span>
+      </span>
     </a>
   );
 }


### PR DESCRIPTION
## What

The footer's Vercel OSS Program badge was an `<img>` pointing at `https://vercel.com/oss/program-badge-2026.svg`. It's now rendered directly in React: the Vercel triangle from `public/assets/vercel-light.svg` / `vercel-dark.svg` plus two lines of mono text (`VERCEL INC. // 2026` / `OPEN SOURCE SOFTWARE PROGRAM`).

## Why

- Drops a third-party image request on every landing page load.
- Theme handling now uses the existing `logo-light` / `logo-dark` swap the rest of the landing page already uses, so the `.vercel-oss-badge { filter: invert(1) }` dark-mode hack in `landing.css` is gone.
- Text scales with the page instead of being a fixed-height raster-ish asset.

## Notes for reviewers

- `imageClassName` prop dropped from `VercelOssBadge` (it only existed to size the remote image); `footer.tsx` updated accordingly.
- The badge only renders inside `.os-landing`, which is where the `logo-light` / `logo-dark` rules are scoped — `Footer` is used solely on the landing page.
- `apps/web` only, so no changeset.
- `pnpm check` and web `types:check` pass. One pre-existing biome error remains in `packages/core/src/http/request-guard.ts`, untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Vercel OSS badge with refreshed branding, clearer program text, and improved accessibility labeling.
  * Added light- and dark-theme logo variants for improved appearance across display modes.

* **Style**
  * Removed legacy landing-page filter adjustments from the badge styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->