### PR TITLE
fix(core): select imported/shared components in the inspector

### DIFF
--- a/.changeset/shared-inspector-select.md
+++ b/.changeset/shared-inspector-select.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Make the inspector selectable for elements rendered by imported/shared components.

--- a/packages/core/e2e/fixture/components/shared.tsx
+++ b/packages/core/e2e/fixture/components/shared.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+export function Heading({ children }: { children: ReactNode }) {
+  return <div style={{ fontSize: 64, fontWeight: 700 }}>{children}</div>;
+}
+
+export function Card({ children }: { children: ReactNode }) {
+  return <div style={{ padding: 24, border: '1px solid #444', borderRadius: 12 }}>{children}</div>;
+}

--- a/packages/core/e2e/fixture/slides/shared-select/index.tsx
+++ b/packages/core/e2e/fixture/slides/shared-select/index.tsx
@@ -1,0 +1,18 @@
+﻿import type { Page, SlideMeta } from '@open-slide/core';
+import { Card, Heading } from '../../components/shared';
+
+export const meta: SlideMeta = {
+  title: 'Shared Select',
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const Only: Page = () => (
+  <>
+    <Heading>Shared heading click target</Heading>
+    <Card>
+      <Heading>Nested shared heading</Heading>
+    </Card>
+  </>
+);
+
+export default [Only] satisfies Page[];

--- a/packages/core/e2e/fixture/tsconfig.json
+++ b/packages/core/e2e/fixture/tsconfig.json
@@ -13,5 +13,5 @@
     "skipLibCheck": true,
     "types": ["@open-slide/core/env"]
   },
-  "include": ["slides/**/*", "open-slide.config.ts"]
+  "include": ["slides/**/*", "components/**/*", "open-slide.config.ts"]
 }

--- a/packages/core/e2e/tests/inspector.spec.ts
+++ b/packages/core/e2e/tests/inspector.spec.ts
@@ -140,4 +140,24 @@ test.describe('inspector editing', () => {
     await editorCanvas(page).getByText('Editable headline').click();
     await expect(page.locator('aside[data-inspector-ui]')).toBeVisible();
   });
+
+  test('selecting text inside an imported shared component opens the panel', async ({ page }) => {
+    await openSlide(page, 'shared-select');
+    await page.getByTitle('Inspect').click();
+    await editorCanvas(page).getByText('Shared heading click target').click();
+
+    const panel = page.locator('aside[data-inspector-ui]');
+    await expect(panel).toBeVisible();
+    await expect(panel.getByPlaceholder('Element text')).toHaveValue('Shared heading click target');
+  });
+
+  test('selecting text inside a nested shared component opens the panel', async ({ page }) => {
+    await openSlide(page, 'shared-select');
+    await page.getByTitle('Inspect').click();
+    await editorCanvas(page).getByText('Nested shared heading').click();
+
+    const panel = page.locator('aside[data-inspector-ui]');
+    await expect(panel).toBeVisible();
+    await expect(panel.getByPlaceholder('Element text')).toHaveValue('Nested shared heading');
+  });
 });

--- a/packages/core/src/app/components/inspector/inspect-overlay.tsx
+++ b/packages/core/src/app/components/inspector/inspect-overlay.tsx
@@ -39,7 +39,7 @@ export function InspectOverlay() {
       if (!isInspectableEventTarget(e.target)) return setHover(null);
       const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
       if (!el) return setHover(null);
-      const hit = findSlideSource(el, slideId, { hostOnly: true });
+      const hit = findSlideSource(el, slideId);
       if (!hit) return setHover(null);
       setHover({ hit });
     };
@@ -48,7 +48,7 @@ export function InspectOverlay() {
       if (!isInspectableEventTarget(e.target)) return;
       const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
       if (!el) return;
-      const hit = findSlideSource(el, slideId, { hostOnly: true });
+      const hit = findSlideSource(el, slideId);
       if (!hit) return;
       e.preventDefault();
       e.stopPropagation();
@@ -60,7 +60,7 @@ export function InspectOverlay() {
       if (!isInspectableEventTarget(e.target)) return;
       const el = pickInspectorTarget(pickElement(e.clientX, e.clientY));
       if (!el) return;
-      const hit = findSlideSource(el, slideId, { hostOnly: true });
+      const hit = findSlideSource(el, slideId);
       if (!hit) return;
       if (!(hit.anchor instanceof HTMLImageElement)) return;
       e.preventDefault();

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -1061,17 +1061,37 @@ function parseLetterSpacing(value: string): number {
   return Number.isFinite(n) ? round2(n) : 0;
 }
 
+/**
+ * Re-resolve a selection whose anchor has been detached, which happens on
+ * every HMR round that replaces the DOM node behind the selected element.
+ *
+ * The `data-slide-loc` query is exact and settles the common case. The scan
+ * below covers what that attribute cannot: imported and shared components
+ * carry their call site in the fiber tree rather than the DOM, so they are
+ * never tagged.
+ *
+ * That scan prefers a line *and* column hit before falling back to line alone.
+ * Several elements routinely originate on one source line, and dropping
+ * `hostOnly` from the lookup (needed so shared components stay selectable)
+ * widened the candidate set further, so a line-only match hands back whichever
+ * element the DOM walk happened to reach first. Keeping the line-only result
+ * as a last resort means an edit that shifts a column degrades to the previous
+ * behavior instead of dropping the selection outright.
+ */
 function findElementByLine(slideId: string, line: number, column: number): HTMLElement | null {
   const root = document.querySelector('[data-inspector-root]');
   if (!root) return null;
   const tagged = root.querySelector<HTMLElement>(`[data-slide-loc="${line}:${column}"]`);
   if (tagged) return tagged;
   const candidates = root.querySelectorAll<HTMLElement>('*');
+  let lineOnly: HTMLElement | null = null;
   for (const el of candidates) {
     const hit = findSlideSource(el, slideId);
-    if (hit && hit.line === line) return hit.anchor;
+    if (!hit || hit.line !== line) continue;
+    if (hit.column === column) return hit.anchor;
+    lineOnly ??= hit.anchor;
   }
-  return null;
+  return lineOnly;
 }
 
 function useReloadCounter(): number {

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -64,7 +64,7 @@ type RangeStylePreview = {
 };
 
 function resolveSelectedTarget(target: SelectedTarget, slideId: string): SelectedTarget {
-  const hit = findSlideSource(target.anchor, slideId, { hostOnly: true });
+  const hit = findSlideSource(target.anchor, slideId);
   if (!hit) return target;
   if (hit.line === target.line && hit.column === target.column && hit.anchor === target.anchor) {
     return target;
@@ -1068,7 +1068,7 @@ function findElementByLine(slideId: string, line: number, column: number): HTMLE
   if (tagged) return tagged;
   const candidates = root.querySelectorAll<HTMLElement>('*');
   for (const el of candidates) {
-    const hit = findSlideSource(el, slideId, { hostOnly: true });
+    const hit = findSlideSource(el, slideId);
     if (hit && hit.line === line) return hit.anchor;
   }
   return null;

--- a/packages/core/src/app/lib/inspector/fiber.test.ts
+++ b/packages/core/src/app/lib/inspector/fiber.test.ts
@@ -198,6 +198,35 @@ describe('findSlideSource fallback', () => {
     expect(hit?.anchor).toBe(el as unknown as HTMLElement);
   });
 
+  it('anchors an imported call site to the nearest host fiber, not the clicked node', () => {
+    const hostEl = makeEl();
+    const callSite = makeFiber({
+      fileName: '/repo/slides/cover/index.tsx',
+      line: 20,
+      column: 4,
+    });
+    const libraryHost = makeFiber({
+      fileName: '/repo/components/Heading.tsx',
+      line: 3,
+      column: 2,
+      hostEl,
+      parent: callSite,
+    });
+    const leaf = makeFiber({ parent: libraryHost });
+    const el = makeEl({ fiber: leaf });
+
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(20);
+    expect(hit?.column).toBe(4);
+    // Assert against hostEl rather than el. `anchor` is seeded with the clicked
+    // element, so the sibling test above would still pass if the walk never
+    // recognised libraryHost as a host fiber; only a distinct host element
+    // proves the `instanceof HTMLElement` branch actually ran.
+    expect(hit?.anchor).toBe(hostEl as unknown as HTMLElement);
+    expect(hit?.anchor).not.toBe(el as unknown as HTMLElement);
+  });
+
   it('rejects imported call sites when hostOnly is set', () => {
     const callSite = makeFiber({
       fileName: '/repo/slides/cover/index.tsx',

--- a/packages/core/src/app/lib/inspector/fiber.test.ts
+++ b/packages/core/src/app/lib/inspector/fiber.test.ts
@@ -3,12 +3,12 @@ import { findSlideSource } from './fiber.ts';
 
 class FakeHTMLElement {
   dataset: Record<string, string> = {};
-  private closestSelf: FakeHTMLElement | null = null;
-  setClosestSelfForSlideLoc() {
-    this.closestSelf = this;
-  }
+  parentElement: FakeHTMLElement | null = null;
   closest(selector: string): FakeHTMLElement | null {
-    if (selector === '[data-slide-loc]') return this.closestSelf;
+    if (selector !== '[data-slide-loc]') return null;
+    for (let cur: FakeHTMLElement | null = this; cur; cur = cur.parentElement) {
+      if (cur.dataset.slideLoc) return cur;
+    }
     return null;
   }
 }
@@ -20,11 +20,15 @@ type FakeFiber = {
   _debugSource?: DebugSource;
 };
 
-function makeEl(opts: { slideLoc?: string; fiber?: FakeFiber } = {}): FakeHTMLElement {
+function makeEl(
+  opts: { slideLoc?: string; fiber?: FakeFiber; parent?: FakeHTMLElement } = {},
+): FakeHTMLElement {
   const el = new FakeHTMLElement();
   if (opts.slideLoc) {
     el.dataset.slideLoc = opts.slideLoc;
-    el.setClosestSelfForSlideLoc();
+  }
+  if (opts.parent) {
+    el.parentElement = opts.parent;
   }
   if (opts.fiber) {
     (el as unknown as Record<string, FakeFiber>).__reactFiber$test = opts.fiber;
@@ -37,15 +41,22 @@ function makeFiber(opts: {
   line?: number;
   column?: number;
   host?: boolean;
+  hostEl?: FakeHTMLElement;
   parent?: FakeFiber | null;
 }): FakeFiber {
   const source: DebugSource | undefined =
     opts.fileName !== undefined
       ? { fileName: opts.fileName, lineNumber: opts.line, columnNumber: opts.column }
       : undefined;
+  let stateNode: unknown;
+  if (opts.hostEl) {
+    stateNode = opts.hostEl;
+  } else if (opts.host) {
+    stateNode = new FakeHTMLElement();
+  }
   return {
     return: opts.parent ?? null,
-    stateNode: opts.host ? new FakeHTMLElement() : undefined,
+    stateNode,
     _debugSource: source,
   };
 }
@@ -59,13 +70,23 @@ afterAll(() => {
 });
 
 describe('findSlideSource primary path', () => {
-  it('reads line:column from data-slide-loc', () => {
+  it('reads line:column from data-slide-loc on the element itself', () => {
     const el = makeEl({ slideLoc: '42:7' });
     const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
     expect(hit).not.toBeNull();
     expect(hit?.line).toBe(42);
     expect(hit?.column).toBe(7);
     expect(hit?.anchor).toBe(el as unknown as HTMLElement);
+  });
+
+  it('falls back to a tagged ancestor when fiber debug source is missing', () => {
+    const wrapper = makeEl({ slideLoc: '5:2' });
+    const el = makeEl({ parent: wrapper });
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(5);
+    expect(hit?.column).toBe(2);
+    expect(hit?.anchor).toBe(wrapper as unknown as HTMLElement);
   });
 });
 
@@ -150,5 +171,128 @@ describe('findSlideSource fallback', () => {
     expect(hit).not.toBeNull();
     expect(hit?.line).toBe(99);
     expect(hit?.column).toBe(3);
+  });
+
+  it('selects an imported component call site and keeps the host anchor', () => {
+    const hostEl = makeEl();
+    const callSite = makeFiber({
+      fileName: '/repo/slides/cover/index.tsx',
+      line: 20,
+      column: 4,
+    });
+    const libraryHost = makeFiber({
+      fileName: '/repo/components/Heading.tsx',
+      line: 3,
+      column: 2,
+      hostEl,
+      parent: callSite,
+    });
+    const el = makeEl({ fiber: libraryHost });
+    // Point the leaf fiber's stateNode at the clicked element itself.
+    libraryHost.stateNode = el;
+
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(20);
+    expect(hit?.column).toBe(4);
+    expect(hit?.anchor).toBe(el as unknown as HTMLElement);
+  });
+
+  it('rejects imported call sites when hostOnly is set', () => {
+    const callSite = makeFiber({
+      fileName: '/repo/slides/cover/index.tsx',
+      line: 20,
+      column: 4,
+    });
+    const libraryHost = makeFiber({
+      fileName: '/repo/components/Heading.tsx',
+      line: 3,
+      column: 2,
+      host: true,
+      parent: callSite,
+    });
+    const el = makeEl({ fiber: libraryHost });
+    libraryHost.stateNode = el;
+
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover', { hostOnly: true });
+    expect(hit).toBeNull();
+  });
+
+  it('prefers a shared call site over a tagged slide ancestor', () => {
+    const wrapper = makeEl({ slideLoc: '8:2' });
+    const callSite = makeFiber({
+      fileName: '/repo/slides/cover/index.tsx',
+      line: 12,
+      column: 6,
+    });
+    const libraryHost = makeFiber({
+      fileName: '/repo/components/Heading.tsx',
+      line: 2,
+      column: 0,
+      host: true,
+      parent: callSite,
+    });
+    const el = makeEl({ fiber: libraryHost, parent: wrapper });
+    libraryHost.stateNode = el;
+
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(12);
+    expect(hit?.column).toBe(6);
+    expect(hit?.anchor).toBe(el as unknown as HTMLElement);
+  });
+
+  it('resolves nested shared components to the nearest slide call site', () => {
+    const outerCall = makeFiber({
+      fileName: '/repo/slides/cover/index.tsx',
+      line: 30,
+      column: 2,
+    });
+    const innerCall = makeFiber({
+      fileName: '/repo/slides/cover/index.tsx',
+      line: 31,
+      column: 4,
+      parent: outerCall,
+    });
+    // Inner library host under <Heading>, which is itself under <Card>.
+    const libraryHost = makeFiber({
+      fileName: '/repo/components/Heading.tsx',
+      line: 2,
+      column: 0,
+      host: true,
+      parent: innerCall,
+    });
+    const el = makeEl({ fiber: libraryHost });
+    libraryHost.stateNode = el;
+
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(31);
+    expect(hit?.column).toBe(4);
+  });
+
+  it('maps a text-bearing host under a shared component to the call site', () => {
+    // Mirrors clicking the text node "Click me" inside <Heading>Click me</Heading>:
+    // elementsFromPoint returns the host div; fiber points at the library file.
+    const callSite = makeFiber({
+      fileName: '/repo/slides/demo/index.tsx',
+      line: 7,
+      column: 15,
+    });
+    const libraryHost = makeFiber({
+      fileName: '/repo/components/Heading.tsx',
+      line: 2,
+      column: 4,
+      host: true,
+      parent: callSite,
+    });
+    const el = makeEl({ fiber: libraryHost });
+    libraryHost.stateNode = el;
+
+    const hit = findSlideSource(el as unknown as HTMLElement, 'demo');
+    expect(hit).not.toBeNull();
+    expect(hit?.line).toBe(7);
+    expect(hit?.column).toBe(15);
+    expect(hit?.anchor).toBe(el as unknown as HTMLElement);
   });
 });

--- a/packages/core/src/app/lib/inspector/fiber.ts
+++ b/packages/core/src/app/lib/inspector/fiber.ts
@@ -5,9 +5,10 @@ export type SlideSourceHit = {
 };
 
 export type FindSlideSourceOptions = {
-  // Visual editor uses this: skip component-invocation JSX (`<MyComp/>`)
-  // since most components don't forward `style`. Comments leave it off
-  // so any JSX can be annotated.
+  // When true, only match host DOM fibers (`div`, `p`, …). Component
+  // call-site fibers (`<MyComp/>`) are skipped. Prefer leaving this off so
+  // imported/shared components remain selectable; their host children are
+  // authored outside `slides/` and never get `data-slide-loc`.
   hostOnly?: boolean;
 };
 
@@ -34,30 +35,22 @@ function normalizeDebugFileName(fileName: string): string {
   return fileName.split(/[?#]/)[0].replace(/\\/g, '/');
 }
 
-export function findSlideSource(
+function parseSlideLoc(el: HTMLElement): { line: number; column: number } | null {
+  const loc = el.dataset.slideLoc;
+  if (!loc) return null;
+  const idx = loc.indexOf(':');
+  if (idx <= 0) return null;
+  const line = Number(loc.slice(0, idx));
+  const column = Number(loc.slice(idx + 1));
+  if (!Number.isFinite(line) || !Number.isFinite(column)) return null;
+  return { line, column };
+}
+
+function findViaFiber(
   el: HTMLElement,
   slideId: string,
   opts?: FindSlideSourceOptions,
 ): SlideSourceHit | null {
-  // Primary path: the `data-slide-loc` attribute injected by the
-  // loc-tags Vite plugin. Immune to HMR-stale fiber state.
-  const tagged = el.closest<HTMLElement>('[data-slide-loc]');
-  if (tagged) {
-    const loc = tagged.dataset.slideLoc;
-    if (loc) {
-      const idx = loc.indexOf(':');
-      if (idx > 0) {
-        const line = Number(loc.slice(0, idx));
-        const column = Number(loc.slice(idx + 1));
-        if (Number.isFinite(line) && Number.isFinite(column)) {
-          return { line, column, anchor: tagged };
-        }
-      }
-    }
-  }
-
-  // Fallback for JSX rendered from imported component files (which the
-  // loc-tags plugin doesn't transform).
   const needle = `/slides/${slideId}/index.tsx`;
   let fiber = getFiber(el);
   let anchor: HTMLElement = el;
@@ -81,5 +74,33 @@ export function findSlideSource(
     }
     fiber = fiber.return;
   }
+  return null;
+}
+
+export function findSlideSource(
+  el: HTMLElement,
+  slideId: string,
+  opts?: FindSlideSourceOptions,
+): SlideSourceHit | null {
+  // Exact tag on the clicked element (slide-authored host JSX). Immune to
+  // HMR-stale fiber state.
+  const own = parseSlideLoc(el);
+  if (own) {
+    return { ...own, anchor: el };
+  }
+
+  // Fiber walk resolves imported/shared component call sites. Host children
+  // rendered from another file are never tagged by loc-tags, and must win
+  // over a tagged slide ancestor (otherwise a wrapper steals the click).
+  const fiberHit = findViaFiber(el, slideId, opts);
+  if (fiberHit) return fiberHit;
+
+  // Ancestor tag: last-resort mapping when fiber debug source is missing.
+  const tagged = el.closest<HTMLElement>('[data-slide-loc]');
+  if (tagged) {
+    const loc = parseSlideLoc(tagged);
+    if (loc) return { ...loc, anchor: tagged };
+  }
+
   return null;
 }

--- a/packages/core/src/app/lib/inspector/fiber.ts
+++ b/packages/core/src/app/lib/inspector/fiber.ts
@@ -35,6 +35,17 @@ function normalizeDebugFileName(fileName: string): string {
   return fileName.split(/[?#]/)[0].replace(/\\/g, '/');
 }
 
+/**
+ * Read the `line:column` pair that the loc-tags Vite plugin writes into
+ * `data-slide-loc`.
+ *
+ * Every rejection path matters more than it looks: callers treat a returned
+ * object as an authoritative source position, so a malformed attribute has to
+ * degrade to "untagged" and let the fiber walk take over. Handing back a `NaN`
+ * line instead would point the inspector at a source location that does not
+ * exist. Returns null for a missing attribute, a missing or leading separator,
+ * or a non-finite half.
+ */
 function parseSlideLoc(el: HTMLElement): { line: number; column: number } | null {
   const loc = el.dataset.slideLoc;
   if (!loc) return null;
@@ -46,6 +57,20 @@ function parseSlideLoc(el: HTMLElement): { line: number; column: number } | null
   return { line, column };
 }
 
+/**
+ * Resolve a source position by walking the React fiber chain up from `el`.
+ *
+ * This exists because the loc-tags plugin only transforms files under
+ * `slides/`. JSX rendered from an imported or shared component carries no
+ * `data-slide-loc`, so the only record of where it was invoked lives in the
+ * fiber's debug source. The walk stops at the first ancestor whose debug file
+ * is the slide's own `index.tsx`, which is the call site the author can
+ * actually edit.
+ *
+ * `anchor` tracks the nearest host element seen so far rather than the matched
+ * fiber, because a component-invocation fiber has no DOM node of its own; the
+ * inspector still needs something on screen to outline and measure.
+ */
 function findViaFiber(
   el: HTMLElement,
   slideId: string,
@@ -77,6 +102,19 @@ function findViaFiber(
   return null;
 }
 
+/**
+ * Map a clicked DOM element back to the JSX that produced it.
+ *
+ * The three strategies are ordered by how specific their answer is, not by how
+ * cheap they are. An exact tag on the element itself is unambiguous, so it
+ * wins outright. The fiber walk comes second because it is the only strategy
+ * that can see an imported or shared component's call site, and it has to
+ * outrank the tagged-ancestor lookup: a shared component nested inside tagged
+ * slide markup would otherwise resolve to its wrapper, and clicking the
+ * component would silently select the container around it (#327). The ancestor
+ * tag is the last resort for the case the fiber walk cannot cover, which is
+ * an HMR-stale or absent debug source.
+ */
 export function findSlideSource(
   el: HTMLElement,
   slideId: string,


### PR DESCRIPTION
## Summary

Fixes #327.

In inspect mode, clicking an element rendered by an imported/shared component produced no selection (or, when nested under a tagged slide host, selected the wrong ancestor). Host JSX authored outside `slides/` never gets `data-slide-loc`, and the fiber fallback required a host fiber whose `_debugSource` pointed at the slide file, so component call sites were skipped.

- Prefer an exact `data-slide-loc` on the clicked element
- Then walk fibers and allow slide-file component call sites (drop `hostOnly` at inspector call sites), anchoring highlight to the nearest descendant host
- Only then fall back to a tagged ancestor (HMR-immune last resort)
- Covers nested shared components and text inside shared hosts

## Evidence (product path)

Scratch e2e fixture `shared-select` with `components/shared.tsx` (`Heading` / `Card`), Playwright against the live inspector.

**Before (main HEAD):** click Shared heading click target with Inspect on -> inspector panel stays closed (`panelVisible: false`).

**After (this branch):** same click opens the panel with Element text `Shared heading click target` (host styles 64px / weight 700). Nested Card > Heading (`Nested shared heading`) also selects.

```text
pnpm exec vitest run packages/core/src/app/lib/inspector/fiber.test.ts
Test Files  1 passed (1)
Tests  13 passed (13)

pnpm exec playwright test e2e/tests/inspector.spec.ts -g "shared component|nested shared|selecting an element opens"
  ok selecting an element opens the panel with its tag and text
  ok selecting text inside an imported shared component opens the panel
  ok selecting text inside a nested shared component opens the panel
```

Screenshots / logs live under `handoff/evidence-open-slide-327/` on the contributor machine (before unselectable, after shared + nested selected).

## What was not tested

- Style edits that require the shared component to forward `style` / props (selection + source mapping are fixed; forwarding is still per-component)
- Configurable `FORWARDING_COMPONENTS` (issue alternative); not needed for selection

## AI assistance

This change was prepared with AI assistance (Cursor/Grok). I reviewed the diff, ran the unit and Playwright checks above, and verified the inspector click path before/after on the shared-component fixture.

## Test plan

- [x] Unit: shared call site, nested call site, tagged-ancestor must not steal, hostOnly still rejects when set
- [x] E2E: select text inside imported Heading; select nested Heading under Card; inline host regression
- [ ] Maintainer: quick click-through in a deck that imports a local component library


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The inspector can now select elements rendered by imported or shared components, including nested shared components.
  * Selected shared component content appears in the inspector’s “Element text” field.

* **Bug Fixes**
  * Improved target resolution when clicked elements lack direct location metadata, including line and column fallback behavior.

* **Tests**
  * Added end-to-end and unit coverage for shared component selection and nested behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->