### PR TITLE
fix(core): write inspector edits to the loc source file

### DIFF
--- a/.changeset/loc-dotted-source.md
+++ b/.changeset/loc-dotted-source.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Parse dotted sibling names like `Card.preview.tsx` in `data-slide-loc` instead of dropping the tag.

--- a/.changeset/loc-dotted-source.md
+++ b/.changeset/loc-dotted-source.md
@@ -2,4 +2,4 @@
 "@open-slide/core": patch
 ---
 
-Parse dotted sibling names like `Card.preview.tsx` in `data-slide-loc` instead of dropping the tag.
+Keep inspector loc tags on sibling files with dotted names such as `Card.preview.tsx`.

--- a/.changeset/loc-source-file.md
+++ b/.changeset/loc-source-file.md
@@ -1,0 +1,5 @@
+---
+"@open-slide/core": patch
+---
+
+Name the source file in `data-slide-loc` and write inspector edits to that file instead of always `index.tsx`.

--- a/packages/core/src/app/components/image-placeholder.tsx
+++ b/packages/core/src/app/components/image-placeholder.tsx
@@ -1,6 +1,7 @@
 import { type CSSProperties, type HTMLAttributes, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { uploadWithAutoRename } from '@/lib/assets';
+import { parseSlideLoc } from '@/lib/inspector/slide-loc';
 import { useLocale } from '@/lib/use-locale';
 import { dragHasFiles } from '../lib/dom';
 
@@ -54,13 +55,10 @@ export function ImagePlaceholder({
           const slideId = root.closest<HTMLElement>('[data-slide-id]')?.dataset.slideId;
           const loc = root.dataset.slideLoc;
           if (!slideId || !loc) return;
-          const idx = loc.indexOf(':');
-          if (idx <= 0) return;
-          const line = Number(loc.slice(0, idx));
-          const column = Number(loc.slice(idx + 1));
-          if (!Number.isFinite(line) || !Number.isFinite(column)) return;
+          const parsed = parseSlideLoc(loc);
+          if (!parsed) return;
           setUploading(true);
-          handleDrop(slideId, file, line, column)
+          handleDrop(slideId, file, parsed.line, parsed.column, parsed.file)
             .catch(() => toast.error(t.imagePlaceholder.uploadFailed))
             .finally(() => setUploading(false));
         },
@@ -195,7 +193,13 @@ function pickImageFile(files: FileList): File | null {
   return null;
 }
 
-async function handleDrop(slideId: string, file: File, line: number, column: number) {
+async function handleDrop(
+  slideId: string,
+  file: File,
+  line: number,
+  column: number,
+  sourceFile: string | null,
+) {
   const { ok, entry } = await uploadWithAutoRename(slideId, file);
   if (!ok || !entry) throw new Error('upload failed');
   const res = await fetch('/__edit', {
@@ -205,6 +209,7 @@ async function handleDrop(slideId: string, file: File, line: number, column: num
       slideId,
       line,
       column,
+      ...(sourceFile ? { file: sourceFile } : {}),
       ops: [{ kind: 'replace-placeholder-with-image', assetPath: `./assets/${entry.name}` }],
     }),
   });

--- a/packages/core/src/app/components/inspector/inline-text-editor.tsx
+++ b/packages/core/src/app/components/inspector/inline-text-editor.tsx
@@ -286,16 +286,24 @@ function ActiveInlineEditor({
     (key: string, value: string | null) => {
       if (!anchor.isConnected) return;
       if (sel && sel.end > sel.start && RANGE_STYLE_KEYS.has(key)) {
-        bufferOps(target.line, target.column, anchor, [
-          { kind: 'set-text-range-style', start: sel.start, end: sel.end, key, value },
-        ]);
+        bufferOps(
+          target.line,
+          target.column,
+          anchor,
+          [{ kind: 'set-text-range-style', start: sel.start, end: sel.end, key, value }],
+          target.file,
+        );
         return;
       }
-      bufferOps(target.line, target.column, anchor, [
-        { kind: 'set-style', key, value, prevText: readEditableText(anchor) },
-      ]);
+      bufferOps(
+        target.line,
+        target.column,
+        anchor,
+        [{ kind: 'set-style', key, value, prevText: readEditableText(anchor) }],
+        target.file,
+      );
     },
-    [anchor, sel, target.line, target.column, bufferOps],
+    [anchor, sel, target.line, target.column, target.file, bufferOps],
   );
 
   const toggleBold = useCallback(() => {

--- a/packages/core/src/app/components/inspector/inline-text-editor.tsx
+++ b/packages/core/src/app/components/inspector/inline-text-editor.tsx
@@ -24,11 +24,7 @@ const RANGE_STYLE_KEYS = new Set(['fontSize', 'fontWeight', 'fontStyle', 'color'
 const TOOLBAR_GAP = 8;
 const TOOLBAR_HEIGHT = 36;
 
-function pickEditableAnchor(
-  x: number,
-  y: number,
-  slideId: string,
-): { line: number; column: number; anchor: HTMLElement } | null {
+function pickEditableAnchor(x: number, y: number, slideId: string) {
   const el = pickInspectorTarget(pickElement(x, y));
   if (!el) return null;
   const hit = findSlideSource(el, slideId, { hostOnly: true });
@@ -58,6 +54,7 @@ export function InlineEditLayer() {
       e.preventDefault();
       e.stopPropagation();
       startInlineEdit({
+        file: hit.file,
         line: hit.line,
         column: hit.column,
         anchor: hit.anchor,
@@ -81,6 +78,7 @@ export function InlineEditLayer() {
       e.preventDefault();
       e.stopPropagation();
       startInlineEdit({
+        file: hit.file,
         line: hit.line,
         column: hit.column,
         anchor: hit.anchor,
@@ -105,6 +103,7 @@ export function InlineEditLayer() {
         if (hit) {
           e.preventDefault();
           startInlineEdit({
+            file: hit.file,
             line: hit.line,
             column: hit.column,
             anchor: hit.anchor,
@@ -274,10 +273,14 @@ function ActiveInlineEditor({
 
   const commit = useCallback(() => {
     if (!anchor.isConnected) return;
-    bufferOps(target.line, target.column, anchor, [
-      { kind: 'set-text', value: readEditableText(anchor) },
-    ]);
-  }, [anchor, target.line, target.column, bufferOps]);
+    bufferOps(
+      target.line,
+      target.column,
+      anchor,
+      [{ kind: 'set-text', value: readEditableText(anchor) }],
+      target.file,
+    );
+  }, [anchor, target.line, target.column, target.file, bufferOps]);
 
   const applyTextStyle = useCallback(
     (key: string, value: string | null) => {

--- a/packages/core/src/app/components/inspector/inspect-overlay.tsx
+++ b/packages/core/src/app/components/inspector/inspect-overlay.tsx
@@ -61,7 +61,7 @@ export function InspectOverlay() {
       if (!hit) return;
       e.preventDefault();
       e.stopPropagation();
-      setSelected({ line: hit.line, column: hit.column, anchor: hit.anchor });
+      setSelected({ file: hit.file, line: hit.line, column: hit.column, anchor: hit.anchor });
       setHover({ hit });
     };
 
@@ -75,7 +75,7 @@ export function InspectOverlay() {
       if (!(hit.anchor instanceof HTMLImageElement)) return;
       e.preventDefault();
       e.stopPropagation();
-      setSelected({ line: hit.line, column: hit.column, anchor: hit.anchor });
+      setSelected({ file: hit.file, line: hit.line, column: hit.column, anchor: hit.anchor });
       openCrop(hit.anchor);
     };
 

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -30,6 +30,7 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { findSlideSource } from '@/lib/inspector/fiber';
 import { hasOnlyInlineTextChildren } from '@/lib/inspector/inline-text';
+import { slideLocSelector } from '@/lib/inspector/slide-loc';
 import type { EditOp } from '@/lib/inspector/use-editor';
 import { useAgentSocketConnected } from '@/lib/use-agent-socket';
 import { useLocale } from '@/lib/use-locale';
@@ -66,10 +67,15 @@ type RangeStylePreview = {
 function resolveSelectedTarget(target: SelectedTarget, slideId: string): SelectedTarget {
   const hit = findSlideSource(target.anchor, slideId, { hostOnly: true });
   if (!hit) return target;
-  if (hit.line === target.line && hit.column === target.column && hit.anchor === target.anchor) {
+  if (
+    hit.line === target.line &&
+    hit.column === target.column &&
+    (hit.file ?? null) === (target.file ?? null) &&
+    hit.anchor === target.anchor
+  ) {
     return target;
   }
-  return { line: hit.line, column: hit.column, anchor: hit.anchor };
+  return { file: hit.file, line: hit.line, column: hit.column, anchor: hit.anchor };
 }
 
 export function InspectorPanel() {
@@ -106,7 +112,7 @@ export function InspectorPanel() {
     }
     let anchor = selected.anchor;
     if (!anchor.isConnected) {
-      const next = findElementByLine(slideId, selected.line, selected.column);
+      const next = findElementByLine(slideId, selected.line, selected.column, selected.file);
       if (next) {
         anchor = next;
         setSelected({ ...selected, anchor: next });
@@ -333,6 +339,7 @@ export function InspectorPanel() {
               hint={pinSnapshot.placeholder.hint}
               line={pinSelected.line}
               column={pinSelected.column}
+              file={pinSelected.file}
               applyEdit={applyEdit}
             />
           </Section>
@@ -795,13 +802,15 @@ function PlaceholderField({
   hint,
   line,
   column,
+  file,
   applyEdit,
 }: {
   slideId: string;
   hint: string;
   line: number;
   column: number;
-  applyEdit: (line: number, column: number, ops: EditOp[]) => Promise<void>;
+  file?: string | null;
+  applyEdit: (line: number, column: number, ops: EditOp[], file?: string | null) => Promise<void>;
 }) {
   const [open, setOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -833,12 +842,17 @@ function PlaceholderField({
             try {
               const assetPath =
                 scope === 'global' ? `@assets/${asset.name}` : `./assets/${asset.name}`;
-              await applyEdit(line, column, [
-                {
-                  kind: 'replace-placeholder-with-image',
-                  assetPath,
-                },
-              ]);
+              await applyEdit(
+                line,
+                column,
+                [
+                  {
+                    kind: 'replace-placeholder-with-image',
+                    assetPath,
+                  },
+                ],
+                file,
+              );
             } finally {
               setSubmitting(false);
             }
@@ -1071,15 +1085,22 @@ function parseLetterSpacing(value: string): number {
   return Number.isFinite(n) ? round2(n) : 0;
 }
 
-function findElementByLine(slideId: string, line: number, column: number): HTMLElement | null {
+function findElementByLine(
+  slideId: string,
+  line: number,
+  column: number,
+  file?: string | null,
+): HTMLElement | null {
   const root = document.querySelector('[data-inspector-root]');
   if (!root) return null;
-  const tagged = root.querySelector<HTMLElement>(`[data-slide-loc="${line}:${column}"]`);
+  const tagged = root.querySelector<HTMLElement>(
+    slideLocSelector({ file: file ?? null, line, column }),
+  );
   if (tagged) return tagged;
   const candidates = root.querySelectorAll<HTMLElement>('*');
   for (const el of candidates) {
     const hit = findSlideSource(el, slideId, { hostOnly: true });
-    if (hit && hit.line === line) return hit.anchor;
+    if (hit && hit.line === line && (hit.file ?? null) === (file ?? null)) return hit.anchor;
   }
   return null;
 }

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -152,7 +152,7 @@ export function InspectorPanel() {
       if (!selected) return;
       const target = resolveSelectedTarget(selected, slideId);
       if (target !== selected) setSelected(target);
-      bufferOps(target.line, target.column, target.anchor, ops);
+      bufferOps(target.line, target.column, target.anchor, ops, target.file);
       if (target.anchor.isConnected) setSnapshot(readSnapshot(target.anchor));
     },
     [selected, setSelected, slideId, bufferOps],
@@ -213,6 +213,7 @@ export function InspectorPanel() {
           value: op.value,
           prevText: pinSnapshot.text ?? undefined,
         })),
+        target.file,
       );
       setRangeStylePreview((current) => ({
         anchor: target.anchor,
@@ -241,6 +242,7 @@ export function InspectorPanel() {
         target.column,
         target.anchor,
         styleOps.map((op) => ({ ...op, prevText: pinSnapshot.text ?? undefined })),
+        target.file,
       );
       if (target.anchor.isConnected) setSnapshot(readSnapshot(target.anchor));
       return;

--- a/packages/core/src/app/components/inspector/inspector-panel.tsx
+++ b/packages/core/src/app/components/inspector/inspector-panel.tsx
@@ -30,7 +30,7 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { findSlideSource } from '@/lib/inspector/fiber';
 import { hasOnlyInlineTextChildren } from '@/lib/inspector/inline-text';
-import { slideLocSelector } from '@/lib/inspector/slide-loc';
+import { sameSlideLoc, slideLocSelector } from '@/lib/inspector/slide-loc';
 import type { EditOp } from '@/lib/inspector/use-editor';
 import { useAgentSocketConnected } from '@/lib/use-agent-socket';
 import { useLocale } from '@/lib/use-locale';
@@ -67,12 +67,7 @@ type RangeStylePreview = {
 function resolveSelectedTarget(target: SelectedTarget, slideId: string): SelectedTarget {
   const hit = findSlideSource(target.anchor, slideId, { hostOnly: true });
   if (!hit) return target;
-  if (
-    hit.line === target.line &&
-    hit.column === target.column &&
-    (hit.file ?? null) === (target.file ?? null) &&
-    hit.anchor === target.anchor
-  ) {
+  if (sameSlideLoc(hit, target) && hit.anchor === target.anchor) {
     return target;
   }
   return { file: hit.file, line: hit.line, column: hit.column, anchor: hit.anchor };
@@ -1102,7 +1097,7 @@ function findElementByLine(
   const candidates = root.querySelectorAll<HTMLElement>('*');
   for (const el of candidates) {
     const hit = findSlideSource(el, slideId, { hostOnly: true });
-    if (hit && hit.line === line && (hit.file ?? null) === (file ?? null)) return hit.anchor;
+    if (hit && sameSlideLoc(hit, { file: file ?? null, line, column })) return hit.anchor;
   }
   return null;
 }

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -12,6 +12,12 @@ import {
 import { toast } from 'sonner';
 import { useHistory } from '@/components/history-provider';
 import { Button } from '@/components/ui/button';
+import {
+  formatSlideLoc,
+  parseSlideLoc,
+  type SlideLoc,
+  slideLocSelector,
+} from '@/lib/inspector/slide-loc';
 import { type SlideComment, useComments } from '@/lib/inspector/use-comments';
 import { type Edit, type EditOp, useEditor } from '@/lib/inspector/use-editor';
 import { isTypingTarget } from '@/lib/keys';
@@ -22,6 +28,7 @@ import { AssetPickerDialog } from './asset-picker-dialog';
 import { ImageCropDialog, type ImageCropRect } from './image-crop-dialog';
 
 export type SelectedTarget = {
+  file?: string | null;
   line: number;
   column: number;
   anchor: HTMLElement;
@@ -50,6 +57,7 @@ type TextRangeStyleOp = {
 };
 
 type Bucket = {
+  file: string | null;
   line: number;
   column: number;
   styleOps: Map<string, Sequenced<StyleOp>>;
@@ -69,6 +77,16 @@ type Bucket = {
 };
 
 const INSTANCE_ID_ATTR = 'data-slide-instance-id';
+
+function locOf(file: string | null | undefined, line: number, column: number): SlideLoc {
+  return { file: file ?? null, line, column };
+}
+
+function locFromAnchor(anchor: HTMLElement | null | undefined, fallback: SlideLoc): SlideLoc {
+  const raw = anchor?.dataset.slideLoc;
+  if (!raw) return fallback;
+  return parseSlideLoc(raw) ?? fallback;
+}
 
 function readInstanceId(el: HTMLElement): string | null {
   return el.getAttribute(INSTANCE_ID_ATTR);
@@ -251,11 +269,17 @@ type InspectorCtx = {
   // Bumped on every buffered-op mutation (including undo/redo restores) so
   // panels can re-read DOM snapshots without polling.
   opsVersion: number;
-  applyEdit: (line: number, column: number, ops: EditOp[]) => Promise<void>;
+  applyEdit: (line: number, column: number, ops: EditOp[], file?: string | null) => Promise<void>;
   // Mutate the DOM optimistically, snapshot the pre-edit values, and
   // remember the ops. `commitEdits` (manual Save or auto-flush on
   // close) is what actually writes to disk; `cancelEdits` reverts.
-  bufferOps: (line: number, column: number, anchor: HTMLElement, ops: EditOp[]) => void;
+  bufferOps: (
+    line: number,
+    column: number,
+    anchor: HTMLElement,
+    ops: EditOp[],
+    file?: string | null,
+  ) => void;
   pendingCount: number;
   commitEdits: () => Promise<void>;
   cancelEdits: () => void;
@@ -295,6 +319,7 @@ export function InspectorProvider({
   const [pendingCount, setPendingCount] = useState(0);
   const [committing, setCommitting] = useState(false);
   const [cropTarget, setCropTarget] = useState<{
+    file?: string | null;
     line: number;
     column: number;
     anchor: HTMLImageElement;
@@ -306,6 +331,7 @@ export function InspectorProvider({
     initialRect: ImageCropRect | null;
   } | null>(null);
   const [replaceTarget, setReplaceTarget] = useState<{
+    file?: string | null;
     line: number;
     column: number;
     anchor: HTMLElement;
@@ -340,26 +366,27 @@ export function InspectorProvider({
   // since the original `anchor` reference may have unmounted. With an
   // instance id, prefer the matching DOM node so per-instance text edits
   // round-trip onto the right element.
-  const findAnchor = useCallback((line: number, column: number, instanceId?: string) => {
+  const findAnchor = useCallback((loc: SlideLoc, instanceId?: string) => {
     const root = document.querySelector<HTMLElement>('[data-inspector-root]');
     if (!root) return null;
     if (instanceId) {
       const byInstance = root.querySelector<HTMLElement>(`[${INSTANCE_ID_ATTR}="${instanceId}"]`);
       if (byInstance) return byInstance;
     }
-    return root.querySelector<HTMLElement>(`[data-slide-loc="${line}:${column}"]`);
+    return root.querySelector<HTMLElement>(slideLocSelector(loc));
   }, []);
 
   // Mutate bucket + DOM without recording history. Shared by `bufferOps`
   // (the public, history-recording entry point) and by `redo` closures.
   const applyOpsRaw = useCallback(
-    (line: number, column: number, anchor: HTMLElement | null, ops: EditOp[]) => {
-      const key = `${line}:${column}`;
+    (loc: SlideLoc, anchor: HTMLElement | null, ops: EditOp[]) => {
+      const key = formatSlideLoc(loc);
       let bucket = pendingRef.current.get(key);
       if (!bucket) {
         bucket = {
-          line,
-          column,
+          file: loc.file,
+          line: loc.line,
+          column: loc.column,
           styleOps: new Map(),
           rangeStyleOps: new Map(),
           textOps: new Map(),
@@ -465,8 +492,8 @@ export function InspectorProvider({
   type Snap = StyleSnap | RangeStyleSnap | TextSnap | AttrSnap;
 
   const snapshotForOps = useCallback(
-    (line: number, column: number, anchor: HTMLElement, ops: EditOp[]): Snap[] => {
-      const key = `${line}:${column}`;
+    (loc: SlideLoc, anchor: HTMLElement, ops: EditOp[]): Snap[] => {
+      const key = formatSlideLoc(loc);
       const bucket = pendingRef.current.get(key);
       const style = anchor.style as unknown as Record<string, string>;
       const snaps: Snap[] = [];
@@ -543,13 +570,13 @@ export function InspectorProvider({
   // Restore the snapshotted values to bucket + DOM. Mirrors the bucket-empty
   // logic of `cancelEdits` so an undo back to the absolute baseline cleans up.
   const restoreSnapshot = useCallback(
-    (line: number, column: number, snaps: Snap[]) => {
-      const key = `${line}:${column}`;
+    (loc: SlideLoc, snaps: Snap[]) => {
+      const key = formatSlideLoc(loc);
       const bucket = pendingRef.current.get(key);
       if (!bucket) return;
       // Style/attr snaps share the loc-level anchor (first match);
       // text snaps look up their per-instance node below.
-      const sharedAnchor = findAnchor(line, column);
+      const sharedAnchor = findAnchor(loc);
       const sharedStyle = (sharedAnchor?.style ?? {}) as unknown as Record<string, string>;
       for (const snap of snaps) {
         if (snap.kind === 'style') {
@@ -567,7 +594,7 @@ export function InspectorProvider({
             if (sharedAnchor?.isConnected) sharedStyle[snap.key] = orig ?? '';
           }
         } else if (snap.kind === 'range-style') {
-          const textAnchor = findAnchor(line, column, snap.instanceId);
+          const textAnchor = findAnchor(loc, snap.instanceId);
           if (snap.existed && snap.value) {
             bucket.rangeStyleOps.set(snap.id, { ...snap.value, seq: ++pendingSeqRef.current });
           } else {
@@ -584,7 +611,7 @@ export function InspectorProvider({
             );
           }
         } else if (snap.kind === 'text') {
-          const textAnchor = findAnchor(line, column, snap.instanceId);
+          const textAnchor = findAnchor(loc, snap.instanceId);
           if (snap.existed) {
             bucket.textOps.set(snap.instanceId, {
               value: snap.value ?? '',
@@ -625,14 +652,15 @@ export function InspectorProvider({
   );
 
   const bufferOps = useCallback(
-    (line: number, column: number, anchor: HTMLElement, ops: EditOp[]) => {
+    (line: number, column: number, anchor: HTMLElement, ops: EditOp[], file?: string | null) => {
+      const loc = locFromAnchor(anchor, locOf(file, line, column));
       const instanceId = ops.some(
         (op) => op.kind === 'set-text' || op.kind === 'set-text-range-style',
       )
         ? ensureInstanceId(anchor)
         : undefined;
-      const snaps = snapshotForOps(line, column, anchor, ops);
-      applyOpsRaw(line, column, anchor, ops);
+      const snaps = snapshotForOps(loc, anchor, ops);
+      applyOpsRaw(loc, anchor, ops);
       const first = ops[0];
       const opKey = first
         ? first.kind === 'set-style'
@@ -641,11 +669,11 @@ export function InspectorProvider({
             ? first.attr
             : 'text'
         : 'noop';
-      const coalesceKey = `inspector:${line}:${column}:${first?.kind ?? 'noop'}:${opKey}`;
+      const coalesceKey = `inspector:${formatSlideLoc(loc)}:${first?.kind ?? 'noop'}:${opKey}`;
       history.record({
         coalesceKey,
-        undo: () => restoreSnapshot(line, column, snaps),
-        redo: () => applyOpsRaw(line, column, findAnchor(line, column, instanceId), ops),
+        undo: () => restoreSnapshot(loc, snaps),
+        redo: () => applyOpsRaw(loc, findAnchor(loc, instanceId), ops),
       });
     },
     [applyOpsRaw, snapshotForOps, restoreSnapshot, findAnchor, history, ensureInstanceId],
@@ -662,12 +690,13 @@ export function InspectorProvider({
     };
     const pending: PendingItem[] = [];
     for (const [key, bucket] of buckets) {
-      const { line, column, styleOps, rangeStyleOps, textOps, attrOps, origTexts } = bucket;
+      const { file, line, column, styleOps, rangeStyleOps, textOps, attrOps, origTexts } = bucket;
       for (const [k, op] of styleOps) {
         pending.push({
           key,
           seq: op.seq,
           edit: {
+            ...(file ? { file } : {}),
             line,
             column,
             ops: [{ kind: 'set-style', key: k, value: op.value, prevText: op.prevText }],
@@ -682,6 +711,7 @@ export function InspectorProvider({
           key,
           seq: op.seq,
           edit: {
+            ...(file ? { file } : {}),
             line,
             column,
             ops: [
@@ -703,6 +733,7 @@ export function InspectorProvider({
           key,
           seq: op.seq,
           edit: {
+            ...(file ? { file } : {}),
             line,
             column,
             ops: [
@@ -729,6 +760,7 @@ export function InspectorProvider({
           key,
           seq: textOp.seq,
           edit: {
+            ...(file ? { file } : {}),
             line,
             column,
             ops: [{ kind: 'set-text', value: textOp.value, prevText: orig?.value }],
@@ -789,7 +821,9 @@ export function InspectorProvider({
     }
     const root = document.querySelector<HTMLElement>('[data-inspector-root]');
     for (const b of pendingRef.current.values()) {
-      const sharedEl = root?.querySelector<HTMLElement>(`[data-slide-loc="${b.line}:${b.column}"]`);
+      const sharedEl = root?.querySelector<HTMLElement>(
+        slideLocSelector(locOf(b.file, b.line, b.column)),
+      );
       if (sharedEl) {
         const style = sharedEl.style as unknown as Record<string, string>;
         for (const [k, v] of b.origStyle) style[k] = v;
@@ -902,7 +936,7 @@ export function InspectorProvider({
     const revalidate = () => {
       if (selected.anchor.isConnected) return;
       const next = root.querySelector<HTMLElement>(
-        `[data-slide-loc="${selected.line}:${selected.column}"]`,
+        slideLocSelector(locOf(selected.file, selected.line, selected.column)),
       );
       if (next && next !== selected.anchor) {
         setSelected({ ...selected, anchor: next });
@@ -929,7 +963,12 @@ export function InspectorProvider({
 
   const inlineEditSessionRef = useRef(0);
   const startInlineEdit = useCallback((target: InlineEditTarget) => {
-    setSelected({ line: target.line, column: target.column, anchor: target.anchor });
+    setSelected({
+      file: target.file,
+      line: target.line,
+      column: target.column,
+      anchor: target.anchor,
+    });
     setInlineEdit({ ...target, session: ++inlineEditSessionRef.current });
   }, []);
 
@@ -947,11 +986,9 @@ export function InspectorProvider({
   const openReplace = useCallback((anchor: HTMLElement) => {
     const loc = anchor.dataset.slideLoc;
     if (!loc) return;
-    const [lineStr, columnStr] = loc.split(':');
-    const line = Number(lineStr);
-    const column = Number(columnStr);
-    if (!Number.isFinite(line) || !Number.isFinite(column)) return;
-    setReplaceTarget({ line, column, anchor });
+    const parsed = parseSlideLoc(loc);
+    if (!parsed) return;
+    setReplaceTarget({ ...parsed, anchor });
   }, []);
 
   useEffect(() => {
@@ -968,14 +1005,11 @@ export function InspectorProvider({
   const openCrop = useCallback((anchor: HTMLImageElement) => {
     const loc = anchor.dataset.slideLoc;
     if (!loc) return;
-    const [lineStr, columnStr] = loc.split(':');
-    const line = Number(lineStr);
-    const column = Number(columnStr);
-    if (!Number.isFinite(line) || !Number.isFinite(column)) return;
+    const parsed = parseSlideLoc(loc);
+    if (!parsed) return;
     const cs = window.getComputedStyle(anchor);
     setCropTarget({
-      line,
-      column,
+      ...parsed,
       anchor,
       src: anchor.currentSrc || anchor.src,
       targetWidth: anchor.offsetWidth || anchor.getBoundingClientRect().width,
@@ -1044,7 +1078,7 @@ export function InspectorProvider({
           slideId={slideId}
           onClose={() => setReplaceTarget(null)}
           onPick={(asset, scope) => {
-            const { line, column, anchor } = replaceTarget;
+            const { file, line, column, anchor } = replaceTarget;
             const assetPath =
               scope === 'global' ? `@assets/${asset.name}` : `./assets/${asset.name}`;
             const ops: EditOp[] = [
@@ -1065,7 +1099,7 @@ export function InspectorProvider({
                 ops.push({ kind: 'set-style', key: 'objectPosition', value: '50% 50%' });
               }
             }
-            bufferOps(line, column, anchor, ops);
+            bufferOps(line, column, anchor, ops, file);
             setReplaceTarget(null);
           }}
         />
@@ -1080,7 +1114,7 @@ export function InspectorProvider({
           initialRect={cropTarget.initialRect}
           onClose={() => setCropTarget(null)}
           onApply={(result) => {
-            const { line, column, anchor } = cropTarget;
+            const { file, line, column, anchor } = cropTarget;
             if (anchor.isConnected) {
               const ops: EditOp[] = [
                 { kind: 'set-style', key: 'objectFit', value: result.fit },
@@ -1100,7 +1134,7 @@ export function InspectorProvider({
               } else {
                 ops.push({ kind: 'set-style', key: 'objectViewBox', value: null });
               }
-              bufferOps(line, column, anchor, ops);
+              bufferOps(line, column, anchor, ops, file);
             }
             setCropTarget(null);
           }}

--- a/packages/core/src/app/lib/inspector/fiber.test.ts
+++ b/packages/core/src/app/lib/inspector/fiber.test.ts
@@ -63,9 +63,19 @@ describe('findSlideSource primary path', () => {
     const el = makeEl({ slideLoc: '42:7' });
     const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
     expect(hit).not.toBeNull();
+    expect(hit?.file).toBeNull();
     expect(hit?.line).toBe(42);
     expect(hit?.column).toBe(7);
     expect(hit?.anchor).toBe(el as unknown as HTMLElement);
+  });
+
+  it('reads a sibling file from a prefixed loc', () => {
+    const el = makeEl({ slideLoc: 'pages.tsx:12:4' });
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.file).toBe('pages.tsx');
+    expect(hit?.line).toBe(12);
+    expect(hit?.column).toBe(4);
   });
 });
 
@@ -123,6 +133,21 @@ describe('findSlideSource fallback', () => {
     expect(hit).not.toBeNull();
     expect(hit?.line).toBe(13);
     expect(hit?.column).toBe(1);
+  });
+
+  it('matches a sibling file under the same slide folder', () => {
+    const fiber = makeFiber({
+      fileName: '/repo/slides/cover/pages.tsx',
+      line: 14,
+      column: 2,
+      host: true,
+    });
+    const el = makeEl({ fiber });
+    const hit = findSlideSource(el as unknown as HTMLElement, 'cover');
+    expect(hit).not.toBeNull();
+    expect(hit?.file).toBe('pages.tsx');
+    expect(hit?.line).toBe(14);
+    expect(hit?.column).toBe(2);
   });
 
   it('returns null when the fiber fileName points at a different slideId', () => {

--- a/packages/core/src/app/lib/inspector/fiber.ts
+++ b/packages/core/src/app/lib/inspector/fiber.ts
@@ -1,4 +1,7 @@
+import { parseSlideLoc } from './slide-loc.ts';
+
 export type SlideSourceHit = {
+  file: string | null;
   line: number;
   column: number;
   anchor: HTMLElement;
@@ -34,6 +37,17 @@ function normalizeDebugFileName(fileName: string): string {
   return fileName.split(/[?#]/)[0].replace(/\\/g, '/');
 }
 
+function relUnderSlide(fileName: string, slideId: string): string | null {
+  const norm = normalizeDebugFileName(fileName);
+  const marker = `/slides/${slideId}/`;
+  const idx = norm.lastIndexOf(marker);
+  if (idx === -1) return null;
+  const rel = norm.slice(idx + marker.length);
+  if (!rel.endsWith('.tsx') || rel.endsWith('.d.ts') || rel.endsWith('.test.tsx')) return null;
+  if (rel.includes('..') || rel.startsWith('/')) return null;
+  return rel;
+}
+
 export function findSlideSource(
   el: HTMLElement,
   slideId: string,
@@ -45,32 +59,22 @@ export function findSlideSource(
   if (tagged) {
     const loc = tagged.dataset.slideLoc;
     if (loc) {
-      const idx = loc.indexOf(':');
-      if (idx > 0) {
-        const line = Number(loc.slice(0, idx));
-        const column = Number(loc.slice(idx + 1));
-        if (Number.isFinite(line) && Number.isFinite(column)) {
-          return { line, column, anchor: tagged };
-        }
-      }
+      const parsed = parseSlideLoc(loc);
+      if (parsed) return { ...parsed, anchor: tagged };
     }
   }
 
-  // Fallback for JSX rendered from imported component files (which the
-  // loc-tags plugin doesn't transform).
-  const needle = `/slides/${slideId}/index.tsx`;
+  // Fallback for JSX rendered from files the loc-tags plugin didn't
+  // transform (library components, or a sibling the tag missed).
   let fiber = getFiber(el);
   let anchor: HTMLElement = el;
   while (fiber) {
     const src = getSource(fiber);
     const isHost = fiber.stateNode instanceof HTMLElement;
-    if (
-      src?.fileName &&
-      normalizeDebugFileName(src.fileName).endsWith(needle) &&
-      src.lineNumber &&
-      (!opts?.hostOnly || isHost)
-    ) {
+    const rel = src?.fileName ? relUnderSlide(src.fileName, slideId) : null;
+    if (rel && src?.lineNumber && (!opts?.hostOnly || isHost)) {
       return {
+        file: rel === 'index.tsx' ? null : rel,
         line: src.lineNumber,
         column: src.columnNumber ?? 0,
         anchor: isHost ? (fiber.stateNode as HTMLElement) : anchor,

--- a/packages/core/src/app/lib/inspector/slide-loc.test.ts
+++ b/packages/core/src/app/lib/inspector/slide-loc.test.ts
@@ -67,6 +67,7 @@ describe('sameSlideLoc', () => {
     const loc = { file: 'pages.tsx', line: 12, column: 4 };
     expect(sameSlideLoc(loc, loc)).toBe(true);
     expect(sameSlideLoc(loc, { ...loc, column: 8 })).toBe(false);
+    expect(sameSlideLoc(loc, { ...loc, line: 13 })).toBe(false);
     expect(sameSlideLoc(loc, { ...loc, file: 'other.tsx' })).toBe(false);
   });
 });

--- a/packages/core/src/app/lib/inspector/slide-loc.test.ts
+++ b/packages/core/src/app/lib/inspector/slide-loc.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatSlideLoc, parseSlideLoc, slideLocSelector } from './slide-loc.ts';
+import { formatSlideLoc, parseSlideLoc, sameSlideLoc, slideLocSelector } from './slide-loc.ts';
 
 describe('formatSlideLoc', () => {
   it('keeps entry locations as line:column', () => {
@@ -11,6 +11,9 @@ describe('formatSlideLoc', () => {
     expect(formatSlideLoc({ file: 'pages.tsx', line: 12, column: 4 })).toBe('pages.tsx:12:4');
     expect(formatSlideLoc({ file: 'components/Card.tsx', line: 3, column: 4 })).toBe(
       'components/Card.tsx:3:4',
+    );
+    expect(formatSlideLoc({ file: 'components/Card.preview.tsx', line: 3, column: 4 })).toBe(
+      'components/Card.preview.tsx:3:4',
     );
   });
 });
@@ -28,6 +31,11 @@ describe('parseSlideLoc', () => {
       line: 3,
       column: 4,
     });
+    expect(parseSlideLoc('components/Card.preview.tsx:3:4')).toEqual({
+      file: 'components/Card.preview.tsx',
+      line: 3,
+      column: 4,
+    });
   });
 
   it('treats an explicit index.tsx prefix as the entry file', () => {
@@ -38,6 +46,7 @@ describe('parseSlideLoc', () => {
     expect(parseSlideLoc('../other/index.tsx:1:0')).toBeNull();
     expect(parseSlideLoc('/tmp/x.tsx:1:0')).toBeNull();
     expect(parseSlideLoc('pages.ts:1:0')).toBeNull();
+    expect(parseSlideLoc('Card.preview.ts:1:0')).toBeNull();
     expect(parseSlideLoc('not-a-loc')).toBeNull();
     expect(parseSlideLoc('')).toBeNull();
     expect(parseSlideLoc('0:0')).toBeNull();
@@ -50,5 +59,14 @@ describe('slideLocSelector', () => {
     expect(slideLocSelector({ file: 'pages.tsx', line: 2, column: 2 })).toBe(
       '[data-slide-loc="pages.tsx:2:2"]',
     );
+  });
+});
+
+describe('sameSlideLoc', () => {
+  it('requires file, line, and column', () => {
+    const loc = { file: 'pages.tsx', line: 12, column: 4 };
+    expect(sameSlideLoc(loc, loc)).toBe(true);
+    expect(sameSlideLoc(loc, { ...loc, column: 8 })).toBe(false);
+    expect(sameSlideLoc(loc, { ...loc, file: 'other.tsx' })).toBe(false);
   });
 });

--- a/packages/core/src/app/lib/inspector/slide-loc.test.ts
+++ b/packages/core/src/app/lib/inspector/slide-loc.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { formatSlideLoc, parseSlideLoc, slideLocSelector } from './slide-loc.ts';
+
+describe('formatSlideLoc', () => {
+  it('keeps entry locations as line:column', () => {
+    expect(formatSlideLoc({ file: null, line: 12, column: 4 })).toBe('12:4');
+    expect(formatSlideLoc({ file: 'index.tsx', line: 12, column: 4 })).toBe('12:4');
+  });
+
+  it('prefixes sibling files relative to the slide folder', () => {
+    expect(formatSlideLoc({ file: 'pages.tsx', line: 12, column: 4 })).toBe('pages.tsx:12:4');
+    expect(formatSlideLoc({ file: 'components/Card.tsx', line: 3, column: 4 })).toBe(
+      'components/Card.tsx:3:4',
+    );
+  });
+});
+
+describe('parseSlideLoc', () => {
+  it('reads a bare line:column as the entry file', () => {
+    expect(parseSlideLoc('12:4')).toEqual({ file: null, line: 12, column: 4 });
+    expect(parseSlideLoc('1:0')).toEqual({ file: null, line: 1, column: 0 });
+  });
+
+  it('reads a sibling file from everything before the last two segments', () => {
+    expect(parseSlideLoc('pages.tsx:12:4')).toEqual({ file: 'pages.tsx', line: 12, column: 4 });
+    expect(parseSlideLoc('components/Card.tsx:3:4')).toEqual({
+      file: 'components/Card.tsx',
+      line: 3,
+      column: 4,
+    });
+  });
+
+  it('treats an explicit index.tsx prefix as the entry file', () => {
+    expect(parseSlideLoc('index.tsx:8:2')).toEqual({ file: null, line: 8, column: 2 });
+  });
+
+  it('rejects path traversal and non-tsx names', () => {
+    expect(parseSlideLoc('../other/index.tsx:1:0')).toBeNull();
+    expect(parseSlideLoc('/tmp/x.tsx:1:0')).toBeNull();
+    expect(parseSlideLoc('pages.ts:1:0')).toBeNull();
+    expect(parseSlideLoc('not-a-loc')).toBeNull();
+    expect(parseSlideLoc('')).toBeNull();
+    expect(parseSlideLoc('0:0')).toBeNull();
+  });
+});
+
+describe('slideLocSelector', () => {
+  it('quotes the formatted loc for querySelector', () => {
+    expect(slideLocSelector({ file: null, line: 2, column: 2 })).toBe('[data-slide-loc="2:2"]');
+    expect(slideLocSelector({ file: 'pages.tsx', line: 2, column: 2 })).toBe(
+      '[data-slide-loc="pages.tsx:2:2"]',
+    );
+  });
+});

--- a/packages/core/src/app/lib/inspector/slide-loc.ts
+++ b/packages/core/src/app/lib/inspector/slide-loc.ts
@@ -4,7 +4,8 @@ export type SlideLoc = {
   column: number;
 };
 
-const SOURCE_REL_RE = /^(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_-]+\.tsx$/;
+const SOURCE_REL_RE =
+  /^(?:[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*\/)*[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*\.tsx$/;
 
 export function formatSlideLoc(loc: SlideLoc): string {
   const { file, line, column } = loc;
@@ -28,4 +29,8 @@ export function parseSlideLoc(raw: string): SlideLoc | null {
 
 export function slideLocSelector(loc: SlideLoc): string {
   return `[data-slide-loc="${formatSlideLoc(loc)}"]`;
+}
+
+export function sameSlideLoc(a: SlideLoc, b: SlideLoc): boolean {
+  return a.line === b.line && a.column === b.column && (a.file ?? null) === (b.file ?? null);
 }

--- a/packages/core/src/app/lib/inspector/slide-loc.ts
+++ b/packages/core/src/app/lib/inspector/slide-loc.ts
@@ -1,0 +1,31 @@
+export type SlideLoc = {
+  file: string | null;
+  line: number;
+  column: number;
+};
+
+const SOURCE_REL_RE = /^(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_-]+\.tsx$/;
+
+export function formatSlideLoc(loc: SlideLoc): string {
+  const { file, line, column } = loc;
+  if (!file || file === 'index.tsx') return `${line}:${column}`;
+  return `${file}:${line}:${column}`;
+}
+
+export function parseSlideLoc(raw: string): SlideLoc | null {
+  const parts = raw.split(':');
+  if (parts.length < 2) return null;
+  const column = Number(parts[parts.length - 1]);
+  const line = Number(parts[parts.length - 2]);
+  if (!Number.isInteger(line) || !Number.isInteger(column)) return null;
+  if (line < 1 || column < 0) return null;
+
+  const filePart = parts.slice(0, -2).join(':').replace(/\\/g, '/');
+  if (!filePart || filePart === 'index.tsx') return { file: null, line, column };
+  if (!SOURCE_REL_RE.test(filePart)) return null;
+  return { file: filePart, line, column };
+}
+
+export function slideLocSelector(loc: SlideLoc): string {
+  return `[data-slide-loc="${formatSlideLoc(loc)}"]`;
+}

--- a/packages/core/src/app/lib/inspector/use-editor.ts
+++ b/packages/core/src/app/lib/inspector/use-editor.ts
@@ -14,7 +14,7 @@ export type EditOp =
   | { kind: 'set-attr-asset'; attr: string; assetPath: string; previewUrl: string }
   | { kind: 'replace-placeholder-with-image'; assetPath: string };
 
-export type Edit = { line: number; column: number; ops: EditOp[] };
+export type Edit = { file?: string | null; line: number; column: number; ops: EditOp[] };
 
 export type EditResult = { ok: boolean; error?: string };
 
@@ -29,11 +29,17 @@ export class NoOpEditError extends Error {
 
 export function useEditor(slideId: string) {
   const applyEdit = useCallback(
-    async (line: number, column: number, ops: EditOp[]) => {
+    async (line: number, column: number, ops: EditOp[], file?: string | null) => {
       const res = await fetch('/__edit', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ slideId, line, column, ops }),
+        body: JSON.stringify({
+          slideId,
+          line,
+          column,
+          ops,
+          ...(file ? { file } : {}),
+        }),
       });
       const body = (await res.json().catch(() => ({}))) as { error?: string; changed?: boolean };
       if (!res.ok) {
@@ -55,7 +61,10 @@ export function useEditor(slideId: string) {
       const res = await fetch('/__edit/batch', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ slideId, edits }),
+        body: JSON.stringify({
+          slideId,
+          edits: edits.map(({ file, ...rest }) => (file ? { ...rest, file } : rest)),
+        }),
       });
       const body = (await res.json().catch(() => ({}))) as {
         error?: string;

--- a/packages/core/src/editing/slide-ops.test.ts
+++ b/packages/core/src/editing/slide-ops.test.ts
@@ -119,6 +119,9 @@ describe('resolveSlideSourceFile', () => {
     expect(resolveSlideSourceFile(root, 'cover', 'components/Card.tsx')).toBe(
       path.resolve(root, 'cover', 'components', 'Card.tsx'),
     );
+    expect(resolveSlideSourceFile(root, 'cover', 'components/Card.preview.tsx')).toBe(
+      path.resolve(root, 'cover', 'components', 'Card.preview.tsx'),
+    );
   });
 
   it('rejects traversal, other slide ids, and non-tsx names', () => {

--- a/packages/core/src/editing/slide-ops.test.ts
+++ b/packages/core/src/editing/slide-ops.test.ts
@@ -10,6 +10,8 @@ import {
   removePageFromDefaultExportInSource,
   reorderDefaultExportPagesInSource,
   reorderNotesArrayInSource,
+  resolveSlideEntry,
+  resolveSlideSourceFile,
   updateMetaTitleInSource,
   validateSlideName,
 } from './slide-ops.ts';
@@ -102,6 +104,32 @@ describe('validateSlideName', () => {
   it('rejects empty input', () => {
     expect(validateSlideName('')).toBeNull();
     expect(validateSlideName('   ')).toBeNull();
+  });
+});
+
+describe('resolveSlideSourceFile', () => {
+  it('defaults to the slide entry and confines sibling files to the deck folder', () => {
+    const root = path.join(os.tmpdir(), 'open-slide-loc-root');
+    const entry = resolveSlideSourceFile(root, 'cover');
+    expect(entry).toBe(path.resolve(root, 'cover', 'index.tsx'));
+    expect(resolveSlideEntry(root, 'cover')).toBe(entry);
+    expect(resolveSlideSourceFile(root, 'cover', 'pages.tsx')).toBe(
+      path.resolve(root, 'cover', 'pages.tsx'),
+    );
+    expect(resolveSlideSourceFile(root, 'cover', 'components/Card.tsx')).toBe(
+      path.resolve(root, 'cover', 'components', 'Card.tsx'),
+    );
+  });
+
+  it('rejects traversal, other slide ids, and non-tsx names', () => {
+    const root = path.join(os.tmpdir(), 'open-slide-loc-root');
+    expect(resolveSlideSourceFile(root, 'cover', '../other/index.tsx')).toBeNull();
+    expect(
+      resolveSlideSourceFile(root, 'cover', path.resolve(root, 'other', 'index.tsx')),
+    ).toBeNull();
+    expect(resolveSlideSourceFile(root, '../cover', 'index.tsx')).toBeNull();
+    expect(resolveSlideSourceFile(root, 'cover', 'pages.ts')).toBeNull();
+    expect(resolveSlideSourceFile(root, 'cover', 'notes.md')).toBeNull();
   });
 });
 

--- a/packages/core/src/editing/slide-ops.ts
+++ b/packages/core/src/editing/slide-ops.ts
@@ -178,13 +178,36 @@ export async function duplicateSlideDir(
   }
 }
 
-export function resolveSlideEntry(slidesRoot: string, slideId: string): string | null {
+function isInsideDir(dir: string, file: string): boolean {
+  const rel = path.relative(dir, file);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+export function resolveSlideSourceFile(
+  slidesRoot: string,
+  slideId: string,
+  relPath?: string | null,
+): string | null {
   if (!SLIDE_ID_RE.test(slideId)) return null;
-  const dir = path.resolve(slidesRoot, slideId);
-  if (!dir.startsWith(slidesRoot + path.sep)) return null;
-  // The SlideMeta contract says every slide has slides/<id>/index.tsx; we only
-  // edit that file to keep the write surface tiny and predictable.
-  return path.join(dir, 'index.tsx');
+  const root = path.resolve(slidesRoot);
+  const dir = path.resolve(root, slideId);
+  if (!isInsideDir(root, dir)) return null;
+
+  const raw = relPath == null || relPath === '' ? 'index.tsx' : relPath;
+  const posix = raw.replace(/\\/g, '/');
+  if (path.isAbsolute(raw) || path.isAbsolute(posix) || /^[a-zA-Z]:/.test(posix)) return null;
+  if (!posix.endsWith('.tsx') || posix.includes('\0')) return null;
+  const parts = posix.split('/');
+  if (parts.some((part) => part === '' || part === '.' || part === '..')) return null;
+
+  const file = path.resolve(dir, ...parts);
+  if (!isInsideDir(dir, file)) return null;
+  return file;
+}
+
+export function resolveSlideEntry(slidesRoot: string, slideId: string): string | null {
+  // Notes/assets/meta stay on the entry. Inspector writes use resolveSlideSourceFile.
+  return resolveSlideSourceFile(slidesRoot, slideId, 'index.tsx');
 }
 
 function escapeSingleQuoted(s: string): string {

--- a/packages/core/src/vite/loc-tags-plugin.test.ts
+++ b/packages/core/src/vite/loc-tags-plugin.test.ts
@@ -53,6 +53,13 @@ describe('injectLocTags', () => {
     expect(out).toContain('<div data-slide-loc="components/Card.tsx:2:2">hello</div>');
   });
 
+  it('prefixes dotted sibling filenames', () => {
+    const src = ['export default [() => (', '  <div>hello</div>', ')];', ''].join('\n');
+    const out = injectLocTags(src, 'components/Card.preview.tsx');
+    if (out === null) throw new Error('expected transform');
+    expect(out).toContain('<div data-slide-loc="components/Card.preview.tsx:2:2">hello</div>');
+  });
+
   it('skips capitalized component invocations', () => {
     const src = ['export default [() => (', '  <MyComp>hi</MyComp>', ')];', ''].join('\n');
     const out = injectLocTags(src);
@@ -168,6 +175,12 @@ describe('locTagsPlugin', () => {
     const out = transformWithLocTags('/repo/slides/cover/components/Card.tsx');
     if (out === null) throw new Error('expected tagged transform result');
     expect(out.code).toContain('data-slide-loc="components/Card.tsx:');
+  });
+
+  it('tags dotted sibling filenames with a path relative to the slide folder', () => {
+    const out = transformWithLocTags('/repo/slides/cover/components/Card.preview.tsx');
+    if (out === null) throw new Error('expected tagged transform result');
+    expect(out.code).toContain('data-slide-loc="components/Card.preview.tsx:');
   });
 
   it('keeps index.tsx tags as a bare line:column', () => {

--- a/packages/core/src/vite/loc-tags-plugin.test.ts
+++ b/packages/core/src/vite/loc-tags-plugin.test.ts
@@ -34,6 +34,25 @@ describe('injectLocTags', () => {
     expect(out).toContain('<div data-slide-loc="2:2">hello</div>');
   });
 
+  it('keeps entry-file tags as line:column when sourceRel is omitted or index.tsx', () => {
+    const src = ['export default [() => (', '  <div>hello</div>', ')];', ''].join('\n');
+    expect(injectLocTags(src, 'index.tsx')).toContain('<div data-slide-loc="2:2">hello</div>');
+  });
+
+  it('prefixes sibling files in the loc attribute', () => {
+    const src = ['export default [() => (', '  <div>hello</div>', ')];', ''].join('\n');
+    const out = injectLocTags(src, 'pages.tsx');
+    if (out === null) throw new Error('expected transform');
+    expect(out).toContain('<div data-slide-loc="pages.tsx:2:2">hello</div>');
+  });
+
+  it('prefixes nested sibling files relative to the slide folder', () => {
+    const src = ['export default [() => (', '  <div>hello</div>', ')];', ''].join('\n');
+    const out = injectLocTags(src, 'components/Card.tsx');
+    if (out === null) throw new Error('expected transform');
+    expect(out).toContain('<div data-slide-loc="components/Card.tsx:2:2">hello</div>');
+  });
+
   it('skips capitalized component invocations', () => {
     const src = ['export default [() => (', '  <MyComp>hi</MyComp>', ')];', ''].join('\n');
     const out = injectLocTags(src);
@@ -145,8 +164,17 @@ describe('locTagsPlugin', () => {
     expectTaggedTransform('/repo/slides/cover/01-Cover.tsx');
   });
 
-  it('tags slide source files in nested folders', () => {
-    expectTaggedTransform('/repo/slides/cover/components/Card.tsx');
+  it('tags nested slide source files with a path relative to the slide folder', () => {
+    const out = transformWithLocTags('/repo/slides/cover/components/Card.tsx');
+    if (out === null) throw new Error('expected tagged transform result');
+    expect(out.code).toContain('data-slide-loc="components/Card.tsx:');
+  });
+
+  it('keeps index.tsx tags as a bare line:column', () => {
+    const out = transformWithLocTags('/repo/slides/cover/index.tsx');
+    if (out === null) throw new Error('expected tagged transform result');
+    expect(out.code).toMatch(/data-slide-loc="\d+:\d+"/);
+    expect(out.code).not.toContain('index.tsx:');
   });
 
   it('skips tsx files directly under the slides directory', () => {
@@ -190,7 +218,12 @@ describe('locTagsPlugin on Windows-style paths', () => {
   });
 
   it('tags nested slide source files under a Windows slidesRoot', () => {
-    expectTagged('C:\\repo\\slides', 'C:/repo/slides/cover/components/Card.tsx');
+    const out = transformWithMockedResolve(
+      'C:\\repo\\slides',
+      'C:/repo/slides/cover/components/Card.tsx',
+    );
+    if (out === null) throw new Error('expected tagged transform result');
+    expect(out.code).toContain('data-slide-loc="components/Card.tsx:');
   });
 
   it('skips tsx files directly under the Windows slides directory', () => {

--- a/packages/core/src/vite/loc-tags-plugin.ts
+++ b/packages/core/src/vite/loc-tags-plugin.ts
@@ -1,11 +1,13 @@
 import path from 'node:path';
 import * as t from '@babel/types';
 import type { Plugin } from 'vite';
+import { formatSlideLoc } from '../app/lib/inspector/slide-loc.ts';
 import { tryParse, walkJsx } from '../editing/babel-walk.ts';
 
-// Inject `data-slide-loc="<line>:<col>"` onto every host JSX element in
-// slide source files so the inspector can map a click straight to a
-// source location, sidestepping HMR-stale `_debugSource` on fibers.
+// Inject `data-slide-loc` onto every host JSX element in slide source
+// files so the inspector can map a click straight to a source location,
+// sidestepping HMR-stale `_debugSource` on fibers. Entry files keep
+// `line:column`; siblings are `pages.tsx:12:4` (relative to the slide folder).
 
 // Capitalized components that explicitly forward `data-slide-loc` to a
 // host root, so the inspector can target them like a host element.
@@ -23,19 +25,25 @@ function alreadyTagged(opening: t.JSXOpeningElement): boolean {
   );
 }
 
-export function injectLocTags(code: string): string | null {
+export function injectLocTags(code: string, sourceRel?: string | null): string | null {
   const ast = tryParse(code);
   if (!ast) return null;
 
+  const file = !sourceRel || sourceRel === 'index.tsx' ? null : sourceRel.replace(/\\/g, '/');
   const insertions: { offset: number; text: string }[] = [];
   walkJsx(ast, (node) => {
     if (!t.isJSXElement(node) || !node.loc) return;
     const opening = node.openingElement;
     const name = opening.name;
     if (!isTaggableJsxName(name) || alreadyTagged(opening)) return;
+    const loc = formatSlideLoc({
+      file,
+      line: node.loc.start.line,
+      column: node.loc.start.column,
+    });
     insertions.push({
       offset: name.end ?? 0,
-      text: ` data-slide-loc="${node.loc.start.line}:${node.loc.start.column}"`,
+      text: ` data-slide-loc="${loc}"`,
     });
   });
 
@@ -66,6 +74,15 @@ function isSlideSourceFile(id: string, slidesRootPosix: string): boolean {
   return rel.includes('/');
 }
 
+function sourceRelFromId(id: string, slidesRootPosix: string): string | null {
+  const filePath = id.split(/[?#]/)[0].replace(/\\/g, '/');
+  if (!filePath.startsWith(`${slidesRootPosix}/`)) return null;
+  const rel = filePath.slice(slidesRootPosix.length + 1);
+  const slash = rel.indexOf('/');
+  if (slash === -1) return null;
+  return rel.slice(slash + 1);
+}
+
 export function locTagsPlugin(opts: LocTagsPluginOptions): Plugin {
   const slidesRoot = path.resolve(opts.userCwd, opts.slidesDir ?? 'slides').replace(/\\/g, '/');
   return {
@@ -76,7 +93,7 @@ export function locTagsPlugin(opts: LocTagsPluginOptions): Plugin {
     enforce: 'pre',
     transform(code, id) {
       if (!isSlideSourceFile(id, slidesRoot)) return null;
-      const next = injectLocTags(code);
+      const next = injectLocTags(code, sourceRelFromId(id, slidesRoot));
       if (next === null) return null;
       return { code: next, map: null };
     },

--- a/packages/core/src/vite/routes/edit.ts
+++ b/packages/core/src/vite/routes/edit.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import type { ViteDevServer } from 'vite';
 import { applyEdit, type EditOp } from '../../editing/edit-ops.ts';
 import { applyRevertAsset } from '../../editing/revert-asset.ts';
+import { resolveSlideSourceFile } from '../../editing/slide-ops.ts';
 import { validateMutationRequest } from '../../http/request-guard.ts';
 import {
   type ApiContext,
@@ -11,21 +12,28 @@ import {
   resolveSlideEntryPath,
 } from './context.ts';
 
-// POST /__edit                applyEdit({ slideId, line, column, ops })
+// POST /__edit                applyEdit({ slideId, file?, line, column, ops })
 // POST /__edit/revert-asset   applyRevertAsset({ slideId, assetPath })
-// POST /__edit/batch          applyEdit × N — single FS write per request
+// POST /__edit/batch          applyEdit x N, one FS write per source file
 
 type EditBody = {
   slideId?: string;
+  file?: string;
   line?: number;
   column?: number;
   ops?: EditOp[];
 };
 
+type BatchEdit = { file?: string; line?: number; column?: number; ops?: EditOp[] };
+
 type EditBatchBody = {
   slideId?: string;
-  edits?: Array<{ line?: number; column?: number; ops?: EditOp[] }>;
+  edits?: BatchEdit[];
 };
+
+function resolveEditFile(ctx: ApiContext, slideId: string, rel?: string): string | null {
+  return resolveSlideSourceFile(ctx.slidesRoot, slideId, rel);
+}
 
 export function registerEditRoutes(server: ViteDevServer, ctx: ApiContext): void {
   server.middlewares.use('/__edit', async (req, res, next) => {
@@ -39,8 +47,11 @@ export function registerEditRoutes(server: ViteDevServer, ctx: ApiContext): void
       if (url.pathname === '/') {
         const body = (await readBody(req)) as EditBody;
         const slideId = body.slideId ?? '';
-        const file = resolveSlideEntryPath(ctx, slideId);
-        if (!file) return json(res, 400, { error: 'invalid slideId' });
+        if (body.file !== undefined && typeof body.file !== 'string') {
+          return json(res, 400, { error: 'invalid file' });
+        }
+        const file = resolveEditFile(ctx, slideId, body.file);
+        if (!file) return json(res, 400, { error: body.file ? 'invalid file' : 'invalid slideId' });
         if (!body.line || body.line < 1) return json(res, 400, { error: 'invalid line' });
         if (!Array.isArray(body.ops)) return json(res, 400, { error: 'missing ops' });
 
@@ -83,31 +94,60 @@ export function registerEditRoutes(server: ViteDevServer, ctx: ApiContext): void
       if (url.pathname === '/batch') {
         const body = (await readBody(req)) as EditBatchBody;
         const slideId = body.slideId ?? '';
-        const file = resolveSlideEntryPath(ctx, slideId);
-        if (!file) return json(res, 400, { error: 'invalid slideId' });
         if (!Array.isArray(body.edits)) return json(res, 400, { error: 'missing edits' });
 
-        const source = await readSlideSource(file);
-        if (source === null) return json(res, 404, { error: 'slide not found' });
-
-        let next = source;
-        const original = source;
-        const results: Array<{ ok: boolean; error?: string }> = [];
-        for (const edit of body.edits) {
-          if (!edit.line || edit.line < 1 || !Array.isArray(edit.ops)) {
-            results.push({ ok: false, error: 'invalid edit' });
+        const results: Array<{ ok: boolean; error?: string }> = Array.from(
+          { length: body.edits.length },
+          () => ({ ok: false, error: 'invalid edit' }),
+        );
+        const groups = new Map<string, Array<{ index: number; edit: BatchEdit }>>();
+        for (let i = 0; i < body.edits.length; i++) {
+          const edit = body.edits[i];
+          if (!edit.line || edit.line < 1 || !Array.isArray(edit.ops)) continue;
+          if (edit.file !== undefined && typeof edit.file !== 'string') {
+            results[i] = { ok: false, error: 'invalid file' };
             continue;
           }
-          const r = applyEdit(next, edit.line, edit.column ?? 0, edit.ops);
-          if (r.ok) {
-            next = r.source;
-            results.push({ ok: true });
-          } else {
-            results.push({ ok: false, error: r.error });
+          const abs = resolveEditFile(ctx, slideId, edit.file);
+          if (!abs) {
+            results[i] = { ok: false, error: edit.file ? 'invalid file' : 'invalid slideId' };
+            continue;
+          }
+          const group = groups.get(abs);
+          if (group) group.push({ index: i, edit });
+          else groups.set(abs, [{ index: i, edit }]);
+        }
+
+        if (groups.size === 0) {
+          const slideOk = resolveEditFile(ctx, slideId);
+          if (!slideOk) return json(res, 400, { error: 'invalid slideId' });
+          return json(res, 200, { ok: true, changed: false, results });
+        }
+
+        let changed = false;
+        for (const [file, group] of groups) {
+          const source = await readSlideSource(file);
+          if (source === null) {
+            for (const { index } of group) {
+              results[index] = { ok: false, error: 'slide not found' };
+            }
+            continue;
+          }
+          let next = source;
+          for (const { index, edit } of group) {
+            const r = applyEdit(next, edit.line as number, edit.column ?? 0, edit.ops as EditOp[]);
+            if (r.ok) {
+              next = r.source;
+              results[index] = { ok: true };
+            } else {
+              results[index] = { ok: false, error: r.error };
+            }
+          }
+          if (next !== source) {
+            await fs.writeFile(file, next, 'utf8');
+            changed = true;
           }
         }
-        const changed = next !== original;
-        if (changed) await fs.writeFile(file, next, 'utf8');
         return json(res, 200, { ok: true, changed, results });
       }
 

--- a/packages/core/src/vite/routes/edit.ts
+++ b/packages/core/src/vite/routes/edit.ts
@@ -103,6 +103,7 @@ export function registerEditRoutes(server: ViteDevServer, ctx: ApiContext): void
         const groups = new Map<string, Array<{ index: number; edit: BatchEdit }>>();
         for (let i = 0; i < body.edits.length; i++) {
           const edit = body.edits[i];
+          if (edit == null || typeof edit !== 'object') continue;
           if (!edit.line || edit.line < 1 || !Array.isArray(edit.ops)) continue;
           if (edit.file !== undefined && typeof edit.file !== 'string') {
             results[i] = { ok: false, error: 'invalid file' };


### PR DESCRIPTION
## Summary

Fixes #440.

`data-slide-loc` is currently `line:column` only. The plugin still tags every `.tsx` under `slides/<id>/`, and `POST /__edit` always opens `index.tsx`. A click on JSX in `pages.tsx` or `components/Card.tsx` therefore writes into whichever `index.tsx` element happens to share that line:column, or does nothing.

This names the sibling in the loc (`pages.tsx:12:4`), threads `file` through the inspector and the edit routes, and confines the write to a `.tsx` inside that slide folder. Entry files stay `line:column`. Path traversal (`../other/index.tsx`) is rejected.

#433 stops tagging non-entry files, which is a stopgap for the same lying loc. This PR makes the tag honest instead. It does not replace #367 (library components outside `slides/`).

## Evidence

Targeted vitest on this worktree (node, no happy-dom):

```
pnpm exec vitest run packages/core/src/app/lib/inspector/slide-loc.test.ts packages/core/src/app/lib/inspector/fiber.test.ts packages/core/src/vite/loc-tags-plugin.test.ts packages/core/src/editing/slide-ops.test.ts
Test Files  4 passed (4)
Tests      106 passed (106)
```

Reverting the loc prefix / `resolveSlideSourceFile` confine makes the sibling-prefix and `../other/index.tsx` tests fail.

`pnpm core typecheck` is clean. Biome on the touched core files is clean. Full-repo `pnpm check` was not used as Evidence: this Windows checkout has pre-existing CRLF in `apps/demo/**`.

## What was not tested

I did not click through a live inspector session (`pnpm dev` + edit a sibling file). I did not run Playwright e2e. Both should run in CI (`lint`, `typecheck`, `test`, `e2e`).

Library components that live outside `slides/` are still #367.

## AI assistance

This change was prepared with AI assistance (Cursor/Grok). I reviewed the diff, ran the unit tests above, and kept the write path inside `slides/<id>/`.

## Test plan

- [x] Unit: entry loc stays `line:column`
- [x] Unit: sibling loc is `pages.tsx:12:4` / `components/Card.tsx:3:4`
- [x] Unit: parser rejects `../other/index.tsx`
- [x] Unit: `resolveSlideSourceFile` stays inside the slide folder
- [ ] CI: lint, typecheck, test, e2e
- [ ] Maintainer: Inspect-click JSX in a sibling file and confirm the write lands there, not in `index.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inspector locations now identify the relevant slide source file, including sibling `.tsx` files with dotted filenames.
  * Edits, image replacements, cropping, undo/redo, and batch updates are applied to the correct source file.
  * Batch edits can target multiple slide files with individual validation results.
  * Source locations include file paths while preserving concise line-and-column references for entry files.

* **Bug Fixes**
  * Added validation to prevent invalid or unsafe source-file paths from being edited.
  * Invalid batch entries now receive individual failure results without interrupting other valid updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->