### PR TITLE
fix(core): slide toolbar back button follows browser history and preserves last home location

### DIFF
--- a/.changeset/slide-back-browser-history.md
+++ b/.changeset/slide-back-browser-history.md
@@ -2,4 +2,4 @@
 "@open-slide/core": patch
 ---
 
-Return the slide toolbar back button to the previous browser location, preserving home query state like folder filters.
+Slide toolbar back button returns to the previous browser location and preserves home query state like folder filters.

--- a/.changeset/slide-back-browser-history.md
+++ b/.changeset/slide-back-browser-history.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Return the slide toolbar back button to the previous browser location, preserving home query state like folder filters.

--- a/packages/core/e2e/tests/viewer.spec.ts
+++ b/packages/core/e2e/tests/viewer.spec.ts
@@ -90,11 +90,14 @@ test.describe('slide viewer', () => {
   });
 
   test('back returns to the previous browser location with its query intact', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?f=draft');
+    await page.waitForFunction(
+      () => sessionStorage.getItem('open-slide:last-home-location') === '/?f=draft',
+    );
     await page.locator('a[href="/s/alpha"]').first().click();
     await expect(page).toHaveURL(/\/s\/alpha/);
     await page.getByRole('button', { name: 'Back to home' }).click();
-    await expect(page).toHaveURL(/\/$/);
+    await expect(page).toHaveURL(/[?&]f=draft/);
   });
 
   test('back falls back to the last home location, query included', async ({ page }) => {

--- a/packages/core/e2e/tests/viewer.spec.ts
+++ b/packages/core/e2e/tests/viewer.spec.ts
@@ -83,10 +83,28 @@ test.describe('slide viewer', () => {
     await expect(page.getByText('Failed to load slide')).toBeVisible();
   });
 
-  test('back link returns to the home browser', async ({ page }) => {
+  test('back button returns to the home browser', async ({ page }) => {
     await openSlide(page, 'alpha');
-    await page.getByRole('link', { name: 'Back to home' }).click();
+    await page.getByRole('button', { name: 'Back to home' }).click();
     await expect(page.locator('li h3')).toHaveCount(4);
+  });
+
+  test('back returns to the previous browser location with its query intact', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('a[href="/s/alpha"]').first().click();
+    await expect(page).toHaveURL(/\/s\/alpha/);
+    await page.getByRole('button', { name: 'Back to home' }).click();
+    await expect(page).toHaveURL(/\/$/);
+  });
+
+  test('back falls back to the last home location, query included', async ({ page }) => {
+    await page.goto('/?f=draft');
+    await page.waitForFunction(
+      () => sessionStorage.getItem('open-slide:last-home-location') === '/?f=draft',
+    );
+    await openSlide(page, 'alpha');
+    await page.getByRole('button', { name: 'Back to home' }).click();
+    await expect(page).toHaveURL(/[?&]f=draft/);
   });
 
   test('steps render fully revealed in the editor', async ({ page }) => {

--- a/packages/core/src/app/lib/last-home-location.ts
+++ b/packages/core/src/app/lib/last-home-location.ts
@@ -1,0 +1,18 @@
+const LAST_HOME_LOCATION_KEY = 'open-slide:last-home-location';
+
+export function rememberHomeLocation(pathname: string, search: string): void {
+  try {
+    sessionStorage.setItem(LAST_HOME_LOCATION_KEY, pathname + search);
+  } catch {
+    // sessionStorage can be unavailable (private browsing, quota); falling
+    // back to the default home route is fine.
+  }
+}
+
+export function readLastHomeLocation(): string {
+  try {
+    return sessionStorage.getItem(LAST_HOME_LOCATION_KEY) ?? '/';
+  } catch {
+    return '/';
+  }
+}

--- a/packages/core/src/app/routes/home-shell.tsx
+++ b/packages/core/src/app/routes/home-shell.tsx
@@ -1,5 +1,5 @@
 import { Menu } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Outlet, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { LanguageToggle } from '@/components/language-toggle';
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { GLOBAL_ASSET_SCOPE, useAssets } from '@/lib/assets';
 import { useFolders } from '@/lib/folders';
+import { rememberHomeLocation } from '@/lib/last-home-location';
 import { format, useLocale } from '@/lib/use-locale';
 import { cn, pad2 } from '@/lib/utils';
 import { CommandMenuTrigger } from '../components/command/command-menu';
@@ -63,6 +64,10 @@ export function HomeShell() {
   const t = useLocale();
 
   const selectedId = pathToSelectedId(location.pathname, searchParams);
+
+  useEffect(() => {
+    rememberHomeLocation(location.pathname, location.search);
+  }, [location.pathname, location.search]);
 
   const [commandOpen, setCommandOpen] = useState(false);
   const openCommandMenu = useCallback(() => setCommandOpen(true), []);

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -54,6 +54,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useFolders } from '@/lib/folders';
 import { hasModifier, isBackwardKey, isForwardKey, isTypingTarget } from '@/lib/keys';
+import { readLastHomeLocation } from '@/lib/last-home-location';
 import { useAgentSocketConnected } from '@/lib/use-agent-socket';
 import { useClickPageNavigation } from '@/lib/use-click-page-navigation';
 import { useIsMobile } from '@/lib/use-is-mobile';
@@ -85,6 +86,16 @@ export function Slide() {
   const { slideId = '' } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  // react-router records its entry index in history.state; going back is only
+  // safe when we actually pushed an entry, otherwise land on the last home view.
+  const goBack = useCallback(() => {
+    const idx = (window.history.state as { idx?: number } | null)?.idx ?? 0;
+    if (idx > 0) {
+      navigate(-1);
+    } else {
+      navigate(readLastHomeLocation(), { replace: true });
+    }
+  }, [navigate]);
   const { slide, error } = useSlideModule(slideId);
   const [playMode, setPlayMode] = useState<'window' | 'fullscreen' | null>(null);
   // Last deck the Player showed. During a presenter-driven deck switch the
@@ -596,14 +607,15 @@ export function Slide() {
           <header className="relative flex h-12 shrink-0 items-center gap-2 px-2 md:px-3">
             <div className="flex flex-1 items-center gap-1.5 md:flex-none md:gap-2">
               {showSlideBrowser && (
-                <Link
-                  to="/"
+                <button
+                  type="button"
+                  onClick={goBack}
                   aria-label={t.slide.backToHome}
                   title={t.slide.home}
                   className={buttonVariants({ variant: 'ghost', size: 'icon-sm' })}
                 >
                   <ChevronLeft className="size-4" />
-                </Link>
+                </button>
               )}
               <span aria-hidden className="mx-0.5 hidden h-5 w-px bg-hairline md:block" />
               {import.meta.env.DEV && (


### PR DESCRIPTION
## Problem

The toolbar back button (←) on the slide route is a hard `<Link to="/">`. It always lands on the bare home route, which:

- discards query state on the home browser — e.g. a folder filter like `/?f=draft` silently resets to `/`
- ignores where the user actually came from (themes gallery, assets page)

Going "back" is expected to behave like the browser's back, especially since the home URL carries view state in its query.

## Change

The back button now follows browser-history semantics:

1. If there is an in-app history entry to return to (react-router records its entry index in `history.state`; `idx > 0`), it calls `navigate(-1)` — the exact previous location, query intact.
2. Otherwise (slide URL opened directly, fresh tab / deep link), it falls back to the **last remembered home location**, kept in `sessionStorage` by `HomeShell` (which owns `/`, `/themes`, `/assets`), defaulting to `/`.

The element changes from `<Link>` to a `<button>` (role change is covered by an updated e2e test). Page-level navigation inside a deck is untouched — it still uses `replace: true`.

| Scenario | Before | After |
| --- | --- | --- |
| `/?f=draft` → open slide → ← | `/` | `/?f=draft` |
| Themes gallery → open slide → ← | `/` | Themes gallery |
| Deep link to `/s/foo` → ← | `/` | last visited home location (default `/`) |

## Testing

- `pnpm check`, `pnpm typecheck`, `pnpm test` (313 unit tests) — all pass
- `playwright test viewer` — 14 pass, including two new cases:
  - back returns to the previous browser location with its query intact
  - deep-link fallback lands on the last home location, query included
  - (plus the existing back-link test updated from the `link` to the `button` role)
- Manually exercised in `apps/demo`: home → slide → back, folder-filtered home → slide → back, and cold deep-link fallback

## Changeset

Included: `@open-slide/core` patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the slide toolbar’s “Back to home” behavior.
  - Preserves home filters and query parameters when navigating back.
  - Returns to the previous browser location when available.
  - Falls back to the most recent home location when no navigation history exists.
- **Tests**
  - Added coverage for standard, direct-entry, and fallback navigation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->