### PR TITLE
test(core): add Playwright e2e suite for the framework runtime

### DIFF
--- a/.changeset/witty-donkeys-test.md
+++ b/.changeset/witty-donkeys-test.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Add a Playwright e2e suite covering the viewer, present mode, presenter sync, inspector editing, dev API, and static builds.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,11 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      # Image version must match @playwright/test in packages/core/package.json.
+      image: mcr.microsoft.com/playwright:v1.56.1-noble
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,9 +102,6 @@ jobs:
 
       - name: Build core
         run: pnpm --filter @open-slide/core build
-
-      - name: Install Playwright browsers
-        run: pnpm --filter @open-slide/core exec playwright install --with-deps chromium
 
       - name: Run e2e tests
         run: pnpm test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build core
-        run: pnpm --filter @open-slide/core build
-
       - name: Run e2e tests
         run: pnpm test:e2e
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,9 @@ jobs:
         run: pnpm test:e2e
 
       - name: Upload Playwright report
-        if: failure()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-${{ github.run_attempt }}
           path: packages/core/playwright-report
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,38 @@ jobs:
 
       - name: Run unit tests
         run: pnpm test
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build core
+        run: pnpm --filter @open-slide/core build
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @open-slide/core exec playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: pnpm test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: packages/core/playwright-report
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist
 *.tsbuildinfo
 .turbo
 packages/cli/template/.agents/skills
+packages/core/e2e/.scratch
+playwright-report
+test-results

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check:fix": "biome check --write .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "pnpm --filter @open-slide/core test:e2e",
     "core": "pnpm --filter @open-slide/core",
     "cli": "pnpm --filter @open-slide/cli",
     "changeset": "changeset",

--- a/packages/core/e2e/fixture/open-slide.config.ts
+++ b/packages/core/e2e/fixture/open-slide.config.ts
@@ -1,0 +1,5 @@
+import type { OpenSlideConfig } from '@open-slide/core';
+
+const openSlideConfig: OpenSlideConfig = {};
+
+export default openSlideConfig;

--- a/packages/core/e2e/fixture/package.json
+++ b/packages/core/e2e/fixture/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "core-e2e-fixture",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "dependencies": {
+    "@open-slide/core": "workspace:*",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3"
+  }
+}

--- a/packages/core/e2e/fixture/slides/alpha/index.tsx
+++ b/packages/core/e2e/fixture/slides/alpha/index.tsx
@@ -1,0 +1,41 @@
+import type { Page, SlideMeta } from '@open-slide/core';
+
+export const meta: SlideMeta = {
+  title: 'Alpha Deck',
+  theme: 'plain',
+  createdAt: '2026-01-03T00:00:00.000Z',
+};
+
+const fill = {
+  width: '100%',
+  height: '100%',
+  background: '#101014',
+  color: '#f2f2ef',
+  padding: 120,
+  fontFamily: 'system-ui, sans-serif',
+} as const;
+
+const One: Page = () => (
+  <div style={fill}>
+    <h1 style={{ fontSize: 96, margin: 0 }}>Alpha page one</h1>
+    <p style={{ fontSize: 40 }}>Opening content</p>
+  </div>
+);
+
+const Two: Page = () => (
+  <div style={fill}>
+    <h1 style={{ fontSize: 96, margin: 0 }}>Alpha page two</h1>
+    <p style={{ fontSize: 40 }}>Middle content</p>
+  </div>
+);
+
+const Three: Page = () => (
+  <div style={fill}>
+    <h1 style={{ fontSize: 96, margin: 0 }}>Alpha page three</h1>
+    <p style={{ fontSize: 40 }}>Closing content</p>
+  </div>
+);
+
+export const notes: (string | undefined)[] = ['Alpha speaker note', undefined, 'Alpha final note'];
+
+export default [One, Two, Three] satisfies Page[];

--- a/packages/core/e2e/fixture/slides/edit-target/index.tsx
+++ b/packages/core/e2e/fixture/slides/edit-target/index.tsx
@@ -1,0 +1,24 @@
+import type { Page, SlideMeta } from '@open-slide/core';
+
+export const meta: SlideMeta = {
+  title: 'Edit Target',
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const fill = {
+  width: '100%',
+  height: '100%',
+  background: '#1a1408',
+  color: '#f5ead2',
+  padding: 120,
+  fontFamily: 'system-ui, sans-serif',
+} as const;
+
+const Only: Page = () => (
+  <div style={fill}>
+    <h1 style={{ fontSize: 96, margin: 0 }}>Editable headline</h1>
+    <p style={{ fontSize: 40 }}>Editable body copy</p>
+  </div>
+);
+
+export default [Only] satisfies Page[];

--- a/packages/core/e2e/fixture/slides/hot-swap/index.tsx
+++ b/packages/core/e2e/fixture/slides/hot-swap/index.tsx
@@ -1,0 +1,24 @@
+import type { Page, SlideMeta } from '@open-slide/core';
+
+export const meta: SlideMeta = {
+  title: 'Hot Deck',
+  createdAt: '2025-12-31T00:00:00.000Z',
+};
+
+const fill = {
+  width: '100%',
+  height: '100%',
+  background: '#151022',
+  color: '#efe9fb',
+  padding: 120,
+  fontFamily: 'system-ui, sans-serif',
+} as const;
+
+const Only: Page = () => (
+  <div style={fill}>
+    <h1 style={{ fontSize: 96, margin: 0 }}>Hot swap headline</h1>
+    <p style={{ fontSize: 40 }}>Hot swap body copy</p>
+  </div>
+);
+
+export default [Only] satisfies Page[];

--- a/packages/core/e2e/fixture/slides/steps/index.tsx
+++ b/packages/core/e2e/fixture/slides/steps/index.tsx
@@ -1,0 +1,37 @@
+import { type Page, type SlideMeta, Step, Steps } from '@open-slide/core';
+
+export const meta: SlideMeta = {
+  title: 'Steps Deck',
+  createdAt: '2026-01-02T00:00:00.000Z',
+};
+
+const fill = {
+  width: '100%',
+  height: '100%',
+  background: '#0d1117',
+  color: '#e6edf3',
+  padding: 120,
+  fontFamily: 'system-ui, sans-serif',
+} as const;
+
+const One: Page = () => (
+  <div style={fill}>
+    <h1 style={{ fontSize: 96, margin: 0 }}>Steps page one</h1>
+    <Steps>
+      <Step>
+        <p style={{ fontSize: 40 }}>Step item first</p>
+      </Step>
+      <Step>
+        <p style={{ fontSize: 40 }}>Step item second</p>
+      </Step>
+    </Steps>
+  </div>
+);
+
+const Two: Page = () => (
+  <div style={fill}>
+    <h1 style={{ fontSize: 96, margin: 0 }}>Steps page two</h1>
+  </div>
+);
+
+export default [One, Two] satisfies Page[];

--- a/packages/core/e2e/fixture/slides/steps/index.tsx
+++ b/packages/core/e2e/fixture/slides/steps/index.tsx
@@ -17,6 +17,12 @@ const fill = {
 const One: Page = () => (
   <div style={fill}>
     <h1 style={{ fontSize: 96, margin: 0 }}>Steps page one</h1>
+  </div>
+);
+
+const Two: Page = () => (
+  <div style={fill}>
+    <h1 style={{ fontSize: 96, margin: 0 }}>Steps page two</h1>
     <Steps>
       <Step>
         <p style={{ fontSize: 40 }}>Step item first</p>
@@ -28,10 +34,10 @@ const One: Page = () => (
   </div>
 );
 
-const Two: Page = () => (
+const Three: Page = () => (
   <div style={fill}>
-    <h1 style={{ fontSize: 96, margin: 0 }}>Steps page two</h1>
+    <h1 style={{ fontSize: 96, margin: 0 }}>Steps page three</h1>
   </div>
 );
 
-export default [One, Two] satisfies Page[];
+export default [One, Two, Three] satisfies Page[];

--- a/packages/core/e2e/fixture/themes/plain.demo.tsx
+++ b/packages/core/e2e/fixture/themes/plain.demo.tsx
@@ -1,0 +1,25 @@
+import type { Page } from '@open-slide/core';
+
+const base = {
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: '#0b0b0f',
+  color: '#f5f5f5',
+} as const;
+
+const One: Page = () => (
+  <div style={base}>
+    <h1 style={{ fontSize: 96, margin: 0 }}>Theme demo one</h1>
+  </div>
+);
+
+const Two: Page = () => (
+  <div style={base}>
+    <h1 style={{ fontSize: 96, margin: 0 }}>Theme demo two</h1>
+  </div>
+);
+
+export default [One, Two] satisfies Page[];

--- a/packages/core/e2e/fixture/themes/plain.md
+++ b/packages/core/e2e/fixture/themes/plain.md
@@ -1,0 +1,8 @@
+---
+name: Plain
+description: Minimal fixture theme for e2e tests.
+---
+
+# Plain
+
+A minimal theme used only by the e2e fixture project.

--- a/packages/core/e2e/fixture/themes/plain.md
+++ b/packages/core/e2e/fixture/themes/plain.md
@@ -6,3 +6,32 @@ description: Minimal fixture theme for e2e tests.
 # Plain
 
 A minimal theme used only by the e2e fixture project.
+
+## Voice
+
+Keep every slide calm and literal. Prefer one idea per page and let the
+whitespace carry the weight. Avoid decorative gradients, drop shadows, and
+anything that competes with the words.
+
+## Layout
+
+Anchor content to a generous margin. Titles sit large and flush-left; body
+copy stays a single measured column. Never center long-form text, and never
+let a line run past a comfortable reading width.
+
+## Color
+
+Ink on paper. A near-black foreground on a warm off-white background, with a
+single restrained accent reserved for the one thing that matters on a slide.
+Contrast is a feature, not a decoration.
+
+## Typography
+
+One display face for headings, one text face for everything else. Lean on
+size and weight for hierarchy rather than introducing new families. Tighten
+tracking on the largest titles; loosen leading on the smallest captions.
+
+## Motion
+
+Motion is a courtesy, not a spectacle. Cross-fades over cuts, short over
+long, and nothing that draws attention to the transition itself.

--- a/packages/core/e2e/fixture/tsconfig.json
+++ b/packages/core/e2e/fixture/tsconfig.json
@@ -5,21 +5,13 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
-    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/app/*"]
-    },
-    "types": ["node", "vite/client"]
+    "types": ["@open-slide/core/env"]
   },
-  "include": ["src", "tsdown.config.ts", "e2e/tests", "playwright.config.ts"]
+  "include": ["slides/**/*", "open-slide.config.ts"]
 }

--- a/packages/core/e2e/scratch.d.mts
+++ b/packages/core/e2e/scratch.d.mts
@@ -1,0 +1,2 @@
+export declare const fixtureDir: string;
+export declare function prepareScratchProject(name: string): string;

--- a/packages/core/e2e/scratch.mjs
+++ b/packages/core/e2e/scratch.mjs
@@ -1,0 +1,22 @@
+// Copies the fixture project into e2e/.scratch/<name> so tests that write to
+// disk (inspector saves, notes, dev API mutations) never touch the committed
+// fixture sources. node_modules is symlinked back to the fixture's install.
+import { cpSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+export const fixtureDir = path.join(here, 'fixture');
+
+export function prepareScratchProject(name) {
+  const dir = path.join(here, '.scratch', name);
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(dir, { recursive: true });
+  cpSync(fixtureDir, dir, {
+    recursive: true,
+    filter: (src) => path.basename(src) !== 'node_modules',
+  });
+  symlinkSync(path.join(fixtureDir, 'node_modules'), path.join(dir, 'node_modules'), 'junction');
+  return dir;
+}

--- a/packages/core/e2e/start-dev-server.mjs
+++ b/packages/core/e2e/start-dev-server.mjs
@@ -1,0 +1,46 @@
+// Boots `open-slide dev` for the e2e suite against a throwaway copy of the
+// fixture project, so tests that write to disk (inspector saves, notes, dev
+// API mutations) never touch the committed fixture sources.
+import { spawn } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const coreRoot = path.resolve(here, '..');
+const fixtureDir = path.join(here, 'fixture');
+const scratchDir = path.join(here, '.scratch', 'dev');
+
+if (!existsSync(path.join(coreRoot, 'dist', 'cli', 'bin.js'))) {
+  console.error('packages/core/dist is missing. Run `pnpm --filter @open-slide/core build` first.');
+  process.exit(1);
+}
+if (!existsSync(path.join(fixtureDir, 'node_modules'))) {
+  console.error('e2e fixture has no node_modules. Run `pnpm install` first.');
+  process.exit(1);
+}
+
+rmSync(scratchDir, { recursive: true, force: true });
+mkdirSync(scratchDir, { recursive: true });
+cpSync(fixtureDir, scratchDir, {
+  recursive: true,
+  filter: (src) => path.basename(src) !== 'node_modules',
+});
+symlinkSync(
+  path.join(fixtureDir, 'node_modules'),
+  path.join(scratchDir, 'node_modules'),
+  'junction',
+);
+
+const child = spawn(
+  process.execPath,
+  [path.join(coreRoot, 'bin.js'), 'dev', '--no-skills-check', ...process.argv.slice(2)],
+  {
+    cwd: scratchDir,
+    stdio: 'inherit',
+    // OPEN_SLIDE_DEV_SUPERVISED=1 skips the CLI's supervisor fork so Playwright
+    // manages a single server process.
+    env: { ...process.env, OPEN_SLIDE_DEV_SUPERVISED: '1', OPEN_SLIDE_SKIP_SKILLS_CHECK: '1' },
+  },
+);
+child.on('exit', (code, signal) => process.exit(code ?? (signal ? 1 : 0)));

--- a/packages/core/e2e/start-dev-server.mjs
+++ b/packages/core/e2e/start-dev-server.mjs
@@ -32,9 +32,19 @@ symlinkSync(
   'junction',
 );
 
+// Bind to 127.0.0.1 explicitly. Vite's default host resolves to `localhost`,
+// which on CI runners can bind to IPv6 `::1` only, leaving Playwright's IPv4
+// `http://127.0.0.1` readiness probe hanging until the webServer timeout.
 const child = spawn(
   process.execPath,
-  [path.join(coreRoot, 'bin.js'), 'dev', '--no-skills-check', ...process.argv.slice(2)],
+  [
+    path.join(coreRoot, 'bin.js'),
+    'dev',
+    '--no-skills-check',
+    '--host',
+    '127.0.0.1',
+    ...process.argv.slice(2),
+  ],
   {
     cwd: scratchDir,
     stdio: 'inherit',

--- a/packages/core/e2e/start-dev-server.mjs
+++ b/packages/core/e2e/start-dev-server.mjs
@@ -37,8 +37,9 @@ const child = spawn(
     cwd: scratchDir,
     stdio: 'inherit',
     // OPEN_SLIDE_DEV_SUPERVISED=1 skips the CLI's supervisor fork so Playwright
-    // manages a single server process.
-    env: { ...process.env, OPEN_SLIDE_DEV_SUPERVISED: '1', OPEN_SLIDE_SKIP_SKILLS_CHECK: '1' },
+    // manages a single server process. The skills drift check is already
+    // disabled by the --no-skills-check flag above.
+    env: { ...process.env, OPEN_SLIDE_DEV_SUPERVISED: '1' },
   },
 );
 child.on('exit', (code, signal) => process.exit(code ?? (signal ? 1 : 0)));

--- a/packages/core/e2e/start-dev-server.mjs
+++ b/packages/core/e2e/start-dev-server.mjs
@@ -1,15 +1,13 @@
 // Boots `open-slide dev` for the e2e suite against a throwaway copy of the
-// fixture project, so tests that write to disk (inspector saves, notes, dev
-// API mutations) never touch the committed fixture sources.
+// fixture project (see scratch.mjs).
 import { spawn } from 'node:child_process';
-import { cpSync, existsSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { fixtureDir, prepareScratchProject } from './scratch.mjs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const coreRoot = path.resolve(here, '..');
-const fixtureDir = path.join(here, 'fixture');
-const scratchDir = path.join(here, '.scratch', 'dev');
 
 if (!existsSync(path.join(coreRoot, 'dist', 'cli', 'bin.js'))) {
   console.error('packages/core/dist is missing. Run `pnpm --filter @open-slide/core build` first.');
@@ -20,17 +18,7 @@ if (!existsSync(path.join(fixtureDir, 'node_modules'))) {
   process.exit(1);
 }
 
-rmSync(scratchDir, { recursive: true, force: true });
-mkdirSync(scratchDir, { recursive: true });
-cpSync(fixtureDir, scratchDir, {
-  recursive: true,
-  filter: (src) => path.basename(src) !== 'node_modules',
-});
-symlinkSync(
-  path.join(fixtureDir, 'node_modules'),
-  path.join(scratchDir, 'node_modules'),
-  'junction',
-);
+const scratchDir = prepareScratchProject('dev');
 
 // Bind to 127.0.0.1 explicitly. Vite's default host resolves to `localhost`,
 // which on CI runners can bind to IPv6 `::1` only, leaving Playwright's IPv4

--- a/packages/core/e2e/tests/assets.spec.ts
+++ b/packages/core/e2e/tests/assets.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+import { TINY_PNG } from './helpers.ts';
+
+test.describe('asset manager', () => {
+  const ASSET = 'e2e-asset.png';
+
+  test.afterEach(async ({ request }) => {
+    await request.delete(`/__assets/@global/${ASSET}`);
+  });
+
+  test('uploads an asset and deletes it from the grid', async ({ page, request }) => {
+    await request.delete(`/__assets/@global/${ASSET}`);
+    await page.goto('/assets');
+    await expect(page.getByText('Upload', { exact: true })).toBeVisible({ timeout: 30_000 });
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: ASSET,
+      mimeType: 'image/png',
+      buffer: TINY_PNG,
+    });
+    await expect(page.getByText(ASSET, { exact: true })).toBeVisible();
+
+    await page.getByRole('button', { name: `Actions for ${ASSET}` }).click();
+    await page.getByRole('menuitem', { name: 'Delete' }).click();
+    await page.getByRole('button', { name: 'Delete', exact: true }).click();
+    await expect(page.getByText(ASSET, { exact: true })).toHaveCount(0);
+  });
+});

--- a/packages/core/e2e/tests/build.spec.ts
+++ b/packages/core/e2e/tests/build.spec.ts
@@ -30,7 +30,7 @@ test.describe('static build and preview', () => {
     projectDir = prepareScratchProject('build');
     const res = await runCli(['build'], projectDir);
     expect(res.code, res.stderr).toBe(0);
-    preview = startCliServer(['preview', '--port', String(port)], projectDir);
+    preview = startCliServer(['preview', '--host', '127.0.0.1', '--port', String(port)], projectDir);
     await waitForHttpOk(`${baseUrl}/`);
   });
 
@@ -87,7 +87,7 @@ test.describe('build flags', () => {
     await fs.writeFile(path.join(projectDir, 'open-slide.config.ts'), FLAGS_CONFIG);
     const res = await runCli(['build'], projectDir);
     expect(res.code, res.stderr).toBe(0);
-    preview = startCliServer(['preview', '--port', String(port)], projectDir);
+    preview = startCliServer(['preview', '--host', '127.0.0.1', '--port', String(port)], projectDir);
     await waitForHttpOk(`${baseUrl}/`);
   });
 

--- a/packages/core/e2e/tests/build.spec.ts
+++ b/packages/core/e2e/tests/build.spec.ts
@@ -48,7 +48,7 @@ test.describe('static build and preview', () => {
     expect(html).toContain('<title>open-slide</title>');
 
     const assets = await fs.readdir(path.join(dist, 'assets'));
-    for (const slideId of ['alpha', 'steps', 'edit-target']) {
+    for (const slideId of ['alpha', 'steps', 'edit-target', 'hot-swap']) {
       expect(
         assets.some((name) => name.startsWith(`${slideId}-`) && name.endsWith('.js')),
         `expected a chunk for ${slideId}`,
@@ -64,7 +64,9 @@ test.describe('static build and preview', () => {
 
   test('deep links resolve through the spa fallback', async ({ page }) => {
     await page.goto(`${baseUrl}/s/steps`);
-    await expect(page.getByText('Steps page one')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator('main[data-inspector-root]').getByText('Steps page one')).toBeVisible(
+      { timeout: 30_000 },
+    );
   });
 
   test('dev-only endpoints do not exist in preview', async ({ request }) => {

--- a/packages/core/e2e/tests/build.spec.ts
+++ b/packages/core/e2e/tests/build.spec.ts
@@ -1,0 +1,109 @@
+import type { ChildProcess } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+import {
+  prepareScratchProject,
+  runCli,
+  startCliServer,
+  stopServer,
+  waitForHttpOk,
+} from './helpers.ts';
+
+const FLAGS_CONFIG = `import type { OpenSlideConfig } from '@open-slide/core';
+
+const openSlideConfig: OpenSlideConfig = {
+  build: { showSlideBrowser: false, showSlideUi: false },
+};
+
+export default openSlideConfig;
+`;
+
+test.describe('static build and preview', () => {
+  const port = 43119;
+  const baseUrl = `http://127.0.0.1:${port}`;
+  let projectDir: string;
+  let preview: ChildProcess | undefined;
+
+  test.beforeAll(async () => {
+    test.setTimeout(300_000);
+    projectDir = prepareScratchProject('build');
+    const res = await runCli(['build'], projectDir);
+    expect(res.code, res.stderr).toBe(0);
+    preview = startCliServer(['preview', '--port', String(port)], projectDir);
+    await waitForHttpOk(`${baseUrl}/`);
+  });
+
+  test.afterAll(async () => {
+    if (preview) await stopServer(preview);
+  });
+
+  test('emits a single-page bundle with per-slide chunks', async () => {
+    const dist = path.join(projectDir, 'dist');
+    const entries = await fs.readdir(dist);
+    expect(entries.filter((name) => name.endsWith('.html'))).toEqual(['index.html']);
+
+    const html = await fs.readFile(path.join(dist, 'index.html'), 'utf8');
+    expect(html).toContain('<div id="root"></div>');
+    expect(html).toContain('<title>open-slide</title>');
+
+    const assets = await fs.readdir(path.join(dist, 'assets'));
+    for (const slideId of ['alpha', 'steps', 'edit-target']) {
+      expect(
+        assets.some((name) => name.startsWith(`${slideId}-`) && name.endsWith('.js')),
+        `expected a chunk for ${slideId}`,
+      ).toBe(true);
+    }
+  });
+
+  test('serves the slide browser from the static bundle', async ({ page }) => {
+    await page.goto(`${baseUrl}/`);
+    await expect(page.getByText('Alpha Deck')).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText('Steps Deck')).toBeVisible();
+  });
+
+  test('deep links resolve through the spa fallback', async ({ page }) => {
+    await page.goto(`${baseUrl}/s/steps`);
+    await expect(page.getByText('Steps page one')).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('dev-only endpoints do not exist in preview', async ({ request }) => {
+    const res = await request.get(`${baseUrl}/__server-status`);
+    expect(res.status()).toBe(200);
+    expect(res.headers()['content-type']).toContain('text/html');
+  });
+});
+
+test.describe('build flags', () => {
+  const port = 43121;
+  const baseUrl = `http://127.0.0.1:${port}`;
+  let preview: ChildProcess | undefined;
+
+  test.beforeAll(async () => {
+    test.setTimeout(300_000);
+    const projectDir = prepareScratchProject('build-flags');
+    await fs.writeFile(path.join(projectDir, 'open-slide.config.ts'), FLAGS_CONFIG);
+    const res = await runCli(['build'], projectDir);
+    expect(res.code, res.stderr).toBe(0);
+    preview = startCliServer(['preview', '--port', String(port)], projectDir);
+    await waitForHttpOk(`${baseUrl}/`);
+  });
+
+  test.afterAll(async () => {
+    if (preview) await stopServer(preview);
+  });
+
+  test('showSlideBrowser false hides the home browser', async ({ page }) => {
+    await page.goto(`${baseUrl}/`);
+    await expect(page.getByText('Page not found')).toBeVisible();
+  });
+
+  test('showSlideUi false serves a bare read-only player', async ({ page }) => {
+    await page.goto(`${baseUrl}/s/alpha`);
+    await expect(page.getByText('Alpha page one')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator('main[data-inspector-root]')).toHaveCount(0);
+
+    await page.keyboard.press('ArrowRight');
+    await expect(page.getByText('Alpha page two')).toBeVisible();
+  });
+});

--- a/packages/core/e2e/tests/build.spec.ts
+++ b/packages/core/e2e/tests/build.spec.ts
@@ -73,7 +73,7 @@ test.describe('static build and preview', () => {
     );
   });
 
-  test('dev-only endpoints do not exist in preview', async ({ request }) => {
+  test('dev-only endpoints fall through to the spa fallback in preview', async ({ request }) => {
     const res = await request.get(`${baseUrl}/__server-status`);
     expect(res.status()).toBe(200);
     expect(res.headers()['content-type']).toContain('text/html');

--- a/packages/core/e2e/tests/cli.spec.ts
+++ b/packages/core/e2e/tests/cli.spec.ts
@@ -1,0 +1,29 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+import { coreRoot, fixtureDir, runCli } from './helpers.ts';
+
+test.describe('open-slide cli', () => {
+  test('prints the package version', async () => {
+    const pkg = JSON.parse(await fs.readFile(path.join(coreRoot, 'package.json'), 'utf8')) as {
+      version: string;
+    };
+    const res = await runCli(['-v'], coreRoot, 30_000);
+    expect(res.code).toBe(0);
+    expect(res.stdout.trim()).toBe(pkg.version);
+  });
+
+  test('lists commands in help output', async () => {
+    const res = await runCli(['--help'], coreRoot, 30_000);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toContain('Start the dev server');
+    expect(res.stdout).toContain('Build a static site');
+    expect(res.stdout).toContain('Preview the production build');
+  });
+
+  test('rejects an invalid port', async () => {
+    const res = await runCli(['dev', '-p', 'abc'], fixtureDir, 30_000);
+    expect(res.code).toBe(1);
+    expect(res.stderr).toContain('Invalid port: abc');
+  });
+});

--- a/packages/core/e2e/tests/design.spec.ts
+++ b/packages/core/e2e/tests/design.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test';
+import { deleteSlide, duplicateSlide, openSlide, readSlideSource } from './helpers.ts';
+
+test.describe('design panel', () => {
+  test('shuffling and saving writes a design declaration to disk', async ({ page, request }) => {
+    try {
+      await duplicateSlide(request, 'edit-target', 'design-ui');
+      await openSlide(page, 'design-ui');
+
+      await page.keyboard.press('d');
+      const shuffle = page.getByRole('button', { name: 'Shuffle design' });
+      await expect(shuffle).toBeVisible();
+      await shuffle.click();
+
+      const saved = page.waitForResponse(
+        (res) => res.url().includes('/__design') && res.request().method() === 'PUT',
+      );
+      await page.getByRole('button', { name: 'Save' }).click();
+      expect((await saved).status()).toBe(200);
+      await expect.poll(() => readSlideSource('design-ui')).toContain('const design');
+    } finally {
+      await deleteSlide(request, 'design-ui');
+    }
+  });
+});

--- a/packages/core/e2e/tests/dev-api.spec.ts
+++ b/packages/core/e2e/tests/dev-api.spec.ts
@@ -17,6 +17,12 @@ test.describe('dev server http api', () => {
     for (const id of ['api-dup', 'api-notes', 'api-design', 'api-comments', 'api-assets']) {
       await deleteSlide(request, id);
     }
+    const folders = (await (await request.get('/__folders')).json()) as {
+      folders: { id: string }[];
+    };
+    for (const folder of folders.folders) {
+      await request.delete(`/__folders/${folder.id}`);
+    }
   });
 
   test('server status reports a stable execution id', async ({ request }) => {
@@ -229,6 +235,7 @@ test.describe('dev server http api', () => {
   });
 
   test('global assets live in the project assets directory', async ({ request }) => {
+    await request.delete('/__assets/@global/logo.png');
     const uploaded = await request.post('/__assets/@global/logo.png', {
       headers: { 'content-type': 'application/octet-stream' },
       data: TINY_PNG,

--- a/packages/core/e2e/tests/dev-api.spec.ts
+++ b/packages/core/e2e/tests/dev-api.spec.ts
@@ -1,0 +1,242 @@
+import { existsSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+import {
+  coreRoot,
+  deleteSlide,
+  devScratchDir,
+  duplicateSlide,
+  readSlideSource,
+  slideSourcePath,
+  TINY_PNG,
+} from './helpers.ts';
+
+test.describe('dev server http api', () => {
+  test.afterEach(async ({ request }) => {
+    for (const id of ['api-dup', 'api-notes', 'api-design', 'api-comments', 'api-assets']) {
+      await deleteSlide(request, id);
+    }
+  });
+
+  test('server status reports a stable execution id', async ({ request }) => {
+    const first = await request.get('/__server-status');
+    expect(first.status()).toBe(200);
+    const body = (await first.json()) as { executionId: string; canRestart: boolean };
+    expect(body.executionId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(body.canRestart).toBe(true);
+
+    const second = await (await request.get('/__server-status')).json();
+    expect((second as { executionId: string }).executionId).toBe(body.executionId);
+  });
+
+  test('update check reports the running core version', async ({ request }) => {
+    const pkg = JSON.parse(await fs.readFile(path.join(coreRoot, 'package.json'), 'utf8')) as {
+      version: string;
+    };
+    const res = await request.get('/__update-check');
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { current: string };
+    expect(body.current).toBe(pkg.version);
+  });
+
+  test('mutation guard rejects cross-origin requests', async ({ request }) => {
+    const mismatch = await request.post('/__slides/edit-target/duplicate', {
+      headers: { origin: 'http://evil.example' },
+    });
+    expect(mismatch.status()).toBe(403);
+    expect(await mismatch.json()).toEqual({ error: 'origin mismatch' });
+
+    const crossSite = await request.post('/__slides/edit-target/duplicate', {
+      headers: { 'sec-fetch-site': 'cross-site' },
+    });
+    expect(crossSite.status()).toBe(403);
+    expect(await crossSite.json()).toEqual({ error: 'cross-site request blocked' });
+
+    const opaque = await request.post('/__slides/edit-target/duplicate', {
+      headers: { origin: 'null' },
+    });
+    expect(opaque.status()).toBe(403);
+    expect(await opaque.json()).toEqual({ error: 'opaque origin is not allowed' });
+  });
+
+  test('json endpoints reject non-json content types', async ({ request }) => {
+    const res = await request.put('/__notes', {
+      headers: { 'content-type': 'text/plain' },
+      data: 'not json',
+    });
+    expect(res.status()).toBe(415);
+    expect(await res.json()).toEqual({ error: 'content-type must be application/json' });
+  });
+
+  test('folders can be created, assigned, and deleted', async ({ request }) => {
+    const empty = (await (await request.get('/__folders')).json()) as {
+      folders: unknown[];
+      assignments: Record<string, string>;
+    };
+    expect(empty).toEqual({ folders: [], assignments: {} });
+
+    const created = await request.post('/__folders', {
+      data: { name: 'E2E Folder', icon: { type: 'emoji', value: '🧪' } },
+    });
+    expect(created.ok()).toBe(true);
+    const folder = (await created.json()) as { id: string; name: string };
+    expect(folder.id).toMatch(/^f-[a-f0-9]{8}$/);
+    expect(folder.name).toBe('E2E Folder');
+
+    const assigned = await request.put('/__folders/assign', {
+      data: { slideId: 'alpha', folderId: folder.id },
+    });
+    expect(assigned.ok()).toBe(true);
+    const state = (await (await request.get('/__folders')).json()) as {
+      assignments: Record<string, string>;
+    };
+    expect(state.assignments.alpha).toBe(folder.id);
+
+    const removed = await request.delete(`/__folders/${folder.id}`);
+    expect(removed.ok()).toBe(true);
+    const after = (await (await request.get('/__folders')).json()) as {
+      folders: unknown[];
+      assignments: Record<string, string>;
+    };
+    expect(after.folders).toEqual([]);
+    expect(after.assignments).toEqual({});
+  });
+
+  test('slides can be duplicated, renamed, and deleted', async ({ request }) => {
+    const dup = await request.post('/__slides/edit-target/duplicate', {
+      data: { newId: 'api-dup' },
+    });
+    expect(dup.ok()).toBe(true);
+    expect(((await dup.json()) as { slideId: string }).slideId).toBe('api-dup');
+    expect(existsSync(slideSourcePath('api-dup'))).toBe(true);
+
+    const conflict = await request.post('/__slides/edit-target/duplicate', {
+      data: { newId: 'api-dup' },
+    });
+    expect(conflict.status()).toBe(409);
+
+    const invalid = await request.post('/__slides/edit-target/duplicate', {
+      data: { newId: 'bad id!' },
+    });
+    expect(invalid.status()).toBe(400);
+
+    const renamed = await request.patch('/__slides/api-dup', { data: { name: 'Renamed via API' } });
+    expect(renamed.ok()).toBe(true);
+    expect(await readSlideSource('api-dup')).toContain('Renamed via API');
+
+    const deleted = await request.delete('/__slides/api-dup');
+    expect(deleted.ok()).toBe(true);
+    await expect.poll(() => existsSync(slideSourcePath('api-dup'))).toBe(false);
+  });
+
+  test('notes endpoint writes speaker notes into the slide module', async ({ request }) => {
+    await duplicateSlide(request, 'edit-target', 'api-notes');
+    const res = await request.put('/__notes', {
+      data: { slideId: 'api-notes', index: 0, text: 'API speaker note' },
+    });
+    expect(res.ok()).toBe(true);
+    expect((await res.json()) as { ok: boolean }).toMatchObject({ ok: true });
+
+    const source = await readSlideSource('api-notes');
+    expect(source).toContain('export const notes');
+    expect(source).toContain('API speaker note');
+  });
+
+  test('design endpoint creates and resets a design declaration', async ({ request }) => {
+    await duplicateSlide(request, 'edit-target', 'api-design');
+
+    const initial = (await (await request.get('/__design?slideId=api-design')).json()) as {
+      exists: boolean;
+    };
+    expect(initial.exists).toBe(false);
+
+    const updated = await request.put('/__design?slideId=api-design', {
+      data: { patch: { radius: 12 } },
+    });
+    expect(updated.ok()).toBe(true);
+    expect(await readSlideSource('api-design')).toContain('const design: DesignSystem');
+
+    const reset = await request.post('/__design/reset?slideId=api-design');
+    expect(reset.ok()).toBe(true);
+  });
+
+  test('comment markers round-trip through the comments api', async ({ request }) => {
+    await duplicateSlide(request, 'edit-target', 'api-comments');
+    const source = await readSlideSource('api-comments');
+    const line = source.split('\n').findIndex((l) => l.includes('<h1')) + 1;
+    expect(line).toBeGreaterThan(0);
+
+    const added = await request.post('/__comments/add', {
+      data: { slideId: 'api-comments', line, text: 'Make this pop' },
+    });
+    expect(added.ok()).toBe(true);
+    const comment = (await added.json()) as { id: string };
+    expect(comment.id).toMatch(/^c-[a-f0-9]+$/);
+    expect(await readSlideSource('api-comments')).toContain('@slide-comment');
+
+    const list = (await (await request.get('/__comments/?slideId=api-comments')).json()) as {
+      comments: { id: string; text: string }[];
+    };
+    expect(list.comments).toHaveLength(1);
+    expect(list.comments[0]?.text).toBe('Make this pop');
+
+    const removed = await request.delete(`/__comments/${comment.id}?slideId=api-comments`);
+    expect(removed.ok()).toBe(true);
+    expect(await readSlideSource('api-comments')).not.toContain('@slide-comment');
+  });
+
+  test('slide assets can be uploaded, listed, served, renamed, and deleted', async ({
+    request,
+  }) => {
+    await duplicateSlide(request, 'edit-target', 'api-assets');
+
+    const uploaded = await request.post('/__assets/api-assets/dot.png', {
+      headers: { 'content-type': 'application/octet-stream' },
+      data: TINY_PNG,
+    });
+    expect(uploaded.ok()).toBe(true);
+    expect((await uploaded.json()) as { name: string }).toMatchObject({
+      name: 'dot.png',
+      mime: 'image/png',
+    });
+
+    const conflict = await request.post('/__assets/api-assets/dot.png', {
+      headers: { 'content-type': 'application/octet-stream' },
+      data: TINY_PNG,
+    });
+    expect(conflict.status()).toBe(409);
+
+    const list = (await (await request.get('/__assets/api-assets')).json()) as {
+      assets: { name: string; unused: boolean }[];
+    };
+    expect(list.assets).toHaveLength(1);
+    expect(list.assets[0]).toMatchObject({ name: 'dot.png', unused: true });
+
+    const served = await request.get('/__assets/api-assets/dot.png');
+    expect(served.status()).toBe(200);
+    expect(served.headers()['content-type']).toBe('image/png');
+    expect(Buffer.compare(await served.body(), TINY_PNG)).toBe(0);
+
+    const renamed = await request.patch('/__assets/api-assets/dot.png', {
+      data: { name: 'dot-renamed.png' },
+    });
+    expect(renamed.ok()).toBe(true);
+
+    const deleted = await request.delete('/__assets/api-assets/dot-renamed.png');
+    expect(deleted.ok()).toBe(true);
+    expect((await request.get('/__assets/api-assets/dot-renamed.png')).status()).toBe(404);
+  });
+
+  test('global assets live in the project assets directory', async ({ request }) => {
+    const uploaded = await request.post('/__assets/@global/logo.png', {
+      headers: { 'content-type': 'application/octet-stream' },
+      data: TINY_PNG,
+    });
+    expect(uploaded.ok()).toBe(true);
+    expect(existsSync(path.join(devScratchDir, 'assets', 'logo.png'))).toBe(true);
+
+    const deleted = await request.delete('/__assets/@global/logo.png');
+    expect(deleted.ok()).toBe(true);
+  });
+});

--- a/packages/core/e2e/tests/dev-api.spec.ts
+++ b/packages/core/e2e/tests/dev-api.spec.ts
@@ -46,35 +46,6 @@ test.describe('dev server http api', () => {
     expect(body.current).toBe(pkg.version);
   });
 
-  test('mutation guard rejects cross-origin requests', async ({ request }) => {
-    const mismatch = await request.post('/__slides/edit-target/duplicate', {
-      headers: { origin: 'http://evil.example' },
-    });
-    expect(mismatch.status()).toBe(403);
-    expect(await mismatch.json()).toEqual({ error: 'origin mismatch' });
-
-    const crossSite = await request.post('/__slides/edit-target/duplicate', {
-      headers: { 'sec-fetch-site': 'cross-site' },
-    });
-    expect(crossSite.status()).toBe(403);
-    expect(await crossSite.json()).toEqual({ error: 'cross-site request blocked' });
-
-    const opaque = await request.post('/__slides/edit-target/duplicate', {
-      headers: { origin: 'null' },
-    });
-    expect(opaque.status()).toBe(403);
-    expect(await opaque.json()).toEqual({ error: 'opaque origin is not allowed' });
-  });
-
-  test('json endpoints reject non-json content types', async ({ request }) => {
-    const res = await request.put('/__notes', {
-      headers: { 'content-type': 'text/plain' },
-      data: 'not json',
-    });
-    expect(res.status()).toBe(415);
-    expect(await res.json()).toEqual({ error: 'content-type must be application/json' });
-  });
-
   test('folders can be created, assigned, and deleted', async ({ request }) => {
     const empty = (await (await request.get('/__folders')).json()) as {
       folders: unknown[];

--- a/packages/core/e2e/tests/dev-api.spec.ts
+++ b/packages/core/e2e/tests/dev-api.spec.ts
@@ -176,10 +176,10 @@ test.describe('dev server http api', () => {
     expect(await readSlideSource('api-comments')).toContain('@slide-comment');
 
     const list = (await (await request.get('/__comments/?slideId=api-comments')).json()) as {
-      comments: { id: string; text: string }[];
+      comments: { id: string; note: string }[];
     };
     expect(list.comments).toHaveLength(1);
-    expect(list.comments[0]?.text).toBe('Make this pop');
+    expect(list.comments[0]?.note).toBe('Make this pop');
 
     const removed = await request.delete(`/__comments/${comment.id}?slideId=api-comments`);
     expect(removed.ok()).toBe(true);

--- a/packages/core/e2e/tests/helpers.ts
+++ b/packages/core/e2e/tests/helpers.ts
@@ -1,10 +1,11 @@
 import { type ChildProcess, spawn } from 'node:child_process';
-import { cpSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { type APIRequestContext, expect, type Locator, type Page } from '@playwright/test';
 import { DEV_SERVER_PORT } from '../../playwright.config.ts';
+
+export { fixtureDir, prepareScratchProject } from '../scratch.mjs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
@@ -12,7 +13,6 @@ export const devServerUrl = `http://127.0.0.1:${DEV_SERVER_PORT}`;
 
 export const coreRoot = path.resolve(here, '..', '..');
 export const coreBin = path.join(coreRoot, 'bin.js');
-export const fixtureDir = path.join(coreRoot, 'e2e', 'fixture');
 export const devScratchDir = path.join(coreRoot, 'e2e', '.scratch', 'dev');
 
 export function slideSourcePath(slideId: string, projectDir = devScratchDir): string {
@@ -21,18 +21,6 @@ export function slideSourcePath(slideId: string, projectDir = devScratchDir): st
 
 export function readSlideSource(slideId: string, projectDir = devScratchDir): Promise<string> {
   return fs.readFile(slideSourcePath(slideId, projectDir), 'utf8');
-}
-
-export function prepareScratchProject(name: string): string {
-  const dir = path.join(coreRoot, 'e2e', '.scratch', name);
-  rmSync(dir, { recursive: true, force: true });
-  mkdirSync(dir, { recursive: true });
-  cpSync(fixtureDir, dir, {
-    recursive: true,
-    filter: (src) => path.basename(src) !== 'node_modules',
-  });
-  symlinkSync(path.join(fixtureDir, 'node_modules'), path.join(dir, 'node_modules'), 'junction');
-  return dir;
 }
 
 export function editorCanvas(page: Page): Locator {

--- a/packages/core/e2e/tests/helpers.ts
+++ b/packages/core/e2e/tests/helpers.ts
@@ -4,8 +4,11 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { type APIRequestContext, expect, type Locator, type Page } from '@playwright/test';
+import { DEV_SERVER_PORT } from '../../playwright.config.ts';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
+
+export const devServerUrl = `http://127.0.0.1:${DEV_SERVER_PORT}`;
 
 export const coreRoot = path.resolve(here, '..', '..');
 export const coreBin = path.join(coreRoot, 'bin.js');
@@ -36,16 +39,44 @@ export function editorCanvas(page: Page): Locator {
   return page.locator('main[data-inspector-root]');
 }
 
-// The first visit per page load holds an asset-warm loading gate (up to 15s),
-// so slide opens always wait for the editor chrome to appear.
+// The first visit per page load holds an asset-warm loading gate (up to 15s).
+// A slide duplicated moments earlier can also 404 until the slides virtual
+// module refreshes (watcher debounce), and the server's full-reload broadcast
+// can fire before this page's HMR socket connects — so retry with a reload.
 export async function openSlide(page: Page, slideId: string, query = ''): Promise<void> {
   await page.goto(`/s/${slideId}${query}`);
-  await expect(editorCanvas(page)).toBeVisible({ timeout: 30_000 });
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await expect(editorCanvas(page)).toBeVisible({ timeout: 15_000 });
+      return;
+    } catch (err) {
+      if (attempt >= 2) throw err;
+      await page.reload();
+    }
+  }
 }
 
 export async function enterPlayMode(page: Page): Promise<void> {
   await page.keyboard.press('Enter');
   await expect(editorCanvas(page)).toBeHidden();
+}
+
+// The dev server's file watcher does not pick up newly created slide
+// directories on Linux, so the slides virtual module stays stale after a deck
+// is created on disk. Touch an existing (watched) slide source to force the
+// module to invalidate, then poll the served module until the deck appears.
+export async function refreshSlidesModule(expectedSlideId: string): Promise<void> {
+  const watchedFile = slideSourcePath('edit-target');
+  await fs.writeFile(watchedFile, await fs.readFile(watchedFile, 'utf8'));
+  await expect
+    .poll(
+      async () => {
+        const res = await fetch(`${devServerUrl}/@id/__x00__virtual:open-slide/slides`);
+        return res.ok ? await res.text() : '';
+      },
+      { timeout: 15_000 },
+    )
+    .toContain(`"${expectedSlideId}"`);
 }
 
 export async function duplicateSlide(
@@ -55,6 +86,7 @@ export async function duplicateSlide(
 ): Promise<void> {
   const res = await request.post(`/__slides/${sourceId}/duplicate`, { data: { newId } });
   expect(res.ok()).toBe(true);
+  await refreshSlidesModule(newId);
 }
 
 export async function deleteSlide(request: APIRequestContext, slideId: string): Promise<void> {

--- a/packages/core/e2e/tests/helpers.ts
+++ b/packages/core/e2e/tests/helpers.ts
@@ -79,18 +79,22 @@ export async function refreshSlidesModule(expectedSlideId: string): Promise<void
     .toContain(`"${expectedSlideId}"`);
 }
 
+// Deleting first makes the call retry-safe: a CI retry that runs after a
+// half-completed attempt would otherwise hit 409 "slide already exists".
 export async function duplicateSlide(
   request: APIRequestContext,
   sourceId: string,
   newId: string,
 ): Promise<void> {
+  await deleteSlide(request, newId);
   const res = await request.post(`/__slides/${sourceId}/duplicate`, { data: { newId } });
   expect(res.ok()).toBe(true);
   await refreshSlidesModule(newId);
 }
 
 export async function deleteSlide(request: APIRequestContext, slideId: string): Promise<void> {
-  await request.delete(`/__slides/${slideId}`);
+  const res = await request.delete(`/__slides/${slideId}`);
+  expect(res.ok() || res.status() === 404, `delete ${slideId} -> ${res.status()}`).toBe(true);
 }
 
 export const TINY_PNG = Buffer.from(

--- a/packages/core/e2e/tests/helpers.ts
+++ b/packages/core/e2e/tests/helpers.ts
@@ -51,8 +51,7 @@ export async function enterPlayMode(page: Page): Promise<void> {
 
 // The dev server's file watcher does not pick up newly created slide
 // directories on Linux, so the slides virtual module stays stale after a deck
-// is created on disk. Touch an existing (watched) slide source to force the
-// module to invalidate, then poll the served module until the deck appears.
+// is created on disk.
 export async function refreshSlidesModule(expectedSlideId: string): Promise<void> {
   const watchedFile = slideSourcePath('edit-target');
   await fs.writeFile(watchedFile, await fs.readFile(watchedFile, 'utf8'));

--- a/packages/core/e2e/tests/helpers.ts
+++ b/packages/core/e2e/tests/helpers.ts
@@ -1,0 +1,136 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { cpSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { type APIRequestContext, expect, type Locator, type Page } from '@playwright/test';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+export const coreRoot = path.resolve(here, '..', '..');
+export const coreBin = path.join(coreRoot, 'bin.js');
+export const fixtureDir = path.join(coreRoot, 'e2e', 'fixture');
+export const devScratchDir = path.join(coreRoot, 'e2e', '.scratch', 'dev');
+
+export function slideSourcePath(slideId: string, projectDir = devScratchDir): string {
+  return path.join(projectDir, 'slides', slideId, 'index.tsx');
+}
+
+export function readSlideSource(slideId: string, projectDir = devScratchDir): Promise<string> {
+  return fs.readFile(slideSourcePath(slideId, projectDir), 'utf8');
+}
+
+export function prepareScratchProject(name: string): string {
+  const dir = path.join(coreRoot, 'e2e', '.scratch', name);
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(dir, { recursive: true });
+  cpSync(fixtureDir, dir, {
+    recursive: true,
+    filter: (src) => path.basename(src) !== 'node_modules',
+  });
+  symlinkSync(path.join(fixtureDir, 'node_modules'), path.join(dir, 'node_modules'), 'junction');
+  return dir;
+}
+
+export function editorCanvas(page: Page): Locator {
+  return page.locator('main[data-inspector-root]');
+}
+
+// The first visit per page load holds an asset-warm loading gate (up to 15s),
+// so slide opens always wait for the editor chrome to appear.
+export async function openSlide(page: Page, slideId: string, query = ''): Promise<void> {
+  await page.goto(`/s/${slideId}${query}`);
+  await expect(editorCanvas(page)).toBeVisible({ timeout: 30_000 });
+}
+
+export async function enterPlayMode(page: Page): Promise<void> {
+  await page.keyboard.press('Enter');
+  await expect(editorCanvas(page)).toBeHidden();
+}
+
+export async function duplicateSlide(
+  request: APIRequestContext,
+  sourceId: string,
+  newId: string,
+): Promise<void> {
+  const res = await request.post(`/__slides/${sourceId}/duplicate`, { data: { newId } });
+  expect(res.ok()).toBe(true);
+}
+
+export async function deleteSlide(request: APIRequestContext, slideId: string): Promise<void> {
+  await request.delete(`/__slides/${slideId}`);
+}
+
+export const TINY_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+export interface CliResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export function runCli(args: string[], cwd: string, timeoutMs = 180_000): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [coreBin, ...args], {
+      cwd,
+      env: { ...process.env, OPEN_SLIDE_SKIP_SKILLS_CHECK: '1' },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`open-slide ${args.join(' ')} timed out after ${timeoutMs}ms\n${stderr}`));
+    }, timeoutMs);
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+export function startCliServer(args: string[], cwd: string): ChildProcess {
+  return spawn(process.execPath, [coreBin, ...args], {
+    cwd,
+    stdio: 'ignore',
+    env: { ...process.env, OPEN_SLIDE_SKIP_SKILLS_CHECK: '1' },
+  });
+}
+
+export async function waitForHttpOk(url: string, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown = null;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+      lastError = new Error(`HTTP ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`server at ${url} never became ready: ${String(lastError)}`);
+}
+
+export async function stopServer(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.killed) return;
+  const exited = new Promise<void>((resolve) => {
+    child.once('exit', () => resolve());
+  });
+  child.kill('SIGTERM');
+  await Promise.race([exited, new Promise((r) => setTimeout(r, 5_000))]);
+  if (child.exitCode === null) child.kill('SIGKILL');
+}

--- a/packages/core/e2e/tests/hmr.spec.ts
+++ b/packages/core/e2e/tests/hmr.spec.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+import {
+  deleteSlide,
+  devScratchDir,
+  duplicateSlide,
+  editorCanvas,
+  openSlide,
+  slideSourcePath,
+} from './helpers.ts';
+
+const FRESH_DECK = `import type { Page, SlideMeta } from '@open-slide/core';
+
+export const meta: SlideMeta = {
+  title: 'Fresh Deck',
+  createdAt: '2026-01-05T00:00:00.000Z',
+};
+
+const Only: Page = () => (
+  <div style={{ width: '100%', height: '100%', background: '#123', color: '#fff', padding: 120 }}>
+    <h1 style={{ fontSize: 96, margin: 0 }}>Fresh page</h1>
+  </div>
+);
+
+export default [Only] satisfies Page[];
+`;
+
+test.describe('dev server file watching', () => {
+  test('editing a slide source hot-swaps the open slide', async ({ page, request }) => {
+    await duplicateSlide(request, 'edit-target', 'hmr-live');
+    try {
+      await openSlide(page, 'hmr-live');
+      await expect(editorCanvas(page).getByText('Editable headline')).toBeVisible();
+
+      const file = slideSourcePath('hmr-live');
+      const source = await fs.readFile(file, 'utf8');
+      await fs.writeFile(file, source.replace('Editable headline', 'Hot swapped headline'));
+
+      await expect(editorCanvas(page).getByText('Hot swapped headline')).toBeVisible({
+        timeout: 15_000,
+      });
+    } finally {
+      await deleteSlide(request, 'hmr-live');
+    }
+  });
+
+  test('creating and removing a deck updates the home browser', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('li h3')).toHaveCount(3);
+
+    const dir = path.join(devScratchDir, 'slides', 'hmr-new');
+    try {
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, 'index.tsx'), FRESH_DECK);
+      await expect(page.getByText('Fresh Deck')).toBeVisible({ timeout: 15_000 });
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+    await expect(page.getByText('Fresh Deck')).toBeHidden({ timeout: 15_000 });
+  });
+
+  test('a deck with no pages shows the empty state', async ({ page }) => {
+    const dir = path.join(devScratchDir, 'slides', 'hmr-empty');
+    try {
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, 'index.tsx'), 'export default [];\n');
+      await page.waitForTimeout(1_000);
+
+      await page.goto('/s/hmr-empty');
+      await expect(page.getByText('Nothing to show.')).toBeVisible({ timeout: 15_000 });
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/e2e/tests/hmr.spec.ts
+++ b/packages/core/e2e/tests/hmr.spec.ts
@@ -2,11 +2,10 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import {
-  deleteSlide,
   devScratchDir,
-  duplicateSlide,
   editorCanvas,
   openSlide,
+  refreshSlidesModule,
   slideSourcePath,
 } from './helpers.ts';
 
@@ -27,37 +26,44 @@ export default [Only] satisfies Page[];
 `;
 
 test.describe('dev server file watching', () => {
-  test('editing a slide source hot-swaps the open slide', async ({ page, request }) => {
-    await duplicateSlide(request, 'edit-target', 'hmr-live');
-    try {
-      await openSlide(page, 'hmr-live');
-      await expect(editorCanvas(page).getByText('Editable headline')).toBeVisible();
+  test('editing a slide source hot-swaps the open slide', async ({ page }) => {
+    await openSlide(page, 'hot-swap');
+    await expect(editorCanvas(page).getByText('Hot swap headline')).toBeVisible();
 
-      const file = slideSourcePath('hmr-live');
-      const source = await fs.readFile(file, 'utf8');
-      await fs.writeFile(file, source.replace('Editable headline', 'Hot swapped headline'));
+    const file = slideSourcePath('hot-swap');
+    const source = await fs.readFile(file, 'utf8');
+    await fs.writeFile(file, source.replace('Hot swap headline', 'Hot swapped headline'));
 
-      await expect(editorCanvas(page).getByText('Hot swapped headline')).toBeVisible({
-        timeout: 15_000,
-      });
-    } finally {
-      await deleteSlide(request, 'hmr-live');
-    }
+    await expect(editorCanvas(page).getByText('Hot swapped headline')).toBeVisible({
+      timeout: 15_000,
+    });
   });
 
-  test('creating and removing a deck updates the home browser', async ({ page }) => {
-    await page.goto('/');
-    await expect(page.locator('li h3')).toHaveCount(3);
-
-    const dir = path.join(devScratchDir, 'slides', 'hmr-new');
+  test('a deck created on disk appears after a refresh and hot-disappears when removed', async ({
+    page,
+  }) => {
+    const dir = path.join(devScratchDir, 'slides', 'hmr-doomed');
     try {
       await fs.mkdir(dir, { recursive: true });
       await fs.writeFile(path.join(dir, 'index.tsx'), FRESH_DECK);
-      await expect(page.getByText('Fresh Deck')).toBeVisible({ timeout: 15_000 });
+      await refreshSlidesModule('hmr-doomed');
+
+      await page.goto('/');
+      const card = page.getByText('Fresh Deck');
+      try {
+        await expect(card).toBeVisible({ timeout: 10_000 });
+      } catch {
+        await page.reload();
+        await expect(card).toBeVisible({ timeout: 15_000 });
+      }
+
+      // Removal is watched live: the server broadcasts a full reload and the
+      // open page drops the card without manual navigation.
+      await fs.rm(dir, { recursive: true, force: true });
+      await expect(card).toBeHidden({ timeout: 15_000 });
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }
-    await expect(page.getByText('Fresh Deck')).toBeHidden({ timeout: 15_000 });
   });
 
   test('a deck with no pages shows the empty state', async ({ page }) => {
@@ -65,10 +71,16 @@ test.describe('dev server file watching', () => {
     try {
       await fs.mkdir(dir, { recursive: true });
       await fs.writeFile(path.join(dir, 'index.tsx'), 'export default [];\n');
-      await page.waitForTimeout(1_000);
+      await refreshSlidesModule('hmr-empty');
 
       await page.goto('/s/hmr-empty');
-      await expect(page.getByText('Nothing to show.')).toBeVisible({ timeout: 15_000 });
+      const emptyState = page.getByText('Nothing to show.');
+      try {
+        await expect(emptyState).toBeVisible({ timeout: 10_000 });
+      } catch {
+        await page.reload();
+        await expect(emptyState).toBeVisible({ timeout: 15_000 });
+      }
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }

--- a/packages/core/e2e/tests/hmr.spec.ts
+++ b/packages/core/e2e/tests/hmr.spec.ts
@@ -27,16 +27,20 @@ export default [Only] satisfies Page[];
 
 test.describe('dev server file watching', () => {
   test('editing a slide source hot-swaps the open slide', async ({ page }) => {
-    await openSlide(page, 'hot-swap');
-    await expect(editorCanvas(page).getByText('Hot swap headline')).toBeVisible();
-
     const file = slideSourcePath('hot-swap');
     const source = await fs.readFile(file, 'utf8');
-    await fs.writeFile(file, source.replace('Hot swap headline', 'Hot swapped headline'));
+    try {
+      await openSlide(page, 'hot-swap');
+      await expect(editorCanvas(page).getByText('Hot swap headline')).toBeVisible();
 
-    await expect(editorCanvas(page).getByText('Hot swapped headline')).toBeVisible({
-      timeout: 15_000,
-    });
+      await fs.writeFile(file, source.replace('Hot swap headline', 'Hot swapped headline'));
+
+      await expect(editorCanvas(page).getByText('Hot swapped headline')).toBeVisible({
+        timeout: 15_000,
+      });
+    } finally {
+      await fs.writeFile(file, source);
+    }
   });
 
   test('a deck created on disk appears after a refresh and hot-disappears when removed', async ({

--- a/packages/core/e2e/tests/home.spec.ts
+++ b/packages/core/e2e/tests/home.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('home slide browser', () => {
+  test('lists every fixture deck with its display title', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('li h3')).toHaveCount(3);
+    await expect(page.getByText('Alpha Deck')).toBeVisible();
+    await expect(page.getByText('Steps Deck')).toBeVisible();
+    await expect(page.getByText('Edit Target')).toBeVisible();
+  });
+
+  test('slide card links to the viewer', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Alpha Deck' }).click();
+    await expect(page).toHaveURL(/\/s\/alpha$/);
+    await expect(page.locator('main[data-inspector-root]').getByText('Alpha page one')).toBeVisible(
+      { timeout: 30_000 },
+    );
+  });
+
+  test('search filters decks and can be cleared', async ({ page }) => {
+    await page.goto('/');
+    const search = page.getByPlaceholder('Search slides');
+    await search.fill('steps');
+    await expect(page.locator('li h3')).toHaveCount(1);
+    await expect(page.getByText('Steps Deck')).toBeVisible();
+
+    await search.fill('zzz-no-match');
+    await expect(page.getByText('No matches')).toBeVisible();
+    await page.getByRole('button', { name: 'Clear search' }).first().click();
+    await expect(page.locator('li h3')).toHaveCount(3);
+  });
+
+  test('sort control reorders decks by created date', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('li h3').first()).toHaveText('Alpha Deck');
+    await page.getByRole('button', { name: /^Sort:/ }).click();
+    await page.getByRole('menuitem', { name: 'Oldest' }).click();
+    await expect(page.locator('li h3').first()).toHaveText('Edit Target');
+  });
+
+  test('deck theme badge links to the theme page', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'plain' }).click();
+    await expect(page).toHaveURL(/\/themes\/plain$/);
+    await expect(page.getByText('Plain').first()).toBeVisible();
+  });
+
+  test('themes gallery lists fixture themes', async ({ page }) => {
+    await page.goto('/themes');
+    await expect(page.getByText('Plain').first()).toBeVisible();
+    await expect(page.getByText('Minimal fixture theme for e2e tests.')).toBeVisible();
+  });
+
+  test('theme toggle switches to dark mode', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Toggle theme' }).click();
+    await page.getByRole('menuitem', { name: 'Dark' }).click();
+    await expect(page.locator('html')).toHaveClass(/dark/);
+  });
+
+  test('language toggle switches locale and persists across reloads', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Change language' }).click();
+    await page.getByRole('menuitem', { name: '繁體中文' }).click();
+    await expect(page.getByText('投影片').first()).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByText('投影片').first()).toBeVisible();
+  });
+
+  test('unknown routes render the not-found page', async ({ page }) => {
+    await page.goto('/definitely-not-a-route');
+    await expect(page.getByText('Page not found')).toBeVisible();
+  });
+});

--- a/packages/core/e2e/tests/home.spec.ts
+++ b/packages/core/e2e/tests/home.spec.ts
@@ -74,4 +74,33 @@ test.describe('home slide browser', () => {
     await page.goto('/definitely-not-a-route');
     await expect(page.getByText('Page not found')).toBeVisible();
   });
+
+  test('folders can be created and deleted from the sidebar', async ({ page, request }) => {
+    try {
+      await page.goto('/');
+      await page.getByRole('button', { name: 'New folder' }).click();
+      const input = page.getByPlaceholder('Folder name');
+      await input.fill('Sidebar Folder');
+      await expect(input).toHaveValue('Sidebar Folder');
+      const created = page.waitForResponse(
+        (res) => res.url().includes('/__folders') && res.request().method() === 'POST',
+      );
+      await input.press('Enter');
+      expect((await created).status()).toBe(200);
+
+      // "Folder actions" only exists on real folder rows, so its presence proves
+      // the new folder rendered in the sidebar (the name alone also matches the
+      // success toast).
+      const actions = page.getByRole('button', { name: 'Folder actions' });
+      await expect(actions).toBeVisible();
+      await actions.click();
+      await page.getByRole('menuitem', { name: 'Delete' }).click();
+      await expect(actions).toHaveCount(0);
+    } finally {
+      const { folders } = (await (await request.get('/__folders')).json()) as {
+        folders: { id: string }[];
+      };
+      for (const folder of folders) await request.delete(`/__folders/${folder.id}`);
+    }
+  });
 });

--- a/packages/core/e2e/tests/home.spec.ts
+++ b/packages/core/e2e/tests/home.spec.ts
@@ -3,10 +3,11 @@ import { expect, test } from '@playwright/test';
 test.describe('home slide browser', () => {
   test('lists every fixture deck with its display title', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('li h3')).toHaveCount(3);
+    await expect(page.locator('li h3')).toHaveCount(4);
     await expect(page.getByText('Alpha Deck')).toBeVisible();
     await expect(page.getByText('Steps Deck')).toBeVisible();
     await expect(page.getByText('Edit Target')).toBeVisible();
+    await expect(page.getByText('Hot Deck')).toBeVisible();
   });
 
   test('slide card links to the viewer', async ({ page }) => {
@@ -28,7 +29,7 @@ test.describe('home slide browser', () => {
     await search.fill('zzz-no-match');
     await expect(page.getByText('No matches')).toBeVisible();
     await page.getByRole('button', { name: 'Clear search' }).first().click();
-    await expect(page.locator('li h3')).toHaveCount(3);
+    await expect(page.locator('li h3')).toHaveCount(4);
   });
 
   test('sort control reorders decks by created date', async ({ page }) => {
@@ -36,7 +37,7 @@ test.describe('home slide browser', () => {
     await expect(page.locator('li h3').first()).toHaveText('Alpha Deck');
     await page.getByRole('button', { name: /^Sort:/ }).click();
     await page.getByRole('menuitem', { name: 'Oldest' }).click();
-    await expect(page.locator('li h3').first()).toHaveText('Edit Target');
+    await expect(page.locator('li h3').first()).toHaveText('Hot Deck');
   });
 
   test('deck theme badge links to the theme page', async ({ page }) => {

--- a/packages/core/e2e/tests/inspector.spec.ts
+++ b/packages/core/e2e/tests/inspector.spec.ts
@@ -117,6 +117,20 @@ test.describe('inspector editing', () => {
       .toMatch(/fontWeight[\s\S]*fontStyle|fontStyle[\s\S]*fontWeight/);
   });
 
+  test('undo and redo step through an inspector edit', async ({ page, request }) => {
+    await openEditable(page, request, 'insp-undo');
+    await page.getByTitle('Inspect').click();
+    await editorCanvas(page).getByText('Editable headline').click();
+    await page.locator('aside[data-inspector-ui]').getByPlaceholder('Element text').fill('Undo me');
+    await expect(editorCanvas(page).getByText('Undo me')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Undo' }).click();
+    await expect(editorCanvas(page).getByText('Editable headline')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Redo' }).click();
+    await expect(editorCanvas(page).getByText('Undo me')).toBeVisible();
+  });
+
   test('the i shortcut toggles inspect mode', async ({ page, request }) => {
     await openEditable(page, request, 'insp-key');
     await page.keyboard.press('i');

--- a/packages/core/e2e/tests/inspector.spec.ts
+++ b/packages/core/e2e/tests/inspector.spec.ts
@@ -21,8 +21,8 @@ test.describe('inspector editing', () => {
     request: import('@playwright/test').APIRequestContext,
     slideId: string,
   ) {
-    await duplicateSlide(request, 'edit-target', slideId);
     createdSlides.push(slideId);
+    await duplicateSlide(request, 'edit-target', slideId);
     await openSlide(page, slideId);
   }
 

--- a/packages/core/e2e/tests/inspector.spec.ts
+++ b/packages/core/e2e/tests/inspector.spec.ts
@@ -102,19 +102,22 @@ test.describe('inspector editing', () => {
     const italic = panel.getByRole('button', { name: 'Italic' });
     await bold.click();
     await italic.click();
+    await panel.getByRole('button', { name: 'center', exact: true }).click();
     await expect(bold).toHaveAttribute('aria-pressed', 'true');
     await expect(italic).toHaveAttribute('aria-pressed', 'true');
     await expect(headline).toHaveCSS('font-weight', '700');
     await expect(headline).toHaveCSS('font-style', 'italic');
+    await expect(headline).toHaveCSS('text-align', 'center');
 
     const saved = page.waitForResponse(
       (res) => res.url().includes('/__edit') && res.request().method() === 'POST',
     );
     await page.getByRole('button', { name: 'Save' }).click();
     expect((await saved).status()).toBe(200);
-    await expect
-      .poll(() => readSlideSource('insp-style'))
-      .toMatch(/fontWeight[\s\S]*fontStyle|fontStyle[\s\S]*fontWeight/);
+    await expect.poll(() => readSlideSource('insp-style')).toContain('textAlign');
+    const src = await readSlideSource('insp-style');
+    expect(src).toContain('fontWeight');
+    expect(src).toContain('fontStyle');
   });
 
   test('undo and redo step through an inspector edit', async ({ page, request }) => {

--- a/packages/core/e2e/tests/inspector.spec.ts
+++ b/packages/core/e2e/tests/inspector.spec.ts
@@ -91,6 +91,32 @@ test.describe('inspector editing', () => {
     await expect.poll(() => readSlideSource('insp-commit')).toContain('Committed body copy');
   });
 
+  test('style toggles restyle the element live and save to disk', async ({ page, request }) => {
+    await openEditable(page, request, 'insp-style');
+    await page.getByTitle('Inspect').click();
+    const headline = editorCanvas(page).getByText('Editable headline');
+    await headline.click();
+
+    const panel = page.locator('aside[data-inspector-ui]');
+    const bold = panel.getByRole('button', { name: 'Bold' });
+    const italic = panel.getByRole('button', { name: 'Italic' });
+    await bold.click();
+    await italic.click();
+    await expect(bold).toHaveAttribute('aria-pressed', 'true');
+    await expect(italic).toHaveAttribute('aria-pressed', 'true');
+    await expect(headline).toHaveCSS('font-weight', '700');
+    await expect(headline).toHaveCSS('font-style', 'italic');
+
+    const saved = page.waitForResponse(
+      (res) => res.url().includes('/__edit') && res.request().method() === 'POST',
+    );
+    await page.getByRole('button', { name: 'Save' }).click();
+    expect((await saved).status()).toBe(200);
+    await expect
+      .poll(() => readSlideSource('insp-style'))
+      .toMatch(/fontWeight[\s\S]*fontStyle|fontStyle[\s\S]*fontWeight/);
+  });
+
   test('the i shortcut toggles inspect mode', async ({ page, request }) => {
     await openEditable(page, request, 'insp-key');
     await page.keyboard.press('i');

--- a/packages/core/e2e/tests/inspector.spec.ts
+++ b/packages/core/e2e/tests/inspector.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@playwright/test';
+import {
+  deleteSlide,
+  duplicateSlide,
+  editorCanvas,
+  openSlide,
+  readSlideSource,
+} from './helpers.ts';
+
+test.describe('inspector editing', () => {
+  const createdSlides: string[] = [];
+
+  test.afterEach(async ({ request }) => {
+    for (const id of createdSlides.splice(0)) {
+      await deleteSlide(request, id);
+    }
+  });
+
+  async function openEditable(
+    page: import('@playwright/test').Page,
+    request: import('@playwright/test').APIRequestContext,
+    slideId: string,
+  ) {
+    await duplicateSlide(request, 'edit-target', slideId);
+    createdSlides.push(slideId);
+    await openSlide(page, slideId);
+  }
+
+  test('selecting an element opens the panel with its tag and text', async ({ page, request }) => {
+    await openEditable(page, request, 'insp-select');
+    await page.getByTitle('Inspect').click();
+    await editorCanvas(page).getByText('Editable headline').click();
+
+    const panel = page.locator('aside[data-inspector-ui]');
+    await expect(panel).toBeVisible();
+    await expect(panel.getByText('<h1>')).toBeVisible();
+    await expect(panel.getByPlaceholder('Element text')).toHaveValue('Editable headline');
+  });
+
+  test('saving a text edit rewrites the slide source on disk', async ({ page, request }) => {
+    await openEditable(page, request, 'insp-save');
+    await page.getByTitle('Inspect').click();
+    await editorCanvas(page).getByText('Editable headline').click();
+
+    await page
+      .locator('aside[data-inspector-ui]')
+      .getByPlaceholder('Element text')
+      .fill('Edited via inspector');
+    await expect(editorCanvas(page).getByText('Edited via inspector')).toBeVisible();
+    await expect(page.getByText('1 unsaved change')).toBeVisible();
+
+    const saved = page.waitForResponse(
+      (res) => res.url().includes('/__edit') && res.request().method() === 'POST',
+    );
+    await page.getByRole('button', { name: 'Save' }).click();
+    expect((await saved).status()).toBe(200);
+    await expect.poll(() => readSlideSource('insp-save')).toContain('Edited via inspector');
+  });
+
+  test('discard reverts the edit without touching the file', async ({ page, request }) => {
+    await openEditable(page, request, 'insp-discard');
+    await page.getByTitle('Inspect').click();
+    await editorCanvas(page).getByText('Editable headline').click();
+
+    await page
+      .locator('aside[data-inspector-ui]')
+      .getByPlaceholder('Element text')
+      .fill('Discarded text');
+    await expect(editorCanvas(page).getByText('Discarded text')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Discard' }).click();
+    await expect(editorCanvas(page).getByText('Editable headline')).toBeVisible();
+    expect(await readSlideSource('insp-discard')).not.toContain('Discarded text');
+  });
+
+  test('toggling the inspector off commits pending edits', async ({ page, request }) => {
+    await openEditable(page, request, 'insp-commit');
+    await page.getByTitle('Inspect').click();
+    await editorCanvas(page).getByText('Editable body copy').click();
+
+    await page
+      .locator('aside[data-inspector-ui]')
+      .getByPlaceholder('Element text')
+      .fill('Committed body copy');
+
+    const saved = page.waitForResponse(
+      (res) => res.url().includes('/__edit') && res.request().method() === 'POST',
+    );
+    await page.getByTitle('Inspect').click();
+    expect((await saved).status()).toBe(200);
+    await expect.poll(() => readSlideSource('insp-commit')).toContain('Committed body copy');
+  });
+
+  test('the i shortcut toggles inspect mode', async ({ page, request }) => {
+    await openEditable(page, request, 'insp-key');
+    await page.keyboard.press('i');
+    await editorCanvas(page).getByText('Editable headline').click();
+    await expect(page.locator('aside[data-inspector-ui]')).toBeVisible();
+  });
+});

--- a/packages/core/e2e/tests/present.spec.ts
+++ b/packages/core/e2e/tests/present.spec.ts
@@ -76,6 +76,23 @@ test.describe('present mode', () => {
     await expect(editorCanvas(page)).toBeHidden();
   });
 
+  test('laser pointer toggles on with l and follows the cursor', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await enterPlayMode(page);
+
+    const viewport = page.viewportSize();
+    if (!viewport) throw new Error('viewport is not set');
+    const dot = page.locator('[class*="z-[60]"]');
+    await expect(dot).toHaveCount(0);
+
+    await page.keyboard.press('l');
+    await page.mouse.move(viewport.width / 2, viewport.height / 2);
+    await expect(dot).toBeVisible();
+
+    await page.keyboard.press('l');
+    await expect(dot).toHaveCount(0);
+  });
+
   test('help overlay lists the keyboard shortcuts', async ({ page }) => {
     await openSlide(page, 'alpha');
     await enterPlayMode(page);

--- a/packages/core/e2e/tests/present.spec.ts
+++ b/packages/core/e2e/tests/present.spec.ts
@@ -28,6 +28,9 @@ test.describe('present mode', () => {
   test('steps reveal one by one before the page advances', async ({ page }) => {
     await openSlide(page, 'steps');
     await enterPlayMode(page);
+
+    await page.keyboard.press('ArrowRight');
+    await expect(page).toHaveURL(/[?&]p=2/);
     await expect(page.locator('[data-osd-step="pending"]')).toHaveCount(2);
 
     await page.keyboard.press('ArrowRight');
@@ -36,11 +39,11 @@ test.describe('present mode', () => {
     await expect(page.locator('[data-osd-step="revealed"]')).toHaveCount(2);
 
     await page.keyboard.press('ArrowRight');
-    await expect(page).toHaveURL(/[?&]p=2/);
-    await expect(page.getByText('Steps page two')).toBeVisible();
+    await expect(page).toHaveURL(/[?&]p=3/);
+    await expect(page.getByText('Steps page three')).toBeVisible();
 
     await page.keyboard.press('ArrowLeft');
-    await expect(page).toHaveURL(/[?&]p=1/);
+    await expect(page).toHaveURL(/[?&]p=2/);
     await expect(page.locator('[data-osd-step="revealed"]')).toHaveCount(2);
   });
 

--- a/packages/core/e2e/tests/present.spec.ts
+++ b/packages/core/e2e/tests/present.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '@playwright/test';
+import { editorCanvas, enterPlayMode, openSlide } from './helpers.ts';
+
+test.describe('present mode', () => {
+  test('windowed play mode navigates and exits back to the editor', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await enterPlayMode(page);
+
+    await page.keyboard.press('ArrowRight');
+    await expect(page).toHaveURL(/[?&]p=2/);
+    await expect(page.getByText('Alpha page two')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(editorCanvas(page)).toBeVisible();
+    await expect(page).toHaveURL(/[?&]p=2/);
+  });
+
+  test('home and end keys jump to the first and last page', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await enterPlayMode(page);
+
+    await page.keyboard.press('End');
+    await expect(page).toHaveURL(/[?&]p=3/);
+    await page.keyboard.press('Home');
+    await expect(page).toHaveURL(/[?&]p=1/);
+  });
+
+  test('steps reveal one by one before the page advances', async ({ page }) => {
+    await openSlide(page, 'steps');
+    await enterPlayMode(page);
+    await expect(page.locator('[data-osd-step="pending"]')).toHaveCount(2);
+
+    await page.keyboard.press('ArrowRight');
+    await expect(page.locator('[data-osd-step="revealed"]')).toHaveCount(1);
+    await page.keyboard.press('ArrowRight');
+    await expect(page.locator('[data-osd-step="revealed"]')).toHaveCount(2);
+
+    await page.keyboard.press('ArrowRight');
+    await expect(page).toHaveURL(/[?&]p=2/);
+    await expect(page.getByText('Steps page two')).toBeVisible();
+
+    await page.keyboard.press('ArrowLeft');
+    await expect(page).toHaveURL(/[?&]p=1/);
+    await expect(page.locator('[data-osd-step="revealed"]')).toHaveCount(2);
+  });
+
+  test('typing digits jumps to a page', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await enterPlayMode(page);
+
+    await page.keyboard.press('3');
+    await expect(page.locator('[aria-live="polite"]').getByText('3')).toBeVisible();
+    await page.keyboard.press('Enter');
+    await expect(page).toHaveURL(/[?&]p=3/);
+  });
+
+  test('blackout overlays toggle with b and w and clear with escape', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await enterPlayMode(page);
+
+    const black = page.locator('div.absolute.inset-0.bg-black');
+    const white = page.locator('div.absolute.inset-0.bg-white');
+
+    await page.keyboard.press('b');
+    await expect(black).toBeVisible();
+    await page.keyboard.press('b');
+    await expect(black).toBeHidden();
+
+    await page.keyboard.press('w');
+    await expect(white).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(white).toBeHidden();
+    await expect(editorCanvas(page)).toBeHidden();
+  });
+
+  test('help overlay lists the keyboard shortcuts', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await enterPlayMode(page);
+
+    await page.keyboard.press('?');
+    await expect(page.getByText('Keyboard shortcuts')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByText('Keyboard shortcuts')).toBeHidden();
+    await expect(editorCanvas(page)).toBeHidden();
+  });
+
+  test('overview grid works while presenting', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await enterPlayMode(page);
+
+    await page.keyboard.press('o');
+    const overview = page.getByRole('dialog', { name: 'Slide overview' });
+    await expect(overview).toBeVisible();
+    await overview.getByRole('button', { name: 'Go to slide 2' }).click();
+    await expect(overview).toBeHidden();
+    await expect(page).toHaveURL(/[?&]p=2/);
+  });
+
+  test('control bar appears near the bottom edge and navigates', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await enterPlayMode(page);
+
+    const viewport = page.viewportSize();
+    if (!viewport) throw new Error('viewport is not set');
+    await page.mouse.move(viewport.width / 2, viewport.height - 10);
+
+    const next = page.getByRole('button', { name: 'Next slide (→)' });
+    await expect(next).toBeVisible();
+    await next.click();
+    await expect(page).toHaveURL(/[?&]p=2/);
+    await expect(page.getByText('02 / 03')).toBeVisible();
+  });
+});

--- a/packages/core/e2e/tests/presenter.spec.ts
+++ b/packages/core/e2e/tests/presenter.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test';
+import { enterPlayMode, openSlide } from './helpers.ts';
+
+test.describe('presenter view', () => {
+  test('standalone presenter shows notes and the not-linked badge', async ({ page }) => {
+    await page.goto('/s/alpha/presenter');
+    await expect(page.getByText('Presenter')).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText('Not linked')).toBeVisible();
+    await expect(page.getByText('Alpha speaker note')).toBeVisible();
+  });
+
+  test('presenter popup links to the player and drives it', async ({ page, context }) => {
+    await openSlide(page, 'alpha');
+    await enterPlayMode(page);
+
+    const popupPromise = context.waitForEvent('page');
+    await page.keyboard.press('p');
+    const popup = await popupPromise;
+    await popup.waitForLoadState();
+    expect(popup.url()).toContain('/s/alpha/presenter');
+
+    await expect(popup.getByText('01 / 03')).toBeVisible({ timeout: 30_000 });
+    await expect(popup.getByText('Not linked')).toBeHidden();
+    await expect(popup.getByText('Alpha speaker note')).toBeVisible();
+
+    await popup.getByRole('button', { name: 'Next', exact: true }).click();
+    await expect(page).toHaveURL(/[?&]p=2/);
+    await expect(popup.getByText('02 / 03')).toBeVisible();
+    await expect(popup.getByText('No speaker notes for this slide.')).toBeVisible();
+
+    await popup.keyboard.press('ArrowRight');
+    await expect(page).toHaveURL(/[?&]p=3/);
+    await expect(popup.getByText('03 / 03')).toBeVisible();
+    await expect(popup.getByText('Last slide')).toBeVisible();
+    await expect(popup.getByText('End of deck')).toBeVisible();
+    await expect(popup.getByRole('button', { name: 'Next', exact: true })).toBeDisabled();
+
+    await popup.getByRole('button', { name: 'Prev', exact: true }).click();
+    await expect(page).toHaveURL(/[?&]p=2/);
+
+    const jump = popup.locator('input[type="number"]');
+    await jump.fill('1');
+    await jump.press('Enter');
+    await expect(page).toHaveURL(/[?&]p=1/);
+    await expect(popup.getByText('01 / 03')).toBeVisible();
+  });
+
+  test('blackout round-trips between presenter and player', async ({ page, context }) => {
+    await openSlide(page, 'alpha');
+    await enterPlayMode(page);
+
+    const popupPromise = context.waitForEvent('page');
+    await page.keyboard.press('p');
+    const popup = await popupPromise;
+    await expect(popup.getByText('01 / 03')).toBeVisible({ timeout: 30_000 });
+
+    const blackButton = popup.getByRole('button', { name: 'Black', exact: true });
+    await blackButton.click();
+    await expect(blackButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('div.absolute.inset-0.bg-black')).toBeVisible();
+
+    await blackButton.click();
+    await expect(blackButton).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.locator('div.absolute.inset-0.bg-black')).toBeHidden();
+  });
+});

--- a/packages/core/e2e/tests/presenter.spec.ts
+++ b/packages/core/e2e/tests/presenter.spec.ts
@@ -62,5 +62,14 @@ test.describe('presenter view', () => {
     await blackButton.click();
     await expect(blackButton).toHaveAttribute('aria-pressed', 'false');
     await expect(page.locator('div.absolute.inset-0.bg-black')).toBeHidden();
+
+    const whiteButton = popup.getByRole('button', { name: 'White', exact: true });
+    await whiteButton.click();
+    await expect(whiteButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('div.absolute.inset-0.bg-white')).toBeVisible();
+
+    await whiteButton.click();
+    await expect(whiteButton).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.locator('div.absolute.inset-0.bg-white')).toBeHidden();
   });
 });

--- a/packages/core/e2e/tests/themes.spec.ts
+++ b/packages/core/e2e/tests/themes.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('theme detail', () => {
+  test('navigates demo pages and expands the prompt', async ({ page }) => {
+    await page.goto('/themes/plain');
+    await expect(page.getByText('Theme demo one')).toBeVisible({ timeout: 30_000 });
+
+    const prev = page.getByRole('button', { name: 'Previous page' });
+    const next = page.getByRole('button', { name: 'Next page' });
+    await expect(prev).toBeDisabled();
+
+    await next.click();
+    await expect(page.getByText('Theme demo two')).toBeVisible();
+    await expect(next).toBeDisabled();
+
+    await prev.click();
+    await expect(page.getByText('Theme demo one')).toBeVisible();
+
+    const expand = page.getByRole('button', { name: 'Expand prompt' });
+    await expand.click();
+    await expect(page.getByRole('button', { name: 'Collapse prompt' })).toBeVisible();
+  });
+});

--- a/packages/core/e2e/tests/viewer.spec.ts
+++ b/packages/core/e2e/tests/viewer.spec.ts
@@ -95,6 +95,24 @@ test.describe('slide viewer', () => {
     await expect(editorCanvas(page).locator('[data-osd-step="pending"]')).toHaveCount(0);
   });
 
+  test('thumbnail context menu duplicates and deletes a page', async ({ page, request }) => {
+    try {
+      await duplicateSlide(request, 'alpha', 'thumb-ops');
+      await openSlide(page, 'thumb-ops');
+      await expect(page.getByRole('button', { name: 'Go to page 3' })).toBeVisible();
+
+      await page.getByRole('button', { name: 'Go to page 1' }).click({ button: 'right' });
+      await page.getByRole('menuitem', { name: 'Duplicate' }).click();
+      await expect(page.getByRole('button', { name: 'Go to page 4' })).toBeVisible();
+
+      await page.getByRole('button', { name: 'Go to page 4' }).click({ button: 'right' });
+      await page.getByRole('menuitem', { name: 'Delete' }).click();
+      await expect(page.getByRole('button', { name: 'Go to page 4' })).toHaveCount(0);
+    } finally {
+      await deleteSlide(request, 'thumb-ops');
+    }
+  });
+
   test('toolbar title editor renames the deck and saves to disk', async ({ page, request }) => {
     try {
       await duplicateSlide(request, 'edit-target', 'rename-ui');

--- a/packages/core/e2e/tests/viewer.spec.ts
+++ b/packages/core/e2e/tests/viewer.spec.ts
@@ -95,6 +95,23 @@ test.describe('slide viewer', () => {
     await expect(editorCanvas(page).locator('[data-osd-step="pending"]')).toHaveCount(0);
   });
 
+  test('toolbar title editor renames the deck and saves to disk', async ({ page, request }) => {
+    try {
+      await duplicateSlide(request, 'edit-target', 'rename-ui');
+      await openSlide(page, 'rename-ui');
+
+      const titleButton = page.getByRole('button', { name: 'Rename slide' });
+      await titleButton.click();
+      await page.keyboard.type('Renamed Deck');
+      await page.keyboard.press('Enter');
+
+      await expect(titleButton).toContainText('Renamed Deck');
+      await expect.poll(() => readSlideSource('rename-ui')).toContain('Renamed Deck');
+    } finally {
+      await deleteSlide(request, 'rename-ui');
+    }
+  });
+
   test('notes drawer autosaves speaker notes to the slide source', async ({ page, request }) => {
     try {
       await duplicateSlide(request, 'edit-target', 'notes-ui');

--- a/packages/core/e2e/tests/viewer.spec.ts
+++ b/packages/core/e2e/tests/viewer.spec.ts
@@ -86,11 +86,11 @@ test.describe('slide viewer', () => {
   test('back link returns to the home browser', async ({ page }) => {
     await openSlide(page, 'alpha');
     await page.getByRole('link', { name: 'Back to home' }).click();
-    await expect(page.locator('li h3')).toHaveCount(3);
+    await expect(page.locator('li h3')).toHaveCount(4);
   });
 
   test('steps render fully revealed in the editor', async ({ page }) => {
-    await openSlide(page, 'steps');
+    await openSlide(page, 'steps', '?p=2');
     await expect(editorCanvas(page).locator('[data-osd-step="revealed"]')).toHaveCount(2);
     await expect(editorCanvas(page).locator('[data-osd-step="pending"]')).toHaveCount(0);
   });

--- a/packages/core/e2e/tests/viewer.spec.ts
+++ b/packages/core/e2e/tests/viewer.spec.ts
@@ -96,8 +96,8 @@ test.describe('slide viewer', () => {
   });
 
   test('notes drawer autosaves speaker notes to the slide source', async ({ page, request }) => {
-    await duplicateSlide(request, 'edit-target', 'notes-ui');
     try {
+      await duplicateSlide(request, 'edit-target', 'notes-ui');
       await openSlide(page, 'notes-ui');
       const toggle = page.getByRole('button', { name: /Notes/ });
       await expect(toggle).toHaveAttribute('aria-expanded', 'false');

--- a/packages/core/e2e/tests/viewer.spec.ts
+++ b/packages/core/e2e/tests/viewer.spec.ts
@@ -104,8 +104,11 @@ test.describe('slide viewer', () => {
       await toggle.click();
       await expect(toggle).toHaveAttribute('aria-expanded', 'true');
 
+      const saved = page.waitForResponse(
+        (res) => res.url().includes('/__notes') && res.request().method() === 'PUT',
+      );
       await page.getByPlaceholder('Write speaker notes for this slide…').fill('Drawer note text');
-      await expect(page.getByText('Saved', { exact: true })).toBeVisible();
+      expect((await saved).status()).toBe(200);
       await expect.poll(() => readSlideSource('notes-ui')).toContain('Drawer note text');
     } finally {
       await deleteSlide(request, 'notes-ui');

--- a/packages/core/e2e/tests/viewer.spec.ts
+++ b/packages/core/e2e/tests/viewer.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from '@playwright/test';
+import {
+  deleteSlide,
+  duplicateSlide,
+  editorCanvas,
+  openSlide,
+  readSlideSource,
+} from './helpers.ts';
+
+test.describe('slide viewer', () => {
+  test('opens on page one with the deck title in the toolbar', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await expect(editorCanvas(page).getByText('Alpha page one')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Alpha Deck' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Go to page 1' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+
+  test('arrow keys navigate pages and update the url', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await page.keyboard.press('ArrowRight');
+    await expect(page).toHaveURL(/[?&]p=2/);
+    await expect(editorCanvas(page).getByText('Alpha page two')).toBeVisible();
+
+    await page.keyboard.press('ArrowLeft');
+    await expect(page).toHaveURL(/[?&]p=1/);
+    await expect(editorCanvas(page).getByText('Alpha page one')).toBeVisible();
+
+    await page.keyboard.press('ArrowLeft');
+    await expect(page).toHaveURL(/[?&]p=1/);
+  });
+
+  test('deep links clamp the page query param', async ({ page }) => {
+    await openSlide(page, 'alpha', '?p=999');
+    await expect(editorCanvas(page).getByText('Alpha page three')).toBeVisible();
+
+    await openSlide(page, 'alpha', '?p=0');
+    await expect(editorCanvas(page).getByText('Alpha page one')).toBeVisible();
+  });
+
+  test('clicking a thumbnail jumps to that page', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await page.getByRole('button', { name: 'Go to page 2' }).click();
+    await expect(page).toHaveURL(/[?&]p=2/);
+    await expect(page.getByRole('button', { name: 'Go to page 2' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+
+  test('overview grid opens, navigates with the keyboard, and closes', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await page.keyboard.press('o');
+    const overview = page.getByRole('dialog', { name: 'Slide overview' });
+    await expect(overview).toBeVisible();
+    await expect(overview.getByRole('button', { name: 'Go to slide 1' })).toHaveAttribute(
+      'aria-current',
+      'true',
+    );
+
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('Enter');
+    await expect(overview).toBeHidden();
+    await expect(page).toHaveURL(/[?&]p=2/);
+
+    await page.keyboard.press('o');
+    await expect(overview).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(overview).toBeHidden();
+  });
+
+  test('wheel scrolling navigates pages', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await editorCanvas(page).hover();
+    await page.mouse.wheel(0, 120);
+    await expect(page).toHaveURL(/[?&]p=2/);
+  });
+
+  test('unknown slide ids show the load-failed state', async ({ page }) => {
+    await page.goto('/s/does-not-exist');
+    await expect(page.getByText('Failed to load slide')).toBeVisible();
+  });
+
+  test('back link returns to the home browser', async ({ page }) => {
+    await openSlide(page, 'alpha');
+    await page.getByRole('link', { name: 'Back to home' }).click();
+    await expect(page.locator('li h3')).toHaveCount(3);
+  });
+
+  test('steps render fully revealed in the editor', async ({ page }) => {
+    await openSlide(page, 'steps');
+    await expect(editorCanvas(page).locator('[data-osd-step="revealed"]')).toHaveCount(2);
+    await expect(editorCanvas(page).locator('[data-osd-step="pending"]')).toHaveCount(0);
+  });
+
+  test('notes drawer autosaves speaker notes to the slide source', async ({ page, request }) => {
+    await duplicateSlide(request, 'edit-target', 'notes-ui');
+    try {
+      await openSlide(page, 'notes-ui');
+      const toggle = page.getByRole('button', { name: /Notes/ });
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+      await toggle.click();
+      await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+      await page.getByPlaceholder('Write speaker notes for this slide…').fill('Drawer note text');
+      await expect(page.getByText('Saved', { exact: true })).toBeVisible();
+      await expect.poll(() => readSlideSource('notes-ui')).toContain('Drawer note text');
+    } finally {
+      await deleteSlide(request, 'notes-ui');
+    }
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test:e2e": "playwright test",
+    "test:e2e": "pnpm run build && playwright test",
     "prepack": "pnpm build"
   },
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test",
     "prepack": "pnpm build"
   },
   "engines": {
@@ -96,6 +97,7 @@
     "vite": "^8.1.5"
   },
   "devDependencies": {
+    "@playwright/test": "~1.56.1",
     "@types/node": "^22.19.17",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/packages/core/playwright.config.ts
+++ b/packages/core/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export const DEV_SERVER_PORT = 43117;
+
+export default defineConfig({
+  testDir: './e2e/tests',
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: `http://127.0.0.1:${DEV_SERVER_PORT}`,
+    contextOptions: { reducedMotion: 'reduce' },
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: `node e2e/start-dev-server.mjs --port ${DEV_SERVER_PORT}`,
+    url: `http://127.0.0.1:${DEV_SERVER_PORT}/`,
+    reuseExistingServer: false,
+    timeout: 180_000,
+  },
+});

--- a/packages/core/playwright.config.ts
+++ b/packages/core/playwright.config.ts
@@ -22,5 +22,7 @@ export default defineConfig({
     url: `http://127.0.0.1:${DEV_SERVER_PORT}/`,
     reuseExistingServer: false,
     timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
   },
 });

--- a/packages/core/playwright.config.ts
+++ b/packages/core/playwright.config.ts
@@ -4,7 +4,6 @@ export const DEV_SERVER_PORT = 43117;
 
 export default defineConfig({
   testDir: './e2e/tests',
-  fullyParallel: false,
   workers: 1,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,16 +47,16 @@ importers:
     dependencies:
       fumadocs-core:
         specifier: 16.8.5
-        version: 16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2)
+        version: 16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2)
       fumadocs-mdx:
         specifier: 14.3.2
-        version: 14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0))
+        version: 14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0))
       fumadocs-ui:
         specifier: 16.8.5
-        version: 16.8.5(@tailwindcss/oxide@4.3.3)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.2.4)
+        version: 16.8.5(@tailwindcss/oxide@4.3.3)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.2.4)
       geist:
         specifier: ^1.7.2
-        version: 1.7.2(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 1.7.2(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       lucide-react:
         specifier: ^1.25.0
         version: 1.25.0(react@19.2.7)
@@ -65,7 +65,7 @@ importers:
         version: 12.38.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next:
         specifier: 16.2.10
-        version: 16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -228,6 +228,9 @@ importers:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)
     devDependencies:
+      '@playwright/test':
+        specifier: ~1.56.1
+        version: 1.56.1
       '@types/node':
         specifier: ^22.19.17
         version: 22.19.17
@@ -243,6 +246,25 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  packages/core/e2e/fixture:
+    dependencies:
+      '@open-slide/core':
+        specifier: workspace:*
+        version: link:../..
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
 
 packages:
 
@@ -1345,6 +1367,16 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.56.1':
+    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@posthog/core@1.28.0':
     resolution: {integrity: sha512-753giUMWuk602UtS101tDZuNcwiKkr+3UEhLgfOwHAk2W32n53knOxAjyWT0JwMq5/+0uSQ2y4uaZXQAxwvBSw==}
@@ -2939,6 +2971,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3985,6 +4022,26 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  playwright-core@1.56.1:
+    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.56.1:
+    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-selector-parser@7.1.4:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
@@ -5971,6 +6028,15 @@ snapshots:
   '@oxc-transform/binding-win32-x64-msvc@0.67.0':
     optional: true
 
+  '@playwright/test@1.56.1':
+    dependencies:
+      playwright: 1.56.1
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+    optional: true
+
   '@posthog/core@1.28.0':
     dependencies:
       '@posthog/types': 1.372.6
@@ -7449,10 +7515,13 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2):
+  fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -7478,7 +7547,7 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.14
       lucide-react: 1.25.0(react@19.2.7)
-      next: 16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-router: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -7486,14 +7555,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)):
+  fumadocs-mdx@14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.0
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2)
+      fumadocs-core: 16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -7510,13 +7579,13 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
-      next: 16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       vite: 8.1.5(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.8.5(@tailwindcss/oxide@4.3.3)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.2.4):
+  fumadocs-ui@16.8.5(@tailwindcss/oxide@4.3.3)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.2.4):
     dependencies:
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.3.3)(tailwindcss@4.2.4)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -7530,7 +7599,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2)
+      fumadocs-core: 16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.25.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.2)
       lucide-react: 1.25.0(react@19.2.7)
       motion: 12.38.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -7545,7 +7614,7 @@ snapshots:
     optionalDependencies:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
-      next: 16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@tailwindcss/oxide'
@@ -7556,9 +7625,9 @@ snapshots:
 
   fuzzysort@3.1.0: {}
 
-  geist@1.7.2(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
+  geist@1.7.2(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
     dependencies:
-      next: 16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   gensync@1.0.0-beta.2: {}
 
@@ -8512,7 +8581,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
@@ -8532,6 +8601,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.10
       '@next/swc-win32-x64-msvc': 16.2.10
       '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -8732,6 +8802,24 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  playwright-core@1.56.1: {}
+
+  playwright-core@1.61.1:
+    optional: true
+
+  playwright@1.56.1:
+    dependencies:
+      playwright-core: 1.56.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    optional: true
 
   postcss-selector-parser@7.1.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "packages/core/e2e/fixture"


### PR DESCRIPTION
Covers the home browser, slide viewer, present mode, presenter sync,
inspector editing, the dev HTTP API, file watching/HMR, the CLI, and
static build/preview output. Tests run against a throwaway copy of a
dedicated fixture project so disk-writing flows never touch committed
sources.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RaEeXwjeNNpnez2VRTjy6g

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Playwright end-to-end suite covering the slide viewer, home browser (search/sort/themes and localization), present mode, presenter view/sync, inspector editing, notes autosave, HMR hot-update behavior, CLI basics, development HTTP APIs, and build/preview static SPA output (including deep links and assets).
* **Chores**
  * Integrated E2E execution into CI with a new job and Playwright reporting artifacts.
  * Added `test:e2e` scripts/configuration and updated ignore rules for E2E output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->