### PR TITLE
feat: add animated prompt composer to landing page

### DIFF
--- a/apps/web/app/(home)/landing.css
+++ b/apps/web/app/(home)/landing.css
@@ -161,22 +161,29 @@ html.dark .os-landing .bloom {
 }
 
 .os-landing .prompt-stage-glow {
-  background: color-mix(in oklab, var(--color-accent) 8%, transparent);
-  filter: blur(72px);
+  background: radial-gradient(
+    ellipse at center,
+    color-mix(in oklab, var(--color-accent) 10%, transparent) 0%,
+    color-mix(in oklab, var(--color-accent) 5%, transparent) 42%,
+    transparent 72%
+  );
 }
 
 .os-landing .prompt-composer {
-  background: color-mix(in oklab, var(--color-panel) 82%, transparent);
-  backdrop-filter: blur(22px) saturate(135%);
-  -webkit-backdrop-filter: blur(22px) saturate(135%);
+  background: color-mix(in oklab, var(--color-panel) 94%, transparent);
 }
 
 html.dark .os-landing .prompt-stage-glow {
-  background: color-mix(in oklab, var(--color-accent) 13%, transparent);
+  background: radial-gradient(
+    ellipse at center,
+    color-mix(in oklab, var(--color-accent) 15%, transparent) 0%,
+    color-mix(in oklab, var(--color-accent) 7%, transparent) 42%,
+    transparent 72%
+  );
 }
 
 html.dark .os-landing .prompt-composer {
-  background: color-mix(in oklab, var(--color-panel) 76%, transparent);
+  background: color-mix(in oklab, var(--color-panel) 90%, transparent);
 }
 
 @keyframes os-marquee {
@@ -308,8 +315,6 @@ html.dark .os-landing .site-nav[data-scrolled] {
 @media (prefers-reduced-transparency: reduce) {
   .os-landing .prompt-composer {
     background: var(--color-panel);
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 

--- a/apps/web/app/(home)/landing.css
+++ b/apps/web/app/(home)/landing.css
@@ -152,6 +152,33 @@ html.dark .os-landing .bloom {
   box-shadow: var(--shadow-floating);
 }
 
+.os-landing .prompt-stage-grid {
+  color: color-mix(in oklab, var(--color-text) 10%, transparent);
+  background-image: radial-gradient(currentcolor 0.7px, transparent 0.9px);
+  background-size: 20px 20px;
+  -webkit-mask-image: radial-gradient(58% 70% at 50% 50%, #000 0%, transparent 74%);
+  mask-image: radial-gradient(58% 70% at 50% 50%, #000 0%, transparent 74%);
+}
+
+.os-landing .prompt-stage-glow {
+  background: color-mix(in oklab, var(--color-accent) 8%, transparent);
+  filter: blur(72px);
+}
+
+.os-landing .prompt-composer {
+  background: color-mix(in oklab, var(--color-panel) 82%, transparent);
+  backdrop-filter: blur(22px) saturate(135%);
+  -webkit-backdrop-filter: blur(22px) saturate(135%);
+}
+
+html.dark .os-landing .prompt-stage-glow {
+  background: color-mix(in oklab, var(--color-accent) 13%, transparent);
+}
+
+html.dark .os-landing .prompt-composer {
+  background: color-mix(in oklab, var(--color-panel) 76%, transparent);
+}
+
 @keyframes os-marquee {
   from {
     transform: translateX(0);
@@ -275,6 +302,20 @@ html.dark .os-landing .site-nav[data-scrolled] {
   }
   .os-landing .pressable:active {
     transform: none;
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .os-landing .prompt-composer {
+    background: var(--color-panel);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .os-landing .prompt-composer {
+    border-color: var(--color-text-soft);
   }
 }
 

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -10,6 +10,7 @@ import { HowItWorks } from '@/components/landing/how-it-works';
 import { Inspector } from '@/components/landing/inspector';
 import { LiveDemo } from '@/components/landing/live-demo';
 import { Nav } from '@/components/landing/nav';
+import { PromptComposer } from '@/components/landing/prompt-composer';
 import { ScrollReveal } from '@/components/landing/scroll-reveal';
 import { fetchGitHubStars, formatStarCount } from '@/lib/github';
 import { appName, gitConfig, siteUrl } from '@/lib/shared';
@@ -123,6 +124,7 @@ export default async function HomePage() {
       <main className="relative flex-1">
         <Hero />
         <LiveDemo />
+        <PromptComposer />
         <StripeBand />
         <HowItWorks />
         <Anatomy />

--- a/apps/web/components/landing/agent-icon-list.tsx
+++ b/apps/web/components/landing/agent-icon-list.tsx
@@ -1,0 +1,24 @@
+const agents = [
+  ['claude.svg', 'Claude'],
+  ['codex-dark.svg', 'Codex'],
+  ['cursor-dark.svg', 'Cursor'],
+  ['gemini.svg', 'Gemini CLI'],
+] as const;
+
+export function AgentIconList() {
+  return (
+    <span className="inline-flex max-w-full flex-wrap items-center gap-x-3 gap-y-2 normal-case tracking-normal">
+      {agents.map(([file, name]) => (
+        <img
+          key={file}
+          src={`/assets/${file}`}
+          alt={name}
+          className="agent-mono h-[14px] w-auto shrink-0 object-contain"
+        />
+      ))}
+      <span className="text-[10px] tracking-[0.08em] uppercase text-[color:var(--color-muted)]">
+        ...
+      </span>
+    </span>
+  );
+}

--- a/apps/web/components/landing/how-it-works.tsx
+++ b/apps/web/components/landing/how-it-works.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, ReactNode } from 'react';
+import { AgentIconList } from './agent-icon-list';
 
 type Step = {
   num: string;
@@ -32,7 +33,7 @@ const steps: Step[] = [
     code: {
       prompt: '›',
       line: '/create-slide for Q2 roadmap',
-      tail: <AgentRow />,
+      tail: <AgentIconList />,
     },
   },
   {
@@ -67,26 +68,6 @@ function renderLine(line: string) {
   }
   if (last < line.length) parts.push(line.slice(last));
   return <>{parts}</>;
-}
-
-function AgentRow() {
-  const agents: [string, string][] = [
-    ['claude.svg', 'Claude'],
-    ['codex-dark.svg', 'Codex'],
-    ['cursor-dark.svg', 'Cursor'],
-    ['gemini.svg', 'Gemini CLI'],
-  ];
-  const cls = 'agent-mono h-[14px] w-auto object-contain shrink-0';
-  return (
-    <span className="inline-flex flex-wrap items-center gap-x-3 gap-y-2 normal-case tracking-normal">
-      {agents.map(([file, name]) => (
-        <img key={file} src={`/assets/${file}`} alt={name} className={cls} />
-      ))}
-      <span className="text-[10px] tracking-[0.08em] uppercase text-[color:var(--color-muted)]">
-        ...
-      </span>
-    </span>
-  );
 }
 
 export function HowItWorks() {

--- a/apps/web/components/landing/prompt-composer.tsx
+++ b/apps/web/components/landing/prompt-composer.tsx
@@ -78,13 +78,7 @@ export function PromptComposer() {
         >
           <div className="rounded-[13px] border border-[color:var(--color-rule-soft)] bg-[color:var(--color-panel)] sm:rounded-[16px]">
             <div className="flex min-h-[108px] items-center px-5 py-6 sm:min-h-[128px] sm:px-8">
-              <div
-                role="textbox"
-                aria-label={`/create-slide ${prompt}`}
-                aria-readonly="true"
-                tabIndex={0}
-                className="flex h-[58px] w-full flex-wrap content-center items-center gap-x-2 gap-y-1 font-[family-name:var(--font-mono)] text-[16px] leading-[1.55] tracking-[-0.025em] sm:h-[38px] sm:flex-nowrap sm:text-[19px]"
-              >
+              <div className="flex h-[58px] w-full flex-wrap content-center items-center gap-x-2 gap-y-1 font-[family-name:var(--font-mono)] text-[16px] leading-[1.55] tracking-[-0.025em] sm:h-[38px] sm:flex-nowrap sm:text-[19px]">
                 <span className="shrink-0 font-medium text-[color:var(--color-accent)]">
                   /create-slide
                 </span>

--- a/apps/web/components/landing/prompt-composer.tsx
+++ b/apps/web/components/landing/prompt-composer.tsx
@@ -58,7 +58,7 @@ export function PromptComposer() {
     <section
       id="prompt"
       ref={sectionRef}
-      className="prompt-stage relative flex min-h-[420px] items-center overflow-hidden sm:min-h-[520px]"
+      className="prompt-stage relative flex min-h-[420px] items-center overflow-x-clip overflow-y-visible sm:min-h-[520px]"
       aria-labelledby="prompt-composer-heading"
     >
       <SectionRule />

--- a/apps/web/components/landing/prompt-composer.tsx
+++ b/apps/web/components/landing/prompt-composer.tsx
@@ -43,17 +43,16 @@ export function PromptComposer() {
   const isInView = useInView(sectionRef, { margin: '-20% 0px -20% 0px' });
   const reduceMotion = useReducedMotion();
   const [promptIndex, setPromptIndex] = useState(0);
-  const [isPaused, setIsPaused] = useState(false);
 
   useEffect(() => {
-    if (!isInView || isPaused) return;
+    if (!isInView) return;
 
     const interval = window.setInterval(() => {
       setPromptIndex((current) => (current + 1) % prompts.length);
     }, 3200);
 
     return () => window.clearInterval(interval);
-  }, [isInView, isPaused]);
+  }, [isInView]);
 
   const prompt = prompts[promptIndex];
   const variants = reduceMotion ? reducedPromptVariants : promptVariants;
@@ -78,10 +77,6 @@ export function PromptComposer() {
       <div className="relative mx-auto w-full max-w-[860px] px-5 py-24 sm:px-8 lg:px-12">
         <div
           data-reveal="blur"
-          onPointerEnter={() => setIsPaused(true)}
-          onPointerLeave={() => setIsPaused(false)}
-          onFocusCapture={() => setIsPaused(true)}
-          onBlurCapture={() => setIsPaused(false)}
           className="prompt-composer floating rounded-[18px] border border-[color:var(--color-rule)] p-2 sm:rounded-[22px] sm:p-2.5"
         >
           <div className="rounded-[13px] border border-[color:var(--color-rule-soft)] bg-[color:var(--color-panel)] sm:rounded-[16px]">

--- a/apps/web/components/landing/prompt-composer.tsx
+++ b/apps/web/components/landing/prompt-composer.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { AnimatePresence, motion, useInView, useReducedMotion } from 'motion/react';
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { SectionRule } from './frame';
+
+const prompts = [
+  'a Q2 product launch',
+  'an investor-ready pitch',
+  'our quarterly business review',
+  'a conference keynote',
+  'a customer success story',
+] as const;
+
+const promptVariants = {
+  enter: {
+    opacity: 0,
+    transform: 'translateY(20px) rotateX(-72deg)',
+    filter: 'blur(3px)',
+  },
+  center: {
+    opacity: 1,
+    transform: 'translateY(0px) rotateX(0deg)',
+    filter: 'blur(0px)',
+  },
+  exit: {
+    opacity: 0,
+    transform: 'translateY(-20px) rotateX(72deg)',
+    filter: 'blur(3px)',
+  },
+};
+
+const reducedPromptVariants = {
+  enter: { opacity: 0 },
+  center: { opacity: 1 },
+  exit: { opacity: 0 },
+};
+
+export function PromptComposer() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const isInView = useInView(sectionRef, { margin: '-20% 0px -20% 0px' });
+  const reduceMotion = useReducedMotion();
+  const [promptIndex, setPromptIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+
+  useEffect(() => {
+    if (!isInView || isPaused) return;
+
+    const interval = window.setInterval(() => {
+      setPromptIndex((current) => (current + 1) % prompts.length);
+    }, 3200);
+
+    return () => window.clearInterval(interval);
+  }, [isInView, isPaused]);
+
+  const prompt = prompts[promptIndex];
+  const variants = reduceMotion ? reducedPromptVariants : promptVariants;
+
+  return (
+    <section
+      id="prompt"
+      ref={sectionRef}
+      className="prompt-stage relative flex min-h-[420px] items-center overflow-hidden sm:min-h-[520px]"
+      aria-labelledby="prompt-composer-heading"
+    >
+      <SectionRule />
+      <h2 id="prompt-composer-heading" className="sr-only">
+        Create a slide deck with a prompt
+      </h2>
+
+      <div aria-hidden className="pointer-events-none absolute inset-0">
+        <div className="prompt-stage-grid absolute inset-0" />
+        <div className="prompt-stage-glow absolute left-1/2 top-1/2 h-[260px] w-[min(90vw,820px)] -translate-x-1/2 -translate-y-1/2 rounded-full" />
+      </div>
+
+      <div className="relative mx-auto w-full max-w-[860px] px-5 py-24 sm:px-8 lg:px-12">
+        <div
+          data-reveal="blur"
+          onPointerEnter={() => setIsPaused(true)}
+          onPointerLeave={() => setIsPaused(false)}
+          onFocusCapture={() => setIsPaused(true)}
+          onBlurCapture={() => setIsPaused(false)}
+          className="prompt-composer floating rounded-[18px] border border-[color:var(--color-rule)] p-2 sm:rounded-[22px] sm:p-2.5"
+        >
+          <div className="rounded-[13px] border border-[color:var(--color-rule-soft)] bg-[color:var(--color-panel)] sm:rounded-[16px]">
+            <div className="flex min-h-[108px] items-center px-5 py-6 sm:min-h-[128px] sm:px-8">
+              <div className="relative h-[58px] w-full overflow-hidden [perspective:700px] sm:h-[38px]">
+                <AnimatePresence initial={false} mode="popLayout">
+                  <motion.div
+                    key={prompt}
+                    variants={variants}
+                    initial="enter"
+                    animate="center"
+                    exit="exit"
+                    transition={{
+                      duration: reduceMotion ? 0.2 : 0.52,
+                      ease: [0.23, 1, 0.32, 1],
+                    }}
+                    role="textbox"
+                    aria-label={`/create-slide ${prompt}`}
+                    aria-readonly="true"
+                    className="absolute inset-0 flex origin-center flex-wrap content-center items-baseline gap-x-2 gap-y-1 font-[family-name:var(--font-mono)] text-[16px] leading-[1.55] tracking-[-0.025em] will-change-[transform,opacity] sm:flex-nowrap sm:text-[19px]"
+                  >
+                    <span className="shrink-0 font-medium text-[color:var(--color-accent)]">
+                      /create-slide
+                    </span>
+                    <span className="text-[color:var(--color-text)]">{prompt}</span>
+                  </motion.div>
+                </AnimatePresence>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between border-t border-[color:var(--color-rule-soft)] px-3 py-3 sm:px-4">
+              <span className="inline-flex items-center gap-2 rounded-full px-2.5 py-1.5 font-[family-name:var(--font-mono)] text-[11px] tracking-[0.02em] text-[color:var(--color-muted)]">
+                <SparkGlyph />
+                open-slide skill
+              </span>
+
+              <Link
+                href="/docs/skills/create-slide"
+                aria-label="Learn how to use the create-slide skill"
+                className="pressable group flex h-10 w-10 items-center justify-center rounded-full bg-[color:var(--color-text)] text-[color:var(--color-panel)] shadow-[0_1px_0_oklch(1_0_0/0.16)_inset] hover:bg-[color:var(--color-accent)] sm:h-11 sm:w-11"
+              >
+                <ArrowUpGlyph />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SparkGlyph() {
+  return (
+    <svg aria-hidden width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <path
+        d="M7 1.25c.35 2.65 2.1 4.4 4.75 4.75C9.1 6.35 7.35 8.1 7 10.75 6.65 8.1 4.9 6.35 2.25 6 4.9 5.65 6.65 3.9 7 1.25Z"
+        stroke="currentColor"
+        strokeWidth="1.1"
+        strokeLinejoin="round"
+      />
+      <path d="M11.25 9.25v3M9.75 10.75h3" stroke="currentColor" strokeWidth="1.1" />
+    </svg>
+  );
+}
+
+function ArrowUpGlyph() {
+  return (
+    <svg
+      aria-hidden
+      width="17"
+      height="17"
+      viewBox="0 0 17 17"
+      fill="none"
+      className="transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover:-translate-y-0.5"
+    >
+      <path
+        d="M8.5 13.5v-10m0 0-4 4m4-4 4 4"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/apps/web/components/landing/prompt-composer.tsx
+++ b/apps/web/components/landing/prompt-composer.tsx
@@ -3,6 +3,7 @@
 import { AnimatePresence, motion, useInView, useReducedMotion } from 'motion/react';
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
+import { AgentIconList } from './agent-icon-list';
 import { SectionRule } from './frame';
 
 const prompts = [
@@ -85,36 +86,40 @@ export function PromptComposer() {
         >
           <div className="rounded-[13px] border border-[color:var(--color-rule-soft)] bg-[color:var(--color-panel)] sm:rounded-[16px]">
             <div className="flex min-h-[108px] items-center px-5 py-6 sm:min-h-[128px] sm:px-8">
-              <div className="relative h-[58px] w-full overflow-hidden [perspective:700px] sm:h-[38px]">
-                <AnimatePresence initial={false} mode="popLayout">
-                  <motion.div
-                    key={prompt}
-                    variants={variants}
-                    initial="enter"
-                    animate="center"
-                    exit="exit"
-                    transition={{
-                      duration: reduceMotion ? 0.2 : 0.52,
-                      ease: [0.23, 1, 0.32, 1],
-                    }}
-                    role="textbox"
-                    aria-label={`/create-slide ${prompt}`}
-                    aria-readonly="true"
-                    className="absolute inset-0 flex origin-center flex-wrap content-center items-baseline gap-x-2 gap-y-1 font-[family-name:var(--font-mono)] text-[16px] leading-[1.55] tracking-[-0.025em] will-change-[transform,opacity] sm:flex-nowrap sm:text-[19px]"
-                  >
-                    <span className="shrink-0 font-medium text-[color:var(--color-accent)]">
-                      /create-slide
-                    </span>
-                    <span className="text-[color:var(--color-text)]">{prompt}</span>
-                  </motion.div>
-                </AnimatePresence>
+              <div
+                role="textbox"
+                aria-label={`/create-slide ${prompt}`}
+                aria-readonly="true"
+                tabIndex={0}
+                className="flex h-[58px] w-full flex-wrap content-center items-center gap-x-2 gap-y-1 font-[family-name:var(--font-mono)] text-[16px] leading-[1.55] tracking-[-0.025em] sm:h-[38px] sm:flex-nowrap sm:text-[19px]"
+              >
+                <span className="shrink-0 font-medium text-[color:var(--color-accent)]">
+                  /create-slide
+                </span>
+                <span className="relative h-[1.55em] min-w-0 flex-[1_1_220px] overflow-hidden [perspective:700px]">
+                  <AnimatePresence initial={false} mode="popLayout">
+                    <motion.span
+                      key={prompt}
+                      variants={variants}
+                      initial="enter"
+                      animate="center"
+                      exit="exit"
+                      transition={{
+                        duration: reduceMotion ? 0.2 : 0.52,
+                        ease: [0.23, 1, 0.32, 1],
+                      }}
+                      className="absolute inset-0 flex origin-center items-center text-[color:var(--color-text)] will-change-[transform,opacity]"
+                    >
+                      {prompt}
+                    </motion.span>
+                  </AnimatePresence>
+                </span>
               </div>
             </div>
 
             <div className="flex items-center justify-between border-t border-[color:var(--color-rule-soft)] px-3 py-3 sm:px-4">
-              <span className="inline-flex items-center gap-2 rounded-full px-2.5 py-1.5 font-[family-name:var(--font-mono)] text-[11px] tracking-[0.02em] text-[color:var(--color-muted)]">
-                <SparkGlyph />
-                open-slide skill
+              <span className="min-w-0 px-2.5 py-1.5">
+                <AgentIconList />
               </span>
 
               <Link
@@ -129,20 +134,6 @@ export function PromptComposer() {
         </div>
       </div>
     </section>
-  );
-}
-
-function SparkGlyph() {
-  return (
-    <svg aria-hidden width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <path
-        d="M7 1.25c.35 2.65 2.1 4.4 4.75 4.75C9.1 6.35 7.35 8.1 7 10.75 6.65 8.1 4.9 6.35 2.25 6 4.9 5.65 6.65 3.9 7 1.25Z"
-        stroke="currentColor"
-        strokeWidth="1.1"
-        strokeLinejoin="round"
-      />
-      <path d="M11.25 9.25v3M9.75 10.75h3" stroke="currentColor" strokeWidth="1.1" />
-    </svg>
   );
 }
 

--- a/apps/web/components/landing/prompt-composer.tsx
+++ b/apps/web/components/landing/prompt-composer.tsx
@@ -18,17 +18,14 @@ const promptVariants = {
   enter: {
     opacity: 0,
     transform: 'translateY(20px) rotateX(-72deg)',
-    filter: 'blur(3px)',
   },
   center: {
     opacity: 1,
     transform: 'translateY(0px) rotateX(0deg)',
-    filter: 'blur(0px)',
   },
   exit: {
     opacity: 0,
     transform: 'translateY(-20px) rotateX(72deg)',
-    filter: 'blur(3px)',
   },
 };
 


### PR DESCRIPTION
## Summary

- Add an animated prompt composer section to the landing page
- Add light/dark styling with grid, glow, glass effects, and accessibility preferences
- Link the composer action to the create-slide skill documentation

## Testing

- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Prompt Composer” to the home landing that cycles through sample slide-creation prompts and links to the create-slide docs.
  * Enhanced the “How it works” section with a new agent icon list.
* **Style**
  * Updated landing prompt visuals with a prompt stage grid overlay, accent glow, and frosted composer styling, including dark-mode tuning.
* **Accessibility**
  * Improved accessibility for the prompt composer, including ARIA labeling and support for reduced motion, reduced transparency, and higher-contrast rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->