### PR TITLE
fix(core): preserve video playback in HTML exports

### DIFF
--- a/.changeset/html-export-video-playback.md
+++ b/.changeset/html-export-video-playback.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Preserve video poster assets and autoplay behavior in HTML exports.

--- a/.changeset/html-export-video-playback.md
+++ b/.changeset/html-export-video-playback.md
@@ -2,4 +2,4 @@
 "@open-slide/core": patch
 ---
 
-Preserve video poster assets and autoplay behavior in HTML exports.
+HTML exports preserve video posters and rendered mute state, limit autoplay to visible pages, and pause and reset videos on hidden pages.

--- a/packages/core/src/app/lib/export-html.ts
+++ b/packages/core/src/app/lib/export-html.ts
@@ -96,6 +96,9 @@ async function renderPagesToHtml(pages: NonNullable<SlideModule['default']>): Pr
       );
       await nextPaint();
       await nextPaint();
+      for (const video of host.querySelectorAll('video')) {
+        video.defaultMuted = video.muted;
+      }
       result.push(host.innerHTML);
       root.unmount();
       container.removeChild(host);
@@ -143,7 +146,7 @@ function collectExternalStylesheetLinks(): string {
 
 function findHtmlAssetUrls(html: string): string[] {
   const out: string[] = [];
-  const attrRe = /\s(?:src|href)="([^"]+)"/g;
+  const attrRe = /\s(?:src|href|poster)="([^"]+)"/g;
   for (const m of html.matchAll(attrRe)) {
     if (looksLikeAsset(m[1])) out.push(m[1]);
   }
@@ -282,7 +285,17 @@ html, body { margin: 0; height: 100%; background: #000; overflow: hidden; font-f
   }
   function go(i) {
     idx = Math.max(0, Math.min(pages.length - 1, i));
-    pages.forEach(function (p, n) { p.hidden = n !== idx; });
+    pages.forEach(function (p, n) {
+      p.hidden = n !== idx;
+      p.querySelectorAll('video').forEach(function (video) {
+        if (p.hidden) {
+          video.pause();
+          try { video.currentTime = 0; } catch {}
+        } else if (video.autoplay) {
+          video.play().catch(function () {});
+        }
+      });
+    });
     cur.textContent = String(idx + 1);
   }
   window.addEventListener('resize', fit);


### PR DESCRIPTION
## Summary

- include local video poster files in HTML export archives
- serialize the rendered muted state before capturing page markup
- play autoplay videos only on the visible page, pausing and resetting videos on hidden pages

## Testing

- `pnpm check`
- `pnpm typecheck`
- `pnpm test` (305 tests)
- `pnpm test:e2e` (72 tests)
- manually exported and opened an offline archive containing local MP4 and poster assets

Fixes #401


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTML exports now preserve video mute settings.
  * Video poster images are retained as local assets.
  * Video playback is managed correctly during page navigation.
  * Hidden videos are paused and reset, while visible autoplay videos start as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->