### PR TITLE
fix(core): keep editor feedback within viewport

### DIFF
--- a/.changeset/viewport-bound-editor.md
+++ b/.changeset/viewport-bound-editor.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Keep the editor shell and feedback toasts within the viewport.

--- a/packages/core/e2e/tests/inspector.spec.ts
+++ b/packages/core/e2e/tests/inspector.spec.ts
@@ -48,6 +48,8 @@ test.describe('inspector editing', () => {
     await content.fill('Editable headline');
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(page.getByText('Saved', { exact: true })).toBeVisible();
+    await page.getByTitle('Copy link').click();
+    await expect(page.locator('[data-sonner-toaster]')).toBeAttached();
 
     const metrics = await page.evaluate(() => {
       const root = document.getElementById('root');

--- a/packages/core/e2e/tests/inspector.spec.ts
+++ b/packages/core/e2e/tests/inspector.spec.ts
@@ -40,14 +40,25 @@ test.describe('inspector editing', () => {
   test('keeps the editor shell within the viewport', async ({ page, request }) => {
     await openEditable(page, request, 'insp-viewport');
 
+    await page.getByTitle('Inspect').click();
+    await editorCanvas(page).getByText('Editable headline').click();
+    const content = page.getByPlaceholder('Element text');
+    await expect(content).toHaveValue('Editable headline');
+    await content.fill('Temporary headline');
+    await content.fill('Editable headline');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Saved', { exact: true })).toBeVisible();
+
     const metrics = await page.evaluate(() => {
       const root = document.getElementById('root');
+      const sonner = document.querySelector<HTMLElement>('[data-sonner-toaster]');
       return {
         documentHeight: document.documentElement.scrollHeight,
         viewportHeight: window.innerHeight,
         htmlOverflow: getComputedStyle(document.documentElement).overflow,
         bodyOverflow: getComputedStyle(document.body).overflow,
         rootOverflow: root ? getComputedStyle(root).overflow : null,
+        sonnerPosition: sonner ? getComputedStyle(sonner).position : null,
       };
     });
 
@@ -55,6 +66,7 @@ test.describe('inspector editing', () => {
     expect(metrics.htmlOverflow).toBe('hidden');
     expect(metrics.bodyOverflow).toBe('hidden');
     expect(metrics.rootOverflow).toBe('hidden');
+    expect(metrics.sonnerPosition).toBe('fixed');
   });
 
   test('saving a text edit rewrites the slide source on disk', async ({ page, request }) => {

--- a/packages/core/e2e/tests/inspector.spec.ts
+++ b/packages/core/e2e/tests/inspector.spec.ts
@@ -37,6 +37,26 @@ test.describe('inspector editing', () => {
     await expect(panel.getByPlaceholder('Element text')).toHaveValue('Editable headline');
   });
 
+  test('keeps the editor shell within the viewport', async ({ page, request }) => {
+    await openEditable(page, request, 'insp-viewport');
+
+    const metrics = await page.evaluate(() => {
+      const root = document.getElementById('root');
+      return {
+        documentHeight: document.documentElement.scrollHeight,
+        viewportHeight: window.innerHeight,
+        htmlOverflow: getComputedStyle(document.documentElement).overflow,
+        bodyOverflow: getComputedStyle(document.body).overflow,
+        rootOverflow: root ? getComputedStyle(root).overflow : null,
+      };
+    });
+
+    expect(metrics.documentHeight).toBe(metrics.viewportHeight);
+    expect(metrics.htmlOverflow).toBe('hidden');
+    expect(metrics.bodyOverflow).toBe('hidden');
+    expect(metrics.rootOverflow).toBe('hidden');
+  });
+
   test('saving a text edit rewrites the slide source on disk', async ({ page, request }) => {
     await openEditable(page, request, 'insp-save');
     await page.getByTitle('Inspect').click();

--- a/packages/core/src/app/app.tsx
+++ b/packages/core/src/app/app.tsx
@@ -1,6 +1,6 @@
 import config from 'virtual:open-slide/config';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { Toaster } from './components/ui/sonner';
+import { AppToaster } from './components/app-toaster';
 import { TooltipProvider } from './components/ui/tooltip';
 import { useLocale } from './lib/use-locale';
 import { AssetsPage } from './routes/assets';
@@ -30,7 +30,7 @@ export function App() {
           <Route path="*" element={<NotFound />} />
         </Routes>
       </TooltipProvider>
-      <Toaster />
+      <AppToaster />
     </BrowserRouter>
   );
 }

--- a/packages/core/src/app/components/app-toaster.tsx
+++ b/packages/core/src/app/components/app-toaster.tsx
@@ -1,0 +1,5 @@
+import { Toaster as GeneratedToaster } from './ui/sonner';
+
+export function AppToaster() {
+  return <GeneratedToaster className="toaster group fixed" />;
+}

--- a/packages/core/src/app/components/ui/sonner.tsx
+++ b/packages/core/src/app/components/ui/sonner.tsx
@@ -24,7 +24,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       style={
         {
-          position: "fixed",
           "--normal-bg": "var(--popover)",
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",

--- a/packages/core/src/app/components/ui/sonner.tsx
+++ b/packages/core/src/app/components/ui/sonner.tsx
@@ -24,6 +24,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       style={
         {
+          position: "fixed",
           "--normal-bg": "var(--popover)",
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",

--- a/packages/core/src/app/styles.css
+++ b/packages/core/src/app/styles.css
@@ -174,6 +174,12 @@
       "tnum" off;
     letter-spacing: -0.005em;
   }
+  html,
+  body,
+  #root {
+    height: 100%;
+    overflow: hidden;
+  }
   ::selection {
     background: var(--brand-soft);
     color: var(--foreground);


### PR DESCRIPTION
## Summary

Keep the open-slide editor shell viewport-bound when feedback is displayed.

This addresses the layout regression reported in [insurgence-ai/ins-open-slides#4](https://github.com/insurgence-ai/ins-open-slides/issues/4), where no-op save feedback could make the entire page vertically scrollable.

## Root cause

The editor route uses viewport-height and overflow constraints, but the document root and the React mount point were not constrained. A feedback node rendered outside the intended fixed toast layer could therefore increase the document height. Sonner also relied on its injected stylesheet alone to establish fixed positioning.

## Changes

- Constrain html, body, and #root to the viewport and clip document-level overflow.
- Set the shared Sonner host to position: fixed explicitly.
- Add an inspector end-to-end regression test for the viewport contract.
- Add the required @open-slide/core patch changeset.

Dedicated inner panels retain their own scrolling behaviour.

## Validation

- pnpm check passes; the repository still reports its existing broken template-symlink warnings.
- pnpm --filter @open-slide/core typecheck passes.
- pnpm --filter @open-slide/core build passes with the existing unresolved virtual-import warning.
- pnpm --filter @open-slide/core exec playwright test e2e/tests/inspector.spec.ts passes: 8 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an editor layout that fills the available viewport height.
  - Prevented unwanted page scrolling while working in the editor.
  - Improved notification placement with a fixed-position toast area.

- **Bug Fixes**
  - Ensured editor content and feedback notifications remain correctly positioned and visible during inspector edits and saves.
  - Improved viewport behavior across the document, page, and application areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->