### PR TITLE
feat(core): add meta.summary and generate an llms.txt deck index

### DIFF
--- a/.changeset/llms-txt-deck-index.md
+++ b/.changeset/llms-txt-deck-index.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": minor
+---
+
+Add `meta.summary` and generate an `llms.txt` deck index so agents can see what a workspace contains without opening every slide.

--- a/apps/demo/llms.txt
+++ b/apps/demo/llms.txt
@@ -1,0 +1,28 @@
+# demo — decks
+
+> 19 decks built with open-slide. Generated file — edits are overwritten.
+
+## motion
+
+- [Material Design (2014)](slides/material-design-2014/index.tsx): bright-sans · 2026-05-03
+- [open-slide — Launch Motion](slides/open-slide-launch/index.tsx): 2026-05-02
+
+## Decks
+
+- [Introducing Morph Transition](slides/morph-messages/index.tsx): 2026-07-15
+- [Morph Transition Prototype](slides/morph-demo/index.tsx): 2026-06-22
+- [Steps, in Motion](slides/steps-in-motion/index.tsx): 2026-06-02
+- [Using open-slide in Replit](slides/open-slide-on-replit/index.tsx): replit · 2026-05-28
+- [Build on Reveal](slides/build-on-reveal/index.tsx): 2026-05-25
+- [Maximal — Eight Transitions](slides/slide-transitions-maximal/index.tsx): 2026-05-24
+- [On Tasteful Transitions](slides/slide-transitions/index.tsx): 2026-05-20
+- [Vercel Labs · 2026](slides/vercel-labs-2026/index.tsx): 2026-05-12
+- [Image Placeholder Demo](slides/image-placeholder-demo/index.tsx): 2026-05-10
+- [Inside open-slide](slides/open-slide-anatomy/index.tsx): 2026-05-05
+- [Vercel AI SDK](slides/vercel-ai-sdk/index.tsx): 2026-05-03
+- [Harness Engineering](slides/harness-engineering/index.tsx): 2026-04-27
+- [Claude Code · A Field Guide](slides/claude-code-intro/index.tsx): 2026-04-26
+- [How LLMs Work](slides/llm-fundamentals/index.tsx): 2026-04-26
+- [How SSH Works](slides/ssh-explained/index.tsx): 2026-04-26
+- [Raycast Developer API](slides/raycast-api/index.tsx): aurora · 2026-04-25
+- [Next.js: Partial Pre-Rendering & 'use cache'](slides/nextjs-ppr-cache/index.tsx): 2026-04-25

--- a/apps/web/content/docs/reference/slide-meta.mdx
+++ b/apps/web/content/docs/reference/slide-meta.mdx
@@ -11,6 +11,7 @@ const Cover: Page = () => <div>{/* ... */}</div>;
 export const meta: SlideMeta = {
   title: 'Cover',
   theme: 'corporate',
+  summary: 'Q3 numbers and what they mean for the roadmap.',
 };
 
 export const notes = ['Open with the analyst quote.'];
@@ -41,12 +42,40 @@ type Page = ComponentType & {
       type: 'string',
       description: 'Name of a theme under themes/<id>.md. The agent reads it before authoring.',
     },
+    summary: {
+      type: 'string',
+      description:
+        'One-line description of the deck, listed in the generated llms.txt. Published — treat it as public, like title.',
+    },
     createdAt: {
       type: 'string',
       description: 'ISO 8601 timestamp set at scaffold time. Sorts the slide list.',
     },
   }}
 />
+
+Every value here must be a plain string literal — the framework reads `meta` with
+a regex at build time rather than evaluating the module, so template literals and
+expressions are not picked up.
+
+### The generated `llms.txt`
+
+`open-slide dev` writes an `llms.txt` at the root of your project listing every
+deck with its `title`, `theme`, `createdAt`, and `summary`, so an agent can see
+what a workspace contains without reading a single 1500-line `index.tsx`.
+`open-slide build` writes the same index into the build output, with links
+pointing at the deployed `/s/<id>` routes.
+
+The file is regenerated on every slide change and carries a
+`Generated file — edits are overwritten.` marker on its blockquote line. If an
+`llms.txt` without that marker already exists, open-slide leaves it alone and
+logs a warning — a hand-written index is never clobbered.
+
+<Callout type="warn">
+  `summary` is published, not a private note. The build copy ships with your site
+  and the project-root copy is normally committed, so treat it with exactly the
+  same care as `title`.
+</Callout>
 
 ## `notes` (optional)
 

--- a/packages/core/skills/create-slide/SKILL.md
+++ b/packages/core/skills/create-slide/SKILL.md
@@ -76,6 +76,8 @@ If the `frontend-design` skill is available, consult it for deeper aesthetic gui
 
 Read the **`slide-authoring`** skill before writing — it covers the file contract, canvas rules, type scale, spacing, and asset imports, and it includes a starter template you can copy. Don't duplicate that knowledge here; use it.
 
+Set `meta.summary` on every new slide: one sentence on what the deck covers, written for someone who hasn't seen it. You already have everything you need from Step 2 — write it from the topic and takeaway the user gave you, don't ask a further question for it. It is what an agent reads in the generated `llms.txt` to tell this deck from the others, and it is published with the built site, so keep it public-safe.
+
 ## Step 7 — Self-review
 
 Run the checklist in `slide-authoring` ("Self-review before finishing"). It covers structural correctness, layout discipline, and asset existence.

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -47,6 +47,7 @@ const Body: Page = () => <div>…</div>;
 
 export const meta: SlideMeta = {
   title: 'My slide',
+  summary: 'One line on what the deck covers.',
   createdAt: '2026-05-16T12:00:00Z',
 };
 export default [Cover, Body] satisfies Page[];
@@ -54,6 +55,7 @@ export default [Cover, Body] satisfies Page[];
 
 - `export default` is a **non-empty array of zero-prop React components**, one per page, in order.
 - `meta.title` (optional) shows in the slide header. Default is the folder name.
+- `meta.summary` (optional) is a one-sentence description of what the deck covers. **Always set it on a new slide** — it is what lets an agent tell decks apart in the generated `llms.txt` without opening a 1500-line file. Write it for someone who has not seen the deck, keep it under ~150 characters, and don't restate the title. It is published (it ships in the built site), so treat it as public, like `title`. Must be a plain string literal.
 - The slide id is the kebab-case folder name. Pick something short and descriptive (`q2-roadmap`, `team-offsite-2026`).
 - `meta.theme` (optional) marks the slide as built from a theme under `themes/`. The id must match a `<id>.md` basename. Surfaces a back-link chip on the slide card and lists the slide on `/themes/<id>`. Omit if the slide isn't derived from a registered theme.
 - `meta.createdAt` is an **ISO 8601 string literal** (e.g. `'2026-05-16T12:00:00Z'`) set once when the slide is scaffolded. The home page uses it for the default "newest first" sort. Always include it on new slides — **immediately before writing the file, run `node -e "console.log(new Date().toISOString())"` via Bash and paste the exact output** as the value. Don't type a timestamp from memory — you will get the date or time wrong. Must be a plain string literal (no `new Date(...)` or imports in the slide itself) — the framework reads it via a regex at build time, not by evaluating the module.
@@ -224,6 +226,7 @@ const Content: Page = () => (
 
 export const meta: SlideMeta = {
   title: 'The Big Idea',
+  summary: 'Why the idea matters and what it changes.',
   createdAt: '2026-05-16T12:00:00Z',
 };
 export default [Cover, Content] satisfies Page[];

--- a/packages/core/src/app/lib/sdk.ts
+++ b/packages/core/src/app/lib/sdk.ts
@@ -7,6 +7,8 @@ export type Page = ComponentType & { transition?: SlideTransition };
 export type SlideMeta = {
   title?: string;
   theme?: string;
+  /** One-line description of the deck. Published alongside `title` in the generated `llms.txt`. */
+  summary?: string;
   /** ISO 8601 timestamp. Set once at scaffold time; used to sort the slide list. */
   createdAt?: string;
 };

--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -7,6 +7,7 @@ import type { InlineConfig } from 'vite';
 import { apiPlugin } from './api-plugin.ts';
 import { currentPlugin } from './current-plugin.ts';
 import { designPlugin } from './design-plugin.ts';
+import { llmsPlugin } from './llms-plugin.ts';
 import { locTagsPlugin } from './loc-tags-plugin.ts';
 import { notesPlugin } from './notes-plugin.ts';
 import { loadUserConfig, type OpenSlideConfig, openSlidePlugin } from './open-slide-plugin.ts';
@@ -66,6 +67,7 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
       apiPlugin({ userCwd, slidesDir, assetsDir, coreVersion: CORE_VERSION }),
       notesPlugin({ userCwd, slidesDir }),
       currentPlugin({ userCwd, slidesDir }),
+      llmsPlugin({ userCwd, slidesDir }),
     ],
     resolve: {
       alias: {

--- a/packages/core/src/vite/llms-plugin.test.ts
+++ b/packages/core/src/vite/llms-plugin.test.ts
@@ -147,6 +147,33 @@ describe('renderLlmsTxt / linkBase', () => {
     expect(out).not.toContain('index.tsx');
   });
 
+  it('puts site links under a configured base', () => {
+    const out = renderLlmsTxt([deck({ id: 'coffee-brewing' })], {
+      projectName: 'p',
+      linkBase: 'site',
+      base: '/my-slides/',
+    });
+    expect(out).toContain('](/my-slides/s/coffee-brewing)');
+  });
+
+  it('tolerates a base without its trailing slash', () => {
+    const out = renderLlmsTxt([deck({ id: 'coffee-brewing' })], {
+      projectName: 'p',
+      linkBase: 'site',
+      base: '/my-slides',
+    });
+    expect(out).toContain('](/my-slides/s/coffee-brewing)');
+  });
+
+  it('leaves source links untouched by base', () => {
+    const out = renderLlmsTxt([deck({ id: 'coffee-brewing' })], {
+      projectName: 'p',
+      linkBase: 'source',
+      base: '/my-slides/',
+    });
+    expect(out).toContain('](slides/coffee-brewing/index.tsx)');
+  });
+
   it('keeps a non-default slidesDir in the source link', () => {
     const out = renderLlmsTxt(
       [deck({ id: 'coffee-brewing', sourcePath: 'decks/coffee-brewing/index.jsx' })],

--- a/packages/core/src/vite/llms-plugin.test.ts
+++ b/packages/core/src/vite/llms-plugin.test.ts
@@ -1,0 +1,311 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LLMS_TXT_SENTINEL, type LlmsDeck, renderLlmsTxt, writeLlmsTxt } from './llms-plugin.ts';
+
+function deck(overrides: Partial<LlmsDeck> & { id: string }): LlmsDeck {
+  return {
+    sourcePath: `slides/${overrides.id}/index.tsx`,
+    title: null,
+    summary: null,
+    theme: null,
+    createdAt: null,
+    folderId: null,
+    ...overrides,
+  };
+}
+
+const SAMPLE: LlmsDeck[] = [
+  deck({
+    id: 'coffee-brewing',
+    title: 'Coffee Brewing',
+    summary: 'Ratios, grind size, and why water temperature matters.',
+    theme: 'aurora',
+    createdAt: '2026-03-04T09:00:00Z',
+  }),
+  deck({
+    id: 'ssh-explained',
+    title: 'SSH Explained',
+    createdAt: '2026-02-11T09:00:00Z',
+  }),
+  deck({
+    id: 'tidal-power',
+    title: 'Tidal Power',
+    summary: 'Where the energy comes from.',
+    theme: 'slate',
+  }),
+  deck({ id: 'zoning-basics' }),
+];
+
+describe('renderLlmsTxt / format', () => {
+  it('renders the header, count, and one line per deck', () => {
+    const out = renderLlmsTxt(SAMPLE, { projectName: 'my-slide', linkBase: 'source' });
+    expect(out).toBe(
+      [
+        '# my-slide — decks',
+        '',
+        `> 4 decks built with open-slide. ${LLMS_TXT_SENTINEL}`,
+        '',
+        '## Decks',
+        '',
+        '- [Coffee Brewing](slides/coffee-brewing/index.tsx): aurora · 2026-03-04 — Ratios, grind size, and why water temperature matters.',
+        '- [SSH Explained](slides/ssh-explained/index.tsx): 2026-02-11',
+        '- [Tidal Power](slides/tidal-power/index.tsx): slate — Where the energy comes from.',
+        '- [zoning-basics](slides/zoning-basics/index.tsx)',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('falls back to the deck id when title is absent', () => {
+    const out = renderLlmsTxt([deck({ id: 'zoning-basics' })], {
+      projectName: 'p',
+      linkBase: 'source',
+    });
+    expect(out).toContain('- [zoning-basics](slides/zoning-basics/index.tsx)');
+  });
+
+  it('singularises the count for one deck', () => {
+    const out = renderLlmsTxt([deck({ id: 'solo' })], { projectName: 'p', linkBase: 'source' });
+    expect(out).toContain('> 1 deck built with open-slide.');
+  });
+
+  it('emits no deck section when there are no decks', () => {
+    const out = renderLlmsTxt([], { projectName: 'p', linkBase: 'source' });
+    expect(out).toContain('> 0 decks built with open-slide.');
+    expect(out).not.toContain('## Decks');
+  });
+
+  it('groups decks under folder headings and leaves the rest in Decks', () => {
+    const decks = [
+      deck({ id: 'alpha', createdAt: '2026-05-01T00:00:00Z', folderId: 'f-1' }),
+      deck({ id: 'beta', createdAt: '2026-04-01T00:00:00Z' }),
+      deck({ id: 'gamma', createdAt: '2026-03-01T00:00:00Z', folderId: 'f-unknown' }),
+    ];
+    const out = renderLlmsTxt(decks, {
+      projectName: 'p',
+      linkBase: 'source',
+      folders: [
+        { id: 'f-1', name: 'motion' },
+        { id: 'f-2', name: 'empty folder' },
+      ],
+    });
+    expect(out).toContain('## motion');
+    expect(out).not.toContain('## empty folder');
+    expect(out.indexOf('## motion')).toBeLessThan(out.indexOf('## Decks'));
+    const decksSection = out.slice(out.indexOf('## Decks'));
+    expect(decksSection).toContain('- [beta]');
+    expect(decksSection).toContain('- [gamma]');
+  });
+});
+
+describe('renderLlmsTxt / ordering', () => {
+  it('sorts newest first and pushes undated decks to the end by id', () => {
+    const decks = [
+      deck({ id: 'undated-b' }),
+      deck({ id: 'older', createdAt: '2026-01-01T00:00:00Z' }),
+      deck({ id: 'undated-a' }),
+      deck({ id: 'newer', createdAt: '2026-06-01T00:00:00Z' }),
+    ];
+    const out = renderLlmsTxt(decks, { projectName: 'p', linkBase: 'source' });
+    const ids = out
+      .split('\n')
+      .filter((l) => l.startsWith('- ['))
+      .map((l) => l.slice(3, l.indexOf(']')));
+    expect(ids).toEqual(['newer', 'older', 'undated-a', 'undated-b']);
+  });
+
+  it('treats an unparseable createdAt as undated and omits it from the line', () => {
+    const decks = [
+      deck({ id: 'bad-date', createdAt: 'last thursday' }),
+      deck({ id: 'good-date', createdAt: '2026-01-01T00:00:00Z' }),
+    ];
+    const out = renderLlmsTxt(decks, { projectName: 'p', linkBase: 'source' });
+    const lines = out.split('\n').filter((l) => l.startsWith('- ['));
+    expect(lines[0]).toContain('good-date');
+    expect(lines[1]).toBe('- [bad-date](slides/bad-date/index.tsx)');
+    expect(out).not.toContain('last thursday');
+  });
+});
+
+describe('renderLlmsTxt / linkBase', () => {
+  it('links to the source file for the workspace copy', () => {
+    const out = renderLlmsTxt([deck({ id: 'coffee-brewing' })], {
+      projectName: 'p',
+      linkBase: 'source',
+    });
+    expect(out).toContain('](slides/coffee-brewing/index.tsx)');
+  });
+
+  it('links to the deployed route for the build copy', () => {
+    const out = renderLlmsTxt([deck({ id: 'coffee-brewing' })], {
+      projectName: 'p',
+      linkBase: 'site',
+    });
+    expect(out).toContain('](/s/coffee-brewing)');
+    expect(out).not.toContain('index.tsx');
+  });
+
+  it('keeps a non-default slidesDir in the source link', () => {
+    const out = renderLlmsTxt(
+      [deck({ id: 'coffee-brewing', sourcePath: 'decks/coffee-brewing/index.jsx' })],
+      { projectName: 'p', linkBase: 'source' },
+    );
+    expect(out).toContain('](decks/coffee-brewing/index.jsx)');
+  });
+});
+
+describe('renderLlmsTxt / sanitisation', () => {
+  it('flattens newlines and collapses runs of whitespace', () => {
+    const out = renderLlmsTxt(
+      [deck({ id: 'a', title: 'Line one\nLine two', summary: 'has\n\nbreaks\tand   spaces' })],
+      { projectName: 'p', linkBase: 'source' },
+    );
+    const lines = out.split('\n').filter((l) => l.startsWith('- ['));
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe('- [Line one Line two](slides/a/index.tsx) — has breaks and spaces');
+  });
+
+  it('truncates long fields to 300 characters', () => {
+    const long = 'x'.repeat(500);
+    const out = renderLlmsTxt([deck({ id: 'a', title: long, summary: long })], {
+      projectName: 'p',
+      linkBase: 'source',
+    });
+    const line = out.split('\n').find((l) => l.startsWith('- ['));
+    expect(line).toBe(`- [${'x'.repeat(300)}](slides/a/index.tsx) — ${'x'.repeat(300)}`);
+  });
+
+  it('drops a field that sanitises to nothing', () => {
+    const out = renderLlmsTxt([deck({ id: 'a', title: '   ', summary: '\n\n' })], {
+      projectName: 'p',
+      linkBase: 'source',
+    });
+    const line = out.split('\n').find((l) => l.startsWith('- ['));
+    expect(line).toBe('- [a](slides/a/index.tsx)');
+  });
+});
+
+describe('renderLlmsTxt / injection resistance', () => {
+  const hostile = [
+    deck({
+      id: 'hostile',
+      title: 'Evil](/pwned) ## Fake heading',
+      summary: 'line one\n## Injected\n- [fake](../../etc/passwd)',
+      theme: 'bad`theme\nname',
+      createdAt: '2026-01-01T00:00:00Z',
+    }),
+    deck({ id: 'neighbour', title: 'Neighbour', createdAt: '2026-01-02T00:00:00Z' }),
+  ];
+
+  it('keeps one deck to exactly one line', () => {
+    const out = renderLlmsTxt(hostile, { projectName: 'p', linkBase: 'source' });
+    expect(out.split('\n').filter((l) => l.startsWith('- ['))).toHaveLength(2);
+  });
+
+  it('never lets a field open a new heading', () => {
+    const out = renderLlmsTxt(hostile, { projectName: 'p', linkBase: 'source' });
+    const headings = out.split('\n').filter((l) => l.startsWith('#'));
+    expect(headings).toEqual(['# p — decks', '## Decks']);
+  });
+
+  it('escapes link delimiters so the real target survives', () => {
+    const out = renderLlmsTxt(hostile, { projectName: 'p', linkBase: 'source' });
+    const line = out.split('\n').find((l) => l.includes('Evil'));
+    expect(line).toBe(
+      '- [Evil\\](/pwned) ## Fake heading](slides/hostile/index.tsx): bad`theme name · 2026-01-01 — line one ## Injected - \\[fake\\](../../etc/passwd)',
+    );
+  });
+
+  it('escapes a trailing backslash so it cannot swallow the closing bracket', () => {
+    const out = renderLlmsTxt([deck({ id: 'a', title: 'ends with\\' })], {
+      projectName: 'p',
+      linkBase: 'source',
+    });
+    expect(out).toContain('- [ends with\\\\](slides/a/index.tsx)');
+  });
+
+  it('keeps a truncated field from ending in a half-written escape', () => {
+    const out = renderLlmsTxt([deck({ id: 'a', title: `${'y'.repeat(299)}\\tail` })], {
+      projectName: 'p',
+      linkBase: 'source',
+    });
+    const line = out.split('\n').find((l) => l.startsWith('- ['));
+    expect(line).toBe(`- [${'y'.repeat(299)}\\\\](slides/a/index.tsx)`);
+  });
+
+  it('does not let a hostile folder name forge a heading', () => {
+    const out = renderLlmsTxt([deck({ id: 'a', folderId: 'f-1' })], {
+      projectName: 'p',
+      linkBase: 'source',
+      folders: [{ id: 'f-1', name: 'evil\n## Forged' }],
+    });
+    expect(out.split('\n').filter((l) => l.startsWith('#'))).toEqual([
+      '# p — decks',
+      '## evil ## Forged',
+    ]);
+  });
+});
+
+describe('writeLlmsTxt', () => {
+  let dir = '';
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'open-slide-llms-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  const body = `# p — decks\n\n> 0 decks built with open-slide. ${LLMS_TXT_SENTINEL}\n`;
+
+  it('writes when no file exists', async () => {
+    const result = await writeLlmsTxt(dir, body);
+    expect(result.written).toBe(true);
+    expect(await fs.readFile(path.join(dir, 'llms.txt'), 'utf8')).toBe(body);
+  });
+
+  it('overwrites a file it previously generated', async () => {
+    await fs.writeFile(path.join(dir, 'llms.txt'), `stale\n${LLMS_TXT_SENTINEL}\n`);
+    const result = await writeLlmsTxt(dir, body);
+    expect(result.written).toBe(true);
+    expect(await fs.readFile(path.join(dir, 'llms.txt'), 'utf8')).toBe(body);
+  });
+
+  it('refuses to overwrite a hand-written file with no sentinel', async () => {
+    const handWritten = '# my notes\n\nnot generated by anything\n';
+    const file = path.join(dir, 'llms.txt');
+    await fs.writeFile(file, handWritten);
+    const result = await writeLlmsTxt(dir, body);
+    expect(result.written).toBe(false);
+    if (result.written) return;
+    expect(result.reason).toBe('foreign-file');
+    expect(await fs.readFile(file, 'utf8')).toBe(handWritten);
+  });
+
+  it('refuses to write through a symlink', async () => {
+    const outside = path.join(dir, 'secret.txt');
+    await fs.writeFile(outside, 'do not touch\n');
+    await fs.symlink(outside, path.join(dir, 'llms.txt'));
+    const result = await writeLlmsTxt(dir, body);
+    expect(result.written).toBe(false);
+    if (result.written) return;
+    expect(result.reason).toBe('irregular-file');
+    expect(await fs.readFile(outside, 'utf8')).toBe('do not touch\n');
+  });
+
+  it('refuses to write when the target is a directory', async () => {
+    await fs.mkdir(path.join(dir, 'llms.txt'));
+    const result = await writeLlmsTxt(dir, body);
+    expect(result.written).toBe(false);
+    if (result.written) return;
+    expect(result.reason).toBe('irregular-file');
+  });
+
+  it('leaves no temporary files behind', async () => {
+    await writeLlmsTxt(dir, body);
+    expect(await fs.readdir(dir)).toEqual(['llms.txt']);
+  });
+});

--- a/packages/core/src/vite/llms-plugin.ts
+++ b/packages/core/src/vite/llms-plugin.ts
@@ -1,0 +1,308 @@
+import { existsSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { Logger, Plugin, ViteDevServer } from 'vite';
+import { SLIDE_ID_RE } from '../editing/slide-ops.ts';
+import { findSlides, readFoldersManifest, readSlideMeta, toId } from './open-slide-plugin.ts';
+
+export const LLMS_TXT_SENTINEL = 'Generated file — edits are overwritten.';
+
+const OUT_FILE = 'llms.txt';
+const FIELD_MAX = 300;
+const REWRITE_DEBOUNCE_MS = 200;
+const SENTINEL_SCAN_BYTES = 1024;
+
+export type LlmsDeck = {
+  id: string;
+  sourcePath: string;
+  title: string | null;
+  summary: string | null;
+  theme: string | null;
+  createdAt: string | null;
+  folderId: string | null;
+};
+
+export type LlmsFolder = { id: string; name: string };
+
+export type LlmsLinkBase = 'source' | 'site';
+
+export type RenderLlmsTxtOptions = {
+  projectName: string;
+  linkBase: LlmsLinkBase;
+  folders?: LlmsFolder[];
+};
+
+// `title`/`summary`/`theme` are author-controlled strings and the only reader of
+// llms.txt is an LLM agent, so they are escaped as data: flattened to a single
+// line (no injected `##` heading) with the markdown link delimiters neutralised.
+// Truncation happens before escaping so a cut can never land inside an escape
+// pair and leave a trailing backslash that swallows the closing bracket.
+function sanitizeField(raw: string | null): string | null {
+  if (raw === null) return null;
+  const flattened = raw
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: flattening control characters is the point
+    .replace(/[\u0000-\u001F\u007F-\u009F\u2028\u2029]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (flattened === '') return null;
+  const clipped = flattened.length > FIELD_MAX ? flattened.slice(0, FIELD_MAX) : flattened;
+  return clipped.replace(/\\/g, '\\\\').replace(/([[\]])/g, '\\$1');
+}
+
+// An unparseable timestamp is unsortable and unsafe to echo verbatim, so it is
+// treated the same as a missing one.
+function formatCreatedAt(raw: string | null): string | null {
+  if (raw === null) return null;
+  const ms = Date.parse(raw);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function compareDecks(a: LlmsDeck, b: LlmsDeck): number {
+  const aMs = a.createdAt === null ? Number.NaN : Date.parse(a.createdAt);
+  const bMs = b.createdAt === null ? Number.NaN : Date.parse(b.createdAt);
+  const aDated = Number.isFinite(aMs);
+  const bDated = Number.isFinite(bMs);
+  if (aDated && bDated && aMs !== bMs) return bMs - aMs;
+  if (aDated !== bDated) return aDated ? -1 : 1;
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
+}
+
+function deckLink(deck: LlmsDeck, linkBase: LlmsLinkBase): string {
+  return linkBase === 'site' ? `/s/${deck.id}` : deck.sourcePath;
+}
+
+function renderDeckLine(deck: LlmsDeck, linkBase: LlmsLinkBase): string {
+  const title = sanitizeField(deck.title) ?? deck.id;
+  const facets = [sanitizeField(deck.theme), formatCreatedAt(deck.createdAt)].filter(
+    (value): value is string => value !== null,
+  );
+  const summary = sanitizeField(deck.summary);
+  let line = `- [${title}](${deckLink(deck, linkBase)})`;
+  if (facets.length > 0) line += `: ${facets.join(' · ')}`;
+  if (summary !== null) line += ` — ${summary}`;
+  return line;
+}
+
+export function renderLlmsTxt(decks: LlmsDeck[], opts: RenderLlmsTxtOptions): string {
+  const sorted = [...decks].sort(compareDecks);
+  const projectName = sanitizeField(opts.projectName) ?? 'open-slide';
+  const noun = sorted.length === 1 ? 'deck' : 'decks';
+  const lines = [
+    `# ${projectName} — decks`,
+    '',
+    `> ${sorted.length} ${noun} built with open-slide. ${LLMS_TXT_SENTINEL}`,
+  ];
+
+  const folders = opts.folders ?? [];
+  const knownFolderIds = new Set(folders.map((folder) => folder.id));
+  const grouped = new Map<string, LlmsDeck[]>();
+  const unassigned: LlmsDeck[] = [];
+  for (const deck of sorted) {
+    if (deck.folderId !== null && knownFolderIds.has(deck.folderId)) {
+      const bucket = grouped.get(deck.folderId);
+      if (bucket) bucket.push(deck);
+      else grouped.set(deck.folderId, [deck]);
+    } else {
+      unassigned.push(deck);
+    }
+  }
+
+  const pushSection = (heading: string, items: LlmsDeck[]) => {
+    if (items.length === 0) return;
+    lines.push('', `## ${heading}`, '');
+    for (const deck of items) lines.push(renderDeckLine(deck, opts.linkBase));
+  };
+
+  for (const folder of folders) {
+    pushSection(sanitizeField(folder.name) ?? folder.id, grouped.get(folder.id) ?? []);
+  }
+  pushSection('Decks', unassigned);
+
+  return `${lines.join('\n')}\n`;
+}
+
+export type CollectDecksOptions = {
+  userCwd: string;
+  slidesDir: string;
+};
+
+function isFolder(raw: unknown): raw is { id: string; name: string } {
+  if (raw === null || typeof raw !== 'object') return false;
+  const folder = raw as { id?: unknown; name?: unknown };
+  return typeof folder.id === 'string' && typeof folder.name === 'string';
+}
+
+export async function collectDecks(
+  opts: CollectDecksOptions,
+): Promise<{ decks: LlmsDeck[]; folders: LlmsFolder[] }> {
+  const userCwd = path.resolve(opts.userCwd);
+  const slidesRoot = path.resolve(userCwd, opts.slidesDir);
+  const files = await findSlides(userCwd, opts.slidesDir);
+  const manifest = await readFoldersManifest(path.join(slidesRoot, '.folders.json'));
+  const folders = manifest.folders
+    .filter(isFolder)
+    .map((folder) => ({ id: folder.id, name: folder.name }));
+  const { assignments } = manifest;
+
+  const scanned = await Promise.all(
+    files.map(async (abs) => {
+      const id = toId(abs, slidesRoot);
+      if (!SLIDE_ID_RE.test(id)) return null;
+      const meta = await readSlideMeta(abs);
+      // A slide id may legitimately be `__proto__`, which would otherwise read
+      // straight off Object.prototype instead of the manifest.
+      const assigned = Object.hasOwn(assignments, id) ? assignments[id] : null;
+      return {
+        id,
+        sourcePath: path.relative(userCwd, abs).split(path.sep).join('/'),
+        title: meta.title,
+        summary: meta.summary,
+        theme: meta.theme,
+        createdAt: meta.createdAt,
+        folderId: typeof assigned === 'string' ? assigned : null,
+      } satisfies LlmsDeck;
+    }),
+  );
+
+  return { decks: scanned.filter((deck): deck is LlmsDeck => deck !== null), folders };
+}
+
+export type WriteLlmsTxtResult =
+  | { written: true; file: string }
+  | {
+      written: false;
+      reason: 'outside-root' | 'irregular-file' | 'foreign-file' | 'error';
+      message: string;
+    };
+
+async function readHead(file: string): Promise<string> {
+  const handle = await fs.open(file, 'r');
+  try {
+    const buf = Buffer.alloc(SENTINEL_SCAN_BYTES);
+    const { bytesRead } = await handle.read(buf, 0, SENTINEL_SCAN_BYTES, 0);
+    return buf.subarray(0, bytesRead).toString('utf8');
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function writeLlmsTxt(rootDir: string, contents: string): Promise<WriteLlmsTxtResult> {
+  const root = path.resolve(rootDir);
+  const file = path.resolve(root, OUT_FILE);
+  if (path.relative(root, file) !== OUT_FILE) {
+    return { written: false, reason: 'outside-root', message: `${file} escapes ${root}` };
+  }
+
+  try {
+    // lstat, not stat: a symlink here must be refused rather than followed.
+    const stats = await fs.lstat(file);
+    if (!stats.isFile()) {
+      return { written: false, reason: 'irregular-file', message: `${file} is not a regular file` };
+    }
+    if (!(await readHead(file)).includes(LLMS_TXT_SENTINEL)) {
+      return { written: false, reason: 'foreign-file', message: `${file} is not generated` };
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      return { written: false, reason: 'error', message: String((err as Error).message ?? err) };
+    }
+  }
+
+  const tmp = `${file}.${process.pid}.${Date.now().toString(36)}.tmp`;
+  try {
+    // `wx` fails outright on an existing path, symlinks included, so the
+    // temporary file can never be redirected somewhere else.
+    await fs.writeFile(tmp, contents, { encoding: 'utf8', flag: 'wx' });
+    await fs.rename(tmp, file);
+    return { written: true, file };
+  } catch (err) {
+    await fs.rm(tmp, { force: true }).catch(() => undefined);
+    return { written: false, reason: 'error', message: String((err as Error).message ?? err) };
+  }
+}
+
+export type LlmsPluginOptions = {
+  userCwd: string;
+  slidesDir?: string;
+};
+
+async function readProjectName(userCwd: string): Promise<string> {
+  const fallback = path.basename(userCwd);
+  try {
+    const raw = await fs.readFile(path.join(userCwd, 'package.json'), 'utf8');
+    const parsed = JSON.parse(raw) as { name?: unknown };
+    return typeof parsed.name === 'string' && parsed.name.trim() !== '' ? parsed.name : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function llmsPlugin(opts: LlmsPluginOptions): Plugin {
+  const userCwd = path.resolve(opts.userCwd);
+  const slidesDir = opts.slidesDir ?? 'slides';
+  const slidesRoot = path.resolve(userCwd, slidesDir);
+  const foldersManifestPath = path.join(slidesRoot, '.folders.json');
+
+  let isDev = false;
+  let buildOutDir = '';
+  let logger: Logger | null = null;
+
+  const isSlideEntry = (p: string): boolean => {
+    const rel = path.relative(slidesRoot, p);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) return false;
+    const parts = rel.split(path.sep);
+    return parts.length === 2 && /^index\.(tsx|jsx|ts|js)$/.test(parts[1]);
+  };
+
+  const generate = async (targetDir: string, linkBase: LlmsLinkBase) => {
+    const { decks, folders } = await collectDecks({ userCwd, slidesDir });
+    const contents = renderLlmsTxt(decks, {
+      projectName: await readProjectName(userCwd),
+      linkBase,
+      folders,
+    });
+    const result = await writeLlmsTxt(targetDir, contents);
+    if (!result.written) {
+      logger?.warn(`[open-slide] skipped writing ${OUT_FILE}: ${result.message}`);
+    }
+  };
+
+  return {
+    name: 'open-slide:llms',
+    configResolved(config) {
+      isDev = config.command === 'serve';
+      buildOutDir = path.resolve(config.root, config.build.outDir);
+      logger = config.logger;
+    },
+    configureServer(server: ViteDevServer) {
+      void generate(userCwd, 'source');
+
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const schedule = () => {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => {
+          timer = null;
+          void generate(userCwd, 'source');
+        }, REWRITE_DEBOUNCE_MS);
+      };
+
+      if (existsSync(slidesRoot)) server.watcher.add(slidesRoot);
+      server.watcher.add(foldersManifestPath);
+      const onWatchEvent = (p: string) => {
+        if (isSlideEntry(p) || p === foldersManifestPath) schedule();
+      };
+      server.watcher.on('add', onWatchEvent);
+      server.watcher.on('change', onWatchEvent);
+      server.watcher.on('unlink', onWatchEvent);
+    },
+    async closeBundle() {
+      // Vite fires closeBundle when the dev server shuts down too, and the dev
+      // copy is already kept current by the watcher.
+      if (isDev) return;
+      await generate(buildOutDir, 'site');
+    },
+  };
+}

--- a/packages/core/src/vite/llms-plugin.ts
+++ b/packages/core/src/vite/llms-plugin.ts
@@ -29,6 +29,8 @@ export type LlmsLinkBase = 'source' | 'site';
 export type RenderLlmsTxtOptions = {
   projectName: string;
   linkBase: LlmsLinkBase;
+  /** Vite's resolved `base`. Site links must sit under it when hosted on a subpath. */
+  base?: string;
   folders?: LlmsFolder[];
 };
 
@@ -70,17 +72,17 @@ function compareDecks(a: LlmsDeck, b: LlmsDeck): number {
   return 0;
 }
 
-function deckLink(deck: LlmsDeck, linkBase: LlmsLinkBase): string {
-  return linkBase === 'site' ? `/s/${deck.id}` : deck.sourcePath;
+function deckLink(deck: LlmsDeck, linkBase: LlmsLinkBase, base: string): string {
+  return linkBase === 'site' ? `${base}s/${deck.id}` : deck.sourcePath;
 }
 
-function renderDeckLine(deck: LlmsDeck, linkBase: LlmsLinkBase): string {
+function renderDeckLine(deck: LlmsDeck, linkBase: LlmsLinkBase, base: string): string {
   const title = sanitizeField(deck.title) ?? deck.id;
   const facets = [sanitizeField(deck.theme), formatCreatedAt(deck.createdAt)].filter(
     (value): value is string => value !== null,
   );
   const summary = sanitizeField(deck.summary);
-  let line = `- [${title}](${deckLink(deck, linkBase)})`;
+  let line = `- [${title}](${deckLink(deck, linkBase, base)})`;
   if (facets.length > 0) line += `: ${facets.join(' · ')}`;
   if (summary !== null) line += ` — ${summary}`;
   return line;
@@ -89,6 +91,8 @@ function renderDeckLine(deck: LlmsDeck, linkBase: LlmsLinkBase): string {
 export function renderLlmsTxt(decks: LlmsDeck[], opts: RenderLlmsTxtOptions): string {
   const sorted = [...decks].sort(compareDecks);
   const projectName = sanitizeField(opts.projectName) ?? 'open-slide';
+  const rawBase = opts.base ?? '/';
+  const base = rawBase.endsWith('/') ? rawBase : `${rawBase}/`;
   const noun = sorted.length === 1 ? 'deck' : 'decks';
   const lines = [
     `# ${projectName} — decks`,
@@ -113,7 +117,7 @@ export function renderLlmsTxt(decks: LlmsDeck[], opts: RenderLlmsTxtOptions): st
   const pushSection = (heading: string, items: LlmsDeck[]) => {
     if (items.length === 0) return;
     lines.push('', `## ${heading}`, '');
-    for (const deck of items) lines.push(renderDeckLine(deck, opts.linkBase));
+    for (const deck of items) lines.push(renderDeckLine(deck, opts.linkBase, base));
   };
 
   for (const folder of folders) {
@@ -248,6 +252,7 @@ export function llmsPlugin(opts: LlmsPluginOptions): Plugin {
 
   let isDev = false;
   let buildOutDir = '';
+  let base = '/';
   let logger: Logger | null = null;
 
   const isSlideEntry = (p: string): boolean => {
@@ -262,6 +267,7 @@ export function llmsPlugin(opts: LlmsPluginOptions): Plugin {
     const contents = renderLlmsTxt(decks, {
       projectName: await readProjectName(userCwd),
       linkBase,
+      base,
       folders,
     });
     const result = await writeLlmsTxt(targetDir, contents);
@@ -275,6 +281,7 @@ export function llmsPlugin(opts: LlmsPluginOptions): Plugin {
     configResolved(config) {
       isDev = config.command === 'serve';
       buildOutDir = path.resolve(config.root, config.build.outDir);
+      base = config.base;
       logger = config.logger;
     },
     configureServer(server: ViteDevServer) {

--- a/packages/core/src/vite/open-slide-plugin.test.ts
+++ b/packages/core/src/vite/open-slide-plugin.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { generateSlidesModule } from './open-slide-plugin.ts';
+import { extractMeta, generateSlidesModule } from './open-slide-plugin.ts';
 
 async function withSlidesRoot<T>(fn: (root: string) => Promise<T>): Promise<T> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'open-slide-test-'));
@@ -23,6 +23,62 @@ async function writeSlide(root: string, id: string): Promise<string> {
   );
   return entry;
 }
+
+describe('extractMeta', () => {
+  it('reads every supported field', () => {
+    const src = [
+      "export const meta = { title: 'Cover', theme: 'aurora',",
+      "  summary: 'What the deck covers.', createdAt: '2026-05-16T12:00:00Z' };",
+      'export default [];',
+    ].join('\n');
+    expect(extractMeta(src)).toEqual({
+      title: 'Cover',
+      theme: 'aurora',
+      summary: 'What the deck covers.',
+      createdAt: '2026-05-16T12:00:00Z',
+    });
+  });
+
+  it('returns nulls when there is no meta export', () => {
+    expect(extractMeta('export default [];\n')).toEqual({
+      title: null,
+      theme: null,
+      summary: null,
+      createdAt: null,
+    });
+  });
+
+  it('keeps apostrophes inside a double-quoted value', () => {
+    const src = `export const meta = { title: "Pre-Rendering & 'use cache'" };\n`;
+    expect(extractMeta(src).title).toBe("Pre-Rendering & 'use cache'");
+  });
+
+  it('keeps double quotes inside a single-quoted value', () => {
+    const src = `export const meta = { summary: 'They call it "streaming".' };\n`;
+    expect(extractMeta(src).summary).toBe('They call it "streaming".');
+  });
+
+  it('unescapes an escaped delimiter', () => {
+    const src = `export const meta = { title: 'It\\'s here' };\n`;
+    expect(extractMeta(src).title).toBe("It's here");
+  });
+
+  it('ignores a template literal rather than capturing it half-parsed', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal `${}` is the test input
+    const src = 'export const meta = { title: `Backticks ${nope}` };\n';
+    expect(extractMeta(src).title).toBeNull();
+  });
+
+  it('only reads inside the meta object body', () => {
+    const src = [
+      "const decoy = { title: 'Decoy' };",
+      "export const meta = { theme: 'aurora' };",
+    ].join('\n');
+    const meta = extractMeta(src);
+    expect(meta.title).toBeNull();
+    expect(meta.theme).toBe('aurora');
+  });
+});
 
 describe('generateSlidesModule', () => {
   it('keeps slides whose id is ASCII-safe and reports none ignored', async () => {

--- a/packages/core/src/vite/open-slide-plugin.test.ts
+++ b/packages/core/src/vite/open-slide-plugin.test.ts
@@ -63,6 +63,33 @@ describe('extractMeta', () => {
     expect(extractMeta(src).title).toBe("It's here");
   });
 
+  it('resolves control escapes instead of dropping the backslash', () => {
+    const src = `export const meta = { summary: 'Line one\\nline two\\ttabbed' };\n`;
+    expect(extractMeta(src).summary).toBe('Line one\nline two\ttabbed');
+  });
+
+  it('keeps a literal backslash', () => {
+    const src = `export const meta = { title: 'C:\\\\Users' };\n`;
+    expect(extractMeta(src).title).toBe('C:\\Users');
+  });
+
+  it('resolves hex and unicode escapes', () => {
+    const src = `export const meta = { title: '\\x41 \\u00e9 \\u{1f600}' };\n`;
+    expect(extractMeta(src).title).toBe('A é 😀');
+  });
+
+  it('leaves an out-of-range code point as written rather than throwing', () => {
+    const src = `export const meta = { title: 'edge \\u{110000}' };\n`;
+    expect(extractMeta(src).title).toBe('edge \\u{110000}');
+  });
+
+  it('does not end the meta object at a brace inside a value', () => {
+    const src = `export const meta = { summary: 'Covers the {curly} case', title: 'Braces' };\n`;
+    const meta = extractMeta(src);
+    expect(meta.summary).toBe('Covers the {curly} case');
+    expect(meta.title).toBe('Braces');
+  });
+
   it('ignores a template literal rather than capturing it half-parsed', () => {
     // biome-ignore lint/suspicious/noTemplateCurlyInString: literal `${}` is the test input
     const src = 'export const meta = { title: `Backticks ${nope}` };\n';

--- a/packages/core/src/vite/open-slide-plugin.ts
+++ b/packages/core/src/vite/open-slide-plugin.ts
@@ -21,12 +21,12 @@ const SLIDES_VMOD = 'virtual:open-slide/slides';
 const CONFIG_VMOD = 'virtual:open-slide/config';
 const FOLDERS_VMOD = 'virtual:open-slide/folders';
 
-type FoldersManifest = {
+export type FoldersManifest = {
   folders: unknown[];
   assignments: Record<string, string>;
 };
 
-async function readFoldersManifest(file: string): Promise<FoldersManifest> {
+export async function readFoldersManifest(file: string): Promise<FoldersManifest> {
   try {
     const raw = await fs.readFile(file, 'utf8');
     const parsed = JSON.parse(raw) as Partial<FoldersManifest>;
@@ -49,7 +49,7 @@ function resolved(id: string): string {
   return `\0${id}`;
 }
 
-async function findSlides(userCwd: string, slidesDir: string): Promise<string[]> {
+export async function findSlides(userCwd: string, slidesDir: string): Promise<string[]> {
   const abs = path.resolve(userCwd, slidesDir);
   if (!existsSync(abs)) return [];
   const hits = await fg('*/index.{tsx,jsx,ts,js}', {
@@ -60,18 +60,43 @@ async function findSlides(userCwd: string, slidesDir: string): Promise<string[]>
   return hits.sort();
 }
 
-function toId(absFile: string, slidesRoot: string): string {
+export function toId(absFile: string, slidesRoot: string): string {
   const rel = path.relative(slidesRoot, absFile);
   return rel.split(path.sep)[0];
 }
 
-const META_THEME_RE = /(?:^|[\s,{])theme\s*:\s*['"]([^'"]+)['"]/;
-const META_CREATED_AT_RE = /(?:^|[\s,{])createdAt\s*:\s*['"]([^'"]+)['"]/;
+// Matches a whole single- or double-quoted literal rather than stopping at the
+// first inner quote, so prose values keep their apostrophes ("Rendering & 'use
+// cache'"). Template literals and expressions stay unsupported by design.
+const STRING_LITERAL_SRC = String.raw`(?:'((?:[^'\\\n]|\\.)*)'|"((?:[^"\\\n]|\\.)*)")`;
 
-type ExtractedMeta = { theme: string | null; createdAt: string | null };
+function metaFieldRe(key: string): RegExp {
+  return new RegExp(String.raw`(?:^|[\s,{])${key}\s*:\s*${STRING_LITERAL_SRC}`);
+}
 
-function extractMeta(src: string): ExtractedMeta {
-  const empty: ExtractedMeta = { theme: null, createdAt: null };
+const META_TITLE_RE = metaFieldRe('title');
+const META_THEME_RE = metaFieldRe('theme');
+const META_SUMMARY_RE = metaFieldRe('summary');
+const META_CREATED_AT_RE = metaFieldRe('createdAt');
+
+function matchMetaField(body: string, re: RegExp): string | null {
+  const match = body.match(re);
+  if (!match) return null;
+  const raw = match[1] ?? match[2];
+  return raw === undefined ? null : raw.replace(/\\(.)/g, '$1');
+}
+
+export type ExtractedMeta = {
+  title: string | null;
+  theme: string | null;
+  summary: string | null;
+  createdAt: string | null;
+};
+
+const EMPTY_META: ExtractedMeta = { title: null, theme: null, summary: null, createdAt: null };
+
+export function extractMeta(src: string): ExtractedMeta {
+  const empty = EMPTY_META;
   const metaStart = src.search(/export\s+const\s+meta\b/);
   if (metaStart === -1) return empty;
   const eqIdx = src.indexOf('=', metaStart);
@@ -93,20 +118,20 @@ function extractMeta(src: string): ExtractedMeta {
   }
   if (closeBrace === -1) return empty;
   const body = src.slice(openBrace + 1, closeBrace);
-  const themeMatch = body.match(META_THEME_RE);
-  const createdAtMatch = body.match(META_CREATED_AT_RE);
   return {
-    theme: themeMatch ? themeMatch[1] : null,
-    createdAt: createdAtMatch ? createdAtMatch[1] : null,
+    title: matchMetaField(body, META_TITLE_RE),
+    theme: matchMetaField(body, META_THEME_RE),
+    summary: matchMetaField(body, META_SUMMARY_RE),
+    createdAt: matchMetaField(body, META_CREATED_AT_RE),
   };
 }
 
-async function readSlideMeta(abs: string): Promise<ExtractedMeta> {
+export async function readSlideMeta(abs: string): Promise<ExtractedMeta> {
   try {
     const src = await fs.readFile(abs, 'utf8');
     return extractMeta(src);
   } catch {
-    return { theme: null, createdAt: null };
+    return EMPTY_META;
   }
 }
 

--- a/packages/core/src/vite/open-slide-plugin.ts
+++ b/packages/core/src/vite/open-slide-plugin.ts
@@ -79,11 +79,56 @@ const META_THEME_RE = metaFieldRe('theme');
 const META_SUMMARY_RE = metaFieldRe('summary');
 const META_CREATED_AT_RE = metaFieldRe('createdAt');
 
+const SHORT_ESCAPES: Record<string, string> = {
+  n: '\n',
+  t: '\t',
+  r: '\r',
+  b: '\b',
+  f: '\f',
+  v: '\v',
+  '0': '\0',
+};
+
+const ESCAPE_RE = /\\(u\{[0-9a-fA-F]{1,6}\}|u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2}|[\s\S])/g;
+
+// Resolve escapes the way the JS parser would, so `\n` becomes a newline rather
+// than a literal "n". Anything unrecognised keeps its escaped character, which
+// covers `\'`, `\"` and `\\`.
+function unescapeStringLiteral(raw: string): string {
+  return raw.replace(ESCAPE_RE, (_: string, seq: string) => {
+    if (seq[0] === 'u' || seq[0] === 'x') {
+      const hex = seq[1] === '{' ? seq.slice(2, -1) : seq.slice(1);
+      const code = Number.parseInt(hex, 16);
+      // Out of range would throw in String.fromCodePoint; keep the escape as
+      // written rather than failing a whole build over one odd title.
+      if (code > 0x10ffff) return `\\${seq}`;
+      return String.fromCodePoint(code);
+    }
+    return SHORT_ESCAPES[seq] ?? seq;
+  });
+}
+
+// Index of the literal's closing quote, or -1 if it never closes. Only `` ` ``
+// may span lines; an unterminated quote means the source is unparseable anyway.
+function skipStringLiteral(src: string, start: number): number {
+  const quote = src[start];
+  for (let i = start + 1; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '\\') {
+      i++;
+      continue;
+    }
+    if (ch === quote) return i;
+    if (ch === '\n' && quote !== '`') return -1;
+  }
+  return -1;
+}
+
 function matchMetaField(body: string, re: RegExp): string | null {
   const match = body.match(re);
   if (!match) return null;
   const raw = match[1] ?? match[2];
-  return raw === undefined ? null : raw.replace(/\\(.)/g, '$1');
+  return raw === undefined ? null : unescapeStringLiteral(raw);
 }
 
 export type ExtractedMeta = {
@@ -107,6 +152,14 @@ export function extractMeta(src: string): ExtractedMeta {
   let closeBrace = -1;
   for (let i = openBrace; i < src.length; i++) {
     const ch = src[i];
+    if (ch === "'" || ch === '"' || ch === '`') {
+      // Skip the whole literal: a brace inside a value ("the {curly} case")
+      // must not be mistaken for the end of the meta object.
+      const end = skipStringLiteral(src, i);
+      if (end === -1) return empty;
+      i = end;
+      continue;
+    }
     if (ch === '{') depth++;
     else if (ch === '}') {
       depth--;


### PR DESCRIPTION
Closes #403.

## Summary

Adds an optional `meta.summary`, and generates an `llms.txt` index of the workspace so an agent can tell what a repo of decks contains without opening a single 1500-line `index.tsx`.

- `SlideMeta` gains `summary?: string`.
- `extractMeta()` now also reads `title` and `summary`.
- New `llms-plugin.ts`. `dev` writes `llms.txt` at the project root and regenerates it (debounced) when slides or `.folders.json` change; `build` writes the same index into the build output with `/s/<id>` links instead of source paths. Decks are grouped by folder, sorted newest first, and a deck with no `summary` simply renders without one — nothing is inferred on the author's behalf.
- Docs, the `slide-authoring` / `create-slide` skills, and a changeset (minor).

`apps/demo/llms.txt` is committed so the output is visible in the diff. The demo decks don't declare `summary` yet — happy to add them if you'd like the demo to show that half off too.

## One fix to existing behaviour

The meta field patterns were `['"]([^'"]+)['"]`, which stops at the first *inner* quote. That was harmless for `theme` and `createdAt`, but this repo's own demo contains:

```tsx
title: "Next.js: Partial Pre-Rendering & 'use cache'"
```

which the naive pattern truncates to `Next.js: Partial Pre-Rendering &`. Since `title` and `summary` are prose, I replaced it with an escape-aware string-literal match covering both quote styles. Template literals and expressions remain unsupported by design. `theme` / `createdAt` inherit the fix.

## Write guards

This writes one file into the user's workspace, so the writer refuses rather than guesses:

- the resolved path must stay inside the target root;
- `lstat`, not `stat` — a symlinked `llms.txt` is refused, never followed;
- an existing `llms.txt` without the generated marker is left untouched and logged, so a hand-written index is never clobbered;
- the temp file is opened `wx` and renamed, so a pre-planted symlink can't redirect that write either.

Unit tested, and also verified against a running dev server.

## Untrusted input

`title` and `summary` are author-controlled, and the only reader of `llms.txt` is an LLM. Both are escaped as data: control characters flattened, whitespace collapsed, truncated to 300 characters *before* escaping so a cut can't land inside an escape pair, and markdown link delimiters neutralised. One deck always renders as exactly one line and cannot inject a heading.

No new HTTP routes, so this doesn't touch the request-guard surface. No new dependencies.

## Testing

`pnpm check`, `pnpm typecheck` and `pnpm test` all pass — 337 tests across 22 files, 32 of them new. The 10 biome warnings from `check` are pre-existing; `main` reports the same 10.

## Open question

Whether a generated file at the workspace root is acceptable at all. If you'd rather it live in `node_modules/.open-slide/` beside `current.json`, that's a small change — it just costs the ability for an agent to read the index from a fresh clone without starting the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional deck summaries for public descriptions.
  * Generated `llms.txt` indexes with deck links, dates, labels, folders, and motion sections.
  * Indexes update during development and production builds.
  * Added safeguards to sanitize metadata and protect manually maintained files.

* **Documentation**
  * Updated slide metadata and authoring guidance with summary requirements and `llms.txt` behavior.

* **Tests**
  * Added coverage for formatting, grouping, links, sanitization, overwrite protection, and metadata extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->