### PR TITLE
fix(core): refuse to start when a stale vite devDependency shadows core's Vite

### DIFF
--- a/.changeset/vite-preflight.md
+++ b/.changeset/vite-preflight.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Refuse to start when a stale `vite` devDependency shadows the Vite copy core depends on, and point at the v1 → v2 migration guide.

--- a/apps/web/content/docs/migrate-to-v2.mdx
+++ b/apps/web/content/docs/migrate-to-v2.mdx
@@ -52,7 +52,7 @@ v1 scaffolds carried `"vite"` in `devDependencies` purely so hosting
 providers would detect a Vite project. In v2 it has to go. Core depends on
 Vite 8, and a stale Vite 5 entry makes package managers that hoist without
 checking peer ranges (bun, yarn classic) place core's Vite plugins next to the
-wrong copy, so `open-slide dev` and `open-slide build` fail with:
+wrong copy, so `open-slide dev`, `open-slide build`, and `open-slide preview` fail with:
 
 ```
 Package subpath './internal' is not defined by "exports" in .../node_modules/vite/package.json

--- a/apps/web/content/docs/migrate-to-v2.mdx
+++ b/apps/web/content/docs/migrate-to-v2.mdx
@@ -6,7 +6,7 @@ description: Upgrade a v1 workspace to @open-slide/core v2.
 v2 moves the whole toolchain forward: the runtime now ships **React 19** and
 builds with **Vite 8** (Rolldown-powered). Slides you wrote for v1 need no
 changes — the migration is confined to `package.json`, your Node version, and
-(optionally) your deploy config.
+your deploy config.
 
 ## Requirements
 
@@ -46,12 +46,24 @@ copies would crash the production bundle with React error #525). Bump anyway:
 your editor otherwise typechecks slides against React 18 types while the
 runtime is React 19.
 
-## Drop the `vite` devDependency
+## Remove the `vite` devDependency
 
 v1 scaffolds carried `"vite"` in `devDependencies` purely so hosting
-providers would detect a Vite project. v2 scaffolds drop it and declare the
-build settings explicitly instead. To do the same in an existing workspace,
-remove `vite` from `devDependencies` and mirror the new deploy configs:
+providers would detect a Vite project. In v2 it has to go. Core depends on
+Vite 8, and a stale Vite 5 entry makes package managers that hoist without
+checking peer ranges (bun, yarn classic) place core's Vite plugins next to the
+wrong copy, so `open-slide dev` and `open-slide build` fail with:
+
+```
+Package subpath './internal' is not defined by "exports" in .../node_modules/vite/package.json
+```
+
+npm and pnpm happen to nest the plugins correctly, but don't rely on it.
+`open-slide` checks for a mismatched `vite` on startup and refuses to run
+until it is removed, pointing back to this page.
+
+Remove `vite` from `devDependencies`, reinstall, and declare the build
+settings explicitly so your host still knows how to build the project:
 
 ```json title="vercel.json"
 {
@@ -71,10 +83,6 @@ remove `vite` from `devDependencies` and mirror the new deploy configs:
   to = "/index.html"
   status = 200
 ```
-
-Keeping the old `vite` devDependency also works — it's unused at runtime
-(core bundles its own Vite 8) — but the explicit config is one less stale
-dependency in your lockfile.
 
 ## Slide code
 

--- a/packages/core/src/cli/preflight.test.ts
+++ b/packages/core/src/cli/preflight.test.ts
@@ -1,0 +1,96 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { findViteMismatch, formatViteMismatch } from './preflight.ts';
+
+let root: string;
+
+function addPackage(rel: string, version: string): void {
+  const dir = path.join(root, 'node_modules', rel);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: rel, version }));
+}
+
+function coreDir(): string {
+  const dir = path.join(root, 'node_modules', '@open-slide', 'core', 'dist', 'cli');
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(os.tmpdir(), 'open-slide-preflight-'));
+  addPackage('@open-slide/core', '2.0.0');
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('findViteMismatch', () => {
+  it('flags a hoisted plugin that resolves a different vite than core', () => {
+    addPackage('vite', '5.4.21');
+    addPackage('@vitejs/plugin-react', '6.1.1');
+    addPackage('@open-slide/core/node_modules/vite', '8.2.2');
+
+    const mismatch = findViteMismatch(coreDir());
+    expect(mismatch).not.toBeNull();
+    expect(mismatch?.consumer).toBe('@vitejs/plugin-react');
+    expect(mismatch?.coreVite.version).toBe('8.2.2');
+    expect(mismatch?.consumerVite.version).toBe('5.4.21');
+  });
+
+  it('passes when the plugin is nested next to core vite', () => {
+    addPackage('vite', '5.4.21');
+    addPackage('@open-slide/core/node_modules/vite', '8.2.2');
+    addPackage('@open-slide/core/node_modules/@vitejs/plugin-react', '6.1.1');
+
+    expect(findViteMismatch(coreDir())).toBeNull();
+  });
+
+  it('passes when everything is hoisted onto a single vite', () => {
+    addPackage('vite', '8.2.2');
+    addPackage('@vitejs/plugin-react', '6.1.1');
+    addPackage('@tailwindcss/vite', '4.3.3');
+
+    expect(findViteMismatch(coreDir())).toBeNull();
+  });
+
+  it('passes when two copies of the same vite version coexist', () => {
+    addPackage('vite', '8.2.2');
+    addPackage('@vitejs/plugin-react', '6.1.1');
+    addPackage('@open-slide/core/node_modules/vite', '8.2.2');
+
+    expect(findViteMismatch(coreDir())).toBeNull();
+  });
+
+  it('checks every consumer, not just the first', () => {
+    addPackage('vite', '5.4.21');
+    addPackage('@tailwindcss/vite', '4.3.3');
+    addPackage('@open-slide/core/node_modules/vite', '8.2.2');
+    addPackage('@open-slide/core/node_modules/@vitejs/plugin-react', '6.1.1');
+
+    expect(findViteMismatch(coreDir())?.consumer).toBe('@tailwindcss/vite');
+  });
+
+  it('passes when vite cannot be located at all', () => {
+    expect(findViteMismatch(coreDir())).toBeNull();
+  });
+});
+
+describe('formatViteMismatch', () => {
+  it('names both copies relative to the workspace and links the guide', () => {
+    addPackage('vite', '5.4.21');
+    addPackage('@vitejs/plugin-react', '6.1.1');
+    addPackage('@open-slide/core/node_modules/vite', '8.2.2');
+
+    const mismatch = findViteMismatch(coreDir());
+    if (!mismatch) throw new Error('expected a mismatch');
+    const message = formatViteMismatch(mismatch, root);
+
+    expect(message).toContain('@vitejs/plugin-react resolves vite@5.4.21');
+    expect(message).toContain(path.join('node_modules', 'vite'));
+    expect(message).toContain('@open-slide/core ships vite@8.2.2');
+    expect(message).toContain('migrate-to-v2');
+  });
+});

--- a/packages/core/src/cli/preflight.ts
+++ b/packages/core/src/cli/preflight.ts
@@ -1,0 +1,65 @@
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MIGRATION_URL = 'https://open-slide.dev/docs/migrate-to-v2';
+
+// Plugins core passes to Vite that import from `vite` themselves. Each one
+// resolves `vite` from its own install location, which is not necessarily
+// the copy core resolves.
+const VITE_CONSUMERS = ['@vitejs/plugin-react', '@tailwindcss/vite'];
+
+type ResolvedPackage = { dir: string; version: string };
+
+export type ViteMismatch = {
+  consumer: string;
+  coreVite: ResolvedPackage;
+  consumerVite: ResolvedPackage;
+};
+
+function locatePackage(name: string, fromDir: string): ResolvedPackage | null {
+  let dir = fromDir;
+  while (true) {
+    const candidate = path.join(dir, 'node_modules', name);
+    const pkgPath = path.join(candidate, 'package.json');
+    if (existsSync(pkgPath)) {
+      let version = 'unknown';
+      try {
+        version =
+          (JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string }).version ?? version;
+      } catch {}
+      return { dir: realpathSync(candidate), version };
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+export function findViteMismatch(coreDir: string): ViteMismatch | null {
+  const coreVite = locatePackage('vite', coreDir);
+  if (!coreVite) return null;
+  for (const consumer of VITE_CONSUMERS) {
+    const consumerPkg = locatePackage(consumer, coreDir);
+    if (!consumerPkg) continue;
+    const consumerVite = locatePackage('vite', consumerPkg.dir);
+    if (!consumerVite || consumerVite.version === coreVite.version) continue;
+    return { consumer, coreVite, consumerVite };
+  }
+  return null;
+}
+
+export function formatViteMismatch(mismatch: ViteMismatch, cwd = process.cwd()): string {
+  const rel = (dir: string) => path.relative(cwd, dir) || dir;
+  return [
+    `${mismatch.consumer} resolves vite@${mismatch.consumerVite.version} (${rel(mismatch.consumerVite.dir)}), but @open-slide/core ships vite@${mismatch.coreVite.version} (${rel(mismatch.coreVite.dir)}).`,
+    'A `vite` entry in your package.json (v1 workspaces had one) shadows the copy core depends on. Remove it and reinstall.',
+    `Migration guide: ${MIGRATION_URL}`,
+  ].join('\n');
+}
+
+export function assertViteResolvesToCore(): void {
+  const coreDir = realpathSync(path.dirname(fileURLToPath(import.meta.url)));
+  const mismatch = findViteMismatch(coreDir);
+  if (mismatch) throw new Error(formatViteMismatch(mismatch));
+}

--- a/packages/core/src/cli/run.ts
+++ b/packages/core/src/cli/run.ts
@@ -4,6 +4,7 @@ import * as readline from 'node:readline/promises';
 import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { Command, Option } from 'commander';
+import { assertViteResolvesToCore } from './preflight.ts';
 import { detectSkillsDrift, syncSkills } from './sync.ts';
 
 async function readVersion(): Promise<string> {
@@ -109,6 +110,7 @@ export async function run(argv: string[]): Promise<void> {
       if (flags.skillsCheck !== false) {
         await runSkillsDriftCheck(resolveBuiltinSkillsDir());
       }
+      assertViteResolvesToCore();
       const { dev } = await import('./dev.ts');
       await dev(flags);
     });
@@ -118,6 +120,7 @@ export async function run(argv: string[]): Promise<void> {
     .description('Build a static site')
     .option('--out-dir <dir>', 'output directory (defaults to `dist`)')
     .action(async (flags: BuildFlags) => {
+      assertViteResolvesToCore();
       const { build } = await import('./build.ts');
       await build(flags);
     });
@@ -129,6 +132,7 @@ export async function run(argv: string[]): Promise<void> {
     .addOption(new Option('--host [host]', 'expose on the network (optional host)'))
     .option('--open', 'open the browser on start')
     .action(async (flags: ServerFlags) => {
+      assertViteResolvesToCore();
       const { preview } = await import('./preview.ts');
       await preview(flags);
     });


### PR DESCRIPTION
## What changed

A v1 workspace keeps `vite ^5` in `devDependencies`. Package managers that hoist without checking peer ranges (bun, yarn classic) then place `@vitejs/plugin-react@6` at the top level next to that copy, and its `import ... from "vite/internal"` fails:

```
error: Package subpath './internal' is not defined by "exports" in .../node_modules/vite/package.json imported from .../node_modules/@vitejs/plugin-react/dist/index.js
```

npm and pnpm happen to nest the plugin next to core's own `vite@8`, which is why the manual verification in #420 passed. Reproduced with bun against `@open-slide/core@2.0.0-beta.0`: both `open-slide dev` and `open-slide build` fail until `vite` is removed from `package.json`.

- **Preflight check** (`packages/core/src/cli/preflight.ts`): before `dev` / `build` / `preview` load the Vite config, locate the `vite` package core resolves and the one each bundled Vite plugin (`@vitejs/plugin-react`, `@tailwindcss/vite`) resolves by walking up from their real install paths. If the versions differ, exit with a message naming both copies and linking the migration guide. Same version in two locations is allowed, since bun leaves that layout behind after `bun remove vite`.
- **Migration guide**: removing the `vite` devDependency is now a required step instead of an optional cleanup, with the failure mode spelled out.
- Patch changeset for `@open-slide/core`.

## Verification

- `pnpm test` 320/320, core typecheck clean, `pnpm check` clean
- New unit tests cover bun hoisting, npm nesting, single hoisted vite, same-version duplicates, and no vite found
- End to end in a bun workspace (react 18 + `vite ^5.4.10` + repacked core): `open-slide build` now prints

```
error: @vitejs/plugin-react resolves vite@5.4.21 (node_modules/vite), but @open-slide/core ships vite@8.2.2 (node_modules/@open-slide/core/node_modules/vite).
A `vite` entry in your package.json (v1 workspaces had one) shadows the copy core depends on. Remove it and reinstall.
Migration guide: https://open-slide.dev/docs/migrate-to-v2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added startup validation for Vite dependency resolution before running development, build, or preview commands.
  - Clear errors now identify conflicting Vite installations and link to the v1 → v2 migration guide.
  - Validation detects mismatched, duplicated, or unavailable Vite installations before commands start.

- **Documentation**
  - Updated migration guidance to require removing direct `vite` dependencies from deploy configurations.
  - Explained how hoisted or duplicate Vite installations can prevent commands from starting successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->