### PR TITLE
fix(core): make the sidebar language and theme menus open

### DIFF
--- a/.changeset/fix-sidebar-menu-triggers.md
+++ b/.changeset/fix-sidebar-menu-triggers.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Fix the sidebar language and theme dropdowns not opening when clicked.

--- a/packages/core/src/app/components/icon-tooltip.tsx
+++ b/packages/core/src/app/components/icon-tooltip.tsx
@@ -1,10 +1,19 @@
+import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
 import type { ReactNode } from 'react';
 import { Tooltip, TooltipContent } from '@/components/ui/tooltip';
 
 /**
+ * Tooltip trigger for a button that also opens a menu. The `ui/tooltip` wrapper
+ * is a plain function component, so on React 18 it swallows the ref that
+ * `DropdownMenuTrigger` hands to its `render` element and the menu never opens —
+ * the primitive forwards it.
+ */
+export const MenuTooltipTrigger = TooltipPrimitive.Trigger;
+
+/**
  * Shared hover label for the toolbar icon buttons. `children` supplies the
  * `TooltipTrigger`; a button that also opens a menu has to compose it inward
- * (`<DropdownMenuTrigger render={<TooltipTrigger />}>`) — the other nesting
+ * (`<DropdownMenuTrigger render={<MenuTooltipTrigger />}>`) — the other nesting
  * order swallows the trigger ref and the tooltip never opens.
  */
 export function IconTooltip({

--- a/packages/core/src/app/components/language-toggle.tsx
+++ b/packages/core/src/app/components/language-toggle.tsx
@@ -1,5 +1,5 @@
 import { Languages } from 'lucide-react';
-import { IconTooltip } from '@/components/icon-tooltip';
+import { IconTooltip, MenuTooltipTrigger } from '@/components/icon-tooltip';
 import { buttonVariants } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -7,7 +7,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { TooltipTrigger } from '@/components/ui/tooltip';
 import { LOCALE_OPTIONS, setLocale } from '@/lib/locale-store';
 import { useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
@@ -20,7 +19,7 @@ export function LanguageToggle() {
       <IconTooltip label={t.languageToggle.title}>
         <DropdownMenuTrigger
           render={
-            <TooltipTrigger
+            <MenuTooltipTrigger
               type="button"
               aria-label={t.languageToggle.toggleAria}
               className={cn(buttonVariants({ variant: 'ghost', size: 'icon-sm' }))}

--- a/packages/core/src/app/components/theme-toggle.tsx
+++ b/packages/core/src/app/components/theme-toggle.tsx
@@ -1,7 +1,7 @@
 import { Monitor, Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
-import { IconTooltip } from '@/components/icon-tooltip';
+import { IconTooltip, MenuTooltipTrigger } from '@/components/icon-tooltip';
 import { buttonVariants } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -9,7 +9,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { TooltipTrigger } from '@/components/ui/tooltip';
 import { useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 
@@ -27,7 +26,7 @@ export function ThemeToggle() {
       <IconTooltip label={t.themeToggle.title}>
         <DropdownMenuTrigger
           render={
-            <TooltipTrigger
+            <MenuTooltipTrigger
               type="button"
               aria-label={t.themeToggle.toggleAria}
               className={cn(buttonVariants({ variant: 'ghost', size: 'icon-sm' }), 'relative')}


### PR DESCRIPTION
## What

The language and theme dropdowns in the home sidebar did nothing when clicked — the menu never opened. Same for the two buttons in the mobile header, which reuse the components.

## Why

`TooltipTrigger` in `components/ui/tooltip.tsx` is a plain function component (shadcn's Base UI registry targets React 19, where `ref` is a normal prop). This repo runs React 18, so when it is composed inward as `<DropdownMenuTrigger render={<TooltipTrigger />}>`, the ref Base UI's `MenuTrigger` hands to its render element is dropped. The menu never learns about its trigger element, and `aria-expanded` stays `false` on every click.

React was already logging it:

> Function components cannot be given refs… Check the render method of `MenuTrigger`. at TooltipTrigger

## How

`components/ui` is off-limits per `CLAUDE.md`, so the fix lives in app code: `icon-tooltip.tsx` now exports `MenuTooltipTrigger` — Base UI's own `Tooltip.Trigger`, which forwards refs — and `language-toggle.tsx` / `theme-toggle.tsx` use it in the `render` slot.

## Notes for the reviewer

- Verified against a running dev server: both menus open, picking a locale re-renders the UI, picking a theme applies it, and the hover tooltips still work.
- `pnpm typecheck`, `pnpm check`, `pnpm test` (305 tests) all pass. Changeset added (patch).
- Worth knowing: every wrapper under `components/ui` has this same React-19 shape, so any future `render={<SomeUiComponent />}` composition will hit the same wall. Root fix would be adding `forwardRef` across those wrappers (or moving to React 19) — left alone here since that directory is marked hands-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed sidebar language and theme dropdowns so they open reliably when clicked.
  - Improved menu button interactions while preserving tooltip behavior.

- **Documentation**
  - Updated icon tooltip guidance for composing menu triggers and tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->