### PR TITLE
fix(core): only tag the deck entry for inspector edits

### DIFF
--- a/.changeset/entry-only-loc-tags.md
+++ b/.changeset/entry-only-loc-tags.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Only tag the deck's `index.tsx` for inspector edits, so clicking JSX imported from a sibling file no longer writes to the wrong place in the entry file.

--- a/packages/core/src/vite/loc-tags-plugin.test.ts
+++ b/packages/core/src/vite/loc-tags-plugin.test.ts
@@ -137,16 +137,30 @@ describe('locTagsPlugin', () => {
     expectTaggedTransform('/repo/slides/cover/index.tsx');
   });
 
-  it('tags shared slide source files', () => {
-    expectTaggedTransform('/repo/slides/cover/shared.tsx');
+  /**
+   * These three used to be tagged, and that was the bug. A tag is a bare
+   * `line:column`; `/__edit` always writes to `slides/<id>/index.tsx`. So a tag
+   * minted in a sibling file sent the inspector a position in a file it would
+   * never open, and `findInnermostJsxElement`'s containment fallback then edited
+   * whichever unrelated element in the entry happened to span it. A real deck hit
+   * this: an 8196-line `_shared/*.tsx` behind a 5827-line `index.tsx` meant every
+   * click on the imported pages had a live target to corrupt.
+   *
+   * Not tagging them is the graceful path, not a lost capability: nothing here was
+   * ever editable, and `findSlideSource` falls through to its fiber lookup, which
+   * accepts a `_debugSource` only from `/slides/<id>/index.tsx` and so reports the
+   * element as not targetable.
+   */
+  it('skips sibling slide source files, which /__edit cannot write to', () => {
+    expect(transformWithLocTags('/repo/slides/cover/shared.tsx')).toBeNull();
   });
 
-  it('tags numbered slide source files', () => {
-    expectTaggedTransform('/repo/slides/cover/01-Cover.tsx');
+  it('skips numbered slide source files', () => {
+    expect(transformWithLocTags('/repo/slides/cover/01-Cover.tsx')).toBeNull();
   });
 
-  it('tags slide source files in nested folders', () => {
-    expectTaggedTransform('/repo/slides/cover/components/Card.tsx');
+  it('skips slide source files in nested folders', () => {
+    expect(transformWithLocTags('/repo/slides/cover/components/Card.tsx')).toBeNull();
   });
 
   it('skips tsx files directly under the slides directory', () => {
@@ -159,6 +173,11 @@ describe('locTagsPlugin', () => {
 
   it('skips colocated test files', () => {
     expect(transformWithLocTags('/repo/slides/cover/index.test.tsx')).toBeNull();
+  });
+
+  it('skips a file that merely ends in index.tsx', () => {
+    // `deep/index.tsx` is not the entry either, and a suffix check would take it.
+    expect(transformWithLocTags('/repo/slides/cover/deep/index.tsx')).toBeNull();
   });
 });
 
@@ -189,8 +208,10 @@ describe('locTagsPlugin on Windows-style paths', () => {
     expectTagged('C:\\repo\\slides', 'C:/repo/slides/cover/index.tsx?t=1700000000000');
   });
 
-  it('tags nested slide source files under a Windows slidesRoot', () => {
-    expectTagged('C:\\repo\\slides', 'C:/repo/slides/cover/components/Card.tsx');
+  it('skips nested slide source files under a Windows slidesRoot', () => {
+    expect(
+      transformWithMockedResolve('C:\\repo\\slides', 'C:/repo/slides/cover/components/Card.tsx'),
+    ).toBeNull();
   });
 
   it('skips tsx files directly under the Windows slides directory', () => {

--- a/packages/core/src/vite/loc-tags-plugin.ts
+++ b/packages/core/src/vite/loc-tags-plugin.ts
@@ -62,17 +62,26 @@ export type LocTagsPluginOptions = {
   slidesDir?: string;
 };
 
-// Vite normally hands `id` to plugins with forward slashes, but other
-// plugins or virtual modules can pass through Windows-style paths.
-// Compare both sides in POSIX shape so the match doesn't depend on
-// which separator the caller happened to use.
-function isSlideSourceFile(id: string, slidesRootPosix: string): boolean {
+// Only the deck entry, `<slidesDir>/<id>/index.tsx`. A tag carries a bare
+// `line:column`, and `/__edit` resolves every write to the entry file, so a tag
+// minted in a sibling or nested `.tsx` describes a position in a file nobody
+// will open: `findInnermostJsxElement` falls back to any element whose span
+// covers that position, which in a long entry is some unrelated element on
+// another page, edited silently. `findSlideSource`'s fiber fallback already
+// encodes this invariant — it accepts a `_debugSource` only when its `fileName`
+// ends in `/slides/<id>/index.tsx` — and its comment assumes imported component
+// files are untransformed. They were not, and the tag path runs first, so the
+// guard never got a say. Untagged JSX now reaches that fallback and is correctly
+// reported as not targetable.
+//
+// Vite normally hands `id` to plugins with forward slashes, but other plugins or
+// virtual modules can pass through Windows-style paths. Compare both sides in
+// POSIX shape so the match doesn't depend on which separator the caller used.
+function isSlideEntryFile(id: string, slidesRootPosix: string): boolean {
   const filePath = id.split(/[?#]/)[0].replace(/\\/g, '/');
   if (!filePath.startsWith(`${slidesRootPosix}/`)) return false;
-  if (!filePath.endsWith('.tsx')) return false;
-  if (filePath.endsWith('.d.ts') || filePath.endsWith('.test.tsx')) return false;
   const rel = filePath.slice(slidesRootPosix.length + 1);
-  return rel.includes('/');
+  return /^[^/]+\/index\.tsx$/.test(rel);
 }
 
 export function locTagsPlugin(opts: LocTagsPluginOptions): Plugin {
@@ -84,7 +93,7 @@ export function locTagsPlugin(opts: LocTagsPluginOptions): Plugin {
     // sees our injected attributes.
     enforce: 'pre',
     transform(code, id) {
-      if (!isSlideSourceFile(id, slidesRoot)) return null;
+      if (!isSlideEntryFile(id, slidesRoot)) return null;
       const next = injectLocTags(code);
       if (next === null) return null;
       return { code: next, map: null };


### PR DESCRIPTION
## What

`data-slide-loc` tags carry a bare `line:column`, and `/__edit` resolves every write to `slides/<id>/index.tsx`. The plugin tagged every nested `.tsx` under a deck folder, so a tag minted in an imported file described a position in a file the write path never opens. `findInnermostJsxElement` then fell back to whichever element in the entry file happened to span that position and edited it.

Reproduce with a deck whose `index.tsx` imports pages from a sibling file (e.g. `./_shared/pages.tsx`): clicking any of the imported JSX in the inspector saves an edit into an unrelated element of `index.tsx`. The longer the two files, the more likely the fallback finds a live target instead of failing.

## Fix

Tag only the deck entry, `<slidesDir>/<id>/index.tsx`.

Nothing editable is lost. `findSlideSource`'s fiber fallback already accepts a `_debugSource` only when it ends in `/slides/<id>/index.tsx`, on the stated assumption that imported component files are untransformed — they were not, and the tag path runs first, so that guard never got a say. Untagged JSX now reaches the fallback and is reported as not targetable, which is the correct answer for an element `/__edit` cannot write.

## Tested

- `pnpm test` — 306 passed, 21 files. `loc-tags-plugin.test.ts` (25 tests) had its three "tags nested/shared/numbered file" cases inverted to assert the transform is skipped, plus a new case for a path that merely ends in `index.tsx`.
- `pnpm typecheck` and `pnpm check` clean.
- Changeset included (`patch` for `@open-slide/core`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inspector edits now apply location tags only to slide entry files.
  * Imported JSX, sibling files, numbered slides, and nested non-entry files are no longer incorrectly tagged.
  * Improved path handling across nested folders and Windows-style paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->