### PR TITLE
fix(core): check batch edit changed flag before clearing pending edits

### DIFF
--- a/.changeset/fix-batch-edit-noop.md
+++ b/.changeset/fix-batch-edit-noop.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Check batch edit changed flag before clearing pending edits and show a no-op warning when the file did not change.

--- a/.changeset/fix-batch-edit-noop.md
+++ b/.changeset/fix-batch-edit-noop.md
@@ -2,4 +2,4 @@
 '@open-slide/core': patch
 ---
 
-Check batch edit changed flag before clearing pending edits and show a no-op warning when the file did not change.
+Warn when a batch edit does not change the file and keep the edits pending.

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -241,7 +241,7 @@ type InspectorCtx = {
   // close) is what actually writes to disk; `cancelEdits` reverts.
   bufferOps: (line: number, column: number, anchor: HTMLElement, ops: EditOp[]) => void;
   pendingCount: number;
-  commitEdits: () => Promise<void>;
+  commitEdits: () => Promise<boolean>;
   cancelEdits: () => void;
   committing: boolean;
   openCrop: (anchor: HTMLImageElement) => void;
@@ -632,9 +632,9 @@ export function InspectorProvider({
     [applyOpsRaw, snapshotForOps, restoreSnapshot, findAnchor, history, ensureInstanceId],
   );
 
-  const commitEdits = useCallback(async () => {
+  const commitEdits = useCallback(async (): Promise<boolean> => {
     const buckets = pendingRef.current;
-    if (buckets.size === 0) return;
+    if (buckets.size === 0) return false;
     type PendingItem = {
       key: string;
       seq: number;
@@ -725,7 +725,7 @@ export function InspectorProvider({
       pendingRef.current = new Map();
       setPendingCount(0);
       history.clear();
-      return;
+      return false;
     }
     setCommitting(true);
     try {
@@ -742,7 +742,7 @@ export function InspectorProvider({
       }
       if (changed === false && failures.length === 0) {
         toast.error(t.inspector.noOpEdit);
-        return;
+        return false;
       }
       for (let i = 0; i < results.length; i++) {
         const item = pending[i];
@@ -762,10 +762,11 @@ export function InspectorProvider({
         }
       }
       refreshCount();
+      return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       toast.error(`${t.inspector.saveFailed} ${msg}`);
-      throw err;
+      return false;
     } finally {
       setCommitting(false);
       history.clear();

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -730,10 +730,6 @@ export function InspectorProvider({
     setCommitting(true);
     try {
       const { changed, results } = await applyEdits(pending.map((p) => p.edit));
-      if (changed === false) {
-        toast.error(t.inspector.noOpEdit);
-        return;
-      }
       const failures: string[] = [];
       for (let i = 0; i < results.length; i++) {
         const item = pending[i];
@@ -756,7 +752,11 @@ export function InspectorProvider({
         }
       }
       refreshCount();
-      if (failures.length > 0) toast.error(`${t.inspector.saveFailed} ${failures.join('; ')}`);
+      if (failures.length > 0) {
+        toast.error(`${t.inspector.saveFailed} ${failures.join('; ')}`);
+      } else if (changed === false) {
+        toast.error(t.inspector.noOpEdit);
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       toast.error(`${t.inspector.saveFailed} ${msg}`);

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -732,31 +732,35 @@ export function InspectorProvider({
       const { changed, results } = await applyEdits(pending.map((p) => p.edit));
       const failures: string[] = [];
       for (let i = 0; i < results.length; i++) {
-        const item = pending[i];
         const r = results[i];
-        const bucket = pendingRef.current.get(item.key);
-        if (r.ok) {
-          if (bucket) {
-            item.onSuccess(bucket);
-            if (
-              bucket.styleOps.size === 0 &&
-              bucket.rangeStyleOps.size === 0 &&
-              bucket.textOps.size === 0 &&
-              bucket.attrOps.size === 0
-            ) {
-              pendingRef.current.delete(item.key);
-            }
-          }
-        } else {
-          failures.push(`line ${item.edit.line}: ${r.error ?? 'edit failed'}`);
+        if (!r.ok) {
+          failures.push(`line ${pending[i].edit.line}: ${r.error ?? 'edit failed'}`);
         }
       }
-      refreshCount();
       if (failures.length > 0) {
         toast.error(`${t.inspector.saveFailed} ${failures.join('; ')}`);
       } else if (changed === false) {
         toast.error(t.inspector.noOpEdit);
+        return;
       }
+      for (let i = 0; i < results.length; i++) {
+        const item = pending[i];
+        const r = results[i];
+        if (!r.ok) continue;
+        const bucket = pendingRef.current.get(item.key);
+        if (bucket) {
+          item.onSuccess(bucket);
+          if (
+            bucket.styleOps.size === 0 &&
+            bucket.rangeStyleOps.size === 0 &&
+            bucket.textOps.size === 0 &&
+            bucket.attrOps.size === 0
+          ) {
+            pendingRef.current.delete(item.key);
+          }
+        }
+      }
+      refreshCount();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       toast.error(`${t.inspector.saveFailed} ${msg}`);

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -739,7 +739,8 @@ export function InspectorProvider({
       }
       if (failures.length > 0) {
         toast.error(`${t.inspector.saveFailed} ${failures.join('; ')}`);
-      } else if (changed === false) {
+      }
+      if (changed === false && failures.length === 0) {
         toast.error(t.inspector.noOpEdit);
         return;
       }

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -729,7 +729,11 @@ export function InspectorProvider({
     }
     setCommitting(true);
     try {
-      const results = await applyEdits(pending.map((p) => p.edit));
+      const { changed, results } = await applyEdits(pending.map((p) => p.edit));
+      if (changed === false) {
+        toast.error(t.inspector.noOpEdit);
+        return;
+      }
       const failures: string[] = [];
       for (let i = 0; i < results.length; i++) {
         const item = pending[i];

--- a/packages/core/src/app/components/inspector/save-bar.tsx
+++ b/packages/core/src/app/components/inspector/save-bar.tsx
@@ -17,13 +17,18 @@ export function SaveBar() {
   const dirty = total > 0;
   const committing = insp.committing || design.committing;
 
-  const onSave = async () => {
-    const tasks: Promise<void>[] = [];
+  const onSave = async (): Promise<boolean> => {
+    const tasks: Promise<boolean>[] = [];
     if (inspectorCount > 0) tasks.push(Promise.resolve(insp.commitEdits()));
-    if (designCount > 0) tasks.push(Promise.resolve(design.commit()));
-    // Each provider surfaces its own errors via toast; swallow here so
-    // one failure doesn't reject the combined save.
-    await Promise.all(tasks).catch(() => {});
+    if (designCount > 0)
+      tasks.push(
+        design.commit().then(
+          () => true,
+          () => false,
+        ),
+      );
+    const results = await Promise.all(tasks).catch(() => [false]);
+    return results.some(Boolean);
   };
 
   const onDiscard = () => {

--- a/packages/core/src/app/components/panel/save-card.tsx
+++ b/packages/core/src/app/components/panel/save-card.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils';
 type SaveCardProps = {
   dirty: boolean;
   committing: boolean;
-  onSave: () => Promise<void> | void;
+  onSave: () => Promise<boolean> | boolean;
   onDiscard: () => void;
   unsavedLabel: React.ReactNode;
   savedLabel?: string;
@@ -50,8 +50,8 @@ export function SaveCard({
   if (!mounted) return null;
 
   const handleSave = async () => {
-    await onSave();
-    setJustSaved(true);
+    const saved = await onSave();
+    if (saved) setJustSaved(true);
   };
 
   const dataAttrs = uiAttr === 'inspector' ? { 'data-inspector-ui': '' } : { 'data-design-ui': '' };

--- a/packages/core/src/app/lib/inspector/use-editor.ts
+++ b/packages/core/src/app/lib/inspector/use-editor.ts
@@ -18,6 +18,11 @@ export type Edit = { line: number; column: number; ops: EditOp[] };
 
 export type EditResult = { ok: boolean; error?: string };
 
+export type BatchEditResponse = {
+  changed?: boolean;
+  results?: EditResult[];
+};
+
 export class NoOpEditError extends Error {
   constructor() {
     super(
@@ -50,8 +55,8 @@ export function useEditor(slideId: string) {
   // Returns one result per input edit so callers can keep failed
   // edits buffered while clearing the ones that landed.
   const applyEdits = useCallback(
-    async (edits: Edit[]): Promise<EditResult[]> => {
-      if (edits.length === 0) return [];
+    async (edits: Edit[]): Promise<BatchEditResponse> => {
+      if (edits.length === 0) return { changed: false, results: [] };
       const res = await fetch('/__edit/batch', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -59,12 +64,13 @@ export function useEditor(slideId: string) {
       });
       const body = (await res.json().catch(() => ({}))) as {
         error?: string;
+        changed?: boolean;
         results?: EditResult[];
       };
       if (!res.ok) {
         throw new Error(body.error ?? `POST /__edit/batch → ${res.status}`);
       }
-      return body.results ?? [];
+      return { changed: body.changed, results: body.results ?? [] };
     },
     [slideId],
   );

--- a/packages/core/src/app/lib/inspector/use-editor.ts
+++ b/packages/core/src/app/lib/inspector/use-editor.ts
@@ -19,8 +19,8 @@ export type Edit = { line: number; column: number; ops: EditOp[] };
 export type EditResult = { ok: boolean; error?: string };
 
 export type BatchEditResponse = {
-  changed?: boolean;
-  results?: EditResult[];
+  changed: boolean;
+  results: EditResult[];
 };
 
 export class NoOpEditError extends Error {
@@ -70,7 +70,7 @@ export function useEditor(slideId: string) {
       if (!res.ok) {
         throw new Error(body.error ?? `POST /__edit/batch → ${res.status}`);
       }
-      return { changed: body.changed, results: body.results ?? [] };
+      return { changed: body.changed ?? false, results: body.results ?? [] };
     },
     [slideId],
   );

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -259,6 +259,7 @@ export const en: Locale = {
     commentsApplyHintSuffix: ' in your agent to apply these.',
     commentDeleteAria: 'Delete',
     saveFailed: "Couldn't save:",
+    noOpEdit: 'Edit did not change the file — the value may already match.',
   },
 
   stylePanel: {

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -261,6 +261,7 @@ export const ja: Locale = {
     commentsApplyHintSuffix: ' を実行して適用してください。',
     commentDeleteAria: '削除',
     saveFailed: '保存に失敗しました:',
+    noOpEdit: '編集はファイルを変更しませんでした——値がすでに一致している可能性があります。',
   },
 
   stylePanel: {

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -259,6 +259,7 @@ export type Locale = {
     commentDeleteAria: string;
     /** Prefix for the toast shown when one or more buffered edits fail to write to disk. */
     saveFailed: string;
+    noOpEdit: string;
   };
 
   stylePanel: {

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -257,7 +257,7 @@ export const zhCN: Locale = {
     commentsApplyHintSuffix: ' 以应用这些更改。',
     commentDeleteAria: '删除',
     saveFailed: '保存失败：',
-    noOpEdit: '编辑未改变文件——数值可能已经匹配。',
+    noOpEdit: '编辑未改变文件——值可能已经匹配。',
   },
 
   stylePanel: {

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -257,6 +257,7 @@ export const zhCN: Locale = {
     commentsApplyHintSuffix: ' 以应用这些更改。',
     commentDeleteAria: '删除',
     saveFailed: '保存失败：',
+    noOpEdit: '编辑未改变文件——数值可能已经匹配。',
   },
 
   stylePanel: {

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -257,7 +257,7 @@ export const zhTW: Locale = {
     commentsApplyHintSuffix: ' 以套用這些變更。',
     commentDeleteAria: '刪除',
     saveFailed: '儲存失敗：',
-    noOpEdit: '編輯未改變檔案——數值可能已經相符。',
+    noOpEdit: '編輯未改變檔案——值可能已經相符。',
   },
 
   stylePanel: {

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -257,6 +257,7 @@ export const zhTW: Locale = {
     commentsApplyHintSuffix: ' 以套用這些變更。',
     commentDeleteAria: '刪除',
     saveFailed: '儲存失敗：',
+    noOpEdit: '編輯未改變檔案——數值可能已經相符。',
   },
 
   stylePanel: {


### PR DESCRIPTION
 ## Description:
      Fixes #408
    
  ## Problem
      The batch edit route /__edit/batch reports success even when the
      file did not change. commitEdits() only checks per-edit ok flags
      but ignores the batch-level changed field. This causes the Save
      bar to show success for no-op edits, and users can lose data after
      a page refresh without any warning.
    
      The single-edit route /__edit already handles this case by throwing
      NoOpEditError when body.changed === false.
    
   ## Fix
      - Update applyEdits() in use-editor.ts to return the batch-level
        changed flag alongside the per-edit results
      - Update commitEdits() in inspector-provider.tsx to check the
        changed flag and show a no-op warning instead of clearing pending
        edits
      - Add noOpEdit translation key to all locale files (en, zh-tw,
        zh-cn, ja)
    
   ## Files changed
      - packages/core/src/app/lib/inspector/use-editor.ts
      - packages/core/src/app/components/inspector/inspector-provider.tsx
      - packages/core/src/locale/en.ts
      - packages/core/src/locale/types.ts
      - packages/core/src/locale/zh-tw.ts
      - packages/core/src/locale/zh-cn.ts
      - packages/core/src/locale/ja.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inspector edits now clearly distinguish successful changes, failed edits, and requests that leave files unchanged.
  * Failed edit notifications are prioritized, while failed and unchanged edits remain pending for review.
  * Save confirmations now appear only when changes are successfully saved.
  * Added a notification when requested values already match the file.

* **Localization**
  * Added no-change edit messages in English, Japanese, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->