### PR TITLE
Pin Vite cache to project root and clear on update

### DIFF
--- a/.changeset/vite-cache-dir.md
+++ b/.changeset/vite-cache-dir.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Store Vite's optimize-deps cache at the project root and clear it on in-app update, so upgrading no longer leaves the dev server failing on missing `.vite/deps` chunks.

--- a/packages/core/src/vite/cache-dir.test.ts
+++ b/packages/core/src/vite/cache-dir.test.ts
@@ -1,0 +1,10 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveViteCacheDir } from './cache-dir.ts';
+
+describe('resolveViteCacheDir', () => {
+  it('points at the user project root, not the installed core package', () => {
+    const cwd = path.join(path.sep, 'Users', 'david', 'slides');
+    expect(resolveViteCacheDir(cwd)).toBe(path.join(cwd, 'node_modules', '.vite'));
+  });
+});

--- a/packages/core/src/vite/cache-dir.ts
+++ b/packages/core/src/vite/cache-dir.ts
@@ -1,0 +1,10 @@
+import path from 'node:path';
+
+// Vite defaults its optimize-deps cache to `<nearest package.json>/node_modules/.vite`.
+// Our `root` points inside the installed @open-slide/core package, so that default
+// lands the cache under node_modules/@open-slide/core/node_modules/.vite — inside the
+// very directory the in-app updater swaps out on upgrade, leaving Vite referencing
+// chunks that no longer exist. Pin it to the user's project root instead.
+export function resolveViteCacheDir(userCwd: string): string {
+  return path.join(userCwd, 'node_modules', '.vite');
+}

--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -5,6 +5,7 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import type { InlineConfig } from 'vite';
 import { apiPlugin } from './api-plugin.ts';
+import { resolveViteCacheDir } from './cache-dir.ts';
 import { currentPlugin } from './current-plugin.ts';
 import { designPlugin } from './design-plugin.ts';
 import { locTagsPlugin } from './loc-tags-plugin.ts';
@@ -54,6 +55,7 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
   return {
     base: config.base ?? '/',
     root: APP_ROOT,
+    cacheDir: resolveViteCacheDir(userCwd),
     configFile: false,
     envDir: userCwd,
     plugins: [

--- a/packages/core/src/vite/routes/update.ts
+++ b/packages/core/src/vite/routes/update.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { ViteDevServer } from 'vite';
 import { validateMutationRequest } from '../../http/request-guard.ts';
+import { resolveViteCacheDir } from '../cache-dir.ts';
 import { type ApiContext, json } from './context.ts';
 
 // GET /__update-check  → { current, latest, outdated }
@@ -143,6 +144,18 @@ async function runCommand(spec: CommandSpec, cwd: string): Promise<void> {
   });
 }
 
+// Drop Vite's optimize-deps cache so the post-update restart re-bundles against the
+// freshly installed version. Vite keys that cache off a dep hash that doesn't reflect
+// an @open-slide/core version bump (notably it can't read bun's text lockfile), so
+// without this it keeps serving the previous version's deps. Best-effort: on Windows
+// the outgoing server may still hold the files, and a stale cache only costs a manual
+// restart, never correctness.
+async function clearViteCache(cwd: string): Promise<void> {
+  try {
+    await fs.rm(resolveViteCacheDir(cwd), { recursive: true, force: true });
+  } catch {}
+}
+
 async function updatePackage(ctx: ApiContext): Promise<UpdateResult> {
   const packageManager = await detectPackageManager(ctx.userCwd);
   const updateCommand = updateCommandFor(packageManager);
@@ -150,6 +163,7 @@ async function updatePackage(ctx: ApiContext): Promise<UpdateResult> {
 
   await runCommand(updateCommand, ctx.userCwd);
   await runCommand(syncCommand, ctx.userCwd);
+  await clearViteCache(ctx.userCwd);
 
   cache = null;
   const latest = await fetchLatest(Date.now());


### PR DESCRIPTION
Fixes an issue where upgrading `@open-slide/core` via the in-app updater leaves the dev server failing on missing `.vite/deps` chunks.

**Problem:** Vite's optimize-deps cache defaults to `<nearest package.json>/node_modules/.vite`. Since the framework's Vite config has `root` pointing inside the installed `@open-slide/core` package, the cache lands under `node_modules/@open-slide/core/node_modules/.vite` — inside the directory that gets swapped out during upgrade. This leaves Vite referencing stale chunks that no longer exist.

**Solution:**
- Add `resolveViteCacheDir()` utility to pin the cache to the user's project root (`<userCwd>/node_modules/.vite`)
- Configure Vite's `cacheDir` option to use this path
- Clear the cache after running the in-app update, forcing Vite to re-bundle against the freshly installed version on the next dev server restart

**Changes:**
- New module `packages/core/src/vite/cache-dir.ts` with `resolveViteCacheDir()` function and test
- Updated `packages/core/src/vite/config.ts` to set `cacheDir` in the Vite config
- Updated `packages/core/src/vite/routes/update.ts` to call `clearViteCache()` after package update
- Added changeset documenting the fix

https://claude.ai/code/session_01B9t4YwFJsMczwpVLXf4C12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update reliability by clearing stale Vite caches after in-app updates.
  * Prevented missing dependency chunks and related failures when restarting after upgrades.

* **Maintenance**
  * Vite caches are now stored in the project’s directory for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->