### PR TITLE
fix(core): keep tagged Agenda row text selectable in the inspector

### DIFF
--- a/.changeset/agenda-inspector-pick.md
+++ b/.changeset/agenda-inspector-pick.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Keep loc-tagged inline text selectable when it sits inside an Agenda-style list wrapper.

--- a/packages/core/e2e/fixture/components/agenda.tsx
+++ b/packages/core/e2e/fixture/components/agenda.tsx
@@ -1,0 +1,11 @@
+import { Children, isValidElement, type ReactNode } from 'react';
+
+export function Agenda({ children }: { children: ReactNode }) {
+  return (
+    <ul>
+      {Children.toArray(children).map((child) => (
+        <li key={isValidElement(child) ? child.key : undefined}>{child}</li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/core/e2e/fixture/slides/agenda-select/index.tsx
+++ b/packages/core/e2e/fixture/slides/agenda-select/index.tsx
@@ -1,0 +1,16 @@
+import type { Page, SlideMeta } from '@open-slide/core';
+import { Agenda } from '../../components/agenda';
+
+export const meta: SlideMeta = {
+  title: 'Agenda Select',
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const Only: Page = () => (
+  <Agenda>
+    <span>What changed?</span>
+    <span>What did it expose?</span>
+  </Agenda>
+);
+
+export default [Only] satisfies Page[];

--- a/packages/core/e2e/fixture/tsconfig.json
+++ b/packages/core/e2e/fixture/tsconfig.json
@@ -13,5 +13,5 @@
     "skipLibCheck": true,
     "types": ["@open-slide/core/env"]
   },
-  "include": ["slides/**/*", "open-slide.config.ts"]
+  "include": ["slides/**/*", "components/**/*", "open-slide.config.ts"]
 }

--- a/packages/core/e2e/tests/home.spec.ts
+++ b/packages/core/e2e/tests/home.spec.ts
@@ -3,11 +3,12 @@ import { expect, test } from '@playwright/test';
 test.describe('home slide browser', () => {
   test('lists every fixture deck with its display title', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('li h3')).toHaveCount(4);
+    await expect(page.locator('li h3')).toHaveCount(5);
     await expect(page.getByText('Alpha Deck')).toBeVisible();
     await expect(page.getByText('Steps Deck')).toBeVisible();
     await expect(page.getByText('Edit Target')).toBeVisible();
     await expect(page.getByText('Hot Deck')).toBeVisible();
+    await expect(page.getByText('Agenda Select')).toBeVisible();
   });
 
   test('slide card links to the viewer', async ({ page }) => {
@@ -29,7 +30,7 @@ test.describe('home slide browser', () => {
     await search.fill('zzz-no-match');
     await expect(page.getByText('No matches')).toBeVisible();
     await page.getByRole('button', { name: 'Clear search' }).first().click();
-    await expect(page.locator('li h3')).toHaveCount(4);
+    await expect(page.locator('li h3')).toHaveCount(5);
   });
 
   test('sort control reorders decks by created date', async ({ page }) => {

--- a/packages/core/e2e/tests/inspector.spec.ts
+++ b/packages/core/e2e/tests/inspector.spec.ts
@@ -140,4 +140,15 @@ test.describe('inspector editing', () => {
     await editorCanvas(page).getByText('Editable headline').click();
     await expect(page.locator('aside[data-inspector-ui]')).toBeVisible();
   });
+
+  test('selecting text inside an Agenda wrapper opens the panel', async ({ page }) => {
+    await openSlide(page, 'agenda-select');
+    await page.getByTitle('Inspect').click();
+    await editorCanvas(page).getByText('What changed?').click();
+
+    const panel = page.locator('aside[data-inspector-ui]');
+    await expect(panel).toBeVisible();
+    await expect(panel.getByText('<span>')).toBeVisible();
+    await expect(panel.getByPlaceholder('Element text')).toHaveValue('What changed?');
+  });
 });

--- a/packages/core/e2e/tests/viewer.spec.ts
+++ b/packages/core/e2e/tests/viewer.spec.ts
@@ -86,7 +86,7 @@ test.describe('slide viewer', () => {
   test('back link returns to the home browser', async ({ page }) => {
     await openSlide(page, 'alpha');
     await page.getByRole('link', { name: 'Back to home' }).click();
-    await expect(page.locator('li h3')).toHaveCount(4);
+    await expect(page.locator('li h3')).toHaveCount(5);
   });
 
   test('steps render fully revealed in the editor', async ({ page }) => {

--- a/packages/core/src/app/components/inspector/inspect-overlay.tsx
+++ b/packages/core/src/app/components/inspector/inspect-overlay.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react
 import { PANEL_TRANSITION_MS } from '@/components/panel/panel-shell';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { findSlideSource, type SlideSourceHit } from '@/lib/inspector/fiber';
-import { hasOnlyInlineTextChildren, INLINE_TEXT_TAGS } from '@/lib/inspector/inline-text';
+import { pickInspectorTarget } from '@/lib/inspector/pick-target';
 import { useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 import { useInspector } from './inspector-provider';
@@ -331,20 +331,4 @@ function pickElement(x: number, y: number): HTMLElement | null {
     return el;
   }
   return null;
-}
-
-function pickInspectorTarget(el: HTMLElement | null): HTMLElement | null {
-  if (!el) return null;
-  const root = el.closest('[data-inspector-root]');
-  const startedOnInlineText = INLINE_TEXT_TAGS.has(el.tagName);
-  for (let cur: HTMLElement | null = el; cur && root?.contains(cur); cur = cur.parentElement) {
-    if (startedOnInlineText && INLINE_TEXT_TAGS.has(cur.tagName)) continue;
-    if (isEditableTextContainer(cur)) return cur;
-  }
-  return el;
-}
-
-function isEditableTextContainer(el: HTMLElement): boolean {
-  if (!el.textContent?.trim()) return false;
-  return hasOnlyInlineTextChildren(el);
 }

--- a/packages/core/src/app/lib/inspector/pick-target.test.ts
+++ b/packages/core/src/app/lib/inspector/pick-target.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { isTaggedInlineText, pickInspectorTarget } from './pick-target.ts';
+
+class FakeEl {
+  tagName: string;
+  dataset: { slideLoc?: string };
+  parentElement: FakeEl | null = null;
+  childNodes: Array<FakeEl | { nodeType: number }> = [];
+  textContent: string;
+  private inspectorRoot: boolean;
+
+  constructor(opts: {
+    tagName: string;
+    slideLoc?: string;
+    text?: string;
+    inspectorRoot?: boolean;
+    children?: Array<FakeEl | { nodeType: number; text?: string }>;
+  }) {
+    this.tagName = opts.tagName;
+    this.dataset = opts.slideLoc ? { slideLoc: opts.slideLoc } : {};
+    this.inspectorRoot = opts.inspectorRoot ?? false;
+    this.textContent = opts.text ?? '';
+    if (opts.children) {
+      this.childNodes = opts.children.map((child) => {
+        if (child instanceof FakeEl) {
+          child.parentElement = this;
+          return child;
+        }
+        return { nodeType: child.nodeType };
+      });
+      if (!opts.text) {
+        this.textContent = opts.children
+          .map((child) => (child instanceof FakeEl ? child.textContent : (child.text ?? '')))
+          .join('');
+      }
+    }
+  }
+
+  closest(selector: string): FakeEl | null {
+    if (selector !== '[data-inspector-root]') return null;
+    for (let cur: FakeEl | null = this; cur; cur = cur.parentElement) {
+      if (cur.inspectorRoot) return cur;
+    }
+    return null;
+  }
+
+  contains(other: FakeEl | null): boolean {
+    for (let cur: FakeEl | null = other; cur; cur = cur.parentElement) {
+      if (cur === this) return true;
+    }
+    return false;
+  }
+}
+
+function textNode(text: string): { nodeType: number; text: string } {
+  return { nodeType: 3, text };
+}
+
+function asEl(el: FakeEl): HTMLElement {
+  return el as unknown as HTMLElement;
+}
+
+beforeAll(() => {
+  vi.stubGlobal('HTMLElement', FakeEl);
+  vi.stubGlobal('Node', { TEXT_NODE: 3 });
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('isTaggedInlineText', () => {
+  it('keeps a loc-tagged span as the inspector target', () => {
+    expect(isTaggedInlineText(asEl(new FakeEl({ tagName: 'SPAN', slideLoc: '12:4' })))).toBe(true);
+  });
+
+  it('does not treat an untagged span as a keep', () => {
+    expect(isTaggedInlineText(asEl(new FakeEl({ tagName: 'SPAN' })))).toBe(false);
+  });
+
+  it('does not treat a tagged block host as inline', () => {
+    expect(isTaggedInlineText(asEl(new FakeEl({ tagName: 'LI', slideLoc: '8:2' })))).toBe(false);
+    expect(isTaggedInlineText(asEl(new FakeEl({ tagName: 'DIV', slideLoc: '8:2' })))).toBe(false);
+  });
+});
+
+describe('pickInspectorTarget', () => {
+  it('keeps a loc-tagged span inside an untagged list wrapper', () => {
+    const span = new FakeEl({
+      tagName: 'SPAN',
+      slideLoc: '11:6',
+      children: [textNode('What changed?')],
+    });
+    const li = new FakeEl({ tagName: 'LI', children: [span] });
+    const ul = new FakeEl({ tagName: 'UL', children: [li] });
+    new FakeEl({ tagName: 'MAIN', inspectorRoot: true, children: [ul] });
+
+    expect(pickInspectorTarget(asEl(span))).toBe(span);
+  });
+
+  it('still climbs an untagged inline up to its text container', () => {
+    const span = new FakeEl({
+      tagName: 'SPAN',
+      children: [textNode('Editable body copy')],
+    });
+    const p = new FakeEl({ tagName: 'P', slideLoc: '8:4', children: [span] });
+    new FakeEl({ tagName: 'MAIN', inspectorRoot: true, children: [p] });
+
+    expect(pickInspectorTarget(asEl(span))).toBe(p);
+  });
+
+  it('does not promote a tagged inline to a tagged wrapper host', () => {
+    const span = new FakeEl({
+      tagName: 'SPAN',
+      slideLoc: '9:8',
+      children: [textNode('nested')],
+    });
+    const host = new FakeEl({ tagName: 'DIV', slideLoc: '4:2', children: [span] });
+    new FakeEl({ tagName: 'MAIN', inspectorRoot: true, children: [host] });
+
+    expect(pickInspectorTarget(asEl(span))).toBe(span);
+  });
+});

--- a/packages/core/src/app/lib/inspector/pick-target.ts
+++ b/packages/core/src/app/lib/inspector/pick-target.ts
@@ -1,0 +1,29 @@
+import { hasOnlyInlineTextChildren, INLINE_TEXT_TAGS } from './inline-text';
+
+export function isTaggedInlineText(el: HTMLElement): boolean {
+  return INLINE_TEXT_TAGS.has(el.tagName) && Boolean(el.dataset.slideLoc);
+}
+
+export function pickInspectorTarget(el: HTMLElement | null): HTMLElement | null {
+  if (!el) return null;
+  const root = el.closest('[data-inspector-root]');
+  const startedOnInlineText = INLINE_TEXT_TAGS.has(el.tagName);
+  for (let cur: HTMLElement | null = el; cur && root?.contains(cur); cur = cur.parentElement) {
+    if (startedOnInlineText && INLINE_TEXT_TAGS.has(cur.tagName)) {
+      // Loc-tagged inlines are the author's source, not a text run to climb
+      // past. Agenda-style wrappers (`<li>` around a tagged `<span>`) look
+      // like editable containers, and promoting to them drops the loc before
+      // findSlideSource runs. Shared-component hosts are not inline tags, so
+      // this does not revive the tagged-wrapper steal.
+      if (isTaggedInlineText(cur)) return cur;
+      continue;
+    }
+    if (isEditableTextContainer(cur)) return cur;
+  }
+  return el;
+}
+
+function isEditableTextContainer(el: HTMLElement): boolean {
+  if (!el.textContent?.trim()) return false;
+  return hasOnlyInlineTextChildren(el);
+}


### PR DESCRIPTION
## Summary

Fixes #412.

Inspect mode climbs inline text to the nearest editable container. Agenda (and similar list wrappers) put a loc-tagged `<span>` inside an untagged `<li>`. The climb lands on the `<li>`, and `findSlideSource(..., { hostOnly: true })` then has no slide loc to read, so the panel never opens.

This keeps a loc-tagged inline as the pick target instead of promoting it. Untagged inlines still climb to their paragraph. Tagged wrapper hosts are not inline tags, so this does not undo the shared-component case from #327.

`pickInspectorTarget` now lives in `pick-target.ts` so the unit tests can cover the climb without the overlay.

## Evidence

Unit tests on a fake DOM (node environment, no happy-dom):

```
pnpm exec vitest run packages/core/src/app/lib/inspector/pick-target.test.ts
Test Files  1 passed (1)
Tests  6 passed (6)
```

Reverting the tagged-inline keep makes `keeps a loc-tagged span inside an untagged list wrapper` fail.

Biome 2.5.7 check on the touched files is clean.

## What was not tested

Playwright e2e (`agenda-select` fixture, assert `<span>` + Element text `What changed?`) is in the PR and will run in CI. I did not run it locally: this box is under load and the worktree has no real `pnpm install` (only a temporary junction for vitest).

I also did not click through a live demo deck with the real Agenda primitive.

## AI assistance

This change was prepared with AI assistance (Cursor/Grok). I reviewed the diff, ran the unit tests above, and kept the pick change scoped to tagged inlines.

## Test plan

- [x] Unit: tagged span in untagged `<li>` stays the span
- [x] Unit: untagged span still climbs to `<p>`
- [x] Unit: tagged span is not promoted to a tagged wrapper host
- [ ] CI: Playwright inspector test on `agenda-select`
- [ ] Maintainer: Inspect click on Agenda row text in a real deck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inspector selection for inline text nested within Agenda-style lists.
  - Tagged inline text remains selectable and is correctly identified in the inspector.
  - Inspector details now display the selected element and its text more reliably.

- **Tests**
  - Added coverage for inline-text selection and inspector behavior.
  - Added an Agenda Select example to validate the experience across supported views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->