### PR TITLE
feat(core): switch decks from the presenter window

### DIFF
--- a/.changeset/presenter-deck-switch.md
+++ b/.changeset/presenter-deck-switch.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Switch between decks from the presenter window — the projection follows without leaving present mode, keeping fullscreen and the elapsed timer.

--- a/packages/core/src/app/components/player.tsx
+++ b/packages/core/src/app/components/player.tsx
@@ -40,6 +40,7 @@ type Props = {
   allowExit?: boolean;
   controls?: boolean;
   slideId?: string;
+  onSwitchSlide?: (slideId: string) => void;
   /**
    * When true, the Player enters the browser Fullscreen API on mount.
    * When false, it renders as a window-sized overlay (viewport-filling)
@@ -58,6 +59,7 @@ export function Player({
   allowExit = true,
   controls = false,
   slideId,
+  onSwitchSlide,
   fullscreen = true,
 }: Props) {
   const isMobile = useIsMobile();
@@ -250,9 +252,11 @@ export function Player({
         setBlackout((cur) => (cur === msg.mode ? null : msg.mode));
       } else if (msg.type === 'request-state') {
         send({ type: 'state', state: presenterStateRef.current });
+      } else if (msg.type === 'switch-slide') {
+        if (msg.slideId !== slideId) onSwitchSlide?.(msg.slideId);
       }
     },
-    [goNext, goPrev, handleIndexChange, pages.length],
+    [goNext, goPrev, handleIndexChange, pages.length, slideId, onSwitchSlide],
   );
 
   const channel = usePresenterChannel(slideId ?? '__none__', (msg) => {
@@ -402,7 +406,10 @@ export function Player({
       style={design ? { background: design.palette.bg } : undefined}
     >
       <SlideCanvas flat design={design}>
+        {/* Keyed per deck so a presenter-driven deck switch cuts instead of
+            animating a transition between two unrelated decks. */}
         <SlideTransitionLayer
+          key={slideId}
           pages={pages}
           index={index}
           total={pages.length}

--- a/packages/core/src/app/components/present/use-presenter-channel.ts
+++ b/packages/core/src/app/components/present/use-presenter-channel.ts
@@ -16,7 +16,8 @@ export type PresenterCommand =
   | { type: 'prev' }
   | { type: 'request-state' }
   | { type: 'restart-timer' }
-  | { type: 'toggle-blackout'; mode: 'black' | 'white' };
+  | { type: 'toggle-blackout'; mode: 'black' | 'white' }
+  | { type: 'switch-slide'; slideId: string };
 
 type Handler = (msg: PresenterCommand) => void;
 

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -1,15 +1,25 @@
 import {
   AArrowDown,
   AArrowUp,
+  Check,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   RotateCcw,
   Square,
   Sun,
 } from 'lucide-react';
-import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { format, useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import {
@@ -19,7 +29,8 @@ import {
 import { SlideCanvas } from '../components/slide-canvas';
 import { isDeckWarmed, markDeckWarmed, SlidePreloadLayer } from '../components/slide-preload-layer';
 import { SlidePageProvider } from '../lib/page-context';
-import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../lib/sdk';
+import { CANVAS_HEIGHT, CANVAS_WIDTH, type SlideModule } from '../lib/sdk';
+import { loadSlide, slideIds } from '../lib/slides';
 import { type StepController, StepHost } from '../lib/step-context';
 import { useSlideModule } from '../lib/use-slide-module';
 
@@ -50,6 +61,17 @@ export function Presenter() {
     }
   });
 
+  // A deck switch reuses this route instance, so the handshake state from
+  // the previous deck must be dropped before rejoining on the new channel.
+  // Render-phase reset so the new deck never renders with the old state.
+  const prevSlideIdRef = useRef(slideId);
+  if (prevSlideIdRef.current !== slideId) {
+    prevSlideIdRef.current = slideId;
+    setState(null);
+    setHasProjection(false);
+    requestedRef.current = false;
+  }
+
   // Hydrate from the projection window once.
   useEffect(() => {
     if (!channel.available || requestedRef.current) return;
@@ -60,7 +82,16 @@ export function Presenter() {
     return () => clearTimeout(t);
   }, [channel]);
 
+  const navigate = useNavigate();
   const send = channel.send;
+  const switchDeck = useCallback(
+    (id: string) => {
+      if (id === slideId) return;
+      send({ type: 'switch-slide', slideId: id });
+      navigate(`/s/${encodeURIComponent(id)}/presenter`, { replace: true });
+    },
+    [slideId, send, navigate],
+  );
   const goPrev = useCallback(() => send({ type: 'prev' }), [send]);
   const goNext = useCallback(() => send({ type: 'next' }), [send]);
   const goTo = useCallback((i: number) => send({ type: 'goto', index: i }), [send]);
@@ -71,6 +102,8 @@ export function Presenter() {
   // presenter can drive without the mouse.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // The deck-switcher menu owns its own arrow-key navigation.
+      if (e.defaultPrevented) return;
       if (e.target instanceof HTMLElement && e.target.matches('input, textarea')) return;
       if (e.altKey || e.ctrlKey || e.metaKey) return;
       if (
@@ -175,8 +208,10 @@ export function Presenter() {
         index={index}
         total={total}
         startedAt={startedAt}
+        slideId={slideId}
         slideTitle={slide.meta?.title ?? slideId}
         connected={hasProjection}
+        onSwitchDeck={switchDeck}
       />
 
       <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 px-6 pb-4 lg:grid-cols-[2fr_1fr]">
@@ -252,23 +287,31 @@ function PresenterTopBar({
   index,
   total,
   startedAt,
+  slideId,
   slideTitle,
   connected,
+  onSwitchDeck,
 }: {
   index: number;
   total: number;
   startedAt: number;
+  slideId: string;
   slideTitle: string;
   connected: boolean;
+  onSwitchDeck: (slideId: string) => void;
 }) {
   const t = useLocale();
   return (
     <header className="flex h-12 shrink-0 items-center justify-between border-b border-hairline px-6">
-      <div className="flex items-baseline gap-3">
+      <div className="flex min-w-0 items-center gap-3">
         <span className="eyebrow text-white/45">{t.presenter.eyebrow}</span>
-        <span className="truncate font-heading text-[14px] font-semibold tracking-tight">
-          {slideTitle}
-        </span>
+        {slideIds.length > 1 ? (
+          <DeckSwitcher slideId={slideId} slideTitle={slideTitle} onSwitchDeck={onSwitchDeck} />
+        ) : (
+          <span className="truncate font-heading text-[14px] font-semibold tracking-tight">
+            {slideTitle}
+          </span>
+        )}
         {!connected && (
           <span className="rounded-[3px] border border-amber-300/30 bg-amber-300/10 px-1.5 py-0.5 font-mono text-[10px] tracking-[0.06em] uppercase text-amber-200/85">
             {t.presenter.notLinked}
@@ -285,6 +328,168 @@ function PresenterTopBar({
         </div>
       </div>
     </header>
+  );
+}
+
+// Listing decks means importing every deck's chunk for its meta and pages.
+// That warms the module cache for switches; assets only load on render, so
+// this stays cheap.
+function useDeckModules(): Record<string, SlideModule> {
+  const [modules, setModules] = useState<Record<string, SlideModule>>({});
+  useEffect(() => {
+    let cancelled = false;
+    for (const id of slideIds) {
+      loadSlide(id)
+        .then((mod) => {
+          if (cancelled) return;
+          setModules((cur) => (cur[id] === mod ? cur : { ...cur, [id]: mod }));
+        })
+        .catch(() => {});
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return modules;
+}
+
+function DeckSwitcher({
+  slideId,
+  slideTitle,
+  onSwitchDeck,
+}: {
+  slideId: string;
+  slideTitle: string;
+  onSwitchDeck: (slideId: string) => void;
+}) {
+  const t = useLocale();
+  const modules = useDeckModules();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  const trimmed = query.trim().toLowerCase();
+  const filtered = slideIds.filter((id) => {
+    if (!trimmed) return true;
+    const title = modules[id]?.meta?.title;
+    return id.toLowerCase().includes(trimmed) || title?.toLowerCase().includes(trimmed);
+  });
+  const active = Math.min(activeIndex, Math.max(0, filtered.length - 1));
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next) {
+      setQuery('');
+      setActiveIndex(0);
+    }
+  };
+
+  const select = (id: string) => {
+    setOpen(false);
+    onSwitchDeck(id);
+  };
+
+  useEffect(() => {
+    listRef.current
+      ?.querySelector(`[data-index="${active}"]`)
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [active]);
+
+  const onSearchKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (e.nativeEvent.isComposing) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex(Math.min(filtered.length - 1, active + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex(Math.max(0, active - 1));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const id = filtered[active];
+      if (id) select(id);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger
+        aria-label={t.presenter.switchDeck}
+        title={t.presenter.switchDeck}
+        className="group -mx-1.5 flex min-w-0 items-center gap-1 rounded-[5px] px-1.5 py-0.5 outline-none hover:bg-card focus-visible:ring-2 focus-visible:ring-ring/30"
+      >
+        <span className="truncate font-heading text-[14px] font-semibold tracking-tight">
+          {slideTitle}
+        </span>
+        <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+      </DialogTrigger>
+      <DialogContent
+        showCloseButton={false}
+        className="dark top-[16%] translate-y-0 gap-0 overflow-hidden p-0 sm:max-w-lg"
+      >
+        <DialogTitle className="sr-only">{t.presenter.switchDeck}</DialogTitle>
+        <input
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setActiveIndex(0);
+          }}
+          onKeyDown={onSearchKeyDown}
+          placeholder={t.presenter.searchDecks}
+          className="w-full border-b border-hairline bg-transparent px-4 py-3 text-[13px] text-foreground outline-none placeholder:text-muted-foreground"
+        />
+        <div ref={listRef} className="max-h-[55vh] overflow-y-auto p-1.5">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-8 text-center text-[12px] text-muted-foreground">
+              {t.presenter.noDecksFound}
+            </div>
+          ) : (
+            filtered.map((id, i) => {
+              const mod = modules[id];
+              const FirstPage = mod?.default[0];
+              return (
+                <button
+                  type="button"
+                  key={id}
+                  data-index={i}
+                  onClick={() => select(id)}
+                  onMouseMove={() => setActiveIndex(i)}
+                  className={cn(
+                    'flex w-full items-center gap-3 rounded-[6px] p-2 text-left',
+                    i === active && 'bg-muted',
+                  )}
+                >
+                  <div
+                    className="w-24 shrink-0 overflow-hidden rounded-[4px] bg-black ring-1 ring-border"
+                    style={{ aspectRatio: `${CANVAS_WIDTH}/${CANVAS_HEIGHT}` }}
+                  >
+                    {FirstPage && (
+                      <SlideCanvas flat freezeMotion design={mod.design}>
+                        <SlidePageProvider index={0} total={mod.default.length}>
+                          <PreviewStepHost revealed={0}>
+                            <FirstPage />
+                          </PreviewStepHost>
+                        </SlidePageProvider>
+                      </SlideCanvas>
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-[13px] font-medium text-foreground">
+                      {mod?.meta?.title ?? id}
+                    </div>
+                    <div className="mt-0.5 truncate font-mono text-[10.5px] text-muted-foreground">
+                      {id}
+                      {mod && ` · ${mod.default.length.toString().padStart(2, '0')}`}
+                    </div>
+                  </div>
+                  {id === slideId && <Check className="size-3.5 shrink-0 text-muted-foreground" />}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -73,6 +73,7 @@ export function Presenter() {
   }
 
   // Hydrate from the projection window once.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: slideId re-fires the handshake on a deck switch even when the channel memo keeps its identity (available toggling false→true in one commit nets to no change)
   useEffect(() => {
     if (!channel.available || requestedRef.current) return;
     requestedRef.current = true;
@@ -80,7 +81,7 @@ export function Presenter() {
     // If nothing answers within a beat, surface the "no projection" hint.
     const t = setTimeout(() => setHasProjection((v) => v), 600);
     return () => clearTimeout(t);
-  }, [channel]);
+  }, [channel, slideId]);
 
   const navigate = useNavigate();
   const send = channel.send;

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -17,7 +17,7 @@ import {
   Terminal,
 } from 'lucide-react';
 import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useParams, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { AssetView } from '@/components/asset-view';
 import { HistoryProvider } from '@/components/history-provider';
@@ -73,8 +73,19 @@ const { showSlideUi, showSlideBrowser, allowHtmlDownload } = config.build;
 export function Slide() {
   const { slideId = '' } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
   const { slide, error } = useSlideModule(slideId);
   const [playMode, setPlayMode] = useState<'window' | 'fullscreen' | null>(null);
+  // Last deck the Player showed. During a presenter-driven deck switch the
+  // route's slideId changes while the new module loads and warms; rendering
+  // from this cache keeps the Player mounted, which preserves fullscreen
+  // (re-entry needs a user gesture) and the elapsed timer.
+  const lastPresentedRef = useRef<{
+    slideId: string;
+    slide: SlideModule;
+    pages: SlideModule['default'];
+    index: number;
+  } | null>(null);
   const [exporting, setExporting] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
   const linkCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -119,6 +130,13 @@ export function Slide() {
       view,
     });
   }, [slideId, index, pageCount, slide, view]);
+
+  const switchPresentedSlide = useCallback(
+    (id: string) => {
+      navigate(`/s/${encodeURIComponent(id)}`, { replace: true });
+    },
+    [navigate],
+  );
 
   const goTo = useCallback(
     (i: number) => {
@@ -314,6 +332,45 @@ export function Slide() {
     );
   }
 
+  const presentReady = Boolean(slide) && pageCount > 0 && isDeckWarmed(slideId);
+  if (playMode && slide && presentReady) {
+    lastPresentedRef.current = { slideId, slide, pages, index };
+  }
+  const presented = playMode
+    ? slide && presentReady
+      ? { slideId, slide, pages, index }
+      : (lastPresentedRef.current ??
+        (slide && pageCount > 0 ? { slideId, slide, pages, index } : null))
+    : null;
+
+  if (playMode && presented) {
+    return (
+      <>
+        <Player
+          pages={presented.pages}
+          design={presented.slide.design}
+          transition={presented.slide.transition}
+          index={presented.index}
+          onIndexChange={goTo}
+          onExit={() => setPlayMode(null)}
+          controls
+          slideId={presented.slideId}
+          onSwitchSlide={switchPresentedSlide}
+          fullscreen={playMode === 'fullscreen'}
+        />
+        {!presentReady && slide && pageCount > 0 && (
+          <SlidePreloadLayer
+            pages={pages}
+            index={index}
+            design={slide.design}
+            includeCurrent
+            onDone={handleAssetsWarmed}
+          />
+        )}
+      </>
+    );
+  }
+
   if (!slide) {
     return (
       <div className="grid min-h-dvh place-items-center px-8 text-muted-foreground">
@@ -397,22 +454,6 @@ export function Slide() {
         onIndexChange={goTo}
         onExit={() => {}}
         allowExit={false}
-      />
-    );
-  }
-
-  if (playMode) {
-    return (
-      <Player
-        pages={pages}
-        design={slide.design}
-        transition={slide.transition}
-        index={index}
-        onIndexChange={goTo}
-        onExit={() => setPlayMode(null)}
-        controls
-        slideId={slideId}
-        fullscreen={playMode === 'fullscreen'}
       />
     );
   }

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -70,6 +70,8 @@ import { useSlideModule } from '../lib/use-slide-module';
 
 const { showSlideUi, showSlideBrowser, allowHtmlDownload } = config.build;
 
+const noop = () => {};
+
 export function Slide() {
   const { slideId = '' } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -351,7 +353,7 @@ export function Slide() {
           design={presented.slide.design}
           transition={presented.slide.transition}
           index={presented.index}
-          onIndexChange={goTo}
+          onIndexChange={presentReady ? goTo : noop}
           onExit={() => setPlayMode(null)}
           controls
           slideId={presented.slideId}

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -167,6 +167,9 @@ export const en: Locale = {
     jump: 'Jump',
     loadingSlide: 'Loading {slideId}…',
     loadingAssets: 'Loading assets…',
+    switchDeck: 'Switch presentation',
+    searchDecks: 'Search presentations…',
+    noDecksFound: 'No presentations match',
   },
 
   present: {

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -167,6 +167,9 @@ export const ja: Locale = {
     jump: 'ジャンプ',
     loadingSlide: '{slideId} を読み込み中…',
     loadingAssets: 'アセットを読み込み中…',
+    switchDeck: 'デッキを切り替え',
+    searchDecks: 'デッキを検索…',
+    noDecksFound: '一致するデッキがありません',
   },
 
   present: {

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -168,6 +168,9 @@ export type Locale = {
     /** template: "Loading {slideId}…" */
     loadingSlide: string;
     loadingAssets: string;
+    switchDeck: string;
+    searchDecks: string;
+    noDecksFound: string;
   };
 
   present: {

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -165,6 +165,9 @@ export const zhCN: Locale = {
     jump: '跳至',
     loadingSlide: '正在加载 {slideId}…',
     loadingAssets: '正在加载资源…',
+    switchDeck: '切换演示文稿',
+    searchDecks: '搜索演示文稿…',
+    noDecksFound: '没有匹配的演示文稿',
   },
 
   present: {

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -165,6 +165,9 @@ export const zhTW: Locale = {
     jump: '跳至',
     loadingSlide: '正在載入 {slideId}…',
     loadingAssets: '正在載入資源…',
+    switchDeck: '切換簡報',
+    searchDecks: '搜尋簡報…',
+    noDecksFound: '沒有符合的簡報',
   },
 
   present: {


### PR DESCRIPTION
## What

Adds a deck switcher to the presenter top bar. When there is more than one deck, the deck title becomes a dropdown that opens a searchable list (with first-page thumbnails). Picking a deck switches the projection window too — without leaving present mode.

## Why

Previously, switching to a different deck meant exiting present mode, navigating, and re-entering — which drops fullscreen (re-entry needs a fresh user gesture) and resets the elapsed timer. This keeps both.

## How

- New `switch-slide` command on the presenter BroadcastChannel.
- The projection window (`Player`) reacts to `switch-slide` via a new `onSwitchSlide` prop and navigates its own route.
- `Slide` keeps the `Player` mounted across the switch by rendering from a `lastPresentedRef` cache while the new deck loads and warms, so fullscreen and the timer survive.
- The presenter drops its handshake state on `slideId` change and rejoins on the new channel; the projection re-broadcasts its state when the channel changes, so the two windows re-sync even if the initial `request-state` is missed.
- `SlideTransitionLayer` is keyed per deck so a switch cuts instead of animating between two unrelated decks.
- Adds `switchDeck` / `searchDecks` / `noDecksFound` strings across all locales.

## Notes

Listing decks imports every deck's module chunk (for meta + first-page preview), which warms the module cache for fast switching. Assets still only load on render, so this stays cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added presenter-mode deck switching through a searchable presentation picker.
  * Preserves projection, fullscreen, presentation mode, and elapsed timer while switching decks.
  * Preloads selected decks for smoother transitions and maintains the current presentation until the new deck is ready.
* **Localization**
  * Added deck-switching, search, and empty-result messages in English, Japanese, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->