### PR TITLE
feat(core,cli): redesign CLI output and init prompts

### DIFF
--- a/.changeset/cli-init-prompts.md
+++ b/.changeset/cli-init-prompts.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/cli": patch
+---
+
+Redesign the `init` flow with guided prompts, a dependency-install spinner, and a next-steps card.

--- a/.changeset/core-cli-output.md
+++ b/.changeset/core-cli-output.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Restyle `dev`, `build`, and `preview` output with an open-slide header and URL block, and stop surfacing Vite branding in server logs.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,13 +44,12 @@
     "access": "public"
   },
   "dependencies": {
+    "@clack/prompts": "^1.7.0",
     "chalk": "^6.0.0",
-    "commander": "^15.0.0",
-    "prompts": "^2.4.2"
+    "commander": "^15.0.0"
   },
   "devDependencies": {
     "@types/node": "^26.2.0",
-    "@types/prompts": "^2.4.9",
     "tsdown": "^0.22.14",
     "typescript": "^7.0.2"
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
+import { S_ERROR } from '@clack/prompts';
 import chalk from 'chalk';
 import { run } from './index.ts';
 
 run(process.argv.slice(2)).catch((err: unknown) => {
   const message = err instanceof Error ? err.message : String(err);
-  process.stderr.write(`${chalk.red('error:')} ${message}\n`);
+  process.stderr.write(`\n  ${chalk.red(S_ERROR)} ${message}\n`);
   process.exit(1);
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,10 +1,11 @@
 import { readFile } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import * as p from '@clack/prompts';
 import chalk from 'chalk';
 import { Command } from 'commander';
-import prompts from 'prompts';
-import { type InitOptions, init, isDirNonEmpty, sanitizeDirName } from './init.ts';
+import { gitInitAndCommit } from './git.ts';
+import { installDependencies, isDirNonEmpty, sanitizeDirName, scaffold } from './init.ts';
 import { detectPackageManager, PACKAGE_MANAGERS, type PackageManager } from './package-manager.ts';
 
 async function readVersion(): Promise<string> {
@@ -26,9 +27,12 @@ interface InitCliFlags {
   git?: boolean;
 }
 
-function onCancel(): never {
-  process.stdout.write(chalk.dim('\nCancelled.\n'));
-  process.exit(130);
+function unwrap<T>(value: T | symbol): T {
+  if (p.isCancel(value)) {
+    p.cancel('Cancelled.');
+    process.exit(130);
+  }
+  return value as T;
 }
 
 function packageManagerFromFlags(flags: InitCliFlags): PackageManager | undefined {
@@ -40,31 +44,57 @@ function packageManagerFromFlags(flags: InitCliFlags): PackageManager | undefine
 
   if (picks.length > 1) {
     throw new Error(
-      `Only one of --use-npm / --use-pnpm / --use-yarn / --use-bun may be specified (got ${picks.map((p) => `--use-${p}`).join(', ')}).`,
+      `Only one of --use-npm / --use-pnpm / --use-yarn / --use-bun may be specified (got ${picks.map((pm) => `--use-${pm}`).join(', ')}).`,
     );
   }
   return picks[0];
 }
 
+function displayPath(target: string): string {
+  const rel = relative(process.cwd(), target);
+  if (rel === '' || rel.startsWith('..')) return target;
+  return rel;
+}
+
+// A spinner only makes sense on a live terminal; piped output gets a plain
+// step line so logs stay readable.
+function step(label: string, isTTY: boolean) {
+  const spinner = isTTY ? p.spinner() : undefined;
+  if (spinner) spinner.start(label);
+  else p.log.step(label);
+  return {
+    done(message: string) {
+      if (spinner) spinner.stop(message);
+      else p.log.step(message);
+    },
+    fail(message: string) {
+      if (spinner) spinner.error(message);
+      else p.log.error(message);
+    },
+  };
+}
+
+function tail(output: string, lines = 12): string {
+  return output.split('\n').slice(-lines).join('\n');
+}
+
 async function runInit(dirArg: string | undefined, flags: InitCliFlags): Promise<void> {
   const isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY);
 
-  let dir = dirArg;
-  const name = flags.name;
-  let force = flags.force ?? false;
   let packageManager = packageManagerFromFlags(flags);
+  let dir = dirArg;
+  let force = flags.force ?? false;
+  const install = flags.install !== false;
+  const git = flags.git !== false;
 
   if (isTTY && dir === undefined) {
-    const answers = await prompts(
-      {
-        type: 'text',
-        name: 'dir',
-        message: 'Target directory',
-        initial: '.',
-      },
-      { onCancel },
+    dir = unwrap(
+      await p.text({
+        message: 'Where should we create your workspace?',
+        placeholder: '.',
+        defaultValue: '.',
+      }),
     );
-    dir = answers.dir;
   }
 
   if (dir !== undefined) {
@@ -75,36 +105,32 @@ async function runInit(dirArg: string | undefined, flags: InitCliFlags): Promise
           `Target directory "${dir}" contains characters that break shell commands (spaces, quotes, etc.). Try "${safe}" instead.`,
         );
       }
-      process.stdout.write(
-        `${chalk.yellow('!')} ${chalk.bold(`"${dir}"`)} has characters that confuse shells.\n` +
-          `  Suggested: ${chalk.cyan(`"${safe}"`)}\n`,
+      p.log.warn(`${chalk.bold(`"${dir}"`)} has characters that confuse shells.`);
+      dir = sanitizeDirName(
+        unwrap(
+          await p.text({
+            message: 'Directory name',
+            initialValue: safe,
+            validate: (value) => (value?.trim() ? undefined : 'Enter a directory name.'),
+          }),
+        ),
       );
-      const answers = await prompts(
-        {
-          type: 'text',
-          name: 'dir',
-          message: 'Directory name',
-          initial: safe,
-        },
-        { onCancel },
-      );
-      dir = sanitizeDirName(answers.dir ?? safe);
     }
   }
 
-  if (isTTY && packageManager === undefined && flags.install !== false) {
+  if (isTTY && packageManager === undefined && install) {
     const detected = detectPackageManager();
-    const answers = await prompts(
-      {
-        type: 'select',
-        name: 'packageManager',
+    packageManager = unwrap(
+      await p.select({
         message: 'Package manager',
-        choices: PACKAGE_MANAGERS.map((pm) => ({ title: pm, value: pm })),
-        initial: PACKAGE_MANAGERS.indexOf(detected),
-      },
-      { onCancel },
+        options: PACKAGE_MANAGERS.map((pm) => ({
+          value: pm,
+          label: pm,
+          hint: pm === detected ? 'detected' : undefined,
+        })),
+        initialValue: detected,
+      }),
     );
-    packageManager = answers.packageManager as PackageManager | undefined;
   }
 
   const resolvedDir = dir ?? '.';
@@ -114,31 +140,55 @@ async function runInit(dirArg: string | undefined, flags: InitCliFlags): Promise
     if (!isTTY) {
       throw new Error(`Target ${target} is not empty. Pass --force to scaffold into it anyway.`);
     }
-    const { overwrite } = await prompts(
-      {
-        type: 'confirm',
-        name: 'overwrite',
-        message: `${chalk.yellow(target)} is not empty. Scaffold into it anyway?`,
-        initial: false,
-      },
-      { onCancel },
+    const overwrite = unwrap(
+      await p.confirm({
+        message: `${chalk.yellow(displayPath(target))} is not empty. Scaffold into it anyway?`,
+        initialValue: false,
+      }),
     );
     if (!overwrite) {
-      process.stdout.write(chalk.dim('Aborted.\n'));
+      p.outro(chalk.dim('Nothing written.'));
       return;
     }
     force = true;
   }
 
-  const opts: InitOptions = {
-    dir: resolvedDir,
-    force,
-    name,
-    packageManager: packageManager ?? detectPackageManager(),
-    install: flags.install !== false,
-    git: flags.git !== false,
-  };
-  await init(opts);
+  const pm = packageManager ?? detectPackageManager();
+
+  await scaffold({ target, force, name: flags.name });
+  p.log.step(`Created workspace ${chalk.dim(`in ${displayPath(target)}`)}`);
+
+  let installed = false;
+  if (install) {
+    const task = step(`Installing dependencies with ${pm}`, isTTY);
+    const result = await installDependencies(pm, target);
+    if (result.ok) {
+      installed = true;
+      task.done(`Installed dependencies with ${pm}`);
+    } else {
+      task.fail('Dependency install failed');
+      p.log.message(chalk.dim(tail(result.output)));
+    }
+  }
+
+  if (git) {
+    const result = await gitInitAndCommit(target);
+    if (result.status === 'committed') {
+      p.log.step('Initialized git repository');
+    } else if (result.status === 'failed') {
+      p.log.warn(`Git setup failed ${chalk.dim(`· ${result.message ?? ''}`)}`);
+    } else {
+      p.log.info(`Skipped git init ${chalk.dim(`· ${result.message ?? ''}`)}`);
+    }
+  }
+
+  const next: string[] = [];
+  if (target !== process.cwd()) next.push(`cd ${resolvedDir}`);
+  if (!installed) next.push(`${pm} install`);
+  next.push(pm === 'npm' ? 'npm run dev' : `${pm} dev`);
+  p.note(next.map((line) => chalk.cyan(line)).join('\n'), 'Next steps');
+
+  p.outro(`All set! ${chalk.dim('Docs: https://open-slide.dev/docs')}`);
 }
 
 export async function run(argv: string[]): Promise<void> {
@@ -165,7 +215,13 @@ export async function run(argv: string[]): Promise<void> {
     .option('--no-install', 'skip dependency installation')
     .option('--no-git', 'skip git init and initial commit')
     .action(async (dir: string | undefined, flags: InitCliFlags) => {
-      await runInit(dir, flags);
+      p.intro(`${chalk.inverse.bold(' open-slide ')} ${chalk.dim(`v${version}`)}`);
+      try {
+        await runInit(dir, flags);
+      } catch (err) {
+        p.cancel(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
     });
 
   await program.parseAsync(argv, { from: 'user' });

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -3,21 +3,16 @@ import { existsSync } from 'node:fs';
 import { cp, mkdir, readdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import chalk from 'chalk';
-import { gitInitAndCommit } from './git.ts';
 import type { PackageManager } from './package-manager.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_DIR = resolve(HERE, '..', 'template');
 const IS_WINDOWS = process.platform === 'win32';
 
-export interface InitOptions {
-  dir: string;
+export interface ScaffoldOptions {
+  target: string;
   force: boolean;
   name: string | undefined;
-  packageManager: PackageManager;
-  install: boolean;
-  git: boolean;
 }
 
 export function sanitizeDirName(value: string): string {
@@ -76,18 +71,8 @@ async function materializeTemplateLinks(target: string): Promise<void> {
   }
 }
 
-async function runInstall(pm: PackageManager, cwd: string): Promise<void> {
-  await new Promise<void>((res, rej) => {
-    const child = spawn(pm, ['install'], { cwd, stdio: 'inherit', shell: IS_WINDOWS });
-    child.on('error', rej);
-    child.on('close', (code) =>
-      code === 0 ? res() : rej(new Error(`${pm} install exited with code ${code}`)),
-    );
-  });
-}
-
-export async function init(opts: InitOptions): Promise<void> {
-  const { dir, force, name, packageManager, install, git } = opts;
+export async function scaffold(opts: ScaffoldOptions): Promise<void> {
+  const { target, force, name } = opts;
 
   if (!existsSync(TEMPLATE_DIR)) {
     throw new Error(
@@ -95,7 +80,6 @@ export async function init(opts: InitOptions): Promise<void> {
     );
   }
 
-  const target = resolve(process.cwd(), dir);
   await mkdir(target, { recursive: true });
 
   if ((await isDirNonEmpty(target)) && !force) {
@@ -120,56 +104,30 @@ export async function init(opts: InitOptions): Promise<void> {
   }
 
   await writeFile(join(target, '.gitignore'), 'node_modules\ndist\n.DS_Store\n');
+}
 
-  const cdTarget = dir === '.' ? basename(target) : dir;
-  process.stdout.write(
-    `\n${chalk.green.bold('✔ Created open-slide workspace')} ${chalk.dim(`in ${target}`)}\n`,
-  );
+export type InstallResult = { ok: true } | { ok: false; output: string };
 
-  let installed = false;
-  if (install) {
-    process.stdout.write(`\n${chalk.bold(`Installing dependencies with ${packageManager}…`)}\n\n`);
-    try {
-      await runInstall(packageManager, target);
-      installed = true;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      process.stdout.write(
-        `\n${chalk.yellow('! Dependency install failed:')} ${chalk.dim(msg)}\n` +
-          chalk.dim(`  You can retry manually with \`${packageManager} install\`.\n`),
-      );
-    }
-  }
-
-  if (git) {
-    const result = await gitInitAndCommit(target);
-    if (result.status === 'committed') {
-      process.stdout.write(`${chalk.green('✔')} Initialized git repository with first commit.\n`);
-    } else if (result.status === 'skipped-nested') {
-      process.stdout.write(
-        `${chalk.yellow('!')} Skipped ${chalk.bold('git init')}: ${chalk.dim(result.message ?? '')}\n`,
-      );
-    } else if (result.status === 'skipped-no-git') {
-      process.stdout.write(
-        `${chalk.yellow('!')} Skipped git setup: ${chalk.dim(result.message ?? '')}\n`,
-      );
-    } else {
-      process.stdout.write(
-        `${chalk.yellow('!')} Git setup failed: ${chalk.dim(result.message ?? '')}\n` +
-          chalk.dim('  You can initialize the repo manually.\n'),
-      );
-    }
-  }
-
-  process.stdout.write(`\n${chalk.bold('Next steps:')}\n`);
-  process.stdout.write(`  ${chalk.cyan(`cd ${cdTarget}`)}\n`);
-  if (!installed && install) {
-    process.stdout.write(`  ${chalk.cyan(`${packageManager} install`)}\n`);
-  } else if (!install) {
-    process.stdout.write(
-      `  ${chalk.cyan(`${packageManager} install`)}    ${chalk.dim('# install was skipped')}\n`,
-    );
-  }
-  const devCommand = packageManager === 'npm' ? 'npm run dev' : `${packageManager} dev`;
-  process.stdout.write(`  ${chalk.cyan(devCommand)}\n`);
+// Output is captured rather than inherited so the package manager's own
+// progress UI doesn't fight the spinner; it is shown only on failure.
+export function installDependencies(pm: PackageManager, cwd: string): Promise<InstallResult> {
+  return new Promise((res) => {
+    let output = '';
+    const child = spawn(pm, ['install'], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: IS_WINDOWS,
+    });
+    child.stdout?.on('data', (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+    child.on('error', (err) => res({ ok: false, output: err.message }));
+    child.on('close', (code) => {
+      if (code === 0) res({ ok: true });
+      else res({ ok: false, output: output.trim() || `${pm} install exited with code ${code}` });
+    });
+  });
 }

--- a/packages/core/src/cli/bin.ts
+++ b/packages/core/src/cli/bin.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
 import { run } from './run.ts';
+import { formatError } from './ui.ts';
 
 run(process.argv.slice(2)).catch((err: unknown) => {
   const message = err instanceof Error ? err.message : String(err);
-  process.stderr.write(`${chalk.red('error:')} ${message}\n`);
+  process.stderr.write(formatError(message));
   process.exit(1);
 });

--- a/packages/core/src/cli/build.ts
+++ b/packages/core/src/cli/build.ts
@@ -1,14 +1,17 @@
 import path from 'node:path';
 import { mergeConfig, build as viteBuild } from 'vite';
 import { createViteConfig } from '../vite/config.ts';
+import { createCliLogger, printHeader } from './ui.ts';
 
 export interface BuildOptions {
   outDir?: string;
 }
 
 export async function build(opts: BuildOptions = {}): Promise<void> {
+  printHeader('building for production');
   const base = await createViteConfig({ userCwd: process.cwd(), mode: 'build' });
   const config = mergeConfig(base, {
+    customLogger: createCliLogger(),
     build: {
       ...(opts.outDir !== undefined ? { outDir: path.resolve(process.cwd(), opts.outDir) } : {}),
     },

--- a/packages/core/src/cli/dev.ts
+++ b/packages/core/src/cli/dev.ts
@@ -1,10 +1,18 @@
 import { type ChildProcess, fork } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import chalk from 'chalk';
-import { createServer, mergeConfig } from 'vite';
+import { type BindCLIShortcutsOptions, createServer, mergeConfig, type ViteDevServer } from 'vite';
 import { createViteConfig } from '../vite/config.ts';
 import { DEV_SUPERVISED_ENV, RESTART_EXIT_CODE } from '../vite/routes/restart.ts';
+import {
+  createCliLogger,
+  formatError,
+  printHeader,
+  printShortcutsHint,
+  printUrls,
+  shortcutsEnabled,
+  startupDuration,
+} from './ui.ts';
 
 export interface DevOptions {
   port?: number;
@@ -23,6 +31,7 @@ export async function dev(opts: DevOptions = {}): Promise<void> {
 async function startServer(opts: DevOptions): Promise<void> {
   const base = await createViteConfig({ userCwd: process.cwd() });
   const config = mergeConfig(base, {
+    customLogger: createCliLogger(),
     server: {
       ...(opts.port !== undefined ? { port: opts.port } : {}),
       ...(opts.host !== undefined ? { host: opts.host } : {}),
@@ -31,13 +40,39 @@ async function startServer(opts: DevOptions): Promise<void> {
   });
   const server = await createServer(config);
   await server.listen();
-  server.printUrls();
-  server.bindCLIShortcuts({ print: true });
+
+  printHeader(startupDuration());
+  printUrls(server.resolvedUrls, opts.host);
+  if (shortcutsEnabled()) {
+    printShortcutsHint();
+    server.bindCLIShortcuts({ customShortcuts: devShortcuts(opts) });
+  }
 
   const address = server.httpServer?.address();
   if (process.send && address && typeof address === 'object') {
     process.send({ type: 'open-slide:listening', port: address.port });
   }
+}
+
+// Vite's built-in `r` and `u` print URLs in its own house style; override
+// them so every line on screen stays ours.
+function devShortcuts(opts: DevOptions): BindCLIShortcutsOptions<ViteDevServer>['customShortcuts'] {
+  const showUrls = (server: ViteDevServer) => {
+    console.log('');
+    printUrls(server.resolvedUrls, opts.host);
+  };
+  return [
+    {
+      key: 'r',
+      description: 'restart the server',
+      async action(server) {
+        const before = JSON.stringify(server.resolvedUrls);
+        await server.restart();
+        if (JSON.stringify(server.resolvedUrls) !== before) showUrls(server);
+      },
+    },
+    { key: 'u', description: 'show server url', action: showUrls },
+  ];
 }
 
 // The server runs in a child process so an in-app update can exit with
@@ -56,7 +91,7 @@ function supervise(opts: DevOptions): void {
       env: { ...process.env, [DEV_SUPERVISED_ENV]: '1' },
     });
     child.on('error', (err) => {
-      process.stderr.write(`${chalk.red('error:')} ${err.message}\n`);
+      process.stderr.write(formatError(err.message));
       process.exit(1);
     });
     child.on('message', (message) => {

--- a/packages/core/src/cli/preview.ts
+++ b/packages/core/src/cli/preview.ts
@@ -1,5 +1,13 @@
 import { mergeConfig, preview as vitePreview } from 'vite';
 import { createViteConfig } from '../vite/config.ts';
+import {
+  createCliLogger,
+  printHeader,
+  printShortcutsHint,
+  printUrls,
+  shortcutsEnabled,
+  startupDuration,
+} from './ui.ts';
 
 export interface PreviewOptions {
   port?: number;
@@ -10,6 +18,7 @@ export interface PreviewOptions {
 export async function preview(opts: PreviewOptions = {}): Promise<void> {
   const base = await createViteConfig({ userCwd: process.cwd() });
   const config = mergeConfig(base, {
+    customLogger: createCliLogger(),
     preview: {
       ...(opts.port !== undefined ? { port: opts.port } : {}),
       ...(opts.host !== undefined ? { host: opts.host } : {}),
@@ -17,5 +26,11 @@ export async function preview(opts: PreviewOptions = {}): Promise<void> {
     },
   });
   const server = await vitePreview(config);
-  server.printUrls();
+
+  printHeader(`preview · ${startupDuration()}`);
+  printUrls(server.resolvedUrls, opts.host);
+  if (shortcutsEnabled()) {
+    printShortcutsHint();
+    server.bindCLIShortcuts();
+  }
 }

--- a/packages/core/src/cli/run.ts
+++ b/packages/core/src/cli/run.ts
@@ -1,18 +1,10 @@
-import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import * as readline from 'node:readline/promises';
 import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { Command, Option } from 'commander';
 import { detectSkillsDrift, syncSkills } from './sync.ts';
-
-async function readVersion(): Promise<string> {
-  const here = path.dirname(fileURLToPath(import.meta.url));
-  // dist/cli/bin.js → ../../package.json
-  const pkgPath = path.resolve(here, '..', '..', 'package.json');
-  const raw = await readFile(pkgPath, 'utf8');
-  return (JSON.parse(raw) as { version: string }).version;
-}
+import { glyph, readVersion } from './ui.ts';
 
 export function parsePort(value: string): number {
   const n = Number(value);
@@ -46,27 +38,27 @@ async function runSkillsDriftCheck(skillsDir: string): Promise<void> {
 
   const names = stale.map((d) => d.name).join(', ');
   const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  const notice = `${chalk.yellow(glyph.warn)} Built-in skills are out of date: ${chalk.bold(names)}`;
 
   if (!interactive) {
     process.stderr.write(
-      `${chalk.yellow('!')} Skills out of date (${names}). Run \`open-slide sync:skills\` to update.\n`,
+      `\n  ${notice}\n    ${chalk.dim('Run `open-slide sync:skills` to update.')}\n`,
     );
     return;
   }
 
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   try {
-    const answer = (
-      await rl.question(
-        `${chalk.yellow('!')} Skills out of date: ${chalk.bold(names)}. Sync now? ${chalk.dim('(Y/n) ')}`,
-      )
-    )
+    const answer = (await rl.question(`\n  ${notice}\n    Sync now? ${chalk.dim('(Y/n)')} `))
       .trim()
       .toLowerCase();
     if (answer === '' || answer === 'y' || answer === 'yes') {
+      process.stdout.write('\n');
       await syncSkills(skillsDir);
     } else {
-      process.stdout.write(chalk.dim('Skipped. Run `open-slide sync:skills` later to update.\n'));
+      process.stdout.write(
+        chalk.dim('    Skipped. Run `open-slide sync:skills` later to update.\n'),
+      );
     }
   } finally {
     rl.close();
@@ -88,13 +80,11 @@ function resolveBuiltinSkillsDir(): string {
 }
 
 export async function run(argv: string[]): Promise<void> {
-  const version = await readVersion();
-
   const program = new Command();
   program
     .name('open-slide')
-    .description('Author slides — we handle the Vite/React stack.')
-    .version(version, '-v, --version', 'print version')
+    .description('Author slides in React — open-slide runs the rest.')
+    .version(readVersion(), '-v, --version', 'print version')
     .helpOption('-h, --help', 'show help')
     .showHelpAfterError(chalk.dim('(run `open-slide --help` for usage)'));
 

--- a/packages/core/src/cli/ui.test.ts
+++ b/packages/core/src/cli/ui.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { rewriteViteMessage } from './ui.ts';
+
+describe('rewriteViteMessage', () => {
+  it('translates hmr vocabulary', () => {
+    expect(rewriteViteMessage('hmr update /slides/a/index.tsx')).toBe(
+      'updated /slides/a/index.tsx',
+    );
+    expect(rewriteViteMessage('hmr invalidate /slides/a/index.tsx')).toBe(
+      'invalidated /slides/a/index.tsx',
+    );
+    expect(rewriteViteMessage('page reload slides/a/index.tsx')).toBe(
+      'full reload slides/a/index.tsx',
+    );
+    expect(rewriteViteMessage('page reload')).toBe('full reload');
+    expect(rewriteViteMessage('trigger page reload slides/a/index.tsx')).toBe(
+      'full reload slides/a/index.tsx',
+    );
+  });
+
+  it('keeps ANSI styling around the rewritten phrase', () => {
+    expect(rewriteViteMessage('[32mhmr update [39m[2m/a.tsx[22m')).toBe(
+      '[32mupdated [39m[2m/a.tsx[22m',
+    );
+  });
+
+  it('rephrases dependency re-bundling notices', () => {
+    expect(rewriteViteMessage('optimized dependencies changed. reloading')).toBe(
+      'dependencies changed, reloading',
+    );
+    expect(rewriteViteMessage('Re-optimizing dependencies because vite config has changed')).toBe(
+      'config changed, re-bundling',
+    );
+    expect(rewriteViteMessage('Re-optimizing dependencies because lockfile has changed')).toBe(
+      'lockfile changed, re-bundling',
+    );
+    expect(rewriteViteMessage('Forced re-optimization of dependencies')).toBe(
+      're-bundling dependencies',
+    );
+    expect(rewriteViteMessage('server restarted.')).toBe('server restarted');
+  });
+
+  it('strips the [vite] tag wherever it appears', () => {
+    expect(rewriteViteMessage('[vite] warning: something')).toBe('warning: something');
+    expect(rewriteViteMessage('a [vite] b [vite]')).toBe('a b ');
+  });
+
+  it('strips the builtin reporter plugin tag from build warnings', () => {
+    expect(
+      rewriteViteMessage('[plugin builtin:vite-reporter] \n(!) Some chunks are larger than 500 kB'),
+    ).toBe('(!) Some chunks are larger than 500 kB');
+  });
+
+  it('drops the build banner', () => {
+    expect(
+      rewriteViteMessage('[36mvite v8.2.2 building client environment for production...'),
+    ).toBeNull();
+    expect(
+      rewriteViteMessage('vite v8.2.2 building client environment for production...'),
+    ).toBeNull();
+  });
+
+  it('passes ordinary messages through untouched', () => {
+    expect(rewriteViteMessage('Port 5173 is in use, trying another one...')).toBe(
+      'Port 5173 is in use, trying another one...',
+    );
+    expect(rewriteViteMessage('✓ built in 1.20s')).toBe('✓ built in 1.20s');
+  });
+});

--- a/packages/core/src/cli/ui.ts
+++ b/packages/core/src/cli/ui.ts
@@ -1,0 +1,175 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import * as readline from 'node:readline';
+import { fileURLToPath } from 'node:url';
+import { stripVTControlCharacters } from 'node:util';
+import chalk from 'chalk';
+import type { LogErrorOptions, Logger, LogOptions, LogType, ResolvedServerUrls } from 'vite';
+
+// Legacy Windows consoles render box-drawing glyphs as garbage; Windows
+// Terminal and VS Code's terminal are fine.
+const UNICODE =
+  process.platform !== 'win32' ||
+  Boolean(process.env.WT_SESSION) ||
+  process.env.TERM_PROGRAM === 'vscode';
+
+export const glyph = {
+  bar: UNICODE ? '┃' : '|',
+  warn: UNICODE ? '▲' : '!',
+  cross: UNICODE ? '✖' : 'x',
+} as const;
+
+// Bundled chunks land at unpredictable depths under dist/, so walk up to the
+// package root instead of resolving a fixed relative path.
+export function readVersion(): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  while (dir !== path.dirname(dir)) {
+    const pkgPath = path.join(dir, 'package.json');
+    if (existsSync(pkgPath)) {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { name?: string; version?: string };
+      if (pkg.name === '@open-slide/core' && pkg.version) return pkg.version;
+    }
+    dir = path.dirname(dir);
+  }
+  return '0.0.0';
+}
+
+export function brand(): string {
+  return chalk.inverse.bold(' open-slide ');
+}
+
+export function printHeader(status?: string): void {
+  const parts = [brand(), chalk.dim(`v${readVersion()}`)];
+  if (status) parts.push(chalk.dim(status));
+  process.stdout.write(`\n  ${parts.join('  ')}\n\n`);
+}
+
+export function startupDuration(): string {
+  return `ready in ${Math.round(process.uptime() * 1000)} ms`;
+}
+
+export function printUrls(
+  urls: ResolvedServerUrls | null,
+  host: string | boolean | undefined,
+): void {
+  if (!urls) return;
+  const rows: string[] = [];
+  for (const url of urls.local) rows.push(urlRow('Local', chalk.cyan(url)));
+  urls.network.forEach((url, index) => {
+    const iface = urls.networkInterfaceNames?.[index];
+    rows.push(urlRow('Network', chalk.cyan(url) + (iface ? `  ${chalk.dim(iface)}` : '')));
+  });
+  if (urls.network.length === 0 && host === undefined) {
+    rows.push(urlRow('Network', chalk.dim('use --host to expose')));
+  }
+  process.stdout.write(`${rows.join('\n')}\n`);
+}
+
+function urlRow(label: string, value: string): string {
+  return `  ${chalk.dim(glyph.bar)}  ${chalk.bold(label.padEnd(8))} ${value}`;
+}
+
+export function shortcutsEnabled(): boolean {
+  return Boolean(process.stdin.isTTY) && !process.env.CI;
+}
+
+export function printShortcutsHint(): void {
+  process.stdout.write(
+    `\n  ${chalk.dim('press')} ${chalk.bold('h + enter')} ${chalk.dim('for shortcuts')}\n`,
+  );
+}
+
+export function formatError(message: string): string {
+  return `\n  ${chalk.red(glyph.cross)} ${message}\n`;
+}
+
+const DROPPED = [/^vite v\d+\.\d+\.\d+ building /];
+
+const REWRITES: ReadonlyArray<readonly [RegExp, string]> = [
+  [/hmr update /, 'updated '],
+  [/hmr invalidate /, 'invalidated '],
+  [/trigger page reload /, 'full reload '],
+  [/page reload/, 'full reload'],
+  [/server restarted\./, 'server restarted'],
+  [/optimized dependencies changed\. reloading/, 'dependencies changed, reloading'],
+  [/Re-optimizing dependencies because vite config has changed/, 'config changed, re-bundling'],
+  [/Re-optimizing dependencies because lockfile has changed/, 'lockfile changed, re-bundling'],
+  [/Forced re-optimization of dependencies/, 're-bundling dependencies'],
+  [/\[plugin builtin:vite-[a-z-]+\] ?\n?/, ''],
+  [/\[vite\] ?/g, ''],
+];
+
+// Vite phrases its logs in its own vocabulary; users of open-slide never
+// asked for Vite, so translate the handful of lines they'll actually see.
+export function rewriteViteMessage(msg: string): string | null {
+  const plain = stripVTControlCharacters(msg);
+  if (DROPPED.some((re) => re.test(plain))) return null;
+  let out = msg;
+  for (const [re, replacement] of REWRITES) out = out.replace(re, replacement);
+  return out;
+}
+
+function timestamp(): string {
+  return new Date().toLocaleTimeString([], { hourCycle: 'h23' });
+}
+
+// Only timestamped lines get the two-space gutter: Vite's build reporter writes
+// its progress straight to stdout, so indenting the rest would misalign it.
+function formatLine(type: LogType, text: string, opts?: LogOptions): string {
+  if (!opts?.timestamp) return text;
+  const mark =
+    type === 'warn'
+      ? `${chalk.yellow(glyph.warn)} `
+      : type === 'error'
+        ? `${chalk.red(glyph.cross)} `
+        : '';
+  return `  ${chalk.dim(timestamp())}  ${mark}${text}`;
+}
+
+function clearTerminal(): void {
+  if (!process.stdout.isTTY || process.env.CI) return;
+  const blank = '\n'.repeat(Math.max(process.stdout.rows - 2, 0));
+  console.log(blank);
+  readline.cursorTo(process.stdout, 0, 0);
+  readline.clearScreenDown(process.stdout);
+}
+
+export function createCliLogger(): Logger {
+  const loggedErrors = new WeakSet<object>();
+  const warnedOnce = new Set<string>();
+
+  const write = (type: LogType, msg: string, opts?: LogOptions) => {
+    const text = rewriteViteMessage(msg);
+    if (text === null) return;
+    const method = type === 'info' ? 'log' : type;
+    console[method](formatLine(type, text, opts));
+  };
+
+  const logger: Logger = {
+    hasWarned: false,
+    info(msg, opts) {
+      write('info', msg, opts);
+    },
+    warn(msg, opts) {
+      logger.hasWarned = true;
+      write('warn', msg, opts);
+    },
+    warnOnce(msg, opts) {
+      if (warnedOnce.has(msg)) return;
+      warnedOnce.add(msg);
+      logger.warn(msg, opts);
+    },
+    error(msg, opts?: LogErrorOptions) {
+      logger.hasWarned = true;
+      if (opts?.error) loggedErrors.add(opts.error);
+      write('error', msg, opts);
+    },
+    clearScreen() {
+      clearTerminal();
+    },
+    hasErrorLogged(error) {
+      return loggedErrors.has(error);
+    },
+  };
+  return logger;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,22 +109,19 @@ importers:
 
   packages/cli:
     dependencies:
+      '@clack/prompts':
+        specifier: ^1.7.0
+        version: 1.7.0
       chalk:
         specifier: ^6.0.0
         version: 6.0.0
       commander:
         specifier: ^15.0.0
         version: 15.0.0
-      prompts:
-        specifier: ^2.4.2
-        version: 2.4.2
     devDependencies:
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
-      '@types/prompts':
-        specifier: ^2.4.9
-        version: 2.4.9
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(typescript@7.0.2)
@@ -562,6 +559,14 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -1952,9 +1957,6 @@ packages:
 
   '@types/node@26.2.0':
     resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
-
-  '@types/prompts@2.4.9':
-    resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -5384,6 +5386,18 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
   '@dnd-kit/accessibility@3.1.1(react@19.2.8)':
     dependencies:
       react: 19.2.8
@@ -6744,11 +6758,6 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
-  '@types/prompts@2.4.9':
-    dependencies:
-      '@types/node': 26.2.0
-      kleur: 3.0.3
-
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -7520,20 +7529,17 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-string-truncated-width@3.0.3:
-    optional: true
+  fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
-    optional: true
 
   fast-uri@3.1.3: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
-    optional: true
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION
## Summary

- **`open-slide dev` / `build` / `preview`** get an open-slide header, a bar-gutter URL block, and timestamped logs via a custom Vite `Logger` (`packages/core/src/cli/ui.ts`). It rewrites HMR vocabulary (`hmr update` → `updated`, `page reload` → `full reload`, …), drops the `vite vX building…` banner, and strips `[vite]` / `[plugin builtin:vite-*]` tags. The `r` and `u` shortcuts print URLs in the same style, HMR no longer clears the screen, and `--help` / error output no longer mention Vite.
- **`open-slide init`** is rebuilt on `@clack/prompts` (replacing `prompts` + `@types/prompts`): guided directory and package-manager prompts, an install spinner that captures output and shows the tail only on failure, and a next-steps card. Non-TTY runs print plain step lines instead of a spinner. Scaffolding and install live in `init.ts` as reusable steps; all UI is in `index.ts`.
- Changesets: `@open-slide/core` patch, `@open-slide/cli` patch.

## Preview

```
  open-slide  v2.0.0-beta.0  ready in 412 ms

  ┃  Local    http://localhost:5173/
  ┃  Network  use --host to expose

  press h + enter for shortcuts

  00:16:47  updated /slides/intro/index.tsx
```

```
┌  open-slide  v2.0.0-beta.0
│
◇  Where should we create your workspace?
│  my-slides
│
◇  Package manager
│  pnpm  (detected)
│
◇  Created workspace in my-slides
│
◇  Installed dependencies with pnpm
│
◇  Initialized git repository
│
◇  Next steps ───────╮
│                    │
│  cd my-slides      │
│  pnpm dev          │
│                    │
├────────────────────╯
│
└  All set! Docs: https://open-slide.dev/docs
```

## Test plan

- [x] `pnpm check`, `pnpm typecheck`, `pnpm test` (new `ui.test.ts` covers the Vite message rewrites)
- [x] `open-slide build` in `apps/demo`: header shown, no Vite banner, reporter warning tag stripped
- [x] `init` smoke-tested non-TTY (with/without install) and under a pseudo-TTY with `pnpm install` + `git init`; error paths (`--use-npm --use-pnpm`, non-empty target) exit 1 with a `└` cancel line
- [ ] `pnpm dev` in `apps/demo` to eyeball the live header, URL block, and HMR lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned project initialization with guided prompts, progress indicators, dependency installation feedback, and next-step guidance.
  - Added clearer handling for cancelled prompts, overwrite decisions, installation errors, and optional Git or dependency setup.
  - Added branded CLI headers, URL displays, shortcuts, and improved cross-platform symbols.

- **Style**
  - Restyled development, build, and preview output with clearer, friendlier messages and reduced tool-specific branding.

- **Bug Fixes**
  - Improved CLI error formatting and ensured optional initialization steps are correctly skipped when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->