### PR TITLE
docs: restore star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ pnpm check    # type-checks all packages
 pnpm lint     # lints via biome
 ```
 
+## Star history
+
+If open-slide is useful to you, please [star the repo on GitHub](https://github.com/1weiho/open-slide) — it helps other people find the project.
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=1weiho/open-slide&type=Date)](https://star-history.dera.page/#1weiho/open-slide&Date)
+
 ## Support
 
 If open-slide has been useful to you, consider supporting development:


### PR DESCRIPTION
The star history section was removed in #409 after the old chart stopped working. This restores it in the same spot using a working chart source, so the badge in the README renders again for people who star the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Star History section to the README.
  * Included a GitHub star request and an embedded chart showing star growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->