### PR TITLE
fix(web): landing polish — hero pill link, footer copy, search placeholder layout

### DIFF
--- a/apps/web/components/landing/assets.tsx
+++ b/apps/web/components/landing/assets.tsx
@@ -128,8 +128,12 @@ function AssetManagerMock() {
   // only happens after the dialog is already hidden.
   const typingProgress = useMotionValue(1);
   const dialogPhase = useMotionValue(1);
-  const queryText = useTransform(typingProgress, (p) =>
-    SVGL_QUERY.slice(0, Math.max(0, Math.round(p * SVGL_QUERY.length))),
+  // The leading zero-width space keeps the line box alive when the query is
+  // empty — without it the row collapses to caret height and the absolutely
+  // positioned placeholder drifts out of alignment.
+  const queryText = useTransform(
+    typingProgress,
+    (p) => `\u200B${SVGL_QUERY.slice(0, Math.max(0, Math.round(p * SVGL_QUERY.length)))}`,
   );
   const placeholderOpacity = useTransform(typingProgress, [0, 0.06], [1, 0]);
   const nonMatchOpacity = useTransform(typingProgress, [0, 0.12], [1, 0]);

--- a/apps/web/components/landing/footer.tsx
+++ b/apps/web/components/landing/footer.tsx
@@ -18,8 +18,8 @@ export function Footer() {
             <span className="tracking-[-0.01em]">open-slide</span>
           </div>
           <p className="text-[14px] leading-[1.6] text-[color:var(--color-muted)] max-w-[38ch]">
-            A React-first slide framework authored by AI agents. MIT licensed, built for the long
-            haul.
+            A React-first slide framework authored by AI agents. Free and open source under the MIT
+            license.
           </p>
         </div>
 

--- a/apps/web/components/landing/hero.tsx
+++ b/apps/web/components/landing/hero.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { DotGrid } from './dot-grid';
 import { HeroSetup } from './hero-setup';
 
@@ -11,8 +10,10 @@ export function Hero() {
       <div className="relative mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-12 pt-16 sm:pt-24 lg:pt-32 pb-20 sm:pb-32">
         <div className="flex flex-col gap-10 sm:gap-14 max-w-[920px]">
           <div className="flex flex-col items-start gap-6 sm:gap-8">
-            <Link
-              href="/docs/primitive/morph-element"
+            <a
+              href="https://x.com/1weiho/status/2078505891247329700"
+              target="_blank"
+              rel="noopener noreferrer"
               className="group pressable inline-flex items-center gap-2.5 rounded-full border border-[color:var(--color-rule)] bg-[color:var(--color-panel)]/70 py-1.5 pl-3.5 pr-3 text-[13px] font-medium text-[color:var(--color-text-soft)] backdrop-blur hover:border-[color:var(--color-dim)] hover:text-[color:var(--color-text)] rise"
               style={{ animationDelay: '40ms' }}
             >
@@ -27,7 +28,7 @@ export function Hero() {
               >
                 →
               </span>
-            </Link>
+            </a>
 
             <h1
               className="text-sheen text-[42px] sm:text-[68px] lg:text-[92px] leading-[1.05] sm:leading-[1.0] tracking-[-0.045em] font-medium text-[color:var(--color-text)] rise-blur"


### PR DESCRIPTION
## What changed

Three small landing-page fixes in `apps/web`:

- **Hero pill** — "Introducing Morph Transition" now links to the [announcement post on X](https://x.com/1weiho/status/2078505891247329700) (new tab) instead of `/docs/primitive/morph-element`. Swapped `next/link` for a plain `<a>` and removed the unused import.
- **Footer copy** — replaced "MIT licensed, built for the long haul." with "Free and open source under the MIT license."
- **Assets mock layout fix** — at the start of the Logo-search loop the typed-query span is empty, so its line box collapsed to the 13px caret height: the fake input shrank ~5px (dialog jump) and the absolutely-positioned "Search logos..." placeholder drifted out of alignment. The query text is now prefixed with a zero-width space so the line box never collapses.

## Why

The placeholder misalignment was visible every loop iteration on the "Drop in images. Pull in logos." section; the other two are copy/link polish.

## Notes for review

- Verified the layout fix against the running dev server: empty and typed states now measure identical geometry (input height stable at 37.5px; previously collapsed to 32px).
- `apps/web` is private, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the landing page’s asset search preview to keep cursor and layout alignment stable, including when the search field is empty.

- **Content Updates**
  - Updated footer messaging to clearly state that the project is free and open source under the MIT license.

- **Improvements**
  - Updated the hero call-to-action to open the related announcement in a new browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->