### PR TITLE
docs(skills): route speech-script requests to the built-in notes export

### DIFF
--- a/.changeset/skill-speaker-notes.md
+++ b/.changeset/skill-speaker-notes.md
@@ -1,0 +1,6 @@
+---
+"@open-slide/core": patch
+"@open-slide/cli": patch
+---
+
+Teach the authoring skills and agent guide to write speech scripts into the built-in `notes` export instead of separate markdown files.

--- a/packages/cli/template/AGENTS.md
+++ b/packages/cli/template/AGENTS.md
@@ -16,6 +16,7 @@ You are authoring **slides** in this repo. Every slide is arbitrary React code t
 - **Applying inspector comments** (`@slide-comment` markers in a page) — use the `apply-comments` skill.
 - **Creating or extracting a theme** — use the `create-theme` skill. Themes live as markdown under `themes/<id>.md` and are read by `create-slide` before authoring.
 - **Resolving "this page" / "this element"** — when the user references the current slide or selection without naming it, consult the `current-slide` skill. It reads the dev server's `node_modules/.open-slide/current.json` to find which slide, page, and inspector-picked element they mean.
+- **Writing a speech script / speaker notes** — use the framework's built-in feature: the `notes` export in the slide's `index.tsx`, index-aligned with the page array and shown in the presenter view. See the **Speaker notes** section of the `slide-authoring` skill. Never deliver a script as a markdown or text file.
 - **Any other slide edit** — read the `slide-authoring` skill before writing. It is the technical reference for everything inside `slides/<id>/`: file contract, the 1920×1080 canvas, type scale, palette, layout, assets, self-review checklist, and anti-patterns. `create-slide` and `apply-comments` both defer to it for the *how*.
 
 Keep this file short: hard rules only. All deeper guidance lives in the skills above.

--- a/packages/core/skills/create-slide/SKILL.md
+++ b/packages/core/skills/create-slide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-slide
-description: Use this skill when the user wants to create, draft, author, or generate new slides / a presentation in this open-slide repo. Triggers on phrases like "make slides about X", "make a deck about X", "create a presentation", "draft slides for", "new slide", or when the user asks to add content under `slides/`. Do NOT use for editing the framework itself — only for authoring content inside `slides/<id>/`.
+description: Use this skill when the user wants to create, draft, author, or generate new slides / a presentation in this open-slide repo. Triggers on phrases like "make slides about X", "make a deck about X", "create a presentation", "draft slides for", "new slide", "a deck with speaker notes / a script", or when the user asks to add content under `slides/`. Do NOT use for editing the framework itself — only for authoring content inside `slides/<id>/`.
 ---
 
 # Create a slide in open-slide
@@ -76,6 +76,8 @@ If the `frontend-design` skill is available, consult it for deeper aesthetic gui
 
 Read the **`slide-authoring`** skill before writing — it covers the file contract, canvas rules, type scale, spacing, and asset imports, and it includes a starter template you can copy. Don't duplicate that knowledge here; use it.
 
+If the user asked for a speech script / speaker notes (in the initial request or at any point after), write it into the slide's `export const notes` array — the framework's built-in speaker-notes feature, shown in the presenter view. See **Speaker notes** in `slide-authoring` for the contract. Never deliver a script as a markdown or text file.
+
 ## Step 7 — Self-review
 
 Run the checklist in `slide-authoring` ("Self-review before finishing"). It covers structural correctness, layout discipline, and asset existence.
@@ -86,6 +88,7 @@ Tell the user:
 
 - The slide id and file path you created.
 - That the dev server will hot-reload — they can open `http://localhost:5173/s/<id>` (or refresh the home page).
+- If you wrote speaker notes: that they live in the slide's `notes` export and show up in the viewer's notes drawer and the presenter view in present mode.
 - If dev isn't running: run the project's `dev` script from the project root with its package manager (`npm run dev`, `pnpm dev`, … — match the lockfile).
 
 Don't run the dev server yourself unless asked.

--- a/packages/core/skills/slide-authoring/SKILL.md
+++ b/packages/core/skills/slide-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slide-authoring
-description: Technical reference for writing or editing open-slide pages — file contract, 1920×1080 canvas, type scale, layout, palette/visual direction, assets, stepped reveals, page transitions, and morph transitions. Consult this whenever you are about to write or modify any file under `slides/<id>/`, including from inside the `create-slide` or `apply-comments` workflows, or for any ad-hoc slide edit. Triggers on phrases like "edit slide", "tweak this page", "fix the layout", "change the palette", "reveal one by one", "add a transition", "morph transition", "investigate the slide framework", "how do slides work here".
+description: Technical reference for writing or editing open-slide pages — file contract, 1920×1080 canvas, type scale, layout, palette/visual direction, assets, speaker notes, stepped reveals, page transitions, and morph transitions. Consult this whenever you are about to write or modify any file under `slides/<id>/`, including from inside the `create-slide` or `apply-comments` workflows, or for any ad-hoc slide edit. Triggers on phrases like "edit slide", "tweak this page", "fix the layout", "change the palette", "reveal one by one", "add a transition", "morph transition", "write the speaker notes", "generate the script / talk track", "investigate the slide framework", "how do slides work here".
 ---
 
 # Authoring open-slide pages
@@ -34,7 +34,7 @@ Each framework primitive has a full reference file under `references/` in this s
 - Entry is `slides/<id>/index.tsx`. Images/videos/fonts go under `slides/<id>/assets/`.
 - Do **not** touch `package.json`, `open-slide.config.ts`, or other slides.
 - Do not add dependencies. Only `react`, `@open-slide/core`, and standard web APIs are available.
-- A slide is **one `index.tsx` plus `assets/`** — nothing else. Do not create sibling `.tsx`/`.ts` files (`Card.tsx`, `components/`, `helpers.ts`, etc.); helper components and constants go inside `index.tsx`. Do not create `README.md` or other prose files either.
+- A slide is **one `index.tsx` plus `assets/`** — nothing else. Do not create sibling `.tsx`/`.ts` files (`Card.tsx`, `components/`, `helpers.ts`, etc.); helper components and constants go inside `index.tsx`. Do not create `README.md` or other prose files either — speaker notes / a talk script belong in the `notes` export (see **Speaker notes** below), not in a markdown file.
 
 ## File contract
 
@@ -57,6 +57,27 @@ export default [Cover, Body] satisfies Page[];
 - The slide id is the kebab-case folder name. Pick something short and descriptive (`q2-roadmap`, `team-offsite-2026`).
 - `meta.theme` (optional) marks the slide as built from a theme under `themes/`. The id must match a `<id>.md` basename. Surfaces a back-link chip on the slide card and lists the slide on `/themes/<id>`. Omit if the slide isn't derived from a registered theme.
 - `meta.createdAt` is an **ISO 8601 string literal** (e.g. `'2026-05-16T12:00:00Z'`) set once when the slide is scaffolded. The home page uses it for the default "newest first" sort. Always include it on new slides — **immediately before writing the file, run `node -e "console.log(new Date().toISOString())"` via Bash and paste the exact output** as the value. Don't type a timestamp from memory — you will get the date or time wrong. Must be a plain string literal (no `new Date(...)` or imports in the slide itself) — the framework reads it via a regex at build time, not by evaluating the module.
+
+## Speaker notes (`notes` export)
+
+The framework has **built-in speaker notes**: an optional `notes` export in `index.tsx`, index-aligned with the default page array. The viewer shows them in the notes drawer and present mode shows them in the presenter view next to the timer.
+
+**When the user asks for a speech script, talk track, or presenter notes — in any language — write it into this export, never into a markdown/text file.** A `script.md` or `notes.md` is invisible to the runtime; the `notes` export is the only place the presenter view reads.
+
+```tsx
+export const notes: (string | undefined)[] = [
+  'Open with the analyst quote, then introduce yourself.',
+  undefined,
+  `Walk through the three pillars, one beat each.
+Pause for questions before moving on.`,
+];
+```
+
+- One entry per page, same order as the `export default` array. `notes[0]` belongs to the first page.
+- Entries are **plain text** — line breaks are preserved, markdown is not rendered. Use a template literal for multi-line notes, a normal string for one-liners.
+- Use `undefined` for a page with no notes; trailing `undefined` entries can be dropped.
+- When you add, remove, or reorder pages, re-align `notes` in the same edit — a shifted index silently attaches the wrong script to every page after it.
+- Write notes as something to *say*, not a summary of what's on screen: openers, transitions, numbers to cite, timing cues.
 
 ## Editing an existing slide
 
@@ -331,6 +352,7 @@ This applies whenever the *visual element* repeats, not whenever the *data* does
 - [ ] If a page uses `<Steps>`/`<Step>`, every `<Step>` is a direct child of a `<Steps>`, and the page still reads as complete when jumped to via the overview grid (entering forward builds up; jumping in shows it fully revealed).
 - [ ] If a `SlideTransition` is declared, every page sits in one family — same duration band (140–280 ms), same easing pair, same out-then-in stagger, magnitude under 12 px / 3%. No six-different-vocabularies decks. When in doubt, omit transitions entirely. (Pages that opt into `morph` may exceed the band to match the morph — see `references/morph.md`.)
 - [ ] If a transition opts into `morph`: every morph `id` is unique per page and stable across the pair, morph geometry is pixel-constant (never measured after mount), no `transform` sits on the morph node, and entrance animations are gated behind `useIsActivePage()`.
+- [ ] If the user asked for a speech script / speaker notes, it lives in `export const notes` (index-aligned with the page array) — not in a markdown or text file.
 - [ ] Nothing outside `slides/<id>/` was edited.
 
 ## Anti-patterns
@@ -346,5 +368,6 @@ This applies whenever the *visual element* repeats, not whenever the *data* does
 - ❌ Installing packages. Only `react`, `@open-slide/core`, and standard web APIs are available.
 - ❌ Writing CSS to a shared file. Inline styles or scoped classnames only.
 - ❌ Creating `README.md` or other prose files inside the slide folder.
+- ❌ Delivering a speech script as a markdown or text file. The runtime only surfaces the `notes` export — anything else never reaches the presenter view.
 - ❌ Editing `package.json`, `open-slide.config.ts`, or other slides.
 - ❌ Using a primitive without reading its reference file — each `references/*.md` carries the primitive's own anti-pattern list (placeholder misuse, transition vocabulary, `<Step>` nesting, morph geometry).


### PR DESCRIPTION
## Problem

When a user asks an agent to generate a speech script / speaker notes for a deck, the agent writes a standalone markdown file instead of using the framework's built-in speaker-notes feature (the `notes` export, surfaced in the notes drawer and the presenter view). The root cause is that none of the authoring skills or the agent guide ever mention the `notes` export, so agents have no way to discover it.

## Changes

- **`slide-authoring` skill** — new "Speaker notes (`notes` export)" section documenting the contract: one entry per page index-aligned with the default page array, plain text with preserved line breaks, `undefined` for pages without notes, and re-alignment when pages are added/removed/reordered. Adds trigger phrases ("write the speaker notes", "generate the script / talk track") to the skill description, plus matching entries in the hard rules, self-review checklist, and anti-patterns list stating that a script must go into the `notes` export, never into a markdown/text file.
- **`create-slide` skill** — Step 6 now instructs writing a requested script into `export const notes` (deferring to `slide-authoring` for the contract), and the Step 8 hand-off mentions where the notes appear. The skill description gains a matching trigger phrase.
- **CLI template `AGENTS.md`** — adds a routing entry under "Which skill to use" so scaffolded projects direct speech-script requests to the built-in feature even when no skill triggers.
- Adds a patch changeset for `@open-slide/core` and `@open-slide/cli`.

## Notes

- `packages/core/skills/` is the canonical source; the demo app's `.claude/skills/` entries are symlinks, so they pick up the change automatically. Scaffolded projects receive it via `pnpm sync:skills` after upgrading.
- `pnpm check` passes (the 5 remaining Biome warnings pre-date this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmEEsh7qndk5QQEDAaevX8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating speaker notes and scripts directly within slide presentations.
  * Clarified that notes appear in the viewer’s notes drawer and presenter view.
  * Documented note formatting, slide alignment, plain-text behavior, and authoring best practices.
  * Added checks to discourage separate Markdown or text files for speaker scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->