### PR TITLE
feat(web): refine landing mock animations and hover states

### DIFF
--- a/apps/web/components/landing/assets.tsx
+++ b/apps/web/components/landing/assets.tsx
@@ -1,21 +1,32 @@
-import type { CSSProperties, ReactNode } from 'react';
+'use client';
+
+import {
+  animate,
+  type Easing,
+  motion,
+  useInView,
+  useMotionValue,
+  useReducedMotion,
+  useTransform,
+} from 'motion/react';
+import { type CSSProperties, type ReactNode, useEffect, useRef } from 'react';
 import { SectionRule } from './frame';
 
-type AssetMock = { name: string; size: string; logo: string; themed?: boolean };
+type AssetMock = { name: string; size: string; logo: string; themed?: boolean; unused?: boolean };
 
 const assets: AssetMock[] = [
   { name: 'claude.svg', size: '3.4 KB', logo: 'claude' },
   { name: 'codex-dark.svg', size: '2.1 KB', logo: 'codex-dark' },
   { name: 'gemini.svg', size: '4.0 KB', logo: 'gemini' },
-  { name: 'cursor-dark.svg', size: '5.2 KB', logo: 'cursor-dark' },
+  { name: 'cursor-dark.svg', size: '5.2 KB', logo: 'cursor-dark', unused: true },
   { name: 'cloudflare.svg', size: '6.8 KB', logo: 'cloudflare' },
   { name: 'zeabur-dark.svg', size: '4.7 KB', logo: 'zeabur', themed: true },
 ];
 
-const svglResults: { name: string; logo: string; themed?: boolean }[] = [
-  { name: 'Vercel', logo: 'vercel', themed: true },
-  { name: 'Cloudflare', logo: 'cloudflare' },
-  { name: 'Zeabur', logo: 'zeabur', themed: true },
+const svglResults: { name: string; category: string; logo: string; themed?: boolean }[] = [
+  { name: 'Vercel', category: 'Software', logo: 'vercel', themed: true },
+  { name: 'Cloudflare', category: 'Cloud', logo: 'cloudflare' },
+  { name: 'Zeabur', category: 'Cloud', logo: 'zeabur', themed: true },
 ];
 
 const callouts: { eyebrow: string; title: string; body: ReactNode }[] = [
@@ -97,9 +108,101 @@ export function Assets() {
   );
 }
 
+/* One 14s story: click "Search logos" → dialog opens with three results →
+   type "vercel", the rest filter out → close via ✕ → drag a file in → toast. */
+const ASSET_LOOP_DURATION = 14;
+const SVGL_QUERY = 'vercel';
+const EASE_OUT: Easing = [0.23, 1, 0.32, 1];
+
 function AssetManagerMock() {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { amount: 0.3 });
+  const reduced = useReducedMotion();
+  const active = inView && !reduced;
+
+  // Placeholder and result filtering derive from the typing clock, so they
+  // can never drift out of sync with the text: placeholder dies with the
+  // first keystroke, non-matches stay gone until the query resets — which
+  // only happens after the dialog is already hidden.
+  const typingProgress = useMotionValue(1);
+  const dialogPhase = useMotionValue(1);
+  const queryText = useTransform(typingProgress, (p) =>
+    SVGL_QUERY.slice(0, Math.max(0, Math.round(p * SVGL_QUERY.length))),
+  );
+  const placeholderOpacity = useTransform(typingProgress, [0, 0.06], [1, 0]);
+  const nonMatchOpacity = useTransform(typingProgress, [0, 0.12], [1, 0]);
+  const nonMatchScale = useTransform(typingProgress, [0, 0.12], [1, 0.95]);
+  const dialogScale = useTransform(dialogPhase, [0, 1], [0.96, 1]);
+  const dialogY = useTransform(dialogPhase, [0, 1], [6, 0]);
+  const dialogVisibility = useTransform(dialogPhase, (v) =>
+    v < 0.01 ? ('hidden' as const) : ('visible' as const),
+  );
+
+  // The dropped file becomes real state: hero.png inserts at slot 1, every
+  // card shifts back one slot (the last one is pushed out of the visible
+  // window), and the toolbar count bumps to 07 — all off one clock.
+  const heroPhase = useMotionValue(0);
+  const heroScale = useTransform(heroPhase, [0, 1], [0.96, 1]);
+  const heroVisibility = useTransform(heroPhase, (v) =>
+    v < 0.01 ? ('hidden' as const) : ('visible' as const),
+  );
+  const oldCountOpacity = useTransform(heroPhase, [0, 1], [1, 0]);
+  const shiftX = useTransform(heroPhase, [0, 1], ['calc(0% + 0px)', 'calc(100% + 16px)']);
+  const wrapX = useTransform(heroPhase, [0, 1], ['calc(0% + 0px)', 'calc(-200% - 32px)']);
+  const wrapY = useTransform(heroPhase, [0, 1], ['calc(0% + 0px)', 'calc(100% + 16px)']);
+  const pushedOutOpacity = useTransform(heroPhase, [0, 0.65], [1, 0]);
+  const pushedOutScale = useTransform(heroPhase, [0, 1], [1, 0.95]);
+
+  useEffect(() => {
+    if (!active) {
+      typingProgress.set(1);
+      dialogPhase.set(1);
+      heroPhase.set(0);
+      return;
+    }
+    typingProgress.set(0);
+    dialogPhase.set(0);
+    heroPhase.set(0);
+    const typing = animate(typingProgress, [0, 0, 1, 1, 0, 0], {
+      duration: ASSET_LOOP_DURATION,
+      times: [0, 0.18, 0.26, 0.56, 0.6, 1],
+      ease: 'linear',
+      repeat: Infinity,
+    });
+    const dialog = animate(dialogPhase, [0, 0, 1, 1, 0, 0], {
+      duration: ASSET_LOOP_DURATION,
+      times: [0, 0.13, 0.157, 0.52, 0.542, 1],
+      ease: ['linear', EASE_OUT, 'linear', EASE_OUT, 'linear'],
+      repeat: Infinity,
+    });
+    const hero = animate(heroPhase, [0, 0, 1, 1, 0], {
+      duration: ASSET_LOOP_DURATION,
+      times: [0, 0.73, 0.765, 0.985, 1],
+      ease: ['linear', EASE_OUT, 'linear', 'easeOut'],
+      repeat: Infinity,
+    });
+    return () => {
+      typing.stop();
+      dialog.stop();
+      hero.stop();
+    };
+  }, [active, typingProgress, dialogPhase, heroPhase]);
+
+  const loopTransition = (times: number[], ease: Easing | Easing[] = 'easeInOut') =>
+    active
+      ? {
+          duration: ASSET_LOOP_DURATION,
+          times,
+          ease,
+          repeat: Infinity,
+        }
+      : undefined;
+
   return (
-    <div className="floating relative rounded-[8px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] overflow-hidden">
+    <div
+      ref={ref}
+      className="floating relative rounded-[8px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] overflow-hidden select-none"
+    >
       {/* window header */}
       <div className="flex items-center px-4 sm:px-5 h-10 sm:h-11 border-b border-[color:var(--color-rule-soft)] font-[family-name:var(--font-mono)] text-[12px] text-[color:var(--color-muted)]">
         <div className="flex items-center gap-2">
@@ -111,85 +214,337 @@ function AssetManagerMock() {
         <span className="w-[40px]" />
       </div>
 
-      {/* toolbar — slides/assets switcher + upload */}
-      <div className="flex items-center justify-between gap-3 px-4 sm:px-5 py-3 sm:py-4 border-b border-[color:var(--color-rule)]">
-        <div className="relative inline-flex rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)] p-1">
-          <span
-            aria-hidden
-            className="absolute top-1 bottom-1 left-1/2 right-1 rounded-full border border-[color:var(--color-accent)] bg-[color:var(--color-accent)]/15"
-          />
-          <span className="relative px-4 py-1.5 font-[family-name:var(--font-mono)] text-[12px] text-[color:var(--color-muted)]">
-            Slides
-          </span>
-          <span className="relative px-4 py-1.5 font-[family-name:var(--font-mono)] text-[12px] text-[color:var(--color-accent-soft)]">
-            Assets
+      {/* toolbar — mirrors core's asset view header */}
+      <div className="flex items-center justify-between gap-3 px-4 sm:px-5 py-3 border-b border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)]/40">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="inline-flex items-center gap-0.5 rounded-[7px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)] p-0.5">
+            <span className="rounded-[5px] bg-[color:var(--color-panel)] px-3 py-1 font-[family-name:var(--font-sans)] text-[12px] font-medium text-[color:var(--color-text)] [box-shadow:var(--shadow-edge)]">
+              Slide
+            </span>
+            <span className="rounded-[5px] px-3 py-1 font-[family-name:var(--font-sans)] text-[12px] text-[color:var(--color-muted)] transition-colors hover:text-[color:var(--color-text)]">
+              Global
+            </span>
+          </div>
+          <span className="hidden md:inline-flex items-baseline min-w-0 font-[family-name:var(--font-mono)] text-[11.5px] text-[color:var(--color-muted)]">
+            slides/cover/assets/
+            <span className="mx-1.5 opacity-50">·</span>
+            <span className="relative whitespace-nowrap">
+              <motion.span style={{ opacity: oldCountOpacity }}>06 files</motion.span>
+              <motion.span className="absolute left-0 top-0" style={{ opacity: heroPhase }}>
+                07 files
+              </motion.span>
+            </span>
           </span>
         </div>
-        <span className="inline-flex items-center gap-2 rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)] px-3.5 py-1.5 font-[family-name:var(--font-sans)] text-[13px] text-[color:var(--color-text)]">
-          <span className="text-[color:var(--color-accent-soft)]">↑</span>
-          Upload
-        </span>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <motion.span
+            className="relative inline-flex h-8 items-center gap-1.5 rounded-[5px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-2.5 font-[family-name:var(--font-sans)] text-[12.5px] font-medium text-[color:var(--color-text)] transition-colors hover:border-[color:var(--color-dim)] hover:bg-[color:var(--color-panel-hi)]"
+            animate={active ? { scale: [1, 1, 0.94, 1, 1] } : { scale: 1 }}
+            transition={loopTransition([0, 0.11, 0.125, 0.148, 1], 'easeOut')}
+          >
+            <SearchGlyph />
+            <span className="hidden sm:inline">Search logos</span>
+
+            {/* guided cursor — flies in and presses the button */}
+            <motion.span
+              aria-hidden
+              className="absolute left-1/2 top-1/2 z-10 pointer-events-none"
+              animate={
+                active
+                  ? {
+                      opacity: [0, 0, 1, 1, 1, 0, 0],
+                      x: [-170, -170, 0, 0, 0, 0, 0],
+                      y: [150, 150, 0, 0, 0, 0, 0],
+                      scale: [1, 1, 1, 0.8, 1, 1, 1],
+                    }
+                  : { opacity: 0 }
+              }
+              transition={loopTransition(
+                [0, 0.045, 0.105, 0.12, 0.15, 0.19, 1],
+                [EASE_OUT, EASE_OUT, 'easeOut', 'easeOut', 'easeOut', 'linear'],
+              )}
+            >
+              <PointerGlyph className="w-[15px] drop-shadow-[0_1px_2px_rgba(0,0,0,0.3)]" />
+            </motion.span>
+          </motion.span>
+          <span className="pressable inline-flex h-8 items-center gap-1.5 rounded-[5px] bg-[color:var(--color-text)] px-3 font-[family-name:var(--font-sans)] text-[12.5px] font-medium text-[color:var(--color-ink)] shadow-[inset_0_1px_0_rgba(255,255,255,0.12),0_1px_0_rgba(0,0,0,0.12)] hover:opacity-90">
+            <UploadGlyph />
+            Upload
+          </span>
+        </div>
       </div>
 
       {/* grid */}
       <div className="relative">
-        <div className="grid grid-cols-3 gap-3 sm:gap-4 p-4 sm:p-5">
-          {assets.map((a) => (
-            <AssetCard key={a.name} asset={a} />
-          ))}
+        {/* The 16px in the shift transforms must match this grid's gap-4. */}
+        <div className="grid grid-cols-3 gap-4 p-4 sm:p-5 bg-[color:var(--color-ink)]">
+          {assets.map((a, i) => {
+            const isLastColumn = i % 3 === 2;
+            const isPushedOut = i === assets.length - 1;
+            const shiftStyle = isPushedOut
+              ? { opacity: pushedOutOpacity, scale: pushedOutScale }
+              : isLastColumn
+                ? { x: wrapX, y: wrapY }
+                : { x: shiftX };
+            return i === 0 ? (
+              <div key={a.name} className="relative">
+                <motion.div style={shiftStyle}>
+                  <AssetCard asset={a} />
+                </motion.div>
+                <motion.div
+                  className="absolute inset-0"
+                  style={{ opacity: heroPhase, scale: heroScale, visibility: heroVisibility }}
+                >
+                  <HeroAssetCard />
+                  <motion.div
+                    aria-hidden
+                    className="absolute -inset-px rounded-[7px] ring-2 ring-[color:var(--color-accent)]/40 pointer-events-none"
+                    animate={active ? { opacity: [0, 0, 1, 0, 0] } : { opacity: 0 }}
+                    transition={loopTransition([0, 0.735, 0.78, 0.88, 1], 'easeOut')}
+                  />
+                </motion.div>
+              </div>
+            ) : (
+              <motion.div key={a.name} style={shiftStyle}>
+                <AssetCard asset={a} />
+              </motion.div>
+            );
+          })}
         </div>
 
-        {/* svgl Logo Search dialog */}
-        <div className="floating absolute right-3 sm:right-5 bottom-3 sm:bottom-5 w-[80%] sm:w-[64%] max-w-[420px] rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] p-4">
-          <div className="flex items-center justify-between mb-3 font-[family-name:var(--font-mono)] text-[11px] text-[color:var(--color-muted)]">
-            <span>Search svgl</span>
-            <span className="text-[color:var(--color-dim)]">✕</span>
+        {/* drag ghost — a file card being pulled into the drop zone */}
+        <motion.div
+          aria-hidden
+          className="absolute left-[32%] top-[26%] pointer-events-none"
+          animate={
+            active
+              ? {
+                  opacity: [0, 0, 1, 1, 1, 0, 0],
+                  x: [150, 150, 0, 0, 0, 0, 0],
+                  y: [-110, -110, 0, 0, 0, 0, 0],
+                  scale: [1, 1, 1, 1, 0.92, 0.92, 0.92],
+                  filter: [
+                    'blur(0px)',
+                    'blur(0px)',
+                    'blur(0px)',
+                    'blur(0px)',
+                    'blur(0px)',
+                    'blur(3px)',
+                    'blur(3px)',
+                  ],
+                }
+              : { opacity: 0 }
+          }
+          transition={loopTransition(
+            [0, 0.6, 0.665, 0.715, 0.73, 0.755, 1],
+            [EASE_OUT, EASE_OUT, 'linear', 'easeOut', 'easeOut', 'linear'],
+          )}
+        >
+          <div className="w-[88px] -rotate-[5deg] rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] shadow-[var(--shadow-floating)] overflow-hidden">
+            <div
+              className="flex h-[52px] items-center justify-center"
+              style={{
+                background:
+                  'linear-gradient(135deg, color-mix(in oklab, var(--color-accent) 18%, var(--color-panel)), color-mix(in oklab, var(--color-accent) 50%, var(--color-panel)))',
+              }}
+            >
+              <ImageGlyph />
+            </div>
+            <div className="border-t border-[color:var(--color-rule)] px-2 py-1 font-[family-name:var(--font-mono)] text-[9px] text-[color:var(--color-text-soft)] truncate">
+              hero.png
+            </div>
           </div>
-          <div className="flex items-center gap-2 rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-3 py-2 mb-3 font-[family-name:var(--font-mono)] text-[13px] text-[color:var(--color-text)]">
-            <span className="text-[color:var(--color-muted)]">⌕</span>
-            <span>vercel</span>
-            <span className="caret" aria-hidden />
+        </motion.div>
+
+        {/* pointer riding the ghost */}
+        <motion.div
+          aria-hidden
+          className="absolute left-[32%] top-[26%] ml-[80px] mt-[58px] pointer-events-none"
+          animate={
+            active
+              ? {
+                  opacity: [0, 0, 1, 1, 1, 0, 0],
+                  x: [150, 150, 0, 0, 0, 0, 0],
+                  y: [-110, -110, 0, 0, 0, 0, 0],
+                }
+              : { opacity: 0 }
+          }
+          transition={loopTransition(
+            [0, 0.6, 0.665, 0.73, 0.75, 0.775, 1],
+            [EASE_OUT, EASE_OUT, 'linear', 'linear', 'easeOut', 'linear'],
+          )}
+        >
+          <PointerGlyph className="w-[15px] drop-shadow-[0_1px_2px_rgba(0,0,0,0.3)]" />
+        </motion.div>
+
+        {/* drop overlay — matches core's drag-active state */}
+        <motion.div
+          aria-hidden
+          className="absolute inset-0 pointer-events-none"
+          animate={active ? { opacity: [0, 0, 1, 1, 0, 0] } : { opacity: 0 }}
+          transition={loopTransition(
+            [0, 0.625, 0.65, 0.725, 0.75, 1],
+            ['linear', 'easeOut', 'linear', 'easeOut', 'linear'],
+          )}
+        >
+          <div className="absolute inset-0 bg-[color:var(--color-accent)]/5" />
+          <div className="absolute inset-2 rounded-[10px] border border-dashed border-[color:var(--color-accent)]/40" />
+        </motion.div>
+
+        {/* drop-to-upload pill */}
+        <motion.div
+          aria-hidden
+          className="absolute inset-x-0 bottom-5 flex justify-center pointer-events-none"
+          animate={
+            active
+              ? { opacity: [0, 0, 1, 1, 0, 0], y: ['40%', '40%', '0%', '0%', '40%', '40%'] }
+              : { opacity: 0, y: '40%' }
+          }
+          transition={loopTransition(
+            [0, 0.63, 0.655, 0.725, 0.75, 1],
+            ['linear', EASE_OUT, 'linear', EASE_OUT, 'linear'],
+          )}
+        >
+          <div className="flex items-center gap-2 rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-3 py-1.5 font-[family-name:var(--font-sans)] text-[12px] font-medium text-[color:var(--color-text)] shadow-[var(--shadow-floating)]">
+            <DropGlyph />
+            Drop to upload
+          </div>
+        </motion.div>
+
+        {/* upload toast */}
+        <motion.div
+          aria-hidden
+          className="absolute left-4 bottom-4 pointer-events-none"
+          animate={
+            active
+              ? { opacity: [0, 0, 1, 1, 0, 0], y: ['60%', '60%', '0%', '0%', '60%', '60%'] }
+              : { opacity: 0, y: '60%' }
+          }
+          transition={loopTransition(
+            [0, 0.75, 0.772, 0.92, 0.945, 1],
+            ['linear', EASE_OUT, 'linear', EASE_OUT, 'linear'],
+          )}
+        >
+          <div className="flex items-center gap-2 rounded-[8px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-3 py-2 font-[family-name:var(--font-sans)] text-[12px] font-medium text-[color:var(--color-text)] shadow-[var(--shadow-floating)]">
+            <CheckGlyph />
+            Uploaded{' '}
+            <span className="font-[family-name:var(--font-mono)] text-[11px]">hero.png</span>
+          </div>
+        </motion.div>
+
+        {/* svgl Logo Search dialog — opens from the button, closes via ✕ */}
+        <motion.div
+          className="floating absolute right-3 sm:right-5 bottom-3 sm:bottom-5 w-[80%] sm:w-[64%] max-w-[420px] rounded-[8px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] p-4"
+          style={{
+            transformOrigin: 'top right',
+            opacity: dialogPhase,
+            scale: dialogScale,
+            y: dialogY,
+            visibility: dialogVisibility,
+          }}
+        >
+          <div className="flex items-center justify-between mb-1">
+            <span className="font-[family-name:var(--font-sans)] text-[13px] font-medium text-[color:var(--color-text)]">
+              Logo search
+            </span>
+            <motion.span
+              className="relative inline-flex size-5 items-center justify-center rounded-[4px] text-[12px] text-[color:var(--color-dim)] transition-colors hover:bg-[color:var(--color-panel-hi)] hover:text-[color:var(--color-text)]"
+              animate={active ? { scale: [1, 1, 0.85, 1, 1] } : { scale: 1 }}
+              transition={loopTransition([0, 0.497, 0.512, 0.535, 1], 'easeOut')}
+            >
+              ✕{/* guided cursor — walks up to close the dialog */}
+              <motion.span
+                aria-hidden
+                className="absolute left-1/2 top-1/2 z-10 pointer-events-none"
+                animate={
+                  active
+                    ? {
+                        opacity: [0, 0, 1, 1, 1, 0, 0],
+                        x: [-70, -70, 0, 0, 0, 0, 0],
+                        y: [60, 60, 0, 0, 0, 0, 0],
+                        scale: [1, 1, 1, 0.8, 1, 1, 1],
+                      }
+                    : { opacity: 0 }
+                }
+                transition={loopTransition(
+                  [0, 0.43, 0.478, 0.5, 0.517, 0.545, 1],
+                  [EASE_OUT, EASE_OUT, 'easeOut', 'easeOut', 'easeOut', 'linear'],
+                )}
+              >
+                <PointerGlyph className="w-[15px] drop-shadow-[0_1px_2px_rgba(0,0,0,0.3)]" />
+              </motion.span>
+            </motion.span>
+          </div>
+          <div className="mb-3 font-[family-name:var(--font-sans)] text-[11px] text-[color:var(--color-muted)]">
+            Powered by svgl.app
+          </div>
+          <div className="flex items-center gap-2 rounded-[6px] border border-[color:var(--color-dim)] bg-[color:var(--color-panel)] px-3 py-2 mb-3 font-[family-name:var(--font-mono)] text-[13px] text-[color:var(--color-text)] ring-2 ring-[color:var(--color-text)]/10">
+            <span className="text-[color:var(--color-muted)]">
+              <SearchGlyph />
+            </span>
+            <span className="relative inline-flex items-baseline">
+              <motion.span
+                aria-hidden
+                className="absolute left-0 whitespace-nowrap text-[color:var(--color-muted)]"
+                style={{ opacity: placeholderOpacity }}
+              >
+                Search logos...
+              </motion.span>
+              <motion.span>{queryText}</motion.span>
+              <span className="caret" aria-hidden />
+            </span>
           </div>
           <div className="grid grid-cols-3 gap-2">
-            {svglResults.map((r, i) => (
-              <div
+            {svglResults.map((r, idx) => (
+              <motion.div
                 key={r.name}
-                className={`rounded-[6px] border ${
-                  i === 0
-                    ? 'border-[color:var(--color-accent)] bg-[color:var(--color-accent)]/[0.06]'
-                    : 'border-[color:var(--color-rule)] bg-[color:var(--color-panel)]'
-                } p-2 flex flex-col items-center gap-1.5`}
+                className="group/logo relative rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] p-2 flex flex-col items-center gap-1.5 transition-[border-color,box-shadow,transform] duration-200 hover:border-[color:var(--color-dim)] hover:-translate-y-px hover:[box-shadow:var(--shadow-edge)]"
+                style={idx > 0 ? { opacity: nonMatchOpacity, scale: nonMatchScale } : undefined}
               >
-                <div className="h-8 flex items-center justify-center">
+                <div
+                  className="flex h-9 w-full items-center justify-center rounded-[4px]"
+                  style={{
+                    background:
+                      'repeating-conic-gradient(color-mix(in srgb, var(--color-rule) 55%, transparent) 0 25%, transparent 0 50%) 0 0 / 12px 12px',
+                  }}
+                >
                   {r.themed ? (
                     <>
                       <img
                         src={`/assets/${r.logo}-dark.svg`}
                         alt={r.name}
-                        className="h-7 w-auto object-contain logo-dark"
+                        className="h-6 w-auto object-contain logo-dark"
                       />
                       <img
                         src={`/assets/${r.logo}-light.svg`}
                         alt=""
                         aria-hidden
-                        className="h-7 w-auto object-contain logo-light"
+                        className="h-6 w-auto object-contain logo-light"
                       />
                     </>
                   ) : (
                     <img
                       src={`/assets/${r.logo}.svg`}
                       alt={r.name}
-                      className="h-7 w-auto object-contain"
+                      className="h-6 w-auto object-contain"
                     />
                   )}
                 </div>
-                <span className="font-[family-name:var(--font-mono)] text-[10px] text-[color:var(--color-text-soft)]">
-                  {r.name}
+                <div className="w-full text-center">
+                  <div className="font-[family-name:var(--font-sans)] text-[10.5px] font-medium text-[color:var(--color-text)] truncate">
+                    {r.name}
+                  </div>
+                  <div className="font-[family-name:var(--font-sans)] text-[9px] text-[color:var(--color-muted)] truncate">
+                    {r.category}
+                  </div>
+                </div>
+                <span className="absolute right-1 top-1 rounded-[4px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-1.5 py-0.5 font-[family-name:var(--font-sans)] text-[9px] font-medium text-[color:var(--color-text)] opacity-0 transition-opacity group-hover/logo:opacity-100">
+                  Add
                 </span>
-              </div>
+              </motion.div>
             ))}
           </div>
-        </div>
+        </motion.div>
       </div>
     </div>
   );
@@ -197,9 +552,9 @@ function AssetManagerMock() {
 
 function AssetCard({ asset }: { asset: AssetMock }) {
   return (
-    <div className="rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)] overflow-hidden flex flex-col">
+    <div className="group rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] overflow-hidden flex flex-col [box-shadow:var(--shadow-edge)] transition-shadow duration-300 hover:[box-shadow:var(--shadow-floating)]">
       <div
-        className="h-[80px] sm:h-[120px] flex items-center justify-center"
+        className="h-[80px] sm:h-[120px] flex items-center justify-center border-b border-[color:var(--color-rule-soft)]"
         style={{
           background:
             'repeating-conic-gradient(color-mix(in srgb, var(--color-rule) 70%, transparent) 0 25%, transparent 0 50%) 0 0 / 16px 16px',
@@ -227,24 +582,186 @@ function AssetCard({ asset }: { asset: AssetMock }) {
           />
         )}
       </div>
-      <div className="border-t border-[color:var(--color-rule)] px-3 py-2">
-        <div
-          className="font-[family-name:var(--font-sans)] text-[13px] text-[color:var(--color-text)] truncate"
-          title={asset.name}
-        >
-          {asset.themed ? (
-            <>
-              <span className="logo-dark">{asset.name}</span>
-              <span className="logo-light">{asset.name.replace('-dark', '-light')}</span>
-            </>
-          ) : (
-            asset.name
-          )}
+      <div className="flex items-start gap-1 px-3 py-2">
+        <div className="min-w-0 flex-1">
+          <div
+            className="font-[family-name:var(--font-sans)] text-[13px] text-[color:var(--color-text)] truncate"
+            title={asset.name}
+          >
+            {asset.themed ? (
+              <>
+                <span className="logo-dark">{asset.name}</span>
+                <span className="logo-light">{asset.name.replace('-dark', '-light')}</span>
+              </>
+            ) : (
+              asset.name
+            )}
+          </div>
+          <div className="mt-0.5 flex items-center gap-1.5 font-[family-name:var(--font-mono)] text-[10px] text-[color:var(--color-muted)]">
+            {asset.size}
+            <span
+              className={`rounded-[3px] px-1 py-px font-[family-name:var(--font-sans)] text-[9px] font-medium leading-none ${
+                asset.unused
+                  ? 'bg-[color:var(--color-rule-soft)] text-[color:var(--color-muted)]'
+                  : 'bg-[color:var(--color-mint)]/15 text-[color:var(--color-mint)]'
+              }`}
+            >
+              {asset.unused ? 'Unused' : 'Used'}
+            </span>
+          </div>
         </div>
-        <div className="font-[family-name:var(--font-mono)] text-[10px] text-[color:var(--color-muted)] mt-0.5">
-          {asset.size}
-        </div>
+        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-[4px] text-[color:var(--color-muted)] opacity-0 transition-[opacity,background-color,color] group-hover:opacity-100 hover:bg-[color:var(--color-panel-hi)] hover:text-[color:var(--color-text)]">
+          <KebabGlyph />
+        </span>
       </div>
     </div>
+  );
+}
+
+function HeroAssetCard() {
+  return (
+    <div className="group flex h-full flex-col overflow-hidden rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] [box-shadow:var(--shadow-edge)] transition-shadow duration-300 hover:[box-shadow:var(--shadow-floating)]">
+      <div
+        className="flex min-h-0 flex-1 items-center justify-center border-b border-[color:var(--color-rule-soft)]"
+        style={{
+          background:
+            'linear-gradient(135deg, color-mix(in oklab, var(--color-accent) 18%, var(--color-panel)), color-mix(in oklab, var(--color-accent) 50%, var(--color-panel)))',
+        }}
+      >
+        <ImageGlyph large />
+      </div>
+      <div className="flex items-start gap-1 px-3 py-2">
+        <div className="min-w-0 flex-1">
+          <div className="font-[family-name:var(--font-sans)] text-[13px] text-[color:var(--color-text)] truncate">
+            hero.png
+          </div>
+          <div className="mt-0.5 flex items-center gap-1.5 font-[family-name:var(--font-mono)] text-[10px] text-[color:var(--color-muted)]">
+            248 KB
+            <span className="rounded-[3px] bg-[color:var(--color-rule-soft)] px-1 py-px font-[family-name:var(--font-sans)] text-[9px] font-medium leading-none text-[color:var(--color-muted)]">
+              Unused
+            </span>
+          </div>
+        </div>
+        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-[4px] text-[color:var(--color-muted)] opacity-0 transition-[opacity,background-color,color] group-hover:opacity-100 hover:bg-[color:var(--color-panel-hi)] hover:text-[color:var(--color-text)]">
+          <KebabGlyph />
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function PointerGlyph({ className }: { className?: string }) {
+  return (
+    <svg aria-hidden viewBox="0 0 24 24" className={className}>
+      <title>cursor</title>
+      <path
+        d="M5.5 3.21V20.8c0 .45.54.67.85.35l4.86-4.86a.5.5 0 0 1 .35-.15h6.87c.45 0 .67-.54.35-.85L6.35 2.85a.5.5 0 0 0-.85.36Z"
+        fill="var(--color-text)"
+        stroke="var(--color-ink)"
+        strokeWidth={1.4}
+      />
+    </svg>
+  );
+}
+
+function SearchGlyph() {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      className="size-3.5"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <line x1="21" y1="21" x2="16.5" y2="16.5" />
+    </svg>
+  );
+}
+
+function UploadGlyph() {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-3.5"
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="17 8 12 3 7 8" />
+      <line x1="12" y1="3" x2="12" y2="15" />
+    </svg>
+  );
+}
+
+function DropGlyph() {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="var(--color-accent)"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-3.5"
+    >
+      <path d="M12 17V3" />
+      <path d="m6 11 6 6 6-6" />
+      <path d="M19 21H5" />
+    </svg>
+  );
+}
+
+function CheckGlyph() {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="var(--color-mint)"
+      strokeWidth={2.2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-3.5 shrink-0"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="m8.5 12 2.5 2.5 4.5-5" />
+    </svg>
+  );
+}
+
+function ImageGlyph({ large = false }: { large?: boolean }) {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="rgba(255,255,255,0.9)"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={large ? 'size-8' : 'size-5'}
+    >
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <circle cx="9" cy="9" r="2" />
+      <path d="m21 15-3.5-3.5a2 2 0 0 0-2.83 0L6 20" />
+    </svg>
+  );
+}
+
+function KebabGlyph() {
+  return (
+    <svg aria-hidden viewBox="0 0 24 24" fill="currentColor" className="size-3.5">
+      <circle cx="12" cy="5" r="1.6" />
+      <circle cx="12" cy="12" r="1.6" />
+      <circle cx="12" cy="19" r="1.6" />
+    </svg>
   );
 }

--- a/apps/web/components/landing/inspector.tsx
+++ b/apps/web/components/landing/inspector.tsx
@@ -2,6 +2,7 @@
 
 import {
   animate,
+  type Easing,
   motion,
   useInView,
   useMotionValue,
@@ -101,6 +102,7 @@ function FeatureCell({
 
 const AGENT_LOOP_DURATION = 10;
 const COMMENT_TEXT = 'use the accent color on this title';
+const EASE_OUT: Easing = [0.23, 1, 0.32, 1];
 
 function AgentApplyVisual() {
   const ref = useRef<HTMLDivElement>(null);
@@ -128,12 +130,12 @@ function AgentApplyVisual() {
     return () => controls.stop();
   }, [active, typingProgress]);
 
-  const loopTransition = (times: number[]) =>
+  const loopTransition = (times: number[], ease: Easing | Easing[] = 'easeInOut') =>
     active
       ? {
           duration: AGENT_LOOP_DURATION,
           times,
-          ease: 'easeInOut' as const,
+          ease,
           repeat: Infinity,
         }
       : undefined;
@@ -141,14 +143,14 @@ function AgentApplyVisual() {
   return (
     <div
       ref={ref}
-      className="relative rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] overflow-hidden"
+      className="relative rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] overflow-hidden select-none [box-shadow:var(--shadow-edge)] transition-shadow duration-300 hover:[box-shadow:var(--shadow-floating)]"
     >
       <div
         className="relative aspect-[16/9] grid grid-cols-[1fr_42%]"
         style={{ containerType: 'inline-size' }}
       >
         {/* canvas */}
-        <div className="relative overflow-hidden">
+        <div className="relative overflow-hidden cursor-crosshair">
           <div className="absolute inset-0 px-[5cqw] py-[5cqw] flex flex-col justify-center gap-[1.4cqw]">
             <span className="font-[family-name:var(--font-mono)] text-[1.3cqw] tracking-[0.18em] uppercase text-[color:var(--color-muted)]">
               cover
@@ -161,11 +163,14 @@ function AgentApplyVisual() {
                   active
                     ? {
                         opacity: [0, 0, 1, 1, 0, 0],
-                        scale: [0.92, 0.92, 1, 1, 0.96, 0.96],
+                        scale: [0.92, 0.92, 1, 1, 0.97, 0.97],
                       }
                     : { opacity: 1, scale: 1 }
                 }
-                transition={loopTransition([0, 0.11, 0.14, 0.86, 0.92, 1])}
+                transition={loopTransition(
+                  [0, 0.115, 0.135, 0.9, 0.935, 1],
+                  ['linear', EASE_OUT, 'linear', EASE_OUT, 'linear'],
+                )}
               />
               <motion.span
                 className="relative font-[family-name:var(--font-sans)] font-semibold tracking-[-0.035em] leading-[1.0]"
@@ -181,10 +186,35 @@ function AgentApplyVisual() {
                           'var(--color-text)',
                           'var(--color-text)',
                         ],
+                        backgroundColor: [
+                          'transparent',
+                          'transparent',
+                          'color-mix(in oklab, var(--color-accent) 14%, transparent)',
+                          'transparent',
+                          'transparent',
+                          'transparent',
+                        ],
                       }
-                    : { color: 'var(--color-text)' }
+                    : { color: 'var(--color-text)', backgroundColor: 'transparent' }
                 }
-                transition={loopTransition([0, 0.7, 0.74, 0.86, 0.92, 1])}
+                transition={
+                  active
+                    ? {
+                        color: {
+                          duration: AGENT_LOOP_DURATION,
+                          times: [0, 0.7, 0.735, 0.92, 0.955, 1],
+                          ease: 'easeInOut',
+                          repeat: Infinity,
+                        },
+                        backgroundColor: {
+                          duration: AGENT_LOOP_DURATION,
+                          times: [0, 0.7, 0.725, 0.85, 0.92, 1],
+                          ease: 'easeOut',
+                          repeat: Infinity,
+                        },
+                      }
+                    : undefined
+                }
               >
                 Q2 Launch
               </motion.span>
@@ -222,7 +252,10 @@ function AgentApplyVisual() {
                   }
                 : { opacity: 0 }
             }
-            transition={loopTransition([0, 0.02, 0.1, 0.115, 0.13, 0.16, 1])}
+            transition={loopTransition(
+              [0, 0.02, 0.1, 0.115, 0.13, 0.16, 1],
+              [EASE_OUT, EASE_OUT, 'easeOut', 'easeOut', 'easeOut', 'linear'],
+            )}
           >
             <title>cursor</title>
             <line x1="12" y1="2" x2="12" y2="9" />
@@ -231,6 +264,27 @@ function AgentApplyVisual() {
             <line x1="15" y1="12" x2="22" y2="12" />
             <circle cx="12" cy="12" r="2.5" fill="#3b82f6" fillOpacity={0.25} />
           </motion.svg>
+
+          {/* click ripple — confirms the press before the panel answers */}
+          <motion.span
+            aria-hidden
+            className="absolute pointer-events-none rounded-full border-2 border-[#3b82f6]"
+            style={{
+              left: '5.5cqw',
+              top: 'calc(50% - 3cqw)',
+              width: '6cqw',
+              height: '6cqw',
+            }}
+            animate={
+              active
+                ? { opacity: [0, 0, 0.55, 0, 0], scale: [0.3, 0.3, 0.55, 1, 1] }
+                : { opacity: 0 }
+            }
+            transition={loopTransition(
+              [0, 0.113, 0.125, 0.165, 1],
+              ['linear', 'easeOut', 'easeOut', 'linear'],
+            )}
+          />
 
           {/* "Agent applying..." status pill — appears after submit, fades before style change settles */}
           <motion.div
@@ -244,7 +298,10 @@ function AgentApplyVisual() {
                   }
                 : { opacity: 0, y: '40%' }
             }
-            transition={loopTransition([0, 0.55, 0.6, 0.78, 0.82, 1])}
+            transition={loopTransition(
+              [0, 0.56, 0.585, 0.78, 0.8, 1],
+              ['linear', EASE_OUT, 'linear', EASE_OUT, 'linear'],
+            )}
           >
             <SpinnerGlyph active={active} />
             <span style={{ color: 'var(--color-muted)' }}>Agent applying</span>
@@ -256,34 +313,12 @@ function AgentApplyVisual() {
         <motion.div
           className="border-l border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)] flex flex-col overflow-hidden"
           animate={active ? { x: ['100%', '100%', '0%', '0%', '100%', '100%'] } : { x: '0%' }}
-          transition={loopTransition([0, 0.15, 0.24, 0.86, 0.93, 1])}
+          transition={loopTransition(
+            [0, 0.13, 0.157, 0.9, 0.927, 1],
+            ['linear', EASE_OUT, 'linear', EASE_OUT, 'linear'],
+          )}
         >
-          {/* header */}
-          <div
-            className="border-b border-[color:var(--color-rule)] flex items-center justify-between"
-            style={{ padding: '1.4cqw 1.6cqw' }}
-          >
-            <div className="flex items-center gap-[0.6cqw]">
-              <span
-                className="font-[family-name:var(--font-sans)] font-semibold tracking-tight text-[color:var(--color-text)]"
-                style={{ fontSize: '1.25cqw' }}
-              >
-                Inspect
-              </span>
-              <span
-                aria-hidden
-                className="bg-[color:var(--color-rule)]"
-                style={{ width: '1px', height: '1.4cqw' }}
-              />
-              <span
-                className="rounded-[3px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] font-[family-name:var(--font-mono)] text-[color:var(--color-text)]"
-                style={{ padding: '0.1cqw 0.5cqw', fontSize: '1cqw' }}
-              >
-                &lt;h1&gt;
-              </span>
-            </div>
-            <span className="text-[color:var(--color-dim)]">✕</span>
-          </div>
+          <PanelHeader />
 
           <PanelSection label="Content">
             <PanelTextarea value="Q2 Launch" />
@@ -325,7 +360,7 @@ function AgentApplyVisual() {
                       boxShadow: '0 0 0 0 transparent',
                     }
               }
-              transition={loopTransition([0, 0.25, 0.3, 0.78, 0.82, 1])}
+              transition={loopTransition([0, 0.25, 0.275, 0.78, 0.805, 1], 'easeOut')}
             >
               <motion.span
                 aria-hidden
@@ -357,10 +392,10 @@ function AgentApplyVisual() {
                 Cmd + Enter to submit
               </span>
               <motion.span
-                className="inline-flex items-center font-[family-name:var(--font-sans)] font-medium text-[color:var(--color-brand-foreground,white)] rounded-[4px] bg-[color:var(--color-accent)]"
+                className="inline-flex items-center font-[family-name:var(--font-sans)] font-medium text-[color:var(--color-brand-foreground,white)] rounded-[4px] bg-[color:var(--color-accent)] transition-opacity hover:opacity-90"
                 style={{ fontSize: '1.1cqw', padding: '0.45cqw 0.9cqw' }}
                 animate={active ? { scale: [1, 1, 0.94, 1, 1] } : { scale: 1 }}
-                transition={loopTransition([0, 0.52, 0.54, 0.57, 1])}
+                transition={loopTransition([0, 0.53, 0.545, 0.57, 1], 'easeOut')}
               >
                 Add comment
               </motion.span>
@@ -449,14 +484,14 @@ function VisualEditorVisual() {
   return (
     <div
       ref={ref}
-      className="relative rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] overflow-hidden"
+      className="relative rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] overflow-hidden select-none [box-shadow:var(--shadow-edge)] transition-shadow duration-300 hover:[box-shadow:var(--shadow-floating)]"
     >
       <div
         className="relative aspect-[16/9] grid grid-cols-[1fr_42%]"
         style={{ containerType: 'inline-size' }}
       >
         {/* canvas */}
-        <div className="relative overflow-hidden">
+        <div className="relative overflow-hidden cursor-crosshair">
           <div className="absolute inset-0 px-[5cqw] py-[5cqw] flex flex-col justify-center gap-[1.4cqw]">
             <span className="font-[family-name:var(--font-mono)] text-[1.3cqw] tracking-[0.18em] uppercase text-[color:var(--color-muted)]">
               cover
@@ -484,7 +519,7 @@ function VisualEditorVisual() {
           {/* SaveBar — matches core/SaveCard layout */}
           <div className="absolute left-1/2 -translate-x-1/2" style={{ bottom: '3cqw' }}>
             <div
-              className="inline-flex items-center gap-[0.4cqw] whitespace-nowrap rounded-[6px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)]/95 backdrop-blur-md shadow-[0_8px_24px_-12px_rgba(0,0,0,0.18)]"
+              className="inline-flex items-center gap-[0.4cqw] whitespace-nowrap rounded-[8px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)]/95 backdrop-blur-md shadow-[0_8px_24px_-12px_rgba(0,0,0,0.18)]"
               style={{ padding: '0.35cqw 0.35cqw 0.35cqw 0.5cqw' }}
             >
               <SaveBarIconBtn glyph={<UndoGlyph />} />
@@ -522,13 +557,13 @@ function VisualEditorVisual() {
                 <span>1 unsaved change</span>
               </span>
               <span
-                className="font-[family-name:var(--font-sans)] text-[color:var(--color-muted)]"
+                className="rounded-[4px] font-[family-name:var(--font-sans)] text-[color:var(--color-muted)] transition-colors hover:text-[color:var(--color-text)]"
                 style={{ fontSize: '1.2cqw', padding: '0.4cqw 0.8cqw' }}
               >
                 Discard
               </span>
               <span
-                className="inline-flex items-center gap-[0.4cqw] font-[family-name:var(--font-sans)] font-medium text-[color:var(--color-brand-foreground,white)] rounded-[4px] bg-[color:var(--color-accent)]"
+                className="inline-flex items-center gap-[0.4cqw] font-[family-name:var(--font-sans)] font-medium text-[color:var(--color-brand-foreground,white)] rounded-[4px] bg-[color:var(--color-accent)] transition-opacity hover:opacity-90"
                 style={{ fontSize: '1.2cqw', padding: '0.45cqw 0.9cqw' }}
               >
                 <SaveGlyph />
@@ -540,32 +575,7 @@ function VisualEditorVisual() {
 
         {/* InspectorPanel */}
         <div className="border-l border-[color:var(--color-rule)] bg-[color:var(--color-panel-hi)] flex flex-col overflow-hidden">
-          {/* header */}
-          <div
-            className="border-b border-[color:var(--color-rule)] flex items-center justify-between"
-            style={{ padding: '1.4cqw 1.6cqw' }}
-          >
-            <div className="flex items-center gap-[0.6cqw]">
-              <span
-                className="font-[family-name:var(--font-sans)] font-semibold tracking-tight text-[color:var(--color-text)]"
-                style={{ fontSize: '1.25cqw' }}
-              >
-                Inspect
-              </span>
-              <span
-                aria-hidden
-                className="bg-[color:var(--color-rule)]"
-                style={{ width: '1px', height: '1.4cqw' }}
-              />
-              <span
-                className="rounded-[3px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] font-[family-name:var(--font-mono)] text-[color:var(--color-text)]"
-                style={{ padding: '0.1cqw 0.5cqw', fontSize: '1cqw' }}
-              >
-                &lt;h1&gt;
-              </span>
-            </div>
-            <span className="text-[color:var(--color-dim)]">✕</span>
-          </div>
+          <PanelHeader />
 
           <PanelSection label="Content">
             <PanelTextarea value="Q2 Launch" />
@@ -581,16 +591,28 @@ function VisualEditorVisual() {
                   style={{ width: barWidth }}
                 />
                 <motion.div
-                  className="absolute top-1/2 -translate-y-1/2 rounded-full bg-[color:var(--color-text)] border border-[color:var(--color-accent)]"
+                  className="absolute top-1/2 rounded-full bg-[color:var(--color-text)] border border-[color:var(--color-accent)]"
                   style={{
                     width: '1.1cqw',
                     height: '1.1cqw',
                     left: thumbLeft,
+                    y: '-50%',
                   }}
+                  animate={active ? { scale: [1, 1.3, 1.3, 1, 1, 1.3, 1.3, 1, 1] } : { scale: 1 }}
+                  transition={
+                    active
+                      ? {
+                          duration: 6,
+                          times: [0, 0.03, 0.17, 0.23, 0.47, 0.53, 0.67, 0.73, 1],
+                          ease: 'easeOut',
+                          repeat: Infinity,
+                        }
+                      : undefined
+                  }
                 />
               </div>
               <motion.span
-                className="flex-1 rounded-[4px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] text-[color:var(--color-text)] font-[family-name:var(--font-mono)]"
+                className="flex-1 rounded-[4px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] text-[color:var(--color-text)] font-[family-name:var(--font-mono)] transition-colors hover:border-[color:var(--color-dim)]"
                 style={{ fontSize: '1.05cqw', padding: '0.4cqw 0.6cqw' }}
               >
                 {sizeLabel}
@@ -621,15 +643,69 @@ function VisualEditorVisual() {
   );
 }
 
+function PanelHeader() {
+  return (
+    <div
+      className="border-b border-[color:var(--color-rule)] flex items-center justify-between"
+      style={{ padding: '1.2cqw 1.6cqw' }}
+    >
+      <div className="flex items-center gap-[0.6cqw]">
+        <svg
+          aria-hidden
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          className="text-[color:var(--color-muted)]"
+          style={{ width: '1.2cqw', height: '1.2cqw' }}
+        >
+          <circle cx="12" cy="12" r="8" />
+          <line x1="22" y1="12" x2="18" y2="12" />
+          <line x1="6" y1="12" x2="2" y2="12" />
+          <line x1="12" y1="6" x2="12" y2="2" />
+          <line x1="12" y1="22" x2="12" y2="18" />
+        </svg>
+        <span
+          className="font-[family-name:var(--font-sans)] font-semibold tracking-tight text-[color:var(--color-text)]"
+          style={{ fontSize: '1.25cqw' }}
+        >
+          Inspect
+        </span>
+        <span
+          aria-hidden
+          className="bg-[color:var(--color-rule)]"
+          style={{ width: '1px', height: '1.4cqw' }}
+        />
+        <span
+          className="rounded-[3px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] font-[family-name:var(--font-mono)] text-[color:var(--color-text)]"
+          style={{ padding: '0.1cqw 0.5cqw', fontSize: '1cqw' }}
+        >
+          &lt;h1&gt;
+        </span>
+      </div>
+      <span
+        className="inline-flex items-center justify-center rounded-[4px] text-[color:var(--color-dim)] transition-colors hover:bg-[color:var(--color-panel)] hover:text-[color:var(--color-text)]"
+        style={{ width: '2cqw', height: '2cqw' }}
+      >
+        ✕
+      </span>
+    </div>
+  );
+}
+
 function PanelSection({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex flex-col gap-[0.9cqw]" style={{ padding: '1.2cqw 1.6cqw' }}>
-      <span
-        className="font-[family-name:var(--font-sans)] font-medium text-[color:var(--color-text-soft)]"
-        style={{ fontSize: '1cqw' }}
-      >
-        {label}
-      </span>
+      <div className="flex items-center gap-[0.8cqw]">
+        <span
+          className="font-[family-name:var(--font-sans)] font-medium uppercase text-[color:var(--color-muted)]"
+          style={{ fontSize: '0.9cqw', letterSpacing: '0.08em' }}
+        >
+          {label}
+        </span>
+        <span aria-hidden className="h-px flex-1 bg-[color:var(--color-rule-soft)]" />
+      </div>
       {children}
     </div>
   );
@@ -664,7 +740,7 @@ function PanelInput({
 }) {
   return (
     <span
-      className={`flex-1 rounded-[4px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] text-[color:var(--color-text)] ${
+      className={`flex-1 rounded-[4px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] text-[color:var(--color-text)] transition-colors hover:border-[color:var(--color-dim)] ${
         mono ? 'font-[family-name:var(--font-mono)]' : 'font-[family-name:var(--font-sans)]'
       } ${uppercase ? 'uppercase' : ''}`}
       style={{ fontSize: '1.05cqw', padding: '0.4cqw 0.6cqw' }}
@@ -677,7 +753,7 @@ function PanelInput({
 function PanelSelect({ value }: { value: string }) {
   return (
     <span
-      className="flex-1 inline-flex items-center justify-between rounded-[4px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] font-[family-name:var(--font-sans)] text-[color:var(--color-text)]"
+      className="flex-1 inline-flex items-center justify-between rounded-[4px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] font-[family-name:var(--font-sans)] text-[color:var(--color-text)] transition-colors hover:border-[color:var(--color-dim)]"
       style={{ fontSize: '1.05cqw', padding: '0.4cqw 0.6cqw' }}
     >
       <span>{value}</span>
@@ -691,10 +767,10 @@ function PanelSelect({ value }: { value: string }) {
 function PanelToggle({ glyph, pressed = false }: { glyph: ReactNode; pressed?: boolean }) {
   return (
     <span
-      className={`inline-flex items-center justify-center rounded-[4px] border ${
+      className={`inline-flex items-center justify-center rounded-[4px] border transition-colors ${
         pressed
           ? 'border-[color:var(--color-rule)] bg-[color:var(--color-panel)] text-[color:var(--color-text)]'
-          : 'border-[color:var(--color-rule)] bg-transparent text-[color:var(--color-muted)]'
+          : 'border-[color:var(--color-rule)] bg-transparent text-[color:var(--color-muted)] hover:bg-[color:var(--color-panel)] hover:text-[color:var(--color-text)]'
       }`}
       style={{ width: '2.4cqw', height: '2.4cqw' }}
     >
@@ -706,7 +782,7 @@ function PanelToggle({ glyph, pressed = false }: { glyph: ReactNode; pressed?: b
 function PanelSwatch({ color }: { color: string }) {
   return (
     <span
-      className="inline-flex items-center justify-center rounded-[4px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)]"
+      className="inline-flex items-center justify-center rounded-[4px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] transition-colors hover:border-[color:var(--color-dim)]"
       style={{ width: '2.4cqw', height: '2.4cqw' }}
     >
       <span
@@ -724,7 +800,7 @@ function PanelSwatch({ color }: { color: string }) {
 function PanelTextarea({ value }: { value: string }) {
   return (
     <span
-      className="block rounded-[4px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] font-[family-name:var(--font-sans)] text-[color:var(--color-text)]"
+      className="block rounded-[4px] border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] font-[family-name:var(--font-sans)] text-[color:var(--color-text)] transition-colors hover:border-[color:var(--color-dim)]"
       style={{
         fontSize: '1.1cqw',
         padding: '0.7cqw 0.7cqw',
@@ -740,8 +816,10 @@ function PanelTextarea({ value }: { value: string }) {
 function SaveBarIconBtn({ glyph, dim = false }: { glyph: ReactNode; dim?: boolean }) {
   return (
     <span
-      className={`inline-flex items-center justify-center rounded-[4px] ${
-        dim ? 'text-[color:var(--color-dim)]' : 'text-[color:var(--color-muted)]'
+      className={`inline-flex items-center justify-center rounded-[4px] transition-colors ${
+        dim
+          ? 'text-[color:var(--color-dim)]'
+          : 'text-[color:var(--color-muted)] hover:bg-[color:var(--color-panel)] hover:text-[color:var(--color-text)]'
       }`}
       style={{ width: '2cqw', height: '2cqw' }}
     >


### PR DESCRIPTION
## What changed

Reworks the two embedded product mocks on the landing page — **Talk to the agent.** ([inspector.tsx](https://github.com/1weiho/open-slide/blob/feat/landing-embedded-mock-animations/apps/web/components/landing/inspector.tsx)) and **Drop in images.** ([assets.tsx](https://github.com/1weiho/open-slide/blob/feat/landing-embedded-mock-animations/apps/web/components/landing/assets.tsx)) — so their motion, chrome, and hover behavior match the real open-slide editor.

### Inspector section
- Retimed the agent-apply loop with strong ease-out segments (`cubic-bezier(0.23, 1, 0.32, 1)`); the inspector panel now slides in ~250ms, matching core's `PANEL_TRANSITION_MS`
- Click ripple on the canvas cursor, and an HMR-style highlight pulse on the title when the agent applies the comment
- Panel chrome aligned with core: eyebrow + hairline section headers, Crosshair icon in the header (duplicated header extracted into a shared `PanelHeader`), `rounded-[8px]` save bar
- Hover states across all panel controls, save bar buttons, and close buttons; crosshair cursor on canvas areas; mocks are `select-none` with an edge→floating shadow lift on hover

### Assets section
- Replaces the static mock with a 14s sequential story: pointer clicks **Search logos** → svgl dialog opens with three results → typing `vercel` filters down to one → dialog closed via ✕ → `hero.png` is dragged in and dropped
- After the drop the state actually changes: hero.png inserts at slot 1, every card shifts back one slot (`calc(100% + gap)` transforms, with the last card pushed out of the visible window), the toolbar count bumps to **07 files**, and an upload toast confirms
- Toolbar, asset cards, and the logo-search dialog now mirror core's real asset view: scope tabs, upload button with inset highlight, usage badges, hover kebab menu, and the drag-active overlay
- Guided cursors are anchored inside their click targets (`absolute left-1/2 top-1/2` + fly-in offsets), so they land precisely at any viewport width

## Anything a reviewer should know

- **Sync model:** placeholder visibility, result filtering, the dialog open/close, and the post-drop grid shift all *derive* from three motion-value clocks (`typingProgress`, `dialogPhase`, `heroPhase`) started in one effect, rather than running parallel keyframe timelines — earlier iterations desynced (placeholder visible while typing, results restored before the ✕ click), and derivation makes those states impossible by construction.
- The `16px` in the shift transforms is coupled to the grid's `gap-4` (commented at the grid).
- Both loops gate on `useInView` + `useReducedMotion`; the static/reduced-motion frame is coherent (dialog open with `vercel` typed and one result, original 6-file grid).
- Loop-seam resets (grid slide-back, 07→06, text untype) happen only while the dialog/toast are hidden, during the idle tail.
- Apps-only change, so no changeset. `pnpm check` and `tsc --noEmit` pass; verified SSR output renders the new markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced landing-page asset previews with richer animations, guided interactions, upload states, search filtering, and result highlighting.
  * Added clearer asset details, including file size, usage status, themed names, and hover actions.
  * Improved inspector and visual editor previews with refreshed controls, animated feedback, and click confirmation effects.

* **Style**
  * Refined panel layouts, hover states, transitions, typography controls, and save bar styling.
  * Improved animation behavior for smoother, more responsive interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->