### PR TITLE
fix(core): keep deck warm-up advancing in hidden tabs

### DIFF
--- a/.changeset/preload-hidden-tab.md
+++ b/.changeset/preload-hidden-tab.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Finish loading a deck in a background tab instead of hanging on "Loading assets" until the tab is looked at again.

--- a/packages/core/src/app/components/slide-preload-layer.tsx
+++ b/packages/core/src/app/components/slide-preload-layer.tsx
@@ -6,6 +6,7 @@ import { type StepController, StepHost } from '../lib/step-context';
 
 const PAGES_PER_FRAME = 2;
 const SETTLE_TIMEOUT_MS = 15_000;
+const FRAME_FALLBACK_MS = 200;
 
 type Props = {
   pages: Page[];
@@ -28,8 +29,32 @@ export function markDeckWarmed(slideId: string): void {
   warmedDecks.add(slideId);
 }
 
+// Hidden tabs throttle `requestAnimationFrame` to zero, stranding every
+// frame-driven step below until someone looks at the tab again. A timer keeps
+// firing there, and nothing paints while hidden, so it stands in for the tick.
+function onNextFrame(run: (viaFallback: boolean) => void): () => void {
+  let fired = false;
+  let frame = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const cancel = () => {
+    cancelAnimationFrame(frame);
+    if (timer !== undefined) clearTimeout(timer);
+  };
+  const fire = (viaFallback: boolean) => {
+    if (fired) return;
+    fired = true;
+    cancel();
+    run(viaFallback);
+  };
+  frame = requestAnimationFrame(() => fire(false));
+  timer = setTimeout(() => fire(true), FRAME_FALLBACK_MS);
+  return cancel;
+}
+
 function nextFrame(): Promise<void> {
-  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  return new Promise((resolve) => {
+    onNextFrame(() => resolve());
+  });
 }
 
 function waitForImages(root: HTMLElement): Promise<unknown> {
@@ -104,10 +129,14 @@ export function SlidePreloadLayer({ pages, index, design, includeCurrent = false
 
   useEffect(() => {
     if (done || mountedCount >= order.length) return;
-    const raf = requestAnimationFrame(() => {
-      setMountedCount((n) => Math.min(order.length, n + PAGES_PER_FRAME));
+    return onNextFrame((viaFallback) => {
+      // Pacing exists to keep the first paint smooth; a hidden tab has no
+      // paint to protect, so it takes the remaining pages in one go.
+      const takeAll = viaFallback && document.hidden;
+      setMountedCount((n) =>
+        takeAll ? order.length : Math.min(order.length, n + PAGES_PER_FRAME),
+      );
     });
-    return () => cancelAnimationFrame(raf);
   }, [done, mountedCount, order.length]);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes #399.

## Problem

`SlidePreloadLayer` mounts the deck a couple of pages per `requestAnimationFrame`. Chrome throttles rAF to zero in a background tab, so the chain never advances past frame zero, `isDeckWarmed()` stays `false`, and the viewer sits on "Loading assets" until someone looks at the tab again.

`SETTLE_TIMEOUT_MS` does not cover this: it only starts once every page is mounted, so it guards the second phase (fonts and images) and never the first. The two `nextFrame()` awaits in that second phase are rAF-driven as well, so they stall on the same cause.

Measured inside a stalled tab (16-page deck, `/s/<slideId>`, `apps/demo`):

```
document.hidden        : true
rAF frames in 1 second : 0
mounted <img> elements : 0
document.fonts.status  : "loaded"
```

## Change

One `onNextFrame()` helper replaces the bare rAF calls at both sites: it races the frame against a 200 ms timer, cancels the loser, and tells the callback which path fired.

In the fallback path a hidden tab mounts the remaining pages in one go rather than continuing to pace them. The per-frame pacing exists to keep the first paint smooth, and a hidden tab has no paint to protect — pacing there would only stretch a 50-page deck over several seconds of timers.

Behaviour in a visible tab is unchanged: rAF wins the race after ~16 ms, the timer is cleared, and `PAGES_PER_FRAME` still applies. Should a visible tab ever run frames slower than 200 ms, the fallback takes one normal paced step instead of hanging.

## Testing

- `pnpm check`, `pnpm core typecheck`, `pnpm test` (313 passing).
- Exercised in `apps/demo` against `/s/open-slide-anatomy` in a genuinely hidden tab, before and after the change:

  | | before | after |
  | --- | --- | --- |
  | `document.hidden` | `true` | `true` |
  | rAF frames per second | 0 | 0 |
  | after 6 s | `LOADING ASSETS` | deck rendered |

- Foreground loading checked by hand in the demo; it looks unchanged.

No changeset for the apps, one `patch` changeset for `@open-slide/core`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Decks now finish loading reliably in background tabs instead of remaining stuck on “Loading assets.”
  * Improved asset preloading when browser animation frames are paused or throttled.
  * Remaining pages load automatically in hidden tabs for faster completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->