### PR TITLE
chore: enter beta pre-release mode for v2

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,12 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "demo": "0.0.0",
+    "web": "0.0.0",
+    "@open-slide/cli": "1.4.1",
+    "@open-slide/core": "1.19.1",
+    "core-e2e-fixture": "0.0.0"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
## Summary

- Run \`changeset pre enter beta\` so the next release PR versions \`@open-slide/core\` and \`@open-slide/cli\` as \`2.0.0-beta.0\` and publishes under the \`beta\` npm dist-tag.
- No workflow changes needed: \`changeset publish\` reads \`.changeset/pre.json\` and tags the release automatically.

## Verified

Dry-ran \`changeset version\` in a scratch copy: both packages resolve to \`2.0.0-beta.0\` with all seven pending changesets folded into the CHANGELOG.

## After merge

1. CI opens the \`chore: release packages\` PR with \`2.0.0-beta.0\`; merging it publishes to npm under \`beta\`.
2. Further changesets merged to main roll into \`beta.1\`, \`beta.2\`, and so on.
3. Run \`pnpm changeset pre exit\` when ready to cut the final \`2.0.0\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured beta pre-release versioning for selected packages.
  * Initialized the beta release configuration with no pending changesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->