### PR TITLE
fix(core): warn when batch edit does not change the file

### DIFF
--- a/.changeset/batch-edit-noop.md
+++ b/.changeset/batch-edit-noop.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': patch
+---
+
+Warn and keep pending edits when a batch save does not change the slide file.

--- a/packages/core/e2e/tests/inspector.spec.ts
+++ b/packages/core/e2e/tests/inspector.spec.ts
@@ -57,6 +57,39 @@ test.describe('inspector editing', () => {
     await expect.poll(() => readSlideSource('insp-save')).toContain('Edited via inspector');
   });
 
+  test('a no-op batch save keeps pending edits and does not show success', async ({
+    page,
+    request,
+  }) => {
+    await openEditable(page, request, 'insp-noop');
+    await page.getByTitle('Inspect').click();
+    await editorCanvas(page).getByText('Editable headline').click();
+
+    const textField = page.locator('aside[data-inspector-ui]').getByPlaceholder('Element text');
+    await textField.fill('No-op target');
+    const firstSave = page.waitForResponse(
+      (res) => res.url().includes('/__edit/batch') && res.request().method() === 'POST',
+    );
+    await page.getByRole('button', { name: 'Save' }).click();
+    expect((await firstSave).status()).toBe(200);
+    await expect.poll(() => readSlideSource('insp-noop')).toContain('No-op target');
+
+    await editorCanvas(page).getByText('No-op target').click();
+    await textField.fill('No-op target');
+    await expect(page.getByText('1 unsaved change')).toBeVisible();
+
+    const noopSave = page.waitForResponse(
+      (res) => res.url().includes('/__edit/batch') && res.request().method() === 'POST',
+    );
+    await page.getByRole('button', { name: 'Save' }).click();
+    const body = (await (await noopSave).json()) as { changed?: boolean };
+    expect(body.changed).toBe(false);
+
+    await expect(page.getByText('1 unsaved change')).toBeVisible();
+    await expect(page.getByText('Saved', { exact: true })).toHaveCount(0);
+    await expect(page.getByText(/source file did not change/i)).toBeVisible();
+  });
+
   test('discard reverts the edit without touching the file', async ({ page, request }) => {
     await openEditable(page, request, 'insp-discard');
     await page.getByTitle('Inspect').click();

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -13,7 +13,7 @@ import { toast } from 'sonner';
 import { useHistory } from '@/components/history-provider';
 import { Button } from '@/components/ui/button';
 import { type SlideComment, useComments } from '@/lib/inspector/use-comments';
-import { type Edit, type EditOp, useEditor } from '@/lib/inspector/use-editor';
+import { type Edit, type EditOp, NoOpEditError, useEditor } from '@/lib/inspector/use-editor';
 import { isTypingTarget } from '@/lib/keys';
 import { textDiff } from '@/lib/text-diff';
 import { useLocale } from '@/lib/use-locale';
@@ -748,7 +748,12 @@ export function InspectorProvider({
     }
     setCommitting(true);
     try {
-      const results = await applyEdits(pending.map((p) => p.edit));
+      const { results, changed } = await applyEdits(pending.map((p) => p.edit));
+      // Batch route reports per-edit ok even when the file write was
+      // skipped — match the single-edit NoOp path and keep pending.
+      if (!changed) {
+        throw new NoOpEditError();
+      }
       const failures: string[] = [];
       for (let i = 0; i < results.length; i++) {
         const item = pending[i];
@@ -771,6 +776,7 @@ export function InspectorProvider({
         }
       }
       refreshCount();
+      history.clear();
       if (failures.length > 0) toast.error(`${t.inspector.saveFailed} ${failures.join('; ')}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -778,7 +784,6 @@ export function InspectorProvider({
       throw err;
     } finally {
       setCommitting(false);
-      history.clear();
     }
   }, [applyEdits, history, refreshCount, t]);
 

--- a/packages/core/src/app/components/inspector/save-bar.tsx
+++ b/packages/core/src/app/components/inspector/save-bar.tsx
@@ -21,9 +21,12 @@ export function SaveBar() {
     const tasks: Promise<void>[] = [];
     if (inspectorCount > 0) tasks.push(Promise.resolve(insp.commitEdits()));
     if (designCount > 0) tasks.push(Promise.resolve(design.commit()));
-    // Each provider surfaces its own errors via toast; swallow here so
-    // one failure doesn't reject the combined save.
-    await Promise.all(tasks).catch(() => {});
+    // Providers toast their own errors; still reject if any failed so
+    // the Save bar does not flash success for a no-op or failed write.
+    const settled = await Promise.allSettled(tasks);
+    if (settled.some((r) => r.status === 'rejected')) {
+      throw new Error('save failed');
+    }
   };
 
   const onDiscard = () => {

--- a/packages/core/src/app/components/panel/save-card.tsx
+++ b/packages/core/src/app/components/panel/save-card.tsx
@@ -50,8 +50,12 @@ export function SaveCard({
   if (!mounted) return null;
 
   const handleSave = async () => {
-    await onSave();
-    setJustSaved(true);
+    try {
+      await onSave();
+      setJustSaved(true);
+    } catch {
+      // Caller already toasted; keep dirty UI instead of a false success.
+    }
   };
 
   const dataAttrs = uiAttr === 'inspector' ? { 'data-inspector-ui': '' } : { 'data-design-ui': '' };

--- a/packages/core/src/app/lib/inspector/use-editor.ts
+++ b/packages/core/src/app/lib/inspector/use-editor.ts
@@ -48,10 +48,11 @@ export function useEditor(slideId: string) {
 
   // Batch many element edits into one file write and one HMR tick.
   // Returns one result per input edit so callers can keep failed
-  // edits buffered while clearing the ones that landed.
+  // edits buffered while clearing the ones that landed, plus whether
+  // the source file actually changed (server may skip the write).
   const applyEdits = useCallback(
-    async (edits: Edit[]): Promise<EditResult[]> => {
-      if (edits.length === 0) return [];
+    async (edits: Edit[]): Promise<{ results: EditResult[]; changed: boolean }> => {
+      if (edits.length === 0) return { results: [], changed: false };
       const res = await fetch('/__edit/batch', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -59,12 +60,16 @@ export function useEditor(slideId: string) {
       });
       const body = (await res.json().catch(() => ({}))) as {
         error?: string;
+        changed?: boolean;
         results?: EditResult[];
       };
       if (!res.ok) {
         throw new Error(body.error ?? `POST /__edit/batch → ${res.status}`);
       }
-      return body.results ?? [];
+      return {
+        results: body.results ?? [],
+        changed: body.changed !== false,
+      };
     },
     [slideId],
   );


### PR DESCRIPTION
## Summary
- Treat `/__edit/batch` responses with `changed: false` like the single-edit `NoOpEditError` path: keep pending edits and toast a warning instead of clearing the buffer.
- Stop the Save bar from flashing success when a save rejects (no-op or failed write).
- Add an inspector e2e covering the no-op batch save path.

Fixes #408

## Test plan
- [ ] Open Inspector, change a style (e.g. font size), Save — file updates and Save bar shows success
- [ ] Select the same element, set the same style value again, Save
- [ ] Confirm network response for `/__edit/batch` has `changed: false`
- [ ] Confirm Save bar does **not** show success, pending edits remain, and a warning toast mentions the source file did not change
- [ ] `pnpm check` / typecheck for `@open-slide/core`
- [ ] Optional: `packages/core` inspector e2e `a no-op batch save keeps pending edits and does not show success`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Saving inspector edits now detects when the source file is unchanged.
  - Pending edits remain visible instead of being incorrectly marked as saved.
  - Success notifications are suppressed when no changes are applied.
  - Clear notices are shown when the source file has not changed.
  - Failed saves now preserve the unsaved state and report errors accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->