### PR TITLE
chore(web): add clickable links to agent logos in landing page

### DIFF
--- a/apps/web/components/landing/agents.tsx
+++ b/apps/web/components/landing/agents.tsx
@@ -69,7 +69,7 @@ export function Agents() {
 
 function AgentLogo({ agent }: { agent: Agent }) {
   const alt = agent.name;
-  const cls = 'h-[28px] md:h-[34px] lg:h-[40px] w-auto object-contain shrink-0';
+  const cls = 'h-[22px] sm:h-[28px] lg:h-[36px] w-auto object-contain shrink-0';
 
   if (!agent.variants) {
     return <img src={`/assets/${agent.file}.svg`} alt={alt} className={cls} />;

--- a/apps/web/components/landing/agents.tsx
+++ b/apps/web/components/landing/agents.tsx
@@ -69,7 +69,7 @@ export function Agents() {
 
 function AgentLogo({ agent }: { agent: Agent }) {
   const alt = agent.name;
-  const cls = 'h-[22px] sm:h-[28px] lg:h-[36px] w-auto object-contain shrink-0';
+  const cls = 'h-[18px] sm:h-[22px] lg:h-[28px] w-auto object-contain shrink-0';
 
   if (!agent.variants) {
     return <img src={`/assets/${agent.file}.svg`} alt={alt} className={cls} />;

--- a/apps/web/components/landing/agents.tsx
+++ b/apps/web/components/landing/agents.tsx
@@ -3,16 +3,22 @@ type Agent = {
   /** asset file stem; if no theme variants, `variants: false` */
   file: string;
   variants: boolean;
+  url: string;
 };
 
 const agents: Agent[] = [
-  { name: 'Claude', file: 'claude', variants: false },
-  { name: 'Codex', file: 'codex', variants: true },
-  { name: 'Cursor', file: 'cursor', variants: true },
-  { name: 'Gemini CLI', file: 'gemini', variants: false },
-  { name: 'OpenCode', file: 'opencode', variants: true },
-  { name: 'Windsurf', file: 'windsurf', variants: true },
-  { name: 'Zed', file: 'zed', variants: true },
+  { name: 'Claude', file: 'claude', variants: false, url: 'https://claude.com/claude-code' },
+  { name: 'Codex', file: 'codex', variants: true, url: 'https://openai.com/codex' },
+  { name: 'Cursor', file: 'cursor', variants: true, url: 'https://cursor.com' },
+  {
+    name: 'Gemini CLI',
+    file: 'gemini',
+    variants: false,
+    url: 'https://github.com/google-gemini/gemini-cli',
+  },
+  { name: 'OpenCode', file: 'opencode', variants: true, url: 'https://opencode.ai' },
+  { name: 'Windsurf', file: 'windsurf', variants: true, url: 'https://windsurf.com' },
+  { name: 'Zed', file: 'zed', variants: true, url: 'https://zed.dev' },
 ];
 
 export function Agents() {
@@ -40,12 +46,19 @@ export function Agents() {
         >
           <div className="marquee-track py-10 will-change-transform">
             {track.map((agent, i) => (
-              <span key={`${agent.file}-${i}`} className="inline-flex items-center gap-4">
+              <a
+                key={`${agent.file}-${i}`}
+                href={agent.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={agent.name}
+                className="inline-flex items-center gap-4 transition-opacity hover:opacity-70"
+              >
                 <AgentLogo agent={agent} />
                 <span className="font-[family-name:var(--font-sans)] text-[color:var(--color-text)] text-[22px] sm:text-[28px] lg:text-[36px] tracking-[-0.02em]">
                   {agent.name}
                 </span>
-              </span>
+              </a>
             ))}
           </div>
         </div>


### PR DESCRIPTION
Makes the agent carousel on the landing page interactive by converting agent items from static spans to clickable links that direct users to each tool's website.

**Changes:**
- Added `url` property to the `Agent` type with links to each tool's official site
- Converted agent carousel items from `<span>` to `<a>` elements with proper link attributes (`href`, `target="_blank"`, `rel="noopener noreferrer"`)
- Added `aria-label` for accessibility and hover opacity transition for visual feedback
- Populated URLs for all seven agents: Claude, Codex, Cursor, Gemini CLI, OpenCode, Windsurf, and Zed

**Implementation details:**
- Links open in a new tab with security attributes to prevent window.opener access
- Hover state reduces opacity to 70% for clear interactive affordance
- Maintains existing layout and styling while adding link functionality

https://claude.ai/code/session_01KfA9PSLLQUU7inJRdnMMkn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent logos on the landing page are now clickable and open the related external pages in a new tab.
* **Improvements**
  * Updated agent logo sizing for consistent, responsive display across screen sizes.
* **Accessibility & Security**
  * Added accessible link labels and secure new-tab behavior (including appropriate privacy and safety attributes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->