### PR TITLE
feat(web): stage the landing live demo with spotlight, marks, and scrubber

### DIFF
--- a/apps/web/app/(home)/landing.css
+++ b/apps/web/app/(home)/landing.css
@@ -154,6 +154,61 @@ html.dark .os-landing .bloom {
   box-shadow: var(--shadow-floating);
 }
 
+/* Demo stage — the live player presented like a lit artifact: an accent
+   spotlight wash behind the canvas and a deeper, longer-throw shadow than
+   .floating so the slab reads as elevated above the page. */
+.os-landing .stage-glow {
+  background:
+    radial-gradient(
+      52% 42% at 50% 16%,
+      color-mix(in oklab, var(--color-accent) 15%, transparent),
+      transparent 70%
+    ),
+    radial-gradient(
+      82% 74% at 50% 55%,
+      color-mix(in oklab, var(--color-accent) 6%, transparent),
+      transparent 78%
+    );
+}
+html.dark .os-landing .stage-glow {
+  background:
+    radial-gradient(
+      52% 42% at 50% 16%,
+      color-mix(in oklab, var(--color-accent) 26%, transparent),
+      transparent 70%
+    ),
+    radial-gradient(
+      82% 74% at 50% 55%,
+      color-mix(in oklab, var(--color-accent) 11%, transparent),
+      transparent 78%
+    );
+}
+
+.os-landing .stage-shadow {
+  box-shadow:
+    0 1px 1px oklch(0 0 0 / 0.04),
+    0 12px 32px -12px oklch(0 0 0 / 0.12),
+    0 40px 88px -28px oklch(0 0 0 / 0.2);
+}
+html.dark .os-landing .stage-shadow {
+  box-shadow:
+    0 1px 1px oklch(0 0 0 / 0.3),
+    0 32px 72px -28px oklch(0 0 0 / 0.65);
+}
+
+@keyframes os-livePulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--color-accent) 45%, transparent);
+  }
+  70%,
+  100% {
+    box-shadow: 0 0 0 7px transparent;
+  }
+}
+.os-landing .live-dot {
+  animation: os-livePulse 2.2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
 @keyframes os-marquee {
   from {
     transform: translateX(0);
@@ -223,6 +278,12 @@ html.dark .os-landing .bloom {
 .os-landing [data-reveal="blur"].reveal-hidden {
   filter: blur(7px);
 }
+/* The demo stage lands like a projection warming up: a touch of scale on
+   top of the shared rise + blur. */
+.os-landing [data-reveal="stage"].reveal-hidden {
+  transform: translateY(26px) scale(0.982);
+  filter: blur(9px);
+}
 /* Cells inside seamed grids (gap-px over the rule color) fade in place —
    translating them would smear the hairline seams. */
 .os-landing [data-reveal="fade"].reveal-hidden {
@@ -277,6 +338,9 @@ html.dark .os-landing .site-nav[data-scrolled] {
   }
   .os-landing .pressable:active {
     transform: none;
+  }
+  .os-landing .live-dot {
+    animation: none;
   }
 }
 

--- a/apps/web/components/landing/frame.tsx
+++ b/apps/web/components/landing/frame.tsx
@@ -19,7 +19,7 @@ export function StripeBand() {
   );
 }
 
-function CrossMark({ className }: { className?: string }) {
+export function CrossMark({ className }: { className?: string }) {
   return (
     <svg aria-hidden width="11" height="11" viewBox="0 0 11 11" fill="none" className={className}>
       <path d="M5.5 0v11M0 5.5h11" stroke="var(--color-dim)" strokeWidth="1" />

--- a/apps/web/components/landing/inline-slide-player.tsx
+++ b/apps/web/components/landing/inline-slide-player.tsx
@@ -62,7 +62,7 @@ export function InlineSlidePlayer({ index, onIndexChange }: Props) {
       onKeyDown={onKeyDown}
       aria-roledescription="slide player"
       aria-label={`Slide ${index + 1} of ${count}`}
-      className="group relative h-full w-full outline-none"
+      className="relative h-full w-full outline-none"
     >
       <div ref={stageRef} className="relative h-full w-full overflow-hidden">
         <div
@@ -87,13 +87,6 @@ export function InlineSlidePlayer({ index, onIndexChange }: Props) {
             {Page ? <Page /> : null}
           </div>
         </div>
-      </div>
-
-      <div
-        aria-hidden
-        className="pointer-events-none absolute bottom-3 right-3 font-[family-name:var(--font-mono)] text-[11px] tracking-[0.08em] text-[color:var(--color-muted)] bg-[color:var(--color-panel)]/75 backdrop-blur-sm px-2 py-1 rounded-[4px]"
-      >
-        {String(index + 1).padStart(2, '0')} / {String(count).padStart(2, '0')}
       </div>
     </div>
   );

--- a/apps/web/components/landing/live-demo.tsx
+++ b/apps/web/components/landing/live-demo.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import posthog from 'posthog-js';
-import { useState } from 'react';
+import { type CSSProperties, useState } from 'react';
+import { CrossMark } from './frame';
 import { InlineSlidePlayer, inlineSlideCount } from './inline-slide-player';
 
 export function LiveDemo() {
@@ -11,39 +12,90 @@ export function LiveDemo() {
   const atStart = index === 0;
   const atEnd = index === count - 1;
 
-  const handlePrev = () => {
-    const next = clamp(index - 1);
+  const goTo = (next: number, direction: 'prev' | 'next') => {
     setIndex(next);
     posthog.capture('demo_slide_navigated', {
-      direction: 'prev',
+      direction,
       slide_index: next,
     });
   };
 
-  const handleNext = () => {
-    const next = clamp(index + 1);
-    setIndex(next);
-    posthog.capture('demo_slide_navigated', {
-      direction: 'next',
-      slide_index: next,
-    });
+  const handlePrev = () => goTo(clamp(index - 1), 'prev');
+  const handleNext = () => goTo(clamp(index + 1), 'next');
+  const handleJump = (i: number) => {
+    if (i === index) return;
+    goTo(i, i > index ? 'next' : 'prev');
   };
+
+  const paddleBase =
+    'pressable absolute top-1/2 z-[2] hidden h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-white/15 bg-black/45 text-[15px] text-white/90 backdrop-blur-md opacity-0 group-hover:enabled:opacity-100 focus-visible:enabled:opacity-100 hover:border-white/30 hover:bg-black/65 disabled:pointer-events-none sm:flex';
 
   return (
-    <section id="demo" className="relative" aria-labelledby="demo-heading">
+    <section id="demo" className="relative overflow-hidden" aria-labelledby="demo-heading">
       <div className="mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 pt-4 sm:pt-8 lg:pt-12 pb-20 sm:pb-32">
-        <h2 id="demo-heading" className="sr-only">
-          Live demo
-        </h2>
-        <div
-          data-reveal
-          className="floating relative block w-full overflow-hidden rounded-[8px] border border-[color:var(--color-rule)] bg-black"
-          style={{ aspectRatio: '16 / 9' }}
-        >
-          <InlineSlidePlayer index={index} onIndexChange={setIndex} />
+        <div data-reveal className="mb-4 flex items-center justify-between gap-4">
+          <h2 id="demo-heading" className="caption flex items-center gap-2.5">
+            <span
+              aria-hidden
+              className="live-dot h-1.5 w-1.5 rounded-full bg-[color:var(--color-accent)]"
+            />
+            Live demo
+          </h2>
+          <span className="hidden font-[family-name:var(--font-mono)] text-[11px] tracking-[0.08em] uppercase text-[color:var(--color-muted)] sm:block">
+            every page is code · 1920 × 1080
+          </span>
         </div>
 
-        <div className="mt-6 flex items-center justify-between text-[13px] font-medium text-[color:var(--color-muted)]">
+        <div
+          data-reveal="stage"
+          style={{ '--reveal-delay': '70ms' } as CSSProperties}
+          className="relative"
+        >
+          <div
+            aria-hidden
+            className="stage-glow pointer-events-none absolute -inset-x-10 -top-16 -bottom-10 sm:-inset-x-24 sm:-top-28 sm:-bottom-16"
+          />
+          <div aria-hidden className="pointer-events-none absolute inset-0 z-[2] hidden sm:block">
+            <CrossMark className="absolute -top-[6px] -left-[5px]" />
+            <CrossMark className="absolute -top-[6px] -right-[5px]" />
+            <CrossMark className="absolute -bottom-[6px] -left-[5px]" />
+            <CrossMark className="absolute -bottom-[6px] -right-[5px]" />
+          </div>
+          <div
+            className="group stage-shadow relative z-[1] block w-full overflow-hidden rounded-[8px] border border-[color:var(--color-rule)] bg-black"
+            style={{ aspectRatio: '16 / 9' }}
+          >
+            <InlineSlidePlayer index={index} onIndexChange={setIndex} />
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 z-[1] rounded-[8px] shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+            />
+            <button
+              type="button"
+              onClick={handlePrev}
+              disabled={atStart}
+              aria-label="Previous slide"
+              className={`${paddleBase} left-3`}
+            >
+              ←
+            </button>
+            <button
+              type="button"
+              onClick={handleNext}
+              disabled={atEnd}
+              aria-label="Next slide"
+              className={`${paddleBase} right-3`}
+            >
+              →
+            </button>
+          </div>
+        </div>
+
+        <div
+          data-reveal
+          style={{ '--reveal-delay': '140ms' } as CSSProperties}
+          className="mt-5 flex items-center justify-between text-[13px] font-medium text-[color:var(--color-muted)]"
+        >
           <a
             href="https://demo.open-slide.dev/"
             target="_blank"
@@ -60,6 +112,26 @@ export function LiveDemo() {
             </span>
           </a>
           <span className="flex items-center gap-3">
+            <span className="hidden items-center md:flex">
+              {Array.from({ length: count }, (_, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => handleJump(i)}
+                  aria-label={`Go to slide ${i + 1}`}
+                  aria-current={i === index ? 'true' : undefined}
+                  className="group/seg flex h-6 items-center px-[3px]"
+                >
+                  <span
+                    className={`block h-[3px] rounded-full transition-[width,background-color] duration-300 ${
+                      i === index
+                        ? 'w-[22px] bg-[color:var(--color-accent)]'
+                        : 'w-[14px] bg-[color:var(--color-rule)] group-hover/seg:bg-[color:var(--color-dim)]'
+                    }`}
+                  />
+                </button>
+              ))}
+            </span>
             <span className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.08em] text-[color:var(--color-text-soft)]">
               {String(index + 1).padStart(2, '0')} / {String(count).padStart(2, '0')}
             </span>


### PR DESCRIPTION
Present the demo player as a lit stage: an accent spotlight wash and
deeper shadow behind the canvas, corner registration marks, a header
rail with a pulsing live-demo label and canvas dimensions, hover
paddles over the player, and a clickable per-slide scrubber in the
control row. The stage lands with a scale + blur reveal variant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0173kdYLK3raJmU91oFYm3sQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added slide navigation buttons for quickly jumping between demo slides on medium and larger screens.
  - Added clearer demo stage presentation with decorative overlays, accent lighting, and enhanced visual depth.
  - Added a visible demo section heading and improved navigation controls.

- **Style**
  - Added pulsing live-status indicator and refined slide reveal animations.
  - Added dedicated dark-mode styling for the demo stage.

- **Accessibility**
  - Disabled live-status animation when reduced motion is preferred.
  - Improved slide navigation labeling and active-state indication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->