### PR TITLE
fix(web): make landing Live Demo keyboard-focusable

### DIFF
--- a/apps/web/components/landing/inline-slide-player.tsx
+++ b/apps/web/components/landing/inline-slide-player.tsx
@@ -59,6 +59,7 @@ export function InlineSlidePlayer({ index, onIndexChange }: Props) {
   return (
     <div
       ref={rootRef}
+      tabIndex={0}
       onKeyDown={onKeyDown}
       aria-roledescription="slide player"
       aria-label={`Slide ${index + 1} of ${count}`}


### PR DESCRIPTION
Add tabIndex={0} so Tab can focus the Live Demo player. Existing arrow/Home/End handlers then work. Fixes #425.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Made the inline slide player keyboard-focusable, enabling keyboard navigation when it receives focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->