### PR TITLE
feat(core): resolve deck dependencies before serving

### DIFF
--- a/.changeset/dependency-preflight.md
+++ b/.changeset/dependency-preflight.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': minor
+---
+
+Check and install the fonts and assets a deck needs on dev start, with an `open-slide preflight` command.

--- a/packages/core/src/cli/dev.ts
+++ b/packages/core/src/cli/dev.ts
@@ -5,11 +5,13 @@ import chalk from 'chalk';
 import { createServer, mergeConfig } from 'vite';
 import { createViteConfig } from '../vite/config.ts';
 import { DEV_SUPERVISED_ENV, RESTART_EXIT_CODE } from '../vite/routes/restart.ts';
+import { runPreflight, shouldRunPreflight } from './preflight.ts';
 
 export interface DevOptions {
   port?: number;
   host?: string | boolean;
   open?: boolean;
+  preflight?: boolean;
 }
 
 export async function dev(opts: DevOptions = {}): Promise<void> {
@@ -21,6 +23,16 @@ export async function dev(opts: DevOptions = {}): Promise<void> {
 }
 
 async function startServer(opts: DevOptions): Promise<void> {
+  if (shouldRunPreflight(opts)) {
+    try {
+      await runPreflight(process.cwd());
+    } catch (err) {
+      process.stderr.write(
+        `${chalk.yellow('preflight:')} dependency check failed (${(err as Error).message})\n`,
+      );
+    }
+  }
+
   const base = await createViteConfig({ userCwd: process.cwd() });
   const config = mergeConfig(base, {
     server: {
@@ -93,6 +105,7 @@ function supervise(opts: DevOptions): void {
 
 function devArgs(opts: DevOptions): string[] {
   const args = ['dev', '--no-skills-check'];
+  if (opts.preflight === false) args.push('--no-preflight');
   if (opts.port !== undefined) args.push('--port', String(opts.port));
   if (opts.host === true) args.push('--host');
   else if (typeof opts.host === 'string') args.push('--host', opts.host);

--- a/packages/core/src/cli/preflight.test.ts
+++ b/packages/core/src/cli/preflight.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { shouldRunPreflight } from './preflight.ts';
+
+describe('shouldRunPreflight', () => {
+  it('runs by default on a developer machine', () => {
+    expect(shouldRunPreflight({}, {})).toBe(true);
+  });
+
+  it('is skipped by --no-preflight', () => {
+    expect(shouldRunPreflight({ preflight: false }, {})).toBe(false);
+  });
+
+  it('is skipped under CI', () => {
+    expect(shouldRunPreflight({}, { CI: 'true' })).toBe(false);
+    expect(shouldRunPreflight({}, { CI: '1' })).toBe(false);
+  });
+
+  it('treats an empty CI variable as not CI', () => {
+    expect(shouldRunPreflight({}, { CI: '' })).toBe(true);
+  });
+});

--- a/packages/core/src/cli/preflight.ts
+++ b/packages/core/src/cli/preflight.ts
@@ -1,0 +1,452 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import chalk from 'chalk';
+import { installFontFiles, listInstalledFamilies } from './system-fonts.ts';
+
+/**
+ * A deck is portable code, but what it renders with is not: the fonts it names
+ * and the assets it imports live outside the file, so opening someone else's
+ * deck silently substitutes both.
+ */
+
+/**
+ * Never under CI: the machine is discarded after the run, so resolving what it
+ * is missing only buys latency and one more way for the job to fail.
+ */
+export function shouldRunPreflight(
+  opts: { preflight?: boolean },
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return opts.preflight !== false && !env.CI;
+}
+
+export type PreflightReport = {
+  decks: string[];
+  fontsNeeded: string[];
+  fontsAlreadyPresent: string[];
+  fontsInstalled: string[];
+  fontsUnresolved: { family: string; reason: string }[];
+  assetsDownloaded: string[];
+  assetsMissing: { deck: string; asset: string }[];
+};
+
+const GENERIC_FAMILIES = new Set([
+  'sans-serif',
+  'serif',
+  'monospace',
+  'cursive',
+  'fantasy',
+  'system-ui',
+  'ui-sans-serif',
+  'ui-serif',
+  'ui-monospace',
+  'ui-rounded',
+  'inherit',
+  'initial',
+  'unset',
+  'emoji',
+  'math',
+  'fangsong',
+  '-apple-system',
+  'blinkmacsystemfont',
+]);
+
+/**
+ * The runtime's own typography. Decks inherit it without naming it anywhere, so
+ * a scan of the workspace would never turn it up.
+ */
+const RUNTIME_FAMILIES = ['Geist', 'Geist Mono'];
+
+/** Families whose npm package we know by name rather than by convention. */
+const KNOWN_FONT_PACKAGES: Record<string, string> = {
+  geist: 'geist',
+  'geist variable': 'geist',
+  'geist mono': 'geist',
+  'geist mono variable': 'geist',
+};
+
+export async function runPreflight(
+  userCwd: string,
+  opts: { quiet?: boolean; install?: boolean } = {},
+): Promise<PreflightReport> {
+  const install = opts.install ?? true;
+  const report: PreflightReport = {
+    decks: [],
+    fontsNeeded: [],
+    fontsAlreadyPresent: [],
+    fontsInstalled: [],
+    fontsUnresolved: [],
+    assetsDownloaded: [],
+    assetsMissing: [],
+  };
+
+  const slidesRoot = join(userCwd, 'slides');
+  if (!existsSync(slidesRoot)) return report;
+
+  const families = new Set<string>(RUNTIME_FAMILIES);
+  for (const deck of readdirSync(slidesRoot)) {
+    const entry = join(slidesRoot, deck, 'index.tsx');
+    if (!existsSync(entry)) continue;
+    report.decks.push(deck);
+
+    let source = '';
+    try {
+      source = readFileSync(entry, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const family of extractFamilies(source)) families.add(family);
+    await resolveDeckAssets(userCwd, deck, source, report, install);
+  }
+
+  // Themes carry the typography the decks inherit.
+  const themesRoot = join(userCwd, 'themes');
+  if (existsSync(themesRoot)) {
+    for (const file of readdirSync(themesRoot)) {
+      if (!/\.(md|tsx)$/i.test(file)) continue;
+      try {
+        for (const family of extractFamilies(readFileSync(join(themesRoot, file), 'utf8'))) {
+          families.add(family);
+        }
+      } catch {
+        // Unreadable theme is not fatal.
+      }
+    }
+  }
+
+  if (families.size === 0) return report;
+
+  const installed = listInstalledFamilies();
+  for (const family of families) {
+    report.fontsNeeded.push(family);
+    if (isPresent(family, installed)) {
+      report.fontsAlreadyPresent.push(family);
+      continue;
+    }
+    if (!install) {
+      report.fontsUnresolved.push({ family, reason: 'install disabled' });
+      continue;
+    }
+    const outcome = await installFamily(userCwd, family);
+    if (outcome.ok) report.fontsInstalled.push(family);
+    else report.fontsUnresolved.push({ family, reason: outcome.reason });
+  }
+
+  if (!opts.quiet) printReport(report);
+  return report;
+}
+
+function isPresent(family: string, installed: Set<string>): boolean {
+  const name = family.toLowerCase();
+  if (installed.has(name)) return true;
+  // "Geist Variable" is satisfied by the installed static "Geist".
+  const base = name.replace(/\s+variable$/, '');
+  if (installed.has(base)) return true;
+  for (const candidate of installed) {
+    if (candidate.startsWith(`${base} `)) return true;
+  }
+  return false;
+}
+
+async function installFamily(
+  userCwd: string,
+  family: string,
+): Promise<{ ok: boolean; reason: string }> {
+  const pkg = packageForFamily(family);
+  let files = findFontFiles(userCwd, pkg);
+
+  if (files.length === 0) {
+    // Not on disk yet: fetch it, then look again. Network problems degrade to a
+    // report line instead of blocking the server.
+    try {
+      execFileSync(npmCommand(), ['install', pkg, '--no-audit', '--no-fund'], {
+        cwd: userCwd,
+        stdio: 'ignore',
+        timeout: 180_000,
+      });
+      files = findFontFiles(userCwd, pkg);
+    } catch {
+      // The npm route is optional; Google Fonts below still covers most families.
+    }
+  }
+
+  if (files.length === 0) {
+    // Most font packages ship woff2 only, which no OS can install. Google Fonts
+    // serves the static TTFs for the same families, so fall back to that.
+    files = await downloadFromGoogleFonts(userCwd, family);
+  }
+
+  if (files.length === 0) {
+    return {
+      ok: false,
+      reason: `no .ttf/.otf in ${pkg} nor on Google Fonts; install the font manually, then run "open-slide preflight"`,
+    };
+  }
+  const result = installFontFiles(files);
+  if (result.installed === 0) return { ok: false, reason: 'copy into the fonts folder failed' };
+  return { ok: true, reason: '' };
+}
+
+/** npm ships as a .cmd shim on Windows; naming it avoids spawning a shell. */
+function npmCommand(): string {
+  return process.platform === 'win32' ? 'npm.cmd' : 'npm';
+}
+
+/**
+ * Google Fonts serves a zip of static outlines per family. That is the only
+ * broadly available source of installable TTFs — npm font packages target
+ * browsers and ship woff2, which no operating system can install.
+ */
+async function downloadFromGoogleFonts(userCwd: string, family: string): Promise<string[]> {
+  const slug = family.replace(/\s+Variable$/i, '');
+  const cacheDir = join(
+    userCwd,
+    'node_modules',
+    '.open-slide',
+    'fonts',
+    slug.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+  );
+
+  if (existsSync(cacheDir)) {
+    const cached: string[] = [];
+    collectFonts(cacheDir, cached, 0);
+    if (cached.length > 0) return cached;
+  }
+
+  const dir = slug.toLowerCase().replace(/[^a-z0-9]+/g, '');
+  const entries = await listGoogleFontFiles(dir);
+  if (entries.length === 0) return [];
+
+  // Static faces name their weight in the file itself, which is what a system
+  // install exposes; the variable build is a last resort.
+  const statics = entries.filter((e) => !/\[.*\]/.test(e.name));
+  const chosen = statics.length > 0 ? statics : entries;
+
+  const out: string[] = [];
+  mkdirSync(cacheDir, { recursive: true });
+  for (const entry of chosen) {
+    try {
+      const res = await fetch(entry.url, { signal: AbortSignal.timeout(60_000) });
+      if (!res.ok) continue;
+      const dest = join(cacheDir, entry.name);
+      writeFileSync(dest, Buffer.from(await res.arrayBuffer()));
+      out.push(dest);
+    } catch {
+      // One failed face does not sink the family.
+    }
+  }
+  return out;
+}
+
+type RemoteFont = { name: string; url: string };
+
+/**
+ * The google/fonts repository is the only stable public source of installable
+ * outlines: the fonts.google.com download endpoint now answers with HTML, and
+ * the CSS API serves woff2. Families live under a licence folder, and the
+ * static weights sit in `static/` when a variable build exists.
+ */
+async function listGoogleFontFiles(dir: string): Promise<RemoteFont[]> {
+  for (const licence of ['ofl', 'apache', 'ufl']) {
+    const base = `https://api.github.com/repos/google/fonts/contents/${licence}/${dir}`;
+    const listing = await fetchJson(base);
+    if (!Array.isArray(listing)) continue;
+
+    const statics = listing.find(
+      (item: { name?: string; type?: string }) => item.name === 'static' && item.type === 'dir',
+    );
+    if (statics) {
+      const inner = await fetchJson(`${base}/static`);
+      if (Array.isArray(inner)) {
+        const files = toFontEntries(inner);
+        if (files.length > 0) return files;
+      }
+    }
+    const files = toFontEntries(listing);
+    if (files.length > 0) return files;
+  }
+  return [];
+}
+
+function toFontEntries(listing: unknown[]): RemoteFont[] {
+  const out: RemoteFont[] = [];
+  for (const item of listing as { name?: string; download_url?: string }[]) {
+    if (!item.name || !item.download_url) continue;
+    if (!/\.(ttf|otf)$/i.test(item.name)) continue;
+    out.push({ name: item.name, url: item.download_url });
+  }
+  return out;
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'open-slide-preflight' },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+function packageForFamily(family: string): string {
+  const known = KNOWN_FONT_PACKAGES[family.toLowerCase()];
+  if (known) return known;
+  // Convention used by the fontsource project, which mirrors Google Fonts.
+  const slug = family
+    .toLowerCase()
+    .replace(/\s+variable$/, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+  return `@fontsource/${slug}`;
+}
+
+/** Static outlines only: the browser can use woff2, the OS cannot. */
+function findFontFiles(userCwd: string, pkg: string): string[] {
+  const roots = [join(userCwd, 'node_modules', ...pkg.split('/'))];
+  const store = join(userCwd, 'node_modules', '.pnpm');
+  if (existsSync(store)) {
+    const prefix = `${pkg.replace('/', '+')}@`;
+    for (const entry of readdirSync(store)) {
+      if (entry.startsWith(prefix))
+        roots.push(join(store, entry, 'node_modules', ...pkg.split('/')));
+    }
+  }
+
+  const out: string[] = [];
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+    collectFonts(root, out, 0);
+  }
+  return out;
+}
+
+function collectFonts(dir: string, out: string[], depth: number): void {
+  if (depth > 6) return;
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry === 'node_modules' && depth > 0) continue;
+    const full = join(dir, entry);
+    if (/\.(ttf|otf)$/i.test(entry)) {
+      // Variable files register inconsistently across systems; the static faces
+      // are what the export maps weights onto.
+      if (entry.includes('[wght]') || /Variable/i.test(entry)) continue;
+      out.push(full);
+      continue;
+    }
+    if (!entry.includes('.')) collectFonts(full, out, depth + 1);
+  }
+}
+
+/**
+ * Assets a deck imports have to exist before it renders. A deck can ship an
+ * `assets.manifest.json` mapping file names to URLs; anything listed there and
+ * missing on disk is fetched now.
+ */
+async function resolveDeckAssets(
+  userCwd: string,
+  deck: string,
+  source: string,
+  report: PreflightReport,
+  install: boolean,
+): Promise<void> {
+  const deckDir = join(userCwd, 'slides', deck);
+  const referenced = new Set<string>();
+  for (const match of source.matchAll(/from\s+['"](\.\/assets\/[^'"]+)['"]/g)) {
+    referenced.add(match[1].replace('./', ''));
+  }
+  for (const match of source.matchAll(/['"]@assets\/([^'"]+)['"]/g)) {
+    referenced.add(join('..', '..', 'assets', match[1]));
+  }
+
+  let manifest: Record<string, string> = {};
+  const manifestPath = join(deckDir, 'assets.manifest.json');
+  if (existsSync(manifestPath)) {
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+      for (const name of Object.keys(manifest)) referenced.add(join('assets', name));
+    } catch {
+      // Malformed manifest is reported through the missing-asset list below.
+    }
+  }
+
+  for (const rel of referenced) {
+    const full = join(deckDir, rel);
+    if (existsSync(full)) continue;
+
+    const url = manifest[rel.replace(/^assets[\\/]/, '')];
+    if (url && install) {
+      try {
+        const res = await fetch(url, { signal: AbortSignal.timeout(60_000) });
+        if (!res.ok) throw new Error(String(res.status));
+        mkdirSync(dirname(full), { recursive: true });
+        writeFileSync(full, Buffer.from(await res.arrayBuffer()));
+        report.assetsDownloaded.push(`${deck}/${rel}`);
+        continue;
+      } catch {
+        // Falls through to the missing list.
+      }
+    }
+    report.assetsMissing.push({ deck, asset: rel });
+  }
+}
+
+function extractFamilies(source: string): string[] {
+  const out = new Set<string>();
+  const values: string[] = [];
+
+  const patterns = [
+    /fontFamily\s*:\s*['"`]([^'"`]+)['"`]/g,
+    /font-family\s*:\s*([^;\n}]+)/g,
+    /--osd-font-[a-z]+\s*:\s*([^;\n}]+)/g,
+  ];
+  for (const re of patterns) {
+    for (const match of source.matchAll(re)) values.push(match[1]);
+  }
+
+  // `fontFamily: FONT` with `const FONT = 'Inter, sans-serif'` at the top of the
+  // file is idiomatic in decks, and a literal-only scan would miss it entirely.
+  for (const match of source.matchAll(/fontFamily\s*:\s*([A-Z_][A-Za-z0-9_]*)/g)) {
+    const decl = source.match(
+      new RegExp(`\\b(?:const|let|var)\\s+${match[1]}\\s*=\\s*['"\`]([^'"\`]+)['"\`]`),
+    );
+    if (decl) values.push(decl[1]);
+  }
+
+  for (const value of values) {
+    for (const part of value.split(',')) {
+      const name = part.trim().replace(/^["']|["']$/g, '');
+      if (!name || name.startsWith('var(')) continue;
+      if (GENERIC_FAMILIES.has(name.toLowerCase())) continue;
+      if (name.length > 48) continue;
+      out.add(name);
+    }
+  }
+  return [...out];
+}
+
+function printReport(r: PreflightReport): void {
+  if (r.fontsNeeded.length === 0 && r.assetsMissing.length === 0) return;
+  const line = (msg: string) => process.stdout.write(`${msg}\n`);
+
+  if (r.fontsInstalled.length > 0) {
+    line(`${chalk.green('preflight:')} installed font(s): ${r.fontsInstalled.join(', ')}`);
+  }
+  if (r.assetsDownloaded.length > 0) {
+    line(`${chalk.green('preflight:')} downloaded asset(s): ${r.assetsDownloaded.join(', ')}`);
+  }
+  for (const item of r.fontsUnresolved) {
+    line(`${chalk.yellow('preflight:')} font "${item.family}" unavailable (${item.reason})`);
+  }
+  for (const item of r.assetsMissing) {
+    line(`${chalk.yellow('preflight:')} missing asset in ${item.deck}: ${item.asset}`);
+  }
+}

--- a/packages/core/src/cli/preflight.ts
+++ b/packages/core/src/cli/preflight.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import chalk from 'chalk';
@@ -128,9 +127,16 @@ export async function runPreflight(
       report.fontsUnresolved.push({ family, reason: 'install disabled' });
       continue;
     }
-    const outcome = await installFamily(userCwd, family);
-    if (outcome.ok) report.fontsInstalled.push(family);
-    else report.fontsUnresolved.push({ family, reason: outcome.reason });
+    // One family that cannot be resolved, for any reason including a filesystem
+    // error nobody anticipated, is a line in the report and never the end of the
+    // run: the standalone command has no try/catch above it.
+    try {
+      const outcome = await installFamily(userCwd, family);
+      if (outcome.ok) report.fontsInstalled.push(family);
+      else report.fontsUnresolved.push({ family, reason: outcome.reason });
+    } catch (err) {
+      report.fontsUnresolved.push({ family, reason: (err as Error).message });
+    }
   }
 
   if (!opts.quiet) printReport(report);
@@ -154,26 +160,14 @@ async function installFamily(
   family: string,
 ): Promise<{ ok: boolean; reason: string }> {
   const pkg = packageForFamily(family);
+  // Reuse an outline the workspace already has, but never install the package to
+  // get one: that would write a dependency and a lockfile entry into someone's
+  // project as a side effect of starting a dev server. Font packages target
+  // browsers and ship woff2 anyway, which no operating system can install, so
+  // this path only pays off for the rare package carrying a .ttf.
   let files = findFontFiles(userCwd, pkg);
 
   if (files.length === 0) {
-    // Not on disk yet: fetch it, then look again. Network problems degrade to a
-    // report line instead of blocking the server.
-    try {
-      execFileSync(npmCommand(), ['install', pkg, '--no-audit', '--no-fund'], {
-        cwd: userCwd,
-        stdio: 'ignore',
-        timeout: 180_000,
-      });
-      files = findFontFiles(userCwd, pkg);
-    } catch {
-      // The npm route is optional; Google Fonts below still covers most families.
-    }
-  }
-
-  if (files.length === 0) {
-    // Most font packages ship woff2 only, which no OS can install. Google Fonts
-    // serves the static TTFs for the same families, so fall back to that.
     files = await downloadFromGoogleFonts(userCwd, family);
   }
 
@@ -186,11 +180,6 @@ async function installFamily(
   const result = installFontFiles(files);
   if (result.installed === 0) return { ok: false, reason: 'copy into the fonts folder failed' };
   return { ok: true, reason: '' };
-}
-
-/** npm ships as a .cmd shim on Windows; naming it avoids spawning a shell. */
-function npmCommand(): string {
-  return process.platform === 'win32' ? 'npm.cmd' : 'npm';
 }
 
 /**

--- a/packages/core/src/cli/run.ts
+++ b/packages/core/src/cli/run.ts
@@ -30,6 +30,7 @@ interface ServerFlags {
 
 interface DevFlags extends ServerFlags {
   skillsCheck?: boolean;
+  preflight?: boolean;
 }
 
 async function runSkillsDriftCheck(skillsDir: string): Promise<void> {
@@ -105,6 +106,7 @@ export async function run(argv: string[]): Promise<void> {
     .addOption(new Option('--host [host]', 'expose on the network (optional host)'))
     .option('--open', 'open the browser on start')
     .option('--no-skills-check', 'skip the built-in skills drift check')
+    .option('--no-preflight', 'skip the deck dependency check')
     .action(async (flags: DevFlags) => {
       if (flags.skillsCheck !== false) {
         await runSkillsDriftCheck(resolveBuiltinSkillsDir());
@@ -131,6 +133,23 @@ export async function run(argv: string[]): Promise<void> {
     .action(async (flags: ServerFlags) => {
       const { preview } = await import('./preview.ts');
       await preview(flags);
+    });
+
+  program
+    .command('preflight')
+    .description("Check and install this workspace's deck dependencies (fonts, assets)")
+    .option('--no-install', 'only report what is missing')
+    .action(async (flags: { install?: boolean }) => {
+      const { runPreflight } = await import('./preflight.ts');
+      const report = await runPreflight(process.cwd(), { install: flags.install !== false });
+      const ok = report.fontsUnresolved.length === 0 && report.assetsMissing.length === 0;
+      process.stdout.write(
+        `${ok ? chalk.green('preflight:') : chalk.yellow('preflight:')} ${report.decks.length} deck(s), ` +
+          `${report.fontsAlreadyPresent.length} font(s) already present, ` +
+          `${report.fontsInstalled.length} installed, ` +
+          `${report.fontsUnresolved.length} pending\n`,
+      );
+      if (!ok) process.exitCode = 1;
     });
 
   program

--- a/packages/core/src/cli/system-fonts.ts
+++ b/packages/core/src/cli/system-fonts.ts
@@ -1,0 +1,153 @@
+import { execFileSync } from 'node:child_process';
+import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import { homedir, platform } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Fonts are named by family, so a deck only renders as authored on a machine
+ * that has those families. Installing per user keeps this free of administrator
+ * rights.
+ */
+
+export function listInstalledFamilies(): Set<string> {
+  const families = new Set<string>();
+  const add = (name: string) => {
+    const cleaned = name
+      .replace(/\s*\((TrueType|OpenType)\)\s*$/i, '')
+      // Variable files carry their axes in the name ("Lora[wght]"); the family
+      // the OS reports is the bare one.
+      .replace(/\[[^\]]*\]/g, '')
+      .replace(/\s*&\s*/g, ' ')
+      .trim();
+    if (cleaned) families.add(cleaned.toLowerCase());
+  };
+
+  if (platform() === 'win32') {
+    for (const hive of ['HKCU', 'HKLM']) {
+      try {
+        const out = execFileSync(
+          'reg',
+          ['query', `${hive}\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts`],
+          { encoding: 'utf8', timeout: 10_000 },
+        );
+        for (const line of out.split('\n')) {
+          // "    Geist Black (TrueType)    REG_SZ    C:\path\Geist-Black.ttf"
+          const match = line.match(/^\s{4}(.+?)\s{2,}REG_SZ\s{2,}/);
+          if (match) add(match[1]);
+        }
+      } catch {
+        // Hive unreadable: fall through, the file scan below still helps.
+      }
+    }
+    for (const dir of [
+      join(process.env.LOCALAPPDATA ?? '', 'Microsoft', 'Windows', 'Fonts'),
+      join(process.env.WINDIR ?? 'C:\\Windows', 'Fonts'),
+    ]) {
+      addFromDir(dir, add);
+    }
+  } else if (platform() === 'darwin') {
+    for (const dir of [
+      join(homedir(), 'Library', 'Fonts'),
+      '/Library/Fonts',
+      '/System/Library/Fonts',
+    ]) {
+      addFromDir(dir, add);
+    }
+  } else {
+    for (const dir of [join(homedir(), '.local', 'share', 'fonts'), '/usr/share/fonts']) {
+      addFromDir(dir, add);
+    }
+  }
+
+  return families;
+}
+
+/** File names are a weak signal, but they catch fonts missing from the registry. */
+function addFromDir(dir: string, add: (name: string) => void): void {
+  if (!dir || !existsSync(dir)) return;
+  try {
+    for (const file of readdirSync(dir)) {
+      if (!/\.(ttf|otf|ttc)$/i.test(file)) continue;
+      const base = file.replace(/\.(ttf|otf|ttc)$/i, '');
+      const [family] = base.split('-');
+      add(family.replace(/([a-z])([A-Z])/g, '$1 $2'));
+    }
+  } catch {
+    // Unreadable directory is not fatal.
+  }
+}
+
+export type FontInstallResult = { installed: number; failed: string[] };
+
+export function installFontFiles(files: string[]): FontInstallResult {
+  const failed: string[] = [];
+  let installed = 0;
+
+  const target =
+    platform() === 'win32'
+      ? join(
+          process.env.LOCALAPPDATA ?? join(homedir(), 'AppData', 'Local'),
+          'Microsoft',
+          'Windows',
+          'Fonts',
+        )
+      : platform() === 'darwin'
+        ? join(homedir(), 'Library', 'Fonts')
+        : join(homedir(), '.local', 'share', 'fonts');
+  mkdirSync(target, { recursive: true });
+
+  for (const src of files) {
+    const file = src.split(/[\\/]/).pop();
+    if (!file) continue;
+    const dest = join(target, file);
+    try {
+      const upToDate = existsSync(dest) && statSync(dest).size === statSync(src).size;
+      if (!upToDate) copyFileSync(src, dest);
+      if (platform() === 'win32') {
+        execFileSync(
+          'reg',
+          [
+            'add',
+            'HKCU\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts',
+            '/v',
+            `${faceName(file)} (TrueType)`,
+            '/t',
+            'REG_SZ',
+            '/d',
+            dest,
+            '/f',
+          ],
+          { stdio: 'ignore', timeout: 10_000 },
+        );
+      }
+      installed++;
+    } catch {
+      failed.push(file);
+    }
+  }
+
+  if (platform() === 'linux' && installed > 0) {
+    try {
+      execFileSync('fc-cache', ['-f'], { stdio: 'ignore', timeout: 30_000 });
+    } catch {
+      // Cache refresh is best-effort.
+    }
+  }
+
+  return { installed, failed };
+}
+
+/**
+ * "Geist-SemiBoldItalic.ttf" -> "Geist SemiBold Italic"
+ *
+ * Axis suffixes are dropped: a variable file named `Lora[wght].ttf` installs as
+ * the family "Lora", and keeping the brackets would register a name nothing
+ * matches on later.
+ */
+export function faceName(file: string): string {
+  const base = file.replace(/\.(ttf|otf)$/i, '').replace(/\[[^\]]*\]/g, '');
+  const [family, style] = base.split('-');
+  const spaced = (style ?? '').replace(/([a-z])([A-Z])/g, '$1 $2').trim();
+  const familyName = family.replace(/([a-z])([A-Z])/g, '$1 $2').trim();
+  return spaced && spaced !== 'Regular' ? `${familyName} ${spaced}` : familyName;
+}


### PR DESCRIPTION
Closes #381.

## Problem

A deck is portable code, but what it renders with is not. The fonts it names and the assets it imports live outside the file, so a deck that looks right on the machine that wrote it opens elsewhere with the browser quietly substituting a different family. Nothing reports it.

## Change

`open-slide dev` now resolves that gap before serving. It reads the decks and themes, collects the font families in use (including the runtime's own, which decks inherit without naming it anywhere), and installs what the machine is missing, from the `google/fonts` repository. That is the stable public source of installable outlines: `fonts.google.com/download` returns HTML and the CSS API returns woff2, so neither yields something an operating system can install.

An outline the workspace already carries in `node_modules` is reused, but no package is ever installed to obtain one. Writing a dependency and a lockfile entry into someone's project as a side effect of starting a dev server would be the wrong trade, and font packages ship woff2 anyway.

Installation is per user, so no administrator rights are involved: `%LOCALAPPDATA%\Microsoft\Windows\Fonts` plus the `HKCU` registration on Windows, `~/Library/Fonts` on macOS, `~/.local/share/fonts` on Linux.

Assets follow the same idea: a deck can ship `slides/<id>/assets.manifest.json` mapping file names to URLs, and anything missing on disk is fetched.

Also exposed on its own as `open-slide preflight`, with `--no-install` to only report.

### On not getting in the way

- Nothing here can take the server down. A network failure or an unresolvable family becomes a line in the report, never an exception.
- It does not run under CI, where the machine is discarded after the run and the check would only buy latency and one more way for a job to fail. That also keeps it out of this repo's own e2e suite.
- `--no-preflight` turns it off anywhere else, mirroring the existing `--no-skills-check`.

Static faces are preferred over the variable build when a family ships both, because a static file names its weight in the file itself, which is what a system font install exposes.

## Testing

- `pnpm format:check`, `pnpm lint`, `pnpm typecheck`: clean
- `pnpm test`: 309 passing, including four new cases covering when the check is skipped
- `e2e/tests/cli.spec.ts` and `e2e/tests/dev-api.spec.ts`: 12 passing
- By hand on Windows: `open-slide preflight --no-install` reports across the 19 demo decks without touching the system, and leaves `package.json` byte-identical. Against a scratch workspace naming a family the machine did not have, `--no-install` reported it as pending and a full run downloaded and installed it where the OS then resolves it.

I have only exercised the install path on Windows. The macOS and Linux paths are the conventional per-user font directories, but they deserve a second pair of eyes from someone on those platforms.

No new dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `preflight` command to verify required fonts and deck assets, with optional installation/download of missing items.
  - Development startup now runs preflight checks by default (with opt-out via `--no-preflight`).
  - Added `--no-install` to skip asset installation during preflight.
  - Includes system font discovery and per-user font installation support.
- **Bug Fixes**
  - Preflight failures no longer block starting the development server.
- **Tests**
  - Added coverage for preflight run/skipping behavior in CI and opt-out scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->