### PR TITLE
fix(core): polish viewer micro-interactions and motion consistency

### DIFF
--- a/.changeset/polish-viewer-micro-interactions.md
+++ b/.changeset/polish-viewer-micro-interactions.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Polish viewer micro-interactions: shared motion curve, press and focus feedback across controls, animated enter/exit for overlays and the save bar, flick-to-swipe in present mode, grouped instant tooltips, reduced-motion coverage, tabular numerals, and a dark-mode boot flash fix.

--- a/.changeset/polish-viewer-micro-interactions.md
+++ b/.changeset/polish-viewer-micro-interactions.md
@@ -2,4 +2,4 @@
 '@open-slide/core': patch
 ---
 
-Polish viewer micro-interactions: shared motion curve, press and focus feedback across controls, animated enter/exit for overlays and the save bar, flick-to-swipe in present mode, grouped instant tooltips, reduced-motion coverage, tabular numerals, and a dark-mode boot flash fix.
+Polish viewer micro-interactions: shared motion curve, press and focus feedback across controls, animated enter/exit for overlays and the save bar, flick-to-swipe in present mode, grouped instant tooltips, reduced-motion coverage, tabular numerals, and a fix for the dark-mode boot flash.

--- a/packages/core/src/app/app.tsx
+++ b/packages/core/src/app/app.tsx
@@ -1,6 +1,7 @@
 import config from 'virtual:open-slide/config';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { Toaster } from './components/ui/sonner';
+import { TooltipProvider } from './components/ui/tooltip';
 import { useLocale } from './lib/use-locale';
 import { AssetsPage } from './routes/assets';
 import { Home } from './routes/home';
@@ -12,21 +13,25 @@ import { ThemeDetailPage, ThemesGalleryPage } from './routes/themes';
 export function App() {
   return (
     <BrowserRouter basename={import.meta.env.BASE_URL}>
-      <Routes>
-        {config.build.showSlideBrowser ? (
-          <Route element={<HomeShell />}>
-            <Route path="/" element={<Home />} />
-            <Route path="/themes" element={<ThemesGalleryPage />} />
-            <Route path="/themes/:themeId" element={<ThemeDetailPage />} />
-            <Route path="/assets" element={<AssetsPage />} />
-          </Route>
-        ) : (
-          <Route path="/" element={<NotFound />} />
-        )}
-        <Route path="/s/:slideId" element={<Slide />} />
-        <Route path="/s/:slideId/presenter" element={<Presenter />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+      {/* One app-wide provider so adjacent tooltips group: after the first
+          opens, moving along a toolbar shows the rest instantly. */}
+      <TooltipProvider delay={200}>
+        <Routes>
+          {config.build.showSlideBrowser ? (
+            <Route element={<HomeShell />}>
+              <Route path="/" element={<Home />} />
+              <Route path="/themes" element={<ThemesGalleryPage />} />
+              <Route path="/themes/:themeId" element={<ThemeDetailPage />} />
+              <Route path="/assets" element={<AssetsPage />} />
+            </Route>
+          ) : (
+            <Route path="/" element={<NotFound />} />
+          )}
+          <Route path="/s/:slideId" element={<Slide />} />
+          <Route path="/s/:slideId/presenter" element={<Presenter />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </TooltipProvider>
       <Toaster />
     </BrowserRouter>
   );

--- a/packages/core/src/app/components/asset-view.tsx
+++ b/packages/core/src/app/components/asset-view.tsx
@@ -547,21 +547,28 @@ export function AssetView({ slideId }: Props) {
         )}
       </div>
 
-      {dragActive && (
-        <div
-          className="pointer-events-none absolute inset-0 z-30 animate-in fade-in-0 duration-200"
-          aria-hidden="true"
-        >
-          <div className="absolute inset-0 bg-brand/5" />
-          <div className="absolute inset-2 rounded-[10px] border border-dashed border-brand/40" />
-          <div className="absolute inset-x-0 bottom-8 flex justify-center">
-            <div className="flex animate-in items-center gap-2 rounded-[6px] border border-border bg-card px-3 py-1.5 text-[12px] font-medium shadow-floating fade-in-0 slide-in-from-bottom-1 duration-300">
-              <ArrowDownToLine className="size-3.5 text-brand" />
-              <span>{t.asset.dropToUpload}</span>
-            </div>
+      <div
+        className={cn(
+          'pointer-events-none absolute inset-0 z-30 motion-safe:transition-opacity motion-safe:duration-150',
+          dragActive ? 'opacity-100' : 'opacity-0',
+        )}
+        aria-hidden="true"
+      >
+        <div className="absolute inset-0 bg-brand/5" />
+        <div className="absolute inset-2 rounded-[10px] border border-dashed border-brand/40" />
+        <div className="absolute inset-x-0 bottom-8 flex justify-center">
+          <div
+            className={cn(
+              'flex items-center gap-2 rounded-[6px] border border-border bg-card px-3 py-1.5 text-[12px] font-medium shadow-floating',
+              'ease-swift motion-safe:transition-[opacity,translate] motion-safe:duration-200',
+              dragActive ? 'translate-y-0 opacity-100' : 'translate-y-1 opacity-0',
+            )}
+          >
+            <ArrowDownToLine className="size-3.5 text-brand" />
+            <span>{t.asset.dropToUpload}</span>
           </div>
         </div>
-      )}
+      </div>
 
       {conflict && (
         <ConflictDialog
@@ -806,7 +813,7 @@ function SortableColumnHeader({
         <DirectionIcon className="size-2.5 shrink-0" aria-hidden />
       ) : (
         <ArrowUpDown
-          className="size-2.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-60 group-focus-visible:opacity-60"
+          className="size-2.5 shrink-0 opacity-0 transition-opacity duration-150 group-hover:opacity-60 group-focus-visible:opacity-60 [@media(hover:none)]:opacity-40"
           aria-hidden
         />
       )}
@@ -872,7 +879,7 @@ function AssetCard({
   const isImage = asset.mime.startsWith('image/');
   const t = useLocale();
   return (
-    <div className="group relative flex flex-col overflow-hidden rounded-[6px] border border-border bg-card shadow-edge transition-shadow hover:shadow-floating focus-within:ring-2 focus-within:ring-ring/30">
+    <div className="group relative flex flex-col overflow-hidden rounded-[6px] border border-border bg-card shadow-edge transition-[box-shadow,scale] duration-150 hover:shadow-floating active:scale-[0.99] focus-within:ring-2 focus-within:ring-ring/30">
       <button
         type="button"
         onClick={onPreview}
@@ -934,7 +941,7 @@ function AssetListItem({
   const isImage = asset.mime.startsWith('image/');
   const t = useLocale();
   return (
-    <div className="group flex min-h-14 items-center gap-3 rounded-[6px] border border-border bg-card p-2 shadow-edge transition-shadow hover:shadow-floating focus-within:ring-2 focus-within:ring-ring/30">
+    <div className="group flex min-h-14 items-center gap-3 rounded-[6px] border border-border bg-card p-2 shadow-edge transition-[box-shadow,scale] duration-150 hover:shadow-floating active:scale-[0.995] focus-within:ring-2 focus-within:ring-ring/30">
       <button
         type="button"
         onClick={onPreview}
@@ -1012,7 +1019,7 @@ function AssetActions({
         aria-label={format(t.asset.actionsAria, { name: asset.name })}
         className={cn(
           buttonVariants({ variant: 'ghost', size: 'icon-xs' }),
-          'opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 aria-expanded:opacity-100',
+          'opacity-0 transition-opacity duration-150 group-hover:opacity-100 focus-visible:opacity-100 aria-expanded:opacity-100 [@media(hover:none)]:opacity-100',
         )}
       >
         <MoreVertical />
@@ -1457,7 +1464,7 @@ function LogoSearchDialog({
               {SKELETON_SLOTS.map((slot) => (
                 <div
                   key={slot}
-                  className="aspect-square animate-pulse rounded-lg border bg-muted/40"
+                  className="aspect-square animate-pulse rounded-lg border bg-muted/40 motion-reduce:animate-none"
                 />
               ))}
             </div>
@@ -1581,8 +1588,10 @@ function LogoResultCard({
                 type="button"
                 onClick={() => setVariant('light')}
                 className={cn(
-                  'px-1.5 py-0.5 transition-colors',
-                  variant === 'light' ? 'bg-foreground text-background' : 'hover:bg-muted',
+                  'px-1.5 py-0.5 outline-none transition-colors duration-100 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring/40',
+                  variant === 'light'
+                    ? 'bg-foreground text-background'
+                    : 'hover:bg-muted active:bg-muted',
                 )}
               >
                 {t.asset.logoVariantLight}
@@ -1591,8 +1600,10 @@ function LogoResultCard({
                 type="button"
                 onClick={() => setVariant('dark')}
                 className={cn(
-                  'border-l px-1.5 py-0.5 transition-colors',
-                  variant === 'dark' ? 'bg-foreground text-background' : 'hover:bg-muted',
+                  'border-l px-1.5 py-0.5 outline-none transition-colors duration-100 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring/40',
+                  variant === 'dark'
+                    ? 'bg-foreground text-background'
+                    : 'hover:bg-muted active:bg-muted',
                 )}
               >
                 {t.asset.logoVariantDark}
@@ -1613,7 +1624,11 @@ function LogoResultCard({
             }}
             className="ml-auto h-6 px-2 text-[11px]"
           >
-            {pending ? <Loader2 className="size-3 animate-spin" /> : t.common.add}
+            {pending ? (
+              <Loader2 className="size-3 animate-spin motion-reduce:animate-none" />
+            ) : (
+              t.common.add
+            )}
           </Button>
         </div>
       </div>

--- a/packages/core/src/app/components/asset-view.tsx
+++ b/packages/core/src/app/components/asset-view.tsx
@@ -879,7 +879,7 @@ function AssetCard({
   const isImage = asset.mime.startsWith('image/');
   const t = useLocale();
   return (
-    <div className="group relative flex flex-col overflow-hidden rounded-[6px] border border-border bg-card shadow-edge transition-[box-shadow,scale] duration-150 hover:shadow-floating active:scale-[0.99] focus-within:ring-2 focus-within:ring-ring/30">
+    <div className="group relative flex flex-col overflow-hidden rounded-[6px] border border-border bg-card shadow-edge transition-[box-shadow,scale] duration-150 hover:shadow-floating motion-safe:active:scale-[0.99] focus-within:ring-2 focus-within:ring-ring/30">
       <button
         type="button"
         onClick={onPreview}
@@ -941,7 +941,7 @@ function AssetListItem({
   const isImage = asset.mime.startsWith('image/');
   const t = useLocale();
   return (
-    <div className="group flex min-h-14 items-center gap-3 rounded-[6px] border border-border bg-card p-2 shadow-edge transition-[box-shadow,scale] duration-150 hover:shadow-floating active:scale-[0.995] focus-within:ring-2 focus-within:ring-ring/30">
+    <div className="group flex min-h-14 items-center gap-3 rounded-[6px] border border-border bg-card p-2 shadow-edge transition-[box-shadow,scale] duration-150 hover:shadow-floating motion-safe:active:scale-[0.995] focus-within:ring-2 focus-within:ring-ring/30">
       <button
         type="button"
         onClick={onPreview}

--- a/packages/core/src/app/components/command/command-menu.tsx
+++ b/packages/core/src/app/components/command/command-menu.tsx
@@ -211,7 +211,11 @@ function useSharedCommandGroups(): CommandGroupSpec[] {
             {
               id: 'restart-dev-server',
               label: restarting ? t.home.restartingServer : t.home.restartServer,
-              icon: restarting ? <Loader2 className="animate-spin" /> : <RotateCw />,
+              icon: restarting ? (
+                <Loader2 className="animate-spin motion-reduce:animate-none" />
+              ) : (
+                <RotateCw />
+              ),
               keywords: ['restart', 'dev', 'server', 'reload'],
               disabled: restarting,
               run: restartServer,

--- a/packages/core/src/app/components/command/command.tsx
+++ b/packages/core/src/app/components/command/command.tsx
@@ -31,7 +31,9 @@ function CommandDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton={false}
-        className="top-[14vh] translate-y-0 gap-0 overflow-hidden p-0 sm:max-w-[560px]"
+        // ⌘K fires dozens of times a day — opacity-only and fast, no scale
+        // theater on a keyboard-triggered surface.
+        className="top-[14vh] translate-y-0 gap-0 overflow-hidden p-0 duration-100 data-starting-style:scale-100 data-ending-style:scale-100 sm:max-w-[560px]"
       >
         <DialogTitle className="sr-only">{title}</DialogTitle>
         <DialogDescription className="sr-only">{description}</DialogDescription>
@@ -107,7 +109,7 @@ function CommandItem({ className, ...props }: React.ComponentProps<typeof Comman
       data-slot="command-item"
       className={cn(
         'relative flex cursor-default select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12.5px] outline-none',
-        'data-[selected=true]:bg-muted data-[selected=true]:text-foreground',
+        'data-[selected=true]:bg-muted data-[selected=true]:text-foreground active:bg-muted/80',
         'data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-45',
         "[&_svg]:size-3.5 [&_svg]:shrink-0 [&_svg]:text-muted-foreground [&_svg:not([class*='opacity'])]:opacity-80",
         className,

--- a/packages/core/src/app/components/icon-tooltip.tsx
+++ b/packages/core/src/app/components/icon-tooltip.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Tooltip, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent } from '@/components/ui/tooltip';
 
 /**
  * Shared hover label for the toolbar icon buttons. `children` supplies the
@@ -16,19 +16,19 @@ export function IconTooltip({
   shortcut?: string;
   children: ReactNode;
 }) {
+  // No local provider — tooltips join the app-level group so adjacent
+  // toolbar buttons open instantly once one tooltip is showing.
   return (
-    <TooltipProvider delay={200}>
-      <Tooltip>
-        {children}
-        <TooltipContent side="bottom" sideOffset={6} className="flex items-center gap-1.5">
-          {label}
-          {shortcut && (
-            <kbd className="rounded-[3px] bg-background/18 px-1 py-0.5 font-mono text-[9.5px] tracking-[0.04em] text-background/85">
-              {shortcut}
-            </kbd>
-          )}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      {children}
+      <TooltipContent side="bottom" sideOffset={6} className="flex items-center gap-1.5">
+        {label}
+        {shortcut && (
+          <kbd className="rounded-[3px] bg-background/18 px-1 py-0.5 font-mono text-[9.5px] tracking-[0.04em] text-background/85">
+            {shortcut}
+          </kbd>
+        )}
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/packages/core/src/app/components/inspector/asset-picker-dialog.tsx
+++ b/packages/core/src/app/components/inspector/asset-picker-dialog.tsx
@@ -146,7 +146,7 @@ export function AssetPickerDialog({
                   className={cn(
                     'group flex flex-col overflow-hidden rounded-[8px] border bg-card text-left shadow-edge transition-[translate,scale,box-shadow,border-color] duration-150 ease-swift',
                     'motion-safe:hover:-translate-y-0.5 hover:shadow-floating focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none',
-                    'active:translate-y-0 active:scale-[0.98]',
+                    'motion-safe:active:translate-y-0 motion-safe:active:scale-[0.98]',
                   )}
                 >
                   <div className="flex aspect-square w-full items-center justify-center overflow-hidden bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:12px_12px]">

--- a/packages/core/src/app/components/inspector/asset-picker-dialog.tsx
+++ b/packages/core/src/app/components/inspector/asset-picker-dialog.tsx
@@ -83,7 +83,7 @@ export function AssetPickerDialog({
           )}
         >
           {uploading ? (
-            <Loader2 className="size-3.5 animate-spin" />
+            <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
           ) : (
             <Upload className="size-3.5" />
           )}
@@ -144,8 +144,9 @@ export function AssetPickerDialog({
                   type="button"
                   onClick={() => onPick(asset, scope)}
                   className={cn(
-                    'group flex flex-col overflow-hidden rounded-lg border bg-card text-left shadow-sm transition-all',
-                    'hover:-translate-y-0.5 hover:shadow-md focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none',
+                    'group flex flex-col overflow-hidden rounded-[8px] border bg-card text-left shadow-edge transition-[translate,scale,box-shadow,border-color] duration-150 ease-swift',
+                    'motion-safe:hover:-translate-y-0.5 hover:shadow-floating focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none',
+                    'active:translate-y-0 active:scale-[0.98]',
                   )}
                 >
                   <div className="flex aspect-square w-full items-center justify-center overflow-hidden bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:12px_12px]">
@@ -165,21 +166,22 @@ export function AssetPickerDialog({
               ))}
             </div>
           )}
-          {dragActive && (
-            <div
-              className="pointer-events-none absolute inset-0 z-10 animate-in fade-in-0 duration-200"
-              aria-hidden
-            >
-              <div className="absolute inset-0 bg-brand/5" />
-              <div className="absolute inset-1 rounded-[8px] border border-dashed border-brand/40" />
-              <div className="absolute inset-x-0 bottom-4 flex justify-center">
-                <div className="flex items-center gap-2 rounded-[6px] border border-border bg-card px-3 py-1.5 text-[12px] font-medium shadow-floating">
-                  <ArrowDownToLine className="size-3.5 text-brand" />
-                  <span>{t.asset.dropToUpload}</span>
-                </div>
+          <div
+            className={cn(
+              'pointer-events-none absolute inset-0 z-10 motion-safe:transition-opacity motion-safe:duration-150',
+              dragActive ? 'opacity-100' : 'opacity-0',
+            )}
+            aria-hidden
+          >
+            <div className="absolute inset-0 bg-brand/5" />
+            <div className="absolute inset-1 rounded-[8px] border border-dashed border-brand/40" />
+            <div className="absolute inset-x-0 bottom-4 flex justify-center">
+              <div className="flex items-center gap-2 rounded-[6px] border border-border bg-card px-3 py-1.5 text-[12px] font-medium shadow-floating">
+                <ArrowDownToLine className="size-3.5 text-brand" />
+                <span>{t.asset.dropToUpload}</span>
               </div>
             </div>
-          )}
+          </div>
         </section>
       </DialogContent>
     </Dialog>

--- a/packages/core/src/app/components/inspector/comment-widget.tsx
+++ b/packages/core/src/app/components/inspector/comment-widget.tsx
@@ -1,6 +1,8 @@
 import { MessageSquare, Trash2, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { usePanelMount } from '@/components/panel/panel-shell';
 import { format, plural, useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
 import { useInspector } from './inspector-provider';
 
 export function CommentWidget() {
@@ -9,6 +11,7 @@ export function CommentWidget() {
   const [open, setOpen] = useState(false);
   const count = comments.length;
   const ref = useRef<HTMLDivElement>(null);
+  const { mounted, animVisible } = usePanelMount(open);
 
   useEffect(() => {
     if (!open) return;
@@ -25,21 +28,30 @@ export function CommentWidget() {
       data-inspector-ui
       className="absolute right-4 bottom-4 z-20 flex flex-col items-end gap-2"
     >
-      {open && (
-        <div className="w-80 rounded-md border bg-card shadow-xl animate-in fade-in-0 slide-in-from-bottom-2 duration-200">
+      {mounted && (
+        <div
+          className={cn(
+            'w-80 origin-bottom-right rounded-[8px] border bg-card shadow-overlay',
+            'motion-safe:transition-[opacity,translate,scale] motion-safe:duration-200 motion-safe:ease-swift',
+            animVisible
+              ? 'translate-y-0 scale-100 opacity-100'
+              : 'translate-y-1.5 scale-95 opacity-0',
+          )}
+        >
           <div className="flex items-center justify-between border-b px-3 py-2">
             <span className="text-xs font-semibold">
               {format(plural(count, t.inspector.commentsCount), { count })}
             </span>
             <button
               type="button"
-              className="text-muted-foreground hover:text-foreground"
+              aria-label={t.common.close}
+              className="-m-1 rounded-[5px] p-1 text-muted-foreground transition-[color,scale] duration-150 hover:text-foreground active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               onClick={() => setOpen(false)}
             >
               <X className="size-3.5" />
             </button>
           </div>
-          {error && <p className="px-3 py-2 text-xs text-red-600">{error}</p>}
+          {error && <p className="px-3 py-2 text-xs text-destructive">{error}</p>}
           {count === 0 ? (
             <p className="px-3 py-6 text-center text-xs text-muted-foreground">
               {t.inspector.commentsEmpty}
@@ -61,7 +73,8 @@ export function CommentWidget() {
                     <button
                       type="button"
                       onClick={() => remove(c.id)}
-                      className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-red-600"
+                      className="shrink-0 rounded-[5px] p-1 text-muted-foreground transition-[color,background-color,scale] duration-150 hover:bg-muted hover:text-destructive active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                      aria-label={t.inspector.commentDeleteAria}
                       title={t.inspector.commentDeleteAria}
                     >
                       <Trash2 className="size-3.5" />
@@ -83,10 +96,11 @@ export function CommentWidget() {
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="flex items-center gap-2 rounded-full border bg-card px-3 py-2 text-xs font-medium shadow-lg hover:bg-muted"
+        className="flex items-center gap-2 rounded-full border bg-card px-3 py-2 text-xs font-medium shadow-floating transition-[background-color,scale] duration-150 hover:bg-muted active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+        aria-expanded={open}
       >
         <MessageSquare className="size-4" />
-        {count}
+        <span className="nums">{count}</span>
       </button>
     </div>
   );

--- a/packages/core/src/app/components/inspector/comment-widget.tsx
+++ b/packages/core/src/app/components/inspector/comment-widget.tsx
@@ -11,6 +11,8 @@ export function CommentWidget() {
   const [open, setOpen] = useState(false);
   const count = comments.length;
   const ref = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const fabRef = useRef<HTMLButtonElement>(null);
   const { mounted, animVisible } = usePanelMount(open);
 
   useEffect(() => {
@@ -22,6 +24,13 @@ export function CommentWidget() {
     return () => document.removeEventListener('pointerdown', onPointerDown);
   }, [open]);
 
+  // The panel stays mounted through its close fade; hand focus back to the
+  // toggle so it doesn't sit on a control that's about to unmount.
+  useEffect(() => {
+    if (open) return;
+    if (panelRef.current?.contains(document.activeElement)) fabRef.current?.focus();
+  }, [open]);
+
   return (
     <div
       ref={ref}
@@ -30,12 +39,14 @@ export function CommentWidget() {
     >
       {mounted && (
         <div
+          ref={panelRef}
+          aria-hidden={!animVisible}
           className={cn(
             'w-80 origin-bottom-right rounded-[8px] border bg-card shadow-overlay',
             'motion-safe:transition-[opacity,translate,scale] motion-safe:duration-200 motion-safe:ease-swift',
             animVisible
               ? 'translate-y-0 scale-100 opacity-100'
-              : 'translate-y-1.5 scale-95 opacity-0',
+              : 'pointer-events-none translate-y-1.5 scale-95 opacity-0',
           )}
         >
           <div className="flex items-center justify-between border-b px-3 py-2">
@@ -94,6 +105,7 @@ export function CommentWidget() {
         </div>
       )}
       <button
+        ref={fabRef}
         type="button"
         onClick={() => setOpen((o) => !o)}
         className="flex items-center gap-2 rounded-full border bg-card px-3 py-2 text-xs font-medium shadow-floating transition-[background-color,scale] duration-150 hover:bg-muted active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"

--- a/packages/core/src/app/components/inspector/image-crop-dialog.tsx
+++ b/packages/core/src/app/components/inspector/image-crop-dialog.tsx
@@ -95,7 +95,7 @@ export function ImageCropDialog({
             </ToggleGroupItem>
           </ToggleGroup>
         </div>
-        <div className="flex h-[420px] w-full items-center justify-center overflow-hidden rounded-md border bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:12px_12px]">
+        <div className="flex h-[420px] w-full touch-none select-none items-center justify-center overflow-hidden rounded-md border bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:12px_12px]">
           {fit === 'cover' ? (
             <ReactCrop
               crop={crop}
@@ -108,12 +108,18 @@ export function ImageCropDialog({
                 ref={imgRef}
                 src={src}
                 alt=""
+                draggable={false}
                 style={{ maxHeight: 420, maxWidth: '100%' }}
                 onLoad={onImageLoad}
               />
             </ReactCrop>
           ) : (
-            <img src={src} alt="" className="max-h-full max-w-full object-contain" />
+            <img
+              src={src}
+              alt=""
+              draggable={false}
+              className="max-h-full max-w-full object-contain"
+            />
           )}
         </div>
         <DialogFooter>

--- a/packages/core/src/app/components/inspector/inspect-overlay.tsx
+++ b/packages/core/src/app/components/inspector/inspect-overlay.tsx
@@ -190,9 +190,10 @@ function Frame({
   }, [visible]);
 
   if (!rect) return null;
+  const morphEase = 'var(--ease-swift)';
   const transition = morph
-    ? `left ${FRAME_MORPH_MS}ms ease-out, top ${FRAME_MORPH_MS}ms ease-out, ` +
-      `width ${FRAME_MORPH_MS}ms ease-out, height ${FRAME_MORPH_MS}ms ease-out, ` +
+    ? `left ${FRAME_MORPH_MS}ms ${morphEase}, top ${FRAME_MORPH_MS}ms ${morphEase}, ` +
+      `width ${FRAME_MORPH_MS}ms ${morphEase}, height ${FRAME_MORPH_MS}ms ${morphEase}, ` +
       `opacity ${FRAME_FADE_MS}ms ease-out`
     : `opacity ${FRAME_FADE_MS}ms ease-out`;
 
@@ -265,7 +266,7 @@ function ImageActionPanel({
                   e.stopPropagation();
                   openReplace(anchor);
                 }}
-                className="inline-flex size-7 items-center justify-center rounded-[5px] text-foreground/85 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                className="inline-flex size-7 items-center justify-center rounded-[5px] text-foreground/85 transition-[background-color,color,scale] duration-150 hover:bg-muted hover:text-foreground active:scale-[0.94] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               >
                 <ImageIcon className="size-3.5" />
               </button>
@@ -285,7 +286,7 @@ function ImageActionPanel({
                   e.stopPropagation();
                   openCrop(anchor as HTMLImageElement);
                 }}
-                className="inline-flex size-7 items-center justify-center rounded-[5px] text-foreground/85 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                className="inline-flex size-7 items-center justify-center rounded-[5px] text-foreground/85 transition-[background-color,color,scale] duration-150 hover:bg-muted hover:text-foreground active:scale-[0.94] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               >
                 <Crop className="size-3.5" />
               </button>

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -32,6 +32,7 @@ import { findSlideSource } from '@/lib/inspector/fiber';
 import type { EditOp } from '@/lib/inspector/use-editor';
 import { useAgentSocketConnected } from '@/lib/use-agent-socket';
 import { useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
 import type { Locale } from '../../../locale/types';
 import { AssetPickerDialog } from './asset-picker-dialog';
 import { type SelectedTarget, useInspector } from './inspector-provider';
@@ -688,7 +689,7 @@ function ColorField({
 
   return (
     <Field label={label}>
-      <label className="relative inline-flex size-8 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md border bg-background shadow-xs">
+      <label className="relative inline-flex size-8 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md border bg-background shadow-xs transition-[border-color,scale] duration-150 hover:border-foreground/20 active:scale-[0.96] has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring/40">
         <span
           className="size-5 rounded-sm"
           style={{
@@ -717,7 +718,7 @@ function ColorField({
           setDraft(e.target.value);
           commitHex(e.target.value);
         }}
-        className="h-8 flex-1 font-mono text-[11px] uppercase"
+        className="nums h-8 flex-1 font-mono text-[11px] uppercase"
         spellCheck={false}
       />
       {clearable && onClear && (
@@ -851,12 +852,12 @@ function AgentWatchingBadge() {
           render={
             <button
               type="button"
-              className="flex shrink-0 cursor-help items-center gap-1.5 rounded-[3px] border border-hairline bg-card px-1.5 py-px text-[10.5px] text-foreground/85 outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+              className="flex shrink-0 cursor-help items-center gap-1.5 rounded-[3px] border border-hairline bg-card px-1.5 py-px text-[10.5px] text-foreground/85 outline-none transition-colors duration-150 hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/30"
             >
               <span aria-hidden className="relative flex size-1.5 items-center justify-center">
                 {connected ? (
                   <>
-                    <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-500 opacity-60" />
+                    <span className="absolute inline-flex size-full rounded-full bg-emerald-500 opacity-60 motion-safe:animate-ping" />
                     <span className="relative inline-flex size-1.5 rounded-full bg-emerald-500" />
                   </>
                 ) : (
@@ -879,6 +880,10 @@ function AgentWatchingBadge() {
   );
 }
 
+// The cue animation re-mounts with every element selection; without this
+// guard it replays each time instead of once per inspector session.
+let commentCuePlayed = false;
+
 function CommentsSection({
   selected,
   onAdd,
@@ -888,8 +893,13 @@ function CommentsSection({
 }) {
   const [draft, setDraft] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [showCue] = useState(() => !commentCuePlayed);
   const wrapRef = useRef<HTMLDivElement>(null);
   const t = useLocale();
+
+  useEffect(() => {
+    commentCuePlayed = true;
+  }, []);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -920,7 +930,7 @@ function CommentsSection({
   return (
     <Section title={t.inspector.leaveComment}>
       <div className="flex flex-col gap-2">
-        <div ref={wrapRef} className="comment-cue rounded-[6px]">
+        <div ref={wrapRef} className={cn('rounded-[6px]', showCue && 'comment-cue')}>
           <Textarea
             value={draft}
             onChange={(e) => setDraft(e.target.value)}

--- a/packages/core/src/app/components/notes-drawer.tsx
+++ b/packages/core/src/app/components/notes-drawer.tsx
@@ -56,12 +56,12 @@ export function NotesDrawer({ slideId, index, total, initial }: Props) {
             return !o;
           });
         }}
-        className="flex h-9 w-full items-center gap-2 px-3 text-[12px] text-foreground/80 hover:bg-muted/40"
+        className="flex h-9 w-full items-center gap-2 px-3 text-[12px] text-foreground/80 transition-colors duration-150 hover:bg-muted/40 active:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/30"
         aria-expanded={open}
       >
         <NotebookPen className="size-3.5 text-muted-foreground" />
         <span className="font-medium">{t.notesDrawer.toggle}</span>
-        <span className="font-mono text-[11px] text-muted-foreground">
+        <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
           {format(t.notesDrawer.pageLabel, { n: index + 1, total })}
         </span>
         <span
@@ -81,7 +81,7 @@ export function NotesDrawer({ slideId, index, total, initial }: Props) {
       </button>
       {mounted && (
         <div
-          className="overflow-hidden border-t border-hairline transition-[height] ease-out"
+          className="overflow-hidden border-t border-hairline transition-[height] ease-swift motion-reduce:transition-none"
           style={{
             height: animVisible ? DRAWER_CONTENT_H : 0,
             transitionDuration: `${PANEL_TRANSITION_MS}ms`,

--- a/packages/core/src/app/components/overview-grid.tsx
+++ b/packages/core/src/app/components/overview-grid.tsx
@@ -52,7 +52,9 @@ export function OverviewGrid({
   useEffect(() => {
     if (!open) return;
     focusedRef.current?.focus();
-    focusedRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    // Keyboard-driven focus moves repeat quickly; queued smooth scrolls
+    // fight each other during key repeat, so jump instantly.
+    focusedRef.current?.scrollIntoView({ block: 'nearest', behavior: 'auto' });
   }, [focused, open]);
 
   useEffect(() => {
@@ -108,7 +110,11 @@ export function OverviewGrid({
       role="dialog"
       aria-modal="true"
       aria-label={t.present.overviewDialogAria}
-      className={cn('absolute inset-0 z-50 flex flex-col backdrop-blur-sm', styles.surface)}
+      className={cn(
+        'absolute inset-0 z-50 flex flex-col backdrop-blur-sm',
+        'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-150',
+        styles.surface,
+      )}
     >
       <div className="flex shrink-0 items-center justify-between px-8 pt-6 pb-3">
         <span className={cn('eyebrow', styles.eyebrow)}>{t.present.overviewEyebrow}</span>
@@ -121,7 +127,7 @@ export function OverviewGrid({
             onClick={onClose}
             aria-label={t.common.close}
             className={cn(
-              'flex size-6 items-center justify-center rounded-[4px] outline-none transition-colors',
+              'flex size-6 items-center justify-center rounded-[4px] outline-none transition-[background-color,color,scale] duration-150 active:scale-90',
               styles.closeButton,
             )}
           >
@@ -216,7 +222,7 @@ function OverviewThumb({
       aria-label={format(t.present.overviewGoToAria, { n: index + 1 })}
       aria-current={isCurrent ? 'true' : undefined}
       className={cn(
-        'group/thumb flex flex-col items-start gap-2 rounded-[6px] p-1.5 outline-none transition-colors',
+        'group/thumb flex flex-col items-start gap-2 rounded-[6px] p-1.5 outline-none transition-[background-color,scale] duration-150 active:scale-[0.98]',
         isFocused ? styles.thumbFocused : styles.thumbHover,
       )}
     >

--- a/packages/core/src/app/components/panel/panel-shell.tsx
+++ b/packages/core/src/app/components/panel/panel-shell.tsx
@@ -55,7 +55,7 @@ export function PanelShell({
   return (
     <aside
       {...dataAttrs}
-      className="flex h-full shrink-0 justify-end overflow-hidden bg-sidebar transition-[width,border-left-width] ease-out"
+      className="flex h-full shrink-0 justify-end overflow-hidden bg-sidebar transition-[width,border-left-width] ease-swift motion-reduce:transition-none"
       style={{
         width: animVisible ? PANEL_W : 0,
         borderLeftWidth: animVisible ? 1 : 0,

--- a/packages/core/src/app/components/panel/save-card.tsx
+++ b/packages/core/src/app/components/panel/save-card.tsx
@@ -1,7 +1,9 @@
 import { Check, Loader2, Redo2, Save, Undo2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { usePanelMount } from '@/components/panel/panel-shell';
 import { Button } from '@/components/ui/button';
 import { useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
 
 type SaveCardProps = {
   dirty: boolean;
@@ -44,7 +46,8 @@ export function SaveCard({
   }, [justSaved]);
 
   const visible = dirty || committing || justSaved || canUndo || canRedo;
-  if (!visible) return null;
+  const { mounted, animVisible } = usePanelMount(visible);
+  if (!mounted) return null;
 
   const handleSave = async () => {
     await onSave();
@@ -58,7 +61,13 @@ export function SaveCard({
   return (
     <div
       {...dataAttrs}
-      className="pointer-events-none absolute bottom-6 left-1/2 z-30 -translate-x-1/2 animate-in fade-in slide-in-from-bottom-2 duration-200 ease-out"
+      className={cn(
+        'pointer-events-none absolute bottom-6 left-1/2 z-30 -translate-x-1/2',
+        'motion-safe:transition-[opacity,translate,scale] motion-safe:duration-200 motion-safe:ease-swift',
+        animVisible
+          ? 'translate-y-0 scale-100 opacity-100'
+          : 'translate-y-2 scale-[0.98] opacity-0',
+      )}
     >
       <div className="pointer-events-auto flex h-9 items-center gap-1 rounded-[8px] border border-border bg-popover/95 py-0.5 pr-0.5 pl-1 shadow-overlay backdrop-blur-md">
         {showHistory && (
@@ -125,7 +134,7 @@ export function SaveCard({
           >
             {committing ? (
               <>
-                <Loader2 className="size-3.5 animate-spin" />
+                <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
                 {t.common.saving}
               </>
             ) : (

--- a/packages/core/src/app/components/pdf-progress-toast.tsx
+++ b/packages/core/src/app/components/pdf-progress-toast.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from 'lucide-react';
+import { Check, Loader2 } from 'lucide-react';
 import { format, useLocale } from '@/lib/use-locale';
 import type { PdfExportProgress } from '../lib/export-pdf';
 import { Progress } from './ui/progress';
@@ -17,12 +17,16 @@ export function PdfProgressToast({ progress }: { progress: PdfExportProgress }) 
 
   return (
     <div className="flex w-80 items-start gap-3 rounded-[8px] border border-border bg-popover px-3.5 py-3 text-popover-foreground shadow-floating">
-      <Loader2 className="mt-0.5 size-3.5 shrink-0 animate-spin text-brand" />
+      {progress.phase === 'done' ? (
+        <Check className="mt-0.5 size-3.5 shrink-0 text-[oklch(0.55_0.13_165)]" strokeWidth={2.5} />
+      ) : (
+        <Loader2 className="mt-0.5 size-3.5 shrink-0 animate-spin text-brand motion-reduce:animate-none" />
+      )}
       <div className="min-w-0 flex-1">
         <p className="font-heading text-[12.5px] font-semibold tracking-tight">
           {t.pdfToast.title}
         </p>
-        <p className="truncate font-mono text-[10.5px] tracking-[0.04em] text-muted-foreground">
+        <p className="nums truncate font-mono text-[10.5px] tracking-[0.04em] text-muted-foreground">
           {text}
         </p>
         <Progress value={Math.round(progress.percent)} className="mt-2 h-[3px]" />

--- a/packages/core/src/app/components/pptx-progress-toast.tsx
+++ b/packages/core/src/app/components/pptx-progress-toast.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from 'lucide-react';
+import { Check, Loader2 } from 'lucide-react';
 import { format, useLocale } from '@/lib/use-locale';
 import type { PptxExportProgress } from '../lib/export-pptx';
 import { Progress } from './ui/progress';
@@ -17,12 +17,16 @@ export function PptxProgressToast({ progress }: { progress: PptxExportProgress }
 
   return (
     <div className="flex w-80 items-start gap-3 rounded-[8px] border border-border bg-popover px-3.5 py-3 text-popover-foreground shadow-floating">
-      <Loader2 className="mt-0.5 size-3.5 shrink-0 animate-spin text-brand" />
+      {progress.phase === 'done' ? (
+        <Check className="mt-0.5 size-3.5 shrink-0 text-[oklch(0.55_0.13_165)]" strokeWidth={2.5} />
+      ) : (
+        <Loader2 className="mt-0.5 size-3.5 shrink-0 animate-spin text-brand motion-reduce:animate-none" />
+      )}
       <div className="min-w-0 flex-1">
         <p className="font-heading text-[12.5px] font-semibold tracking-tight">
           {t.pptxToast.title}
         </p>
-        <p className="truncate font-mono text-[10.5px] tracking-[0.04em] text-muted-foreground">
+        <p className="nums truncate font-mono text-[10.5px] tracking-[0.04em] text-muted-foreground">
           {text}
         </p>
         <Progress value={Math.round(progress.percent)} className="mt-2 h-[3px]" />

--- a/packages/core/src/app/components/present/blackout-overlay.tsx
+++ b/packages/core/src/app/components/present/blackout-overlay.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 
 type Props = {
@@ -5,13 +6,19 @@ type Props = {
 };
 
 export function PresentBlackoutOverlay({ mode }: Props) {
-  if (!mode) return null;
+  // Latch the last color so the surface keeps its tone while fading out
+  // instead of hard-cutting on unmount.
+  const [color, setColor] = useState<'black' | 'white'>('black');
+  useEffect(() => {
+    if (mode) setColor(mode);
+  }, [mode]);
   return (
     <div
       aria-hidden
       className={cn(
-        'pointer-events-none absolute inset-0 z-20 motion-safe:transition-opacity motion-safe:duration-150',
-        mode === 'black' ? 'bg-black' : 'bg-white',
+        'pointer-events-none absolute inset-0 z-20 motion-safe:transition-opacity',
+        mode ? 'opacity-100 motion-safe:duration-150' : 'opacity-0 motion-safe:duration-100',
+        color === 'black' ? 'bg-black' : 'bg-white',
       )}
     />
   );

--- a/packages/core/src/app/components/present/blackout-overlay.tsx
+++ b/packages/core/src/app/components/present/blackout-overlay.tsx
@@ -14,6 +14,9 @@ export function PresentBlackoutOverlay({ mode }: Props) {
   useEffect(() => {
     if (mode) setColor(mode);
   }, [mode]);
+  // Render from `mode` directly while active — the latched state is one
+  // frame behind and would flash the previous color on a direct switch.
+  const visibleColor = mode ?? color;
   if (!mounted) return null;
   return (
     <div
@@ -21,7 +24,7 @@ export function PresentBlackoutOverlay({ mode }: Props) {
       className={cn(
         'pointer-events-none absolute inset-0 z-20 motion-safe:transition-opacity',
         animVisible ? 'opacity-100 motion-safe:duration-150' : 'opacity-0 motion-safe:duration-100',
-        color === 'black' ? 'bg-black' : 'bg-white',
+        visibleColor === 'black' ? 'bg-black' : 'bg-white',
       )}
     />
   );

--- a/packages/core/src/app/components/present/blackout-overlay.tsx
+++ b/packages/core/src/app/components/present/blackout-overlay.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { usePanelMount } from '@/components/panel/panel-shell';
 import { cn } from '@/lib/utils';
 
 type Props = {
@@ -6,18 +7,20 @@ type Props = {
 };
 
 export function PresentBlackoutOverlay({ mode }: Props) {
-  // Latch the last color so the surface keeps its tone while fading out
-  // instead of hard-cutting on unmount.
+  // Latch the last color so the surface keeps its tone while fading out,
+  // and unmount only after the fade so the DOM reflects the cleared state.
   const [color, setColor] = useState<'black' | 'white'>('black');
+  const { mounted, animVisible } = usePanelMount(mode !== null);
   useEffect(() => {
     if (mode) setColor(mode);
   }, [mode]);
+  if (!mounted) return null;
   return (
     <div
       aria-hidden
       className={cn(
         'pointer-events-none absolute inset-0 z-20 motion-safe:transition-opacity',
-        mode ? 'opacity-100 motion-safe:duration-150' : 'opacity-0 motion-safe:duration-100',
+        animVisible ? 'opacity-100 motion-safe:duration-150' : 'opacity-0 motion-safe:duration-100',
         color === 'black' ? 'bg-black' : 'bg-white',
       )}
     />

--- a/packages/core/src/app/components/present/control-bar.tsx
+++ b/packages/core/src/app/components/present/control-bar.tsx
@@ -79,11 +79,10 @@ export function PresentControlBar({
       className={cn(
         'pointer-events-none absolute inset-x-0 bottom-0 z-40 flex justify-center px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] md:px-4 md:pb-4',
         'will-change-[translate,scale,opacity,filter]',
-        'motion-safe:transition-[translate,scale,opacity,filter]',
-        'motion-safe:duration-[420ms] motion-safe:[transition-timing-function:cubic-bezier(0.22,1,0.36,1)]',
+        'motion-safe:transition-[translate,scale,opacity,filter] motion-safe:ease-swift',
         visible
-          ? 'translate-y-0 scale-100 opacity-100 blur-none'
-          : 'translate-y-8 scale-90 opacity-0 blur-md',
+          ? 'translate-y-0 scale-100 opacity-100 blur-none motion-safe:duration-[360ms]'
+          : 'translate-y-8 scale-90 opacity-0 blur-sm motion-safe:duration-[220ms]',
       )}
     >
       <TooltipProvider delay={300}>
@@ -229,8 +228,9 @@ function MobileBarButton({
         onClick();
       }}
       className={cn(
-        'inline-flex size-8 shrink-0 touch-manipulation items-center justify-center rounded-full transition-colors',
+        'inline-flex size-8 shrink-0 touch-manipulation items-center justify-center rounded-full transition-[background-color,color,opacity,scale] duration-150',
         'text-white/85 hover:bg-white/12 focus-visible:bg-white/12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/35',
+        'active:scale-[0.94] active:bg-white/12',
         'disabled:pointer-events-none disabled:opacity-30',
       )}
     >
@@ -270,8 +270,9 @@ function BarButton({
               onClick();
             }}
             className={cn(
-              'inline-flex size-8 items-center justify-center rounded-full transition-colors',
-              'hover:bg-white/12 focus-visible:bg-white/12 focus-visible:outline-none',
+              'inline-flex size-8 items-center justify-center rounded-full transition-[background-color,color,opacity,scale] duration-150',
+              'hover:bg-white/12 focus-visible:bg-white/12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/35',
+              'active:scale-[0.94]',
               'disabled:pointer-events-none disabled:opacity-30',
               active && 'bg-[var(--brand,#e5484d)]/85 text-white hover:bg-[var(--brand,#e5484d)]',
             )}
@@ -301,8 +302,15 @@ function ElapsedClock({ startedAt }: { startedAt: number }) {
   const [now, setNow] = useState(() => Date.now());
   const t = useLocale();
   useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(id);
+    // Re-arm against the wall clock each tick; a plain setInterval drifts
+    // and visibly skips seconds over a long talk.
+    let id: ReturnType<typeof setTimeout>;
+    const tick = () => {
+      setNow(Date.now());
+      id = setTimeout(tick, 1000 - (Date.now() % 1000));
+    };
+    id = setTimeout(tick, 1000 - (Date.now() % 1000));
+    return () => clearTimeout(id);
   }, []);
   const elapsed = Math.max(0, Math.floor((now - startedAt) / 1000));
   const m = Math.floor(elapsed / 60);

--- a/packages/core/src/app/components/present/jump-input.tsx
+++ b/packages/core/src/app/components/present/jump-input.tsx
@@ -24,6 +24,14 @@ export function PresentJumpInput({ pageCount, onJump }: Props) {
     if (buffer) setDisplay(buffer);
   }, [buffer]);
 
+  // Drop the latched text once the exit fade finishes so the aria-live
+  // region does not keep a stale value mounted.
+  useEffect(() => {
+    if (buffer || !display) return;
+    const id = setTimeout(() => setDisplay(''), 150);
+    return () => clearTimeout(id);
+  }, [buffer, display]);
+
   useEffect(() => {
     const flush = () => {
       setBuffer((current) => {

--- a/packages/core/src/app/components/present/jump-input.tsx
+++ b/packages/core/src/app/components/present/jump-input.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
 
 const FLUSH_DELAY_MS = 1200;
 
@@ -15,7 +16,13 @@ type Props = {
  */
 export function PresentJumpInput({ pageCount, onJump }: Props) {
   const [buffer, setBuffer] = useState('');
+  // Latch the last text so the badge keeps its digits while fading out.
+  const [display, setDisplay] = useState('');
   const flushRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (buffer) setDisplay(buffer);
+  }, [buffer]);
 
   useEffect(() => {
     const flush = () => {
@@ -61,14 +68,20 @@ export function PresentJumpInput({ pageCount, onJump }: Props) {
     };
   }, [pageCount, onJump]);
 
-  if (!buffer) return null;
+  if (!display && !buffer) return null;
   return (
     <div
       aria-live="polite"
-      className="pointer-events-none absolute top-1/2 left-1/2 z-40 -translate-x-1/2 -translate-y-1/2 select-none rounded-[10px] bg-black/70 px-6 py-4 font-mono text-[44px] font-medium tracking-[0.05em] text-white tabular-nums shadow-[0_8px_40px_-8px_oklch(0_0_0/0.6)] backdrop-blur-md"
+      className={cn(
+        'pointer-events-none absolute top-1/2 left-1/2 z-40 -translate-x-1/2 -translate-y-1/2 select-none rounded-[10px] bg-black/70 px-6 py-4 font-mono text-[44px] font-medium tracking-[0.05em] text-white tabular-nums shadow-[0_8px_40px_-8px_oklch(0_0_0/0.6)] backdrop-blur-md',
+        'motion-safe:transition-[opacity,scale] motion-safe:ease-swift',
+        buffer
+          ? 'scale-100 opacity-100 motion-safe:duration-200'
+          : 'scale-95 opacity-0 motion-safe:duration-150',
+      )}
     >
       <span className="text-white/60">→ </span>
-      {buffer}
+      {buffer || display}
     </div>
   );
 }

--- a/packages/core/src/app/components/present/laser-pointer.tsx
+++ b/packages/core/src/app/components/present/laser-pointer.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from 'react';
-
-type Pos = { x: number; y: number } | null;
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
 
 /**
  * Soft red dot that follows the cursor when the laser tool is active.
@@ -8,27 +7,51 @@ type Pos = { x: number; y: number } | null;
  * applied by the parent.
  */
 export function PresentLaserPointer({ enabled }: { enabled: boolean }) {
-  const [pos, setPos] = useState<Pos>(null);
+  const dotRef = useRef<HTMLDivElement | null>(null);
+  const posRef = useRef<{ x: number; y: number } | null>(null);
+  const rafRef = useRef(0);
+  const [tracking, setTracking] = useState(false);
 
   useEffect(() => {
     if (!enabled) {
-      setPos(null);
+      setTracking(false);
+      posRef.current = null;
       return;
     }
-    const onMove = (e: MouseEvent) => setPos({ x: e.clientX, y: e.clientY });
-    window.addEventListener('mousemove', onMove, { passive: true });
-    return () => window.removeEventListener('mousemove', onMove);
+    // Position is written straight to the element inside rAF — routing it
+    // through React state would re-render at pointer rate and lag the hand.
+    const onMove = (e: PointerEvent) => {
+      posRef.current = { x: e.clientX, y: e.clientY };
+      if (!rafRef.current) {
+        rafRef.current = requestAnimationFrame(() => {
+          rafRef.current = 0;
+          const el = dotRef.current;
+          const p = posRef.current;
+          if (el && p) el.style.transform = `translate3d(${p.x - 9}px, ${p.y - 9}px, 0)`;
+        });
+      }
+      setTracking(true);
+    };
+    window.addEventListener('pointermove', onMove, { passive: true });
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      rafRef.current = 0;
+    };
   }, [enabled]);
 
-  if (!enabled || !pos) return null;
+  if (!enabled) return null;
   return (
     <div
+      ref={dotRef}
       aria-hidden
-      className="pointer-events-none fixed top-0 left-0 z-[60]"
+      className={cn(
+        'pointer-events-none fixed top-0 left-0 z-[60] motion-safe:transition-opacity motion-safe:duration-150',
+        tracking ? 'opacity-100' : 'opacity-0',
+      )}
       style={{
         width: 18,
         height: 18,
-        transform: `translate3d(${pos.x - 9}px, ${pos.y - 9}px, 0)`,
         willChange: 'transform',
         borderRadius: '50%',
         background: 'radial-gradient(circle, oklch(0.66 0.24 28 / 0.95) 30%, transparent 70%)',

--- a/packages/core/src/app/components/present/progress-bar.tsx
+++ b/packages/core/src/app/components/present/progress-bar.tsx
@@ -18,7 +18,7 @@ export function PresentProgressBar({ index, total, visible }: Props) {
       )}
     >
       <div
-        className="h-full w-full origin-left bg-[var(--brand,#e5484d)] transition-transform duration-200 ease-out"
+        className="h-full w-full origin-left bg-[var(--brand,#e5484d)] ease-swift motion-safe:transition-transform motion-safe:duration-200"
         style={{ transform: `scaleX(${pct})` }}
       />
     </div>

--- a/packages/core/src/app/components/present/use-touch-swipe.ts
+++ b/packages/core/src/app/components/present/use-touch-swipe.ts
@@ -2,6 +2,10 @@ import { type RefObject, useEffect, useRef } from 'react';
 
 const MIN_SWIPE_PX = 50;
 const MAX_SWIPE_MS = 600;
+// A fast flick should turn the page even if it travelled a short distance —
+// momentum, not displacement, is what the finger communicated.
+const FLICK_VELOCITY_PX_MS = 0.4;
+const MIN_FLICK_PX = 24;
 
 type Options<T extends HTMLElement> = {
   ref: RefObject<T | null>;
@@ -43,9 +47,12 @@ export function useTouchSwipe<T extends HTMLElement>({
       if (!t) return;
       const dx = t.clientX - s.x;
       const dy = t.clientY - s.y;
-      if (performance.now() - s.t > MAX_SWIPE_MS) return;
-      if (Math.abs(dx) < MIN_SWIPE_PX) return;
       if (Math.abs(dx) <= Math.abs(dy)) return;
+      const dt = performance.now() - s.t;
+      const velocity = Math.abs(dx) / Math.max(dt, 1);
+      const distanceCommit = Math.abs(dx) >= MIN_SWIPE_PX && dt <= MAX_SWIPE_MS;
+      const flickCommit = velocity >= FLICK_VELOCITY_PX_MS && Math.abs(dx) >= MIN_FLICK_PX;
+      if (!distanceCommit && !flickCommit) return;
       if (dx < 0) onNext();
       else onPrev();
     };

--- a/packages/core/src/app/components/sidebar/folder-item.tsx
+++ b/packages/core/src/app/components/sidebar/folder-item.tsx
@@ -158,13 +158,13 @@ export function FolderItem({
     // biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop target wraps interactive children
     <div
       className={cn(
-        'group relative flex items-center gap-2.5 rounded-[5px] px-2 py-[5px] text-[12.5px] transition-colors',
+        'group relative flex items-center gap-2.5 rounded-[5px] px-2 py-[5px] text-[12.5px] transition-[background-color,color,scale] duration-150',
         selected
           ? 'bg-muted text-foreground before:absolute before:inset-y-1.5 before:-left-0.5 before:w-[2px] before:rounded-full before:bg-brand'
           : 'text-foreground/70 hover:bg-muted/60 hover:text-foreground',
         slideDragActive && acceptsSlideDrop && !dragOver && 'ring-1 ring-foreground/10',
         dragOver &&
-          'bg-brand/10 text-foreground ring-1 ring-brand ring-offset-1 ring-offset-sidebar motion-safe:scale-[1.01] motion-safe:transition-transform',
+          'bg-brand/10 text-foreground ring-1 ring-brand ring-offset-1 ring-offset-sidebar motion-safe:scale-[1.01]',
       )}
       onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
@@ -177,7 +177,7 @@ export function FolderItem({
             render={
               <button
                 type="button"
-                className="flex size-5 shrink-0 items-center justify-center rounded transition-transform hover:scale-110"
+                className="flex size-5 shrink-0 items-center justify-center rounded outline-none motion-safe:transition-transform motion-safe:duration-150 hover:scale-110 active:scale-95 focus-visible:ring-1 focus-visible:ring-brand"
                 aria-label={t.home.changeIcon}
                 onClick={(e) => e.stopPropagation()}
               >
@@ -217,7 +217,11 @@ export function FolderItem({
           className="min-w-0 flex-1 rounded-[3px] bg-card px-1 text-[12.5px] outline-none ring-1 ring-foreground/20"
         />
       ) : (
-        <button type="button" onClick={onSelect} className="min-w-0 flex-1 truncate text-left">
+        <button
+          type="button"
+          onClick={onSelect}
+          className="min-w-0 flex-1 truncate rounded-[3px] text-left outline-none focus-visible:ring-1 focus-visible:ring-brand"
+        >
           {label}
         </button>
       )}
@@ -240,7 +244,7 @@ export function FolderItem({
               <button
                 type="button"
                 onClick={(e) => e.stopPropagation()}
-                className="absolute right-2 top-1/2 size-5 -translate-y-1/2 rounded opacity-0 transition-opacity hover:bg-foreground/10 group-hover:opacity-100 aria-expanded:opacity-100"
+                className="absolute right-2 top-1/2 size-5 -translate-y-1/2 rounded opacity-0 outline-none transition-opacity duration-150 hover:bg-foreground/10 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-1 focus-visible:ring-brand aria-expanded:opacity-100"
                 aria-label={t.home.folderActions}
               >
                 <MoreHorizontal className="mx-auto size-3.5" />

--- a/packages/core/src/app/components/sidebar/icon-picker.tsx
+++ b/packages/core/src/app/components/sidebar/icon-picker.tsx
@@ -49,7 +49,7 @@ export function IconPicker({
               key={c}
               type="button"
               onClick={() => onChange({ type: 'color', value: c })}
-              className="size-6 rounded-[4px] ring-1 ring-foreground/10 shadow-[inset_0_1px_0_oklch(1_0_0/0.18)] transition-transform hover:scale-110"
+              className="size-6 rounded-[4px] ring-1 ring-foreground/10 shadow-[inset_0_1px_0_oklch(1_0_0/0.18)] outline-none motion-safe:transition-transform motion-safe:duration-100 hover:scale-110 active:scale-95 focus-visible:ring-2 focus-visible:ring-brand"
               style={{ background: c }}
               aria-label={c}
             />

--- a/packages/core/src/app/components/sidebar/sidebar-footer.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar-footer.tsx
@@ -53,11 +53,18 @@ export function SidebarFooter() {
     }
   }
 
-  const versionRow = (
-    <span className="inline-flex cursor-default items-center gap-1.5">
-      {update?.latest && <span className="size-1.5 rounded-full bg-brand" aria-hidden />}
+  const versionRow = update?.latest ? (
+    // Real button: the tooltip holds actionable controls, so keyboard users
+    // must be able to reach and open it.
+    <button
+      type="button"
+      className="inline-flex cursor-default items-center gap-1.5 rounded-[3px] outline-none focus-visible:ring-1 focus-visible:ring-brand"
+    >
+      <span className="size-1.5 rounded-full bg-brand" aria-hidden />
       {label}
-    </span>
+    </button>
+  ) : (
+    <span className="inline-flex cursor-default items-center gap-1.5">{label}</span>
   );
 
   return (
@@ -93,7 +100,7 @@ export function SidebarFooter() {
                       onClick={restartServer}
                     >
                       {restarting ? (
-                        <Loader2 className="animate-spin" aria-hidden />
+                        <Loader2 className="animate-spin motion-reduce:animate-none" aria-hidden />
                       ) : (
                         <RotateCw aria-hidden />
                       )}
@@ -115,7 +122,7 @@ export function SidebarFooter() {
                     onClick={updatePackage}
                   >
                     {isUpdating ? (
-                      <Loader2 className="animate-spin" aria-hidden />
+                      <Loader2 className="animate-spin motion-reduce:animate-none" aria-hidden />
                     ) : (
                       <RefreshCw aria-hidden />
                     )}

--- a/packages/core/src/app/components/sidebar/sidebar.tsx
+++ b/packages/core/src/app/components/sidebar/sidebar.tsx
@@ -257,7 +257,7 @@ export function Sidebar({
                   render={
                     <button
                       type="button"
-                      className="flex size-5 shrink-0 items-center justify-center rounded transition-transform hover:scale-110"
+                      className="flex size-5 shrink-0 items-center justify-center rounded outline-none motion-safe:transition-transform motion-safe:duration-150 hover:scale-110 active:scale-95 focus-visible:ring-1 focus-visible:ring-brand"
                       aria-label={t.home.pickIcon}
                     >
                       <FolderIconChip icon={newIcon} />
@@ -286,7 +286,7 @@ export function Sidebar({
             <button
               type="button"
               onClick={startCreating}
-              className="mt-1 flex w-full items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12px] text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+              className="mt-1 flex w-full items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12px] text-muted-foreground outline-none transition-[background-color,color,scale] duration-100 hover:bg-muted/60 hover:text-foreground active:scale-[0.98] focus-visible:ring-1 focus-visible:ring-brand"
             >
               <Plus className="size-3.5" />
               <span>{t.home.newFolder}</span>

--- a/packages/core/src/app/components/style-panel/style-panel.tsx
+++ b/packages/core/src/app/components/style-panel/style-panel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { Field, NumberField, Section } from '@/components/panel/panel-fields';
 import { PanelShell, usePanelMount } from '@/components/panel/panel-shell';
 import { useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
@@ -29,12 +30,14 @@ type DesignPanelProps = {
 
 export function DesignPanel({ open, onClose }: DesignPanelProps) {
   const { draft, exists, warning, loaded, dirty, update, shuffle } = useDesignPanelState();
-  const { mounted, animVisible } = usePanelMount(open);
+  // Gate the mount on data readiness so the first open still slides in
+  // instead of popping fully expanded once loading finishes.
+  const ready = loaded && draft != null;
+  const { mounted, animVisible } = usePanelMount(open && ready);
   const t = useLocale();
 
-  if (!loaded) return null;
+  if (!ready) return null;
   if (!mounted) return null;
-  if (!draft) return null;
 
   return (
     <PanelShell
@@ -52,13 +55,14 @@ export function DesignPanel({ open, onClose }: DesignPanelProps) {
                 {t.stylePanel.draftBadge}
               </span>
             )}
-            {dirty && (
-              <span
-                className="size-1.5 rounded-full bg-brand"
-                title={t.stylePanel.unsavedTitle}
-                aria-hidden
-              />
-            )}
+            <span
+              className={cn(
+                'size-1.5 rounded-full bg-brand transition-opacity duration-150',
+                dirty ? 'opacity-100' : 'opacity-0',
+              )}
+              title={dirty ? t.stylePanel.unsavedTitle : undefined}
+              aria-hidden
+            />
           </div>
           <div className="flex items-center gap-0.5">
             <Button
@@ -232,7 +236,7 @@ function ColorField({
 
   return (
     <Field label={label}>
-      <label className="relative inline-flex size-8 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md border bg-background shadow-xs">
+      <label className="relative inline-flex size-8 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md border bg-background shadow-xs transition-[border-color,scale] duration-150 hover:border-foreground/20 active:scale-[0.96] has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring/40">
         <span className="size-5 rounded-sm" style={{ backgroundColor: value }} />
         <input
           type="color"
@@ -252,7 +256,7 @@ function ColorField({
         onBlur={() => {
           if (!/^#[0-9a-fA-F]{6}$/.test(hexDraft)) setHexDraft(value);
         }}
-        className="h-8 flex-1 font-mono text-[11px] uppercase"
+        className="nums h-8 flex-1 font-mono text-[11px] uppercase"
         spellCheck={false}
       />
     </Field>

--- a/packages/core/src/app/components/theme-toggle.tsx
+++ b/packages/core/src/app/components/theme-toggle.tsx
@@ -34,8 +34,8 @@ export function ThemeToggle() {
             />
           }
         >
-          <Sun className="size-3.5 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-          <Moon className="absolute size-3.5 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+          <Sun className="size-3.5 scale-100 rotate-0 opacity-100 ease-swift motion-safe:transition-[opacity,scale,rotate] motion-safe:duration-200 dark:scale-75 dark:-rotate-90 dark:opacity-0" />
+          <Moon className="absolute size-3.5 scale-75 rotate-90 opacity-0 ease-swift motion-safe:transition-[opacity,scale,rotate] motion-safe:duration-200 dark:scale-100 dark:rotate-0 dark:opacity-100" />
         </DropdownMenuTrigger>
       </IconTooltip>
       <DropdownMenuContent align="end" className="min-w-[140px]">

--- a/packages/core/src/app/components/themes/theme-detail.tsx
+++ b/packages/core/src/app/components/themes/theme-detail.tsx
@@ -121,7 +121,7 @@ export function ThemeDetail({ themeId, onBack }: { themeId: string; onBack: () =
                   aria-label={t.themes.prevPageAria}
                   disabled={pageIndex === 0}
                   onClick={() => setPageIndex((i) => Math.max(0, i - 1))}
-                  className="flex size-8 items-center justify-center rounded-[6px] border border-border bg-card text-foreground transition-colors hover:bg-muted disabled:opacity-40"
+                  className="flex size-8 items-center justify-center rounded-[6px] border border-border bg-card text-foreground outline-none transition-[background-color,opacity,scale] duration-100 hover:bg-muted active:scale-95 focus-visible:ring-2 focus-visible:ring-ring/30 disabled:opacity-40"
                 >
                   <ChevronLeft className="size-4" />
                 </button>
@@ -133,7 +133,7 @@ export function ThemeDetail({ themeId, onBack }: { themeId: string; onBack: () =
                   aria-label={t.themes.nextPageAria}
                   disabled={pageIndex === totalPages - 1}
                   onClick={() => setPageIndex((i) => Math.min(totalPages - 1, i + 1))}
-                  className="flex size-8 items-center justify-center rounded-[6px] border border-border bg-card text-foreground transition-colors hover:bg-muted disabled:opacity-40"
+                  className="flex size-8 items-center justify-center rounded-[6px] border border-border bg-card text-foreground outline-none transition-[background-color,opacity,scale] duration-100 hover:bg-muted active:scale-95 focus-visible:ring-2 focus-visible:ring-ring/30 disabled:opacity-40"
                 >
                   <ChevronRight className="size-4" />
                 </button>
@@ -225,10 +225,13 @@ function ThemeSlideCard({ id }: { id: string }) {
   const displayTitle = slide?.meta?.title ?? id;
 
   return (
-    <Link to={`/s/${id}`} className="group block focus-visible:outline-none">
-      <div className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] group-hover:shadow-floating group-hover:ring-foreground/20 motion-safe:transition-[box-shadow,--tw-ring-color] motion-safe:duration-200">
+    <Link
+      to={`/s/${id}`}
+      className="group block rounded-[6px] outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    >
+      <div className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] group-hover:shadow-floating group-hover:ring-foreground/20 group-active:scale-[0.99] motion-safe:transition-[box-shadow,--tw-ring-color,scale] motion-safe:duration-200">
         {FirstPage ? (
-          <div className="h-full w-full motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]">
+          <div className="h-full w-full ease-swift motion-safe:transition-transform motion-safe:duration-200 motion-safe:group-hover:scale-[1.03]">
             <SlideCanvas flat freezeMotion design={slide?.design}>
               <SlidePageProvider index={0} total={slide?.default.length ?? 1}>
                 <FirstPage />

--- a/packages/core/src/app/components/themes/themes-gallery.tsx
+++ b/packages/core/src/app/components/themes/themes-gallery.tsx
@@ -40,9 +40,9 @@ function ThemeCard({
       type="button"
       onClick={onOpen}
       aria-label={ariaLabel}
-      className="group block w-full text-left focus-visible:outline-none"
+      className="group block w-full rounded-[6px] text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
-      <div className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] group-hover:shadow-floating group-hover:ring-foreground/20 motion-safe:transition-[box-shadow,--tw-ring-color] motion-safe:duration-200">
+      <div className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] group-hover:shadow-floating group-hover:ring-foreground/20 group-active:scale-[0.99] motion-safe:transition-[box-shadow,--tw-ring-color,scale] motion-safe:duration-200">
         <ThemePreview theme={theme} />
       </div>
       <div className="mt-3">
@@ -77,7 +77,7 @@ function ThemePreview({ theme }: { theme: Theme }) {
   if (!FirstPage) return <NoDemoState />;
 
   return (
-    <div className="h-full w-full motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]">
+    <div className="h-full w-full ease-swift motion-safe:transition-transform motion-safe:duration-200 motion-safe:group-hover:scale-[1.03]">
       <SlideCanvas flat freezeMotion design={demo.design}>
         <SlidePageProvider index={0} total={demo.default.length}>
           <FirstPage />

--- a/packages/core/src/app/components/thumbnail-rail.tsx
+++ b/packages/core/src/app/components/thumbnail-rail.tsx
@@ -396,8 +396,8 @@ function CurrentThumbnailButton({
 
 function thumbButtonClass(active: boolean): string {
   return cn(
-    'group/thumb flex w-full items-start gap-2.5 rounded-[6px] p-1.5 text-left outline-none motion-safe:transition-colors',
-    'hover:bg-muted/60',
+    'group/thumb flex w-full items-start gap-2.5 rounded-[6px] p-1.5 text-left outline-none motion-safe:transition-[background-color,scale] motion-safe:duration-100',
+    'hover:bg-muted/60 active:scale-[0.985]',
     'focus-visible:ring-1 focus-visible:ring-brand focus-visible:ring-offset-1 focus-visible:ring-offset-sidebar',
     active && 'bg-muted',
   );
@@ -499,7 +499,10 @@ function HorizontalVirtualThumbList({
         onClick={() => onSelect(i)}
         aria-label={format(t.thumbnailRail.goToPageAria, { n: i + 1 })}
         aria-current={active ? 'page' : undefined}
-        className={cn('group/thumb relative flex shrink-0 flex-col items-center gap-1.5')}
+        className={cn(
+          'group/thumb relative flex shrink-0 flex-col items-center gap-1.5 rounded-[6px] outline-none motion-safe:transition-[scale] motion-safe:duration-100 active:scale-[0.985]',
+          'focus-visible:ring-1 focus-visible:ring-brand focus-visible:ring-offset-1 focus-visible:ring-offset-sidebar',
+        )}
       >
         <span
           className={cn(
@@ -939,6 +942,7 @@ function SortableThumb({
 >) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: index + 1,
+    transition: { duration: 180, easing: 'var(--ease-swift)' },
   });
 
   const setRef = (node: HTMLButtonElement | null) => {

--- a/packages/core/src/app/index.html
+++ b/packages/core/src/app/index.html
@@ -16,14 +16,15 @@
     <script>
       // Apply the stored theme before first paint; next-themes only runs
       // after the bundle loads, which flashes white for dark-mode users.
+      let stored = null;
       try {
-        const stored = localStorage.getItem('theme');
-        const dark =
-          stored === 'dark' ||
-          (stored !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches);
-        document.documentElement.classList.toggle('dark', dark);
-        document.documentElement.style.colorScheme = dark ? 'dark' : 'light';
+        stored = localStorage.getItem('theme');
       } catch (_) {}
+      const dark =
+        stored === 'dark' ||
+        (stored !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches);
+      document.documentElement.classList.toggle('dark', dark);
+      document.documentElement.style.colorScheme = dark ? 'dark' : 'light';
     </script>
   </head>
   <body>

--- a/packages/core/src/app/index.html
+++ b/packages/core/src/app/index.html
@@ -5,6 +5,26 @@
     <link rel="icon" href="./favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>open-slide</title>
+    <style>
+      html {
+        background-color: oklch(0.99 0 0);
+      }
+      html.dark {
+        background-color: oklch(0.145 0 0);
+      }
+    </style>
+    <script>
+      // Apply the stored theme before first paint; next-themes only runs
+      // after the bundle loads, which flashes white for dark-mode users.
+      try {
+        const stored = localStorage.getItem('theme');
+        const dark =
+          stored === 'dark' ||
+          (stored !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches);
+        document.documentElement.classList.toggle('dark', dark);
+        document.documentElement.style.colorScheme = dark ? 'dark' : 'light';
+      } catch (_) {}
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/core/src/app/routes/home-shell.tsx
+++ b/packages/core/src/app/routes/home-shell.tsx
@@ -189,7 +189,7 @@ export function HomeShell() {
                   <button
                     type="button"
                     aria-label={t.home.menu}
-                    className="flex size-8 items-center justify-center rounded-[6px] text-muted-foreground hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground"
+                    className="flex size-8 items-center justify-center rounded-[6px] text-muted-foreground outline-none transition-[background-color,color,scale] duration-100 hover:bg-muted hover:text-foreground active:scale-95 focus-visible:ring-2 focus-visible:ring-ring/30 aria-expanded:bg-muted aria-expanded:text-foreground"
                   >
                     <Menu className="size-4" />
                   </button>

--- a/packages/core/src/app/routes/home.tsx
+++ b/packages/core/src/app/routes/home.tsx
@@ -266,7 +266,7 @@ function SearchInput({ value, onChange }: { value: string; onChange: (value: str
           type="button"
           onClick={() => onChange('')}
           aria-label={t.home.clearSearch}
-          className="absolute right-1.5 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-[4px] text-muted-foreground hover:bg-muted hover:text-foreground"
+          className="absolute right-1.5 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-[4px] text-muted-foreground outline-none transition-[background-color,color,scale] duration-100 hover:bg-muted hover:text-foreground active:scale-90 focus-visible:ring-2 focus-visible:ring-ring/30"
         >
           <X className="size-3" />
         </button>
@@ -296,7 +296,7 @@ function SortControl({ value, onChange }: { value: SortKey; onChange: (next: Sor
           <button
             type="button"
             aria-label={`${t.home.sortLabel}: ${labels[value]}`}
-            className="flex h-8 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-[6px] border border-border bg-background pl-2 pr-1.5 text-[12.5px] font-medium text-foreground outline-none hover:bg-muted focus-visible:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring/30"
+            className="flex h-8 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-[6px] border border-border bg-background pl-2 pr-1.5 text-[12.5px] font-medium text-foreground outline-none transition-[background-color,translate] duration-100 hover:bg-muted active:translate-y-px focus-visible:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring/30"
           >
             <FieldIcon k={value} className="size-3.5 text-muted-foreground" />
             <span>{labels[value]}</span>
@@ -510,11 +510,14 @@ function SlideCard({
         onDragEnd={() => setDragging(false)}
         className={cn('group relative motion-safe:transition-opacity', dragging && 'opacity-40')}
       >
-        <Link to={`/s/${id}`} className="block focus-visible:outline-none">
+        <Link
+          to={`/s/${id}`}
+          className="block rounded-[6px] outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
           {/* Slide thumb — tight border, grey baseboard, no shadcn rounded-xl */}
-          <div className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] group-hover:shadow-floating group-hover:ring-foreground/20 motion-safe:transition-[box-shadow,--tw-ring-color] motion-safe:duration-200">
+          <div className="relative aspect-video overflow-hidden rounded-[6px] border border-hairline bg-card shadow-edge ring-1 ring-foreground/[0.04] group-hover:shadow-floating group-hover:ring-foreground/20 motion-safe:transition-[box-shadow,--tw-ring-color,scale] motion-safe:duration-200 group-active:scale-[0.99]">
             {FirstPage ? (
-              <div className="h-full w-full motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]">
+              <div className="h-full w-full ease-swift motion-safe:transition-transform motion-safe:duration-200 motion-safe:group-hover:scale-[1.03]">
                 <SlideCanvas flat freezeMotion design={slide?.design}>
                   <SlidePageProvider index={0} total={slide?.default.length ?? 1}>
                     <FirstPage />
@@ -556,7 +559,7 @@ function SlideCard({
                       e.stopPropagation();
                       e.preventDefault();
                     }}
-                    className="flex size-7 items-center justify-center rounded-[5px] bg-card/90 text-foreground shadow-edge ring-1 ring-border opacity-0 backdrop-blur hover:bg-card group-hover:opacity-100 aria-expanded:opacity-100 motion-safe:transition-opacity"
+                    className="flex size-7 items-center justify-center rounded-[5px] bg-card/90 text-foreground shadow-edge ring-1 ring-border opacity-0 outline-none backdrop-blur hover:bg-card group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-ring/40 aria-expanded:opacity-100 motion-safe:transition-opacity motion-safe:duration-150"
                     aria-label={tCard.home.slideActions}
                   >
                     <MoreHorizontal className="size-3.5" />
@@ -794,7 +797,7 @@ function FolderOption({
       type="button"
       onClick={onClick}
       className={cn(
-        'flex w-full items-center gap-2 border-b border-hairline px-3 py-2 text-left text-[13px] transition-colors last:border-b-0',
+        'flex w-full items-center gap-2 border-b border-hairline px-3 py-2 text-left text-[13px] outline-none transition-colors duration-100 last:border-b-0 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-brand active:bg-muted',
         active ? 'bg-muted text-foreground' : 'hover:bg-muted/60',
       )}
     >

--- a/packages/core/src/app/routes/presenter.tsx
+++ b/packages/core/src/app/routes/presenter.tsx
@@ -232,6 +232,7 @@ export function Presenter() {
                 aria-hidden
                 className={cn(
                   'pointer-events-none absolute inset-0 grid place-items-center text-[11px] tracking-[0.08em] uppercase',
+                  'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-150',
                   blackout === 'black' ? 'bg-black text-white/35' : 'bg-white text-black/35',
                 )}
               >
@@ -456,7 +457,7 @@ function DeckSwitcher({
                   onClick={() => select(id)}
                   onMouseMove={() => setActiveIndex(i)}
                   className={cn(
-                    'flex w-full items-center gap-3 rounded-[6px] p-2 text-left',
+                    'flex w-full items-center gap-3 rounded-[6px] p-2 text-left outline-none transition-[background-color,scale] duration-100 active:scale-[0.99] focus-visible:ring-1 focus-visible:ring-ring/40',
                     i === active && 'bg-muted',
                   )}
                 >
@@ -478,7 +479,7 @@ function DeckSwitcher({
                     <div className="truncate text-[13px] font-medium text-foreground">
                       {mod?.meta?.title ?? id}
                     </div>
-                    <div className="mt-0.5 truncate font-mono text-[10.5px] text-muted-foreground">
+                    <div className="mt-0.5 truncate font-mono text-[10.5px] tabular-nums text-muted-foreground">
                       {id}
                       {mod && ` · ${mod.default.length.toString().padStart(2, '0')}`}
                     </div>
@@ -647,7 +648,7 @@ function PresenterJumpControl({
         placeholder={(current + 1).toString()}
         className="h-8 w-20 rounded-[5px] border border-border bg-card px-2 font-mono text-[12px] tabular-nums outline-none focus-visible:border-foreground/30"
       />
-      <span className="font-mono text-[11px] text-muted-foreground">/ {total}</span>
+      <span className="font-mono text-[11px] tabular-nums text-muted-foreground">/ {total}</span>
     </form>
   );
 }

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -678,7 +678,7 @@ export function Slide() {
                     )}
                   >
                     {exporting ? (
-                      <Loader2 className="size-4 animate-spin" />
+                      <Loader2 className="size-4 animate-spin motion-reduce:animate-none" />
                     ) : (
                       <Download className="size-4" />
                     )}
@@ -701,7 +701,7 @@ export function Slide() {
                     )}
                   >
                     {exporting ? (
-                      <Loader2 className="size-4 animate-spin" />
+                      <Loader2 className="size-4 animate-spin motion-reduce:animate-none" />
                     ) : (
                       <MoreHorizontal className="size-4" />
                     )}
@@ -1008,7 +1008,7 @@ function ResizableRail(props: {
         <span
           aria-hidden
           className={cn(
-            'pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-brand opacity-0 transition-opacity',
+            'pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-brand opacity-0 transition-opacity duration-150',
             'group-hover/resize:opacity-100 group-focus-visible/resize:opacity-100',
             resizing && 'opacity-100',
           )}
@@ -1028,12 +1028,12 @@ function AgentConnectedBadge() {
           render={
             <button
               type="button"
-              className="ml-1 flex shrink-0 cursor-help items-center gap-1.5 rounded-[3px] border border-hairline bg-card px-1.5 py-0.5 text-[10.5px] text-foreground/85 outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+              className="ml-1 flex shrink-0 cursor-help items-center gap-1.5 rounded-[3px] border border-hairline bg-card px-1.5 py-0.5 text-[10.5px] text-foreground/85 outline-none transition-colors duration-150 hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/30"
             >
               <span aria-hidden className="relative flex size-1.5 items-center justify-center">
                 {connected ? (
                   <>
-                    <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-500 opacity-60" />
+                    <span className="absolute inline-flex size-full rounded-full bg-emerald-500 opacity-60 motion-safe:animate-ping" />
                     <span className="relative inline-flex size-1.5 rounded-full bg-emerald-500" />
                   </>
                 ) : (
@@ -1215,7 +1215,7 @@ function InlineTitleEditor({
         onClick={() => setEditing(true)}
         aria-label={t.slide.renameSlide}
         className={cn(
-          'min-w-0 max-w-full cursor-text rounded-[5px] border border-transparent px-2 py-0.5 transition-colors',
+          'min-w-0 max-w-full cursor-text rounded-[5px] border border-transparent px-2 py-0.5 transition-colors duration-100',
           'hover:border-foreground/30 hover:bg-card focus-visible:border-foreground/30 focus-visible:bg-card focus-visible:outline-none',
         )}
       >

--- a/packages/core/src/app/styles.css
+++ b/packages/core/src/app/styles.css
@@ -58,6 +58,10 @@
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
 
+  /* House motion curve — one strong ease-out for every chrome entrance,
+     instead of per-file cubic-bezier literals. */
+  --ease-swift: cubic-bezier(0.22, 1, 0.36, 1);
+
   --shadow-edge: 0 0 0 0.5px oklch(0 0 0 / 0.06), 0 1px 0 oklch(0 0 0 / 0.025);
   --shadow-floating:
     0 0 0 0.5px oklch(0 0 0 / 0.08), 0 1px 1px oklch(0 0 0 / 0.04),
@@ -68,6 +72,9 @@
 }
 
 :root {
+  /* Runtime copy of the @theme token for inline style/JS consumers. */
+  --ease-swift: cubic-bezier(0.22, 1, 0.36, 1);
+
   /* Pure neutral ramp — zero chroma, flat surfaces, hairline borders.
      Near-white background with white cards floating on a slightly
      recessed canvas. */


### PR DESCRIPTION
## What

A focused UI polish pass across the `@open-slide/core` viewer, guided by Apple's fluid-interface principles and Emil Kowalski's design engineering checklist. 37 source files, all small class-level or micro-interaction changes — no structural rewrites.

- **Shared motion curve**: new `--ease-swift` token (`cubic-bezier(0.22, 1, 0.36, 1)`) in `@theme` + `:root`, replacing per-file cubic-bezier literals and weak built-in easings on chrome entrances (control bar, panels, notes drawer, inspector frame morph, dnd-kit sortable).
- **Press & focus feedback**: `:active` scale, `focus-visible` rings, and named transition properties (instead of `transition-all`) on bar buttons, thumbnails, folder rows, color swatches, cards, and dialog controls.
- **Interruptible enter/exit**: save bar, comment popover, jump badge, blackout overlays (player + presenter), and drag-drop hints now stay mounted and transition opacity/translate/scale instead of keyframe-in / hard-unmount-out. Exits mirror entrances and run slightly faster.
- **Keyboard-frequency actions calmed**: ⌘K palette is opacity-only at 100ms; overview-grid arrow-key scrolling is instant instead of queued smooth scrolls.
- **Tooltips group**: one app-level `TooltipProvider`, so after the first tooltip opens, adjacent ones show instantly.
- **Gestures**: touch swipe commits on velocity (fast flick) as well as distance; laser pointer writes transforms directly in rAF instead of re-rendering per pointermove; crop dialog gets `touch-action: none` and `draggable={false}`.
- **Accessibility**: `motion-safe:`/`motion-reduce:` coverage for pings, spinners, and movement animations; keyboard-reachable update tooltip; hover-only action menus become visible on touch devices.
- **Detail work**: tabular numerals on counters/hex inputs, elapsed-clock drift fix (re-arms against the wall clock), dark-mode boot flash fix (stored theme applied before first paint in `index.html`), comment-cue animation plays once per session instead of on every element selection.

## Why

The viewer already has a strong visual foundation; this pass closes the gap on the "unseen details" — feedback on press, interruptible motion, reduced-motion coverage — that compound into an interface that feels right.

## Reviewer notes

- Deliberately **skipped** as too structural for a polish pass: panel width→transform animation, slide-transition-layer WAAPI retargeting, route cross-fades, save-bar content cross-fades.
- The 15 biome warnings on `main` (pre-existing, `useOptionalChain` in editing/vite files) are untouched; `pnpm check` reports no errors, `pnpm typecheck` passes, all 305 tests pass.
- Changeset included (`patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smoother animations and interaction feedback across the editor, galleries, sidebars, dialogs, and presentation controls.
  * Present mode now supports faster flick-based swiping.
  * Export progress displays a completion checkmark.
  * Tooltips are more consistent throughout the application.
  * Dark mode now applies correctly before the app loads.

* **Accessibility**
  * Added improved keyboard focus states and reduced-motion support across interactive controls.
  * Improved touch interactions for image cropping and drag-and-drop uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->