### PR TITLE
Add breathing glow on setup pill when switching to agent mode

### DIFF
--- a/apps/web/app/(home)/landing.css
+++ b/apps/web/app/(home)/landing.css
@@ -278,6 +278,9 @@ html.dark .os-landing .site-nav[data-scrolled] {
   .os-landing .pressable:active {
     transform: none;
   }
+  .os-landing .setup-breathe::after {
+    animation: none;
+  }
 }
 
 @keyframes os-caret {
@@ -324,6 +327,49 @@ html.dark .os-landing .site-nav[data-scrolled] {
   animation:
     os-codePulse 900ms ease-out,
     os-codeSwap 450ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+/* One slow breath of accent light around the setup pill when the visitor
+   switches to agent mode — a quiet ceremony that confirms the switch
+   without moving anything. Lives on ::after so only opacity animates and
+   the pill's own border, hover, and floating shadow stay untouched. */
+@keyframes os-setupBreathe {
+  0% {
+    opacity: 0;
+  }
+  26% {
+    opacity: 1;
+  }
+  44% {
+    opacity: 0.92;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+.os-landing .setup-breathe {
+  position: relative;
+}
+.os-landing .setup-breathe::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 9999px;
+  pointer-events: none;
+  border: 1px solid color-mix(in oklab, var(--color-accent) 55%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in oklab, var(--color-accent) 16%, transparent),
+    0 0 20px color-mix(in oklab, var(--color-accent) 24%, transparent),
+    inset 0 0 14px color-mix(in oklab, var(--color-accent) 10%, transparent);
+  opacity: 0;
+  animation: os-setupBreathe 2.4s ease-in-out 150ms;
+}
+html.dark .os-landing .setup-breathe::after {
+  border-color: color-mix(in oklab, var(--color-accent) 75%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in oklab, var(--color-accent) 24%, transparent),
+    0 0 26px color-mix(in oklab, var(--color-accent) 34%, transparent),
+    inset 0 0 14px color-mix(in oklab, var(--color-accent) 14%, transparent);
 }
 
 @keyframes textReveal {

--- a/apps/web/app/(home)/landing.css
+++ b/apps/web/app/(home)/landing.css
@@ -278,7 +278,7 @@ html.dark .os-landing .site-nav[data-scrolled] {
   .os-landing .pressable:active {
     transform: none;
   }
-  .os-landing .setup-breathe::after {
+  .os-landing .setup-beam::after {
     animation: none;
   }
 }
@@ -329,47 +329,80 @@ html.dark .os-landing .site-nav[data-scrolled] {
     os-codeSwap 450ms cubic-bezier(0.2, 0.7, 0.2, 1);
 }
 
-/* One slow breath of accent light around the setup pill when the visitor
-   switches to agent mode — a quiet ceremony that confirms the switch
-   without moving anything. Lives on ::after so only opacity animates and
-   the pill's own border, hover, and floating shadow stay untouched. */
-@keyframes os-setupBreathe {
+/* A beam of light traces the setup pill's edge once when the visitor
+   switches to agent mode — a quiet ceremony that confirms the switch.
+   The conic gradient IS the beam: a vermillion head trailing off through
+   warm amber into transparency, masked down to a hairline ring on
+   ::after so the pill's own border, hover, and floating shadow stay
+   untouched. It dissolves over the last stretch of the lap, so the
+   light burns out just as it comes home. */
+@property --os-beam-angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+@keyframes os-beamSweep {
+  from {
+    --os-beam-angle: 0deg;
+  }
+  to {
+    --os-beam-angle: 360deg;
+  }
+}
+@keyframes os-beamFade {
   0% {
     opacity: 0;
   }
-  26% {
+  10% {
     opacity: 1;
   }
-  44% {
-    opacity: 0.92;
+  72% {
+    opacity: 1;
   }
   100% {
     opacity: 0;
   }
 }
-.os-landing .setup-breathe {
+.os-landing .setup-beam {
   position: relative;
 }
-.os-landing .setup-breathe::after {
+.os-landing .setup-beam::after {
   content: "";
   position: absolute;
-  inset: -1px;
+  inset: -1.5px;
   border-radius: 9999px;
+  padding: 2px;
   pointer-events: none;
-  border: 1px solid color-mix(in oklab, var(--color-accent) 55%, transparent);
-  box-shadow:
-    0 0 0 1px color-mix(in oklab, var(--color-accent) 16%, transparent),
-    0 0 20px color-mix(in oklab, var(--color-accent) 24%, transparent),
-    inset 0 0 14px color-mix(in oklab, var(--color-accent) 10%, transparent);
+  background: conic-gradient(
+    from var(--os-beam-angle),
+    transparent 0% 58%,
+    color-mix(in oklab, var(--color-warm) 45%, transparent) 80%,
+    color-mix(in oklab, var(--color-accent) 88%, transparent) 96%,
+    var(--color-accent) 100%
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  filter: drop-shadow(0 0 5px color-mix(in oklab, var(--color-accent) 40%, transparent));
   opacity: 0;
-  animation: os-setupBreathe 2.4s ease-in-out 150ms;
+  animation:
+    os-beamSweep 2s cubic-bezier(0.45, 0.05, 0.35, 0.95) 120ms,
+    os-beamFade 2s linear 120ms;
 }
-html.dark .os-landing .setup-breathe::after {
-  border-color: color-mix(in oklab, var(--color-accent) 75%, transparent);
-  box-shadow:
-    0 0 0 1px color-mix(in oklab, var(--color-accent) 24%, transparent),
-    0 0 26px color-mix(in oklab, var(--color-accent) 34%, transparent),
-    inset 0 0 14px color-mix(in oklab, var(--color-accent) 14%, transparent);
+html.dark .os-landing .setup-beam::after {
+  background: conic-gradient(
+    from var(--os-beam-angle),
+    transparent 0% 58%,
+    color-mix(in oklab, var(--color-warm) 60%, transparent) 80%,
+    color-mix(in oklab, var(--color-accent) 92%, transparent) 96%,
+    var(--color-accent) 100%
+  );
+  filter: drop-shadow(0 0 7px color-mix(in oklab, var(--color-accent) 55%, transparent));
 }
 
 @keyframes textReveal {

--- a/apps/web/app/(home)/landing.css
+++ b/apps/web/app/(home)/landing.css
@@ -278,8 +278,8 @@ html.dark .os-landing .site-nav[data-scrolled] {
   .os-landing .pressable:active {
     transform: none;
   }
-  .os-landing .setup-beam::after {
-    animation: none;
+  .os-landing .setup-beam {
+    display: none;
   }
 }
 
@@ -331,32 +331,28 @@ html.dark .os-landing .site-nav[data-scrolled] {
 
 /* A beam of light traces the setup pill's edge once when the visitor
    switches to agent mode — a quiet ceremony that confirms the switch.
-   The conic gradient IS the beam: a vermillion head trailing off through
-   warm amber into transparency, masked down to a hairline ring on
-   ::after so the pill's own border, hover, and floating shadow stay
-   untouched. It dissolves over the last stretch of the lap, so the
-   light burns out just as it comes home. */
-@property --os-beam-angle {
-  syntax: "<angle>";
-  inherits: false;
-  initial-value: 0deg;
-}
-@keyframes os-beamSweep {
+   The track (.setup-beam) is masked down to a hairline ring; its ::after
+   is the beam itself, a gradient blob riding offset-path along the
+   pill's contour — constant speed and constant tail length everywhere,
+   which a center-angle conic sweep can't give on a wide pill. It
+   dissolves over the last stretch of the lap, so the light burns out
+   just as it comes home. */
+@keyframes os-beamTravel {
   from {
-    --os-beam-angle: 0deg;
+    offset-distance: 0%;
   }
   to {
-    --os-beam-angle: 360deg;
+    offset-distance: 100%;
   }
 }
 @keyframes os-beamFade {
   0% {
     opacity: 0;
   }
-  10% {
+  8% {
     opacity: 1;
   }
-  72% {
+  78% {
     opacity: 1;
   }
   100% {
@@ -364,22 +360,11 @@ html.dark .os-landing .site-nav[data-scrolled] {
   }
 }
 .os-landing .setup-beam {
-  position: relative;
-}
-.os-landing .setup-beam::after {
-  content: "";
   position: absolute;
   inset: -1.5px;
   border-radius: 9999px;
   padding: 2px;
   pointer-events: none;
-  background: conic-gradient(
-    from var(--os-beam-angle),
-    transparent 0% 58%,
-    color-mix(in oklab, var(--color-warm) 45%, transparent) 80%,
-    color-mix(in oklab, var(--color-accent) 88%, transparent) 96%,
-    var(--color-accent) 100%
-  );
   -webkit-mask:
     linear-gradient(#000 0 0) content-box,
     linear-gradient(#000 0 0);
@@ -390,19 +375,37 @@ html.dark .os-landing .site-nav[data-scrolled] {
   mask-composite: exclude;
   filter: drop-shadow(0 0 5px color-mix(in oklab, var(--color-accent) 40%, transparent));
   opacity: 0;
-  animation:
-    os-beamSweep 2s cubic-bezier(0.45, 0.05, 0.35, 0.95) 120ms,
-    os-beamFade 2s linear 120ms;
+  animation: os-beamFade 3.2s linear 120ms;
+}
+.os-landing .setup-beam::after {
+  content: "";
+  position: absolute;
+  width: 110px;
+  height: 110px;
+  background: linear-gradient(
+    to left,
+    var(--color-accent),
+    color-mix(in oklab, var(--color-warm) 60%, transparent) 45%,
+    transparent 85%
+  );
+  offset-path: rect(0px auto auto 0px round 9999px);
+  animation: os-beamTravel 3.2s linear 120ms;
+}
+html.dark .os-landing .setup-beam {
+  filter: drop-shadow(0 0 7px color-mix(in oklab, var(--color-accent) 55%, transparent));
 }
 html.dark .os-landing .setup-beam::after {
-  background: conic-gradient(
-    from var(--os-beam-angle),
-    transparent 0% 58%,
-    color-mix(in oklab, var(--color-warm) 60%, transparent) 80%,
-    color-mix(in oklab, var(--color-accent) 92%, transparent) 96%,
-    var(--color-accent) 100%
+  background: linear-gradient(
+    to left,
+    var(--color-accent),
+    color-mix(in oklab, var(--color-warm) 72%, transparent) 45%,
+    transparent 85%
   );
-  filter: drop-shadow(0 0 7px color-mix(in oklab, var(--color-accent) 55%, transparent));
+}
+@supports not (offset-path: rect(0px auto auto 0px)) {
+  .os-landing .setup-beam {
+    display: none;
+  }
 }
 
 @keyframes textReveal {

--- a/apps/web/components/landing/hero-setup.tsx
+++ b/apps/web/components/landing/hero-setup.tsx
@@ -33,7 +33,7 @@ export function HeroSetup() {
   const [mode, setMode] = useState<SetupMode>('you');
   const [direction, setDirection] = useState<SetupDirection>(1);
   const [copied, setCopied] = useState(false);
-  const [breathing, setBreathing] = useState(false);
+  const [beaming, setBeaming] = useState(false);
   const copiedTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const reduceMotion = useReducedMotion();
   const option = setupOptions[mode];
@@ -44,7 +44,7 @@ export function HeroSetup() {
     if (nextMode === mode) return;
     clearTimeout(copiedTimer.current);
     setCopied(false);
-    setBreathing(nextMode === 'agent' && !reduceMotion);
+    setBeaming(nextMode === 'agent' && !reduceMotion);
     setDirection(nextMode === 'agent' ? 1 : -1);
     setMode(nextMode);
     posthog.capture('hero_setup_mode_selected', { mode: nextMode });
@@ -104,9 +104,9 @@ export function HeroSetup() {
         aria-label={option.copyLabel}
         onClick={copySetup}
         onAnimationEnd={(event) => {
-          if (event.animationName === 'os-setupBreathe') setBreathing(false);
+          if (event.animationName === 'os-beamSweep') setBeaming(false);
         }}
-        className={`group pressable floating flex h-[58px] w-[337px] max-w-full items-center gap-3 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-5 text-left hover:border-[color:var(--color-accent)]/50 sm:h-[68px] sm:px-7 ${breathing ? 'setup-breathe' : ''}`}
+        className={`group pressable floating flex h-[58px] w-[337px] max-w-full items-center gap-3 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-5 text-left hover:border-[color:var(--color-accent)]/50 sm:h-[68px] sm:px-7 ${beaming ? 'setup-beam' : ''}`}
       >
         <span className="relative h-[20px] min-w-0 flex-1 overflow-hidden sm:h-[22px]">
           <AnimatePresence initial={false} custom={direction}>

--- a/apps/web/components/landing/hero-setup.tsx
+++ b/apps/web/components/landing/hero-setup.tsx
@@ -33,6 +33,7 @@ export function HeroSetup() {
   const [mode, setMode] = useState<SetupMode>('you');
   const [direction, setDirection] = useState<SetupDirection>(1);
   const [copied, setCopied] = useState(false);
+  const [breathing, setBreathing] = useState(false);
   const copiedTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const reduceMotion = useReducedMotion();
   const option = setupOptions[mode];
@@ -43,6 +44,7 @@ export function HeroSetup() {
     if (nextMode === mode) return;
     clearTimeout(copiedTimer.current);
     setCopied(false);
+    setBreathing(nextMode === 'agent' && !reduceMotion);
     setDirection(nextMode === 'agent' ? 1 : -1);
     setMode(nextMode);
     posthog.capture('hero_setup_mode_selected', { mode: nextMode });
@@ -101,7 +103,10 @@ export function HeroSetup() {
         type="button"
         aria-label={option.copyLabel}
         onClick={copySetup}
-        className="group pressable floating flex h-[58px] w-[337px] max-w-full items-center gap-3 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-5 text-left hover:border-[color:var(--color-accent)]/50 sm:h-[68px] sm:px-7"
+        onAnimationEnd={(event) => {
+          if (event.animationName === 'os-setupBreathe') setBreathing(false);
+        }}
+        className={`group pressable floating flex h-[58px] w-[337px] max-w-full items-center gap-3 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-5 text-left hover:border-[color:var(--color-accent)]/50 sm:h-[68px] sm:px-7 ${breathing ? 'setup-breathe' : ''}`}
       >
         <span className="relative h-[20px] min-w-0 flex-1 overflow-hidden sm:h-[22px]">
           <AnimatePresence initial={false} custom={direction}>

--- a/apps/web/components/landing/hero-setup.tsx
+++ b/apps/web/components/landing/hero-setup.tsx
@@ -104,10 +104,11 @@ export function HeroSetup() {
         aria-label={option.copyLabel}
         onClick={copySetup}
         onAnimationEnd={(event) => {
-          if (event.animationName === 'os-beamSweep') setBeaming(false);
+          if (event.animationName === 'os-beamTravel') setBeaming(false);
         }}
-        className={`group pressable floating flex h-[58px] w-[337px] max-w-full items-center gap-3 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-5 text-left hover:border-[color:var(--color-accent)]/50 sm:h-[68px] sm:px-7 ${beaming ? 'setup-beam' : ''}`}
+        className="group pressable floating relative flex h-[58px] w-[337px] max-w-full items-center gap-3 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)] px-5 text-left hover:border-[color:var(--color-accent)]/50 sm:h-[68px] sm:px-7"
       >
+        {beaming ? <span aria-hidden className="setup-beam" /> : null}
         <span className="relative h-[20px] min-w-0 flex-1 overflow-hidden sm:h-[22px]">
           <AnimatePresence initial={false} custom={direction}>
             <motion.span


### PR DESCRIPTION
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017ZkGP2oAomioQqmfifqjqc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a subtle edge “beam” glow animation to the setup button when agent setup mode is selected.
  * Updated the effect to animate along the button border and fade out after completing.
  * Included dark-mode styling to match the beam glow.
* **Accessibility**
  * Disabled the beam animation when reduced-motion preference is enabled.
  * Automatically disables the effect in browsers that don’t support the required animation path feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->