### PR TITLE
docs: remove star history section and credit author in license

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,6 @@ pnpm check    # type-checks all packages
 pnpm lint     # lints via biome
 ```
 
-## Star history
-
-If open-slide is useful to you, please [star the repo on GitHub](https://github.com/1weiho/open-slide) — it helps other people find the project.
-
-[![Star History Chart](https://api.star-history.com/svg?repos=1weiho/open-slide&type=Date)](https://star-history.com/#1weiho/open-slide&Date)
-
 ## Support
 
 If open-slide has been useful to you, consider supporting development:
@@ -105,4 +99,4 @@ If open-slide has been useful to you, consider supporting development:
 
 ## License
 
-MIT
+MIT © [Yiwei Ho](https://github.com/1weiho)


### PR DESCRIPTION
Removes the "Star history" section from the README and adds author attribution to the License line.

- Drop the `## Star history` section (the star-history chart and star-the-repo blurb)
- License now reads `MIT © [Yiwei Ho](https://github.com/1weiho)`

README-only change, so no changeset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDp29bdJso7SYgrmyYhWxG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Star History section from the README.
  * Updated the License section with MIT license attribution to Yiwei Ho.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->