### PR TITLE
feat(core): keep edit history across pages and jump on undo/redo

### DIFF
--- a/.changeset/cross-page-history.md
+++ b/.changeset/cross-page-history.md
@@ -1,0 +1,5 @@
+---
+'@open-slide/core': minor
+---
+
+Keep edit history across pages: undo/redo jumps to the page the change was made on, and ⌘Z / ⌘⇧Z trigger undo/redo.

--- a/packages/core/src/app/components/history-provider.tsx
+++ b/packages/core/src/app/components/history-provider.tsx
@@ -7,24 +7,22 @@ import {
   useRef,
   useState,
 } from 'react';
+import { type HistoryEntry, HistoryStack } from '@/lib/history-stack';
 
-export type HistoryEntry = {
-  undo: () => void;
-  redo: () => void;
-  coalesceKey?: string;
-  ts: number;
-};
+export type { HistoryEntry };
 
 type HistoryCtx = {
   canUndo: boolean;
   canRedo: boolean;
+  // Page the next undo/redo will jump to; null when it applies to the
+  // current page (or is page-agnostic, like a design change).
+  undoPage: number | null;
+  redoPage: number | null;
   record: (entry: Omit<HistoryEntry, 'ts'>) => void;
   undo: () => void;
   redo: () => void;
   clear: () => void;
 };
-
-const COALESCE_WINDOW_MS = 500;
 
 const Ctx = createContext<HistoryCtx | null>(null);
 
@@ -34,83 +32,48 @@ export function useHistory(): HistoryCtx {
   return v;
 }
 
-export function HistoryProvider({ children }: { children: ReactNode }) {
-  const [past, setPast] = useState<HistoryEntry[]>([]);
-  const [future, setFuture] = useState<HistoryEntry[]>([]);
-  // Set while invoking an entry's undo/redo so providers can skip
-  // re-recording the resulting state mutation.
-  const suppressedRef = useRef(false);
+export function HistoryProvider({
+  page,
+  onNavigate,
+  children,
+}: {
+  page?: number;
+  onNavigate?: (page: number) => void;
+  children: ReactNode;
+}) {
+  const pageRef = useRef(page);
+  pageRef.current = page;
+  const navigateRef = useRef(onNavigate);
+  navigateRef.current = onNavigate;
+  const [version, setVersion] = useState(0);
+  const [stack] = useState(
+    () =>
+      new HistoryStack({
+        currentPage: () => pageRef.current,
+        navigate: (p) => navigateRef.current?.(p),
+        onChange: () => setVersion((v) => v + 1),
+      }),
+  );
 
-  const record = useCallback((entry: Omit<HistoryEntry, 'ts'>) => {
-    if (suppressedRef.current) return;
-    const ts = Date.now();
-    setPast((prev) => {
-      const top = prev.at(-1);
-      if (
-        top &&
-        entry.coalesceKey !== undefined &&
-        top.coalesceKey === entry.coalesceKey &&
-        ts - top.ts < COALESCE_WINDOW_MS
-      ) {
-        const merged: HistoryEntry = {
-          undo: top.undo,
-          redo: entry.redo,
-          coalesceKey: entry.coalesceKey,
-          ts,
-        };
-        return [...prev.slice(0, -1), merged];
-      }
-      return [...prev, { ...entry, ts }];
-    });
-    setFuture([]);
-  }, []);
+  const record = useCallback((entry: Omit<HistoryEntry, 'ts'>) => stack.record(entry), [stack]);
+  const undo = useCallback(() => stack.undo(), [stack]);
+  const redo = useCallback(() => stack.redo(), [stack]);
+  const clear = useCallback(() => stack.clear(), [stack]);
 
-  const undo = useCallback(() => {
-    setPast((prev) => {
-      const top = prev.at(-1);
-      if (!top) return prev;
-      suppressedRef.current = true;
-      try {
-        top.undo();
-      } finally {
-        suppressedRef.current = false;
-      }
-      setFuture((f) => [...f, top]);
-      return prev.slice(0, -1);
-    });
-  }, []);
-
-  const redo = useCallback(() => {
-    setFuture((prev) => {
-      const top = prev.at(-1);
-      if (!top) return prev;
-      suppressedRef.current = true;
-      try {
-        top.redo();
-      } finally {
-        suppressedRef.current = false;
-      }
-      setPast((p) => [...p, top]);
-      return prev.slice(0, -1);
-    });
-  }, []);
-
-  const clear = useCallback(() => {
-    setPast([]);
-    setFuture([]);
-  }, []);
-
-  const value = useMemo<HistoryCtx>(
-    () => ({
-      canUndo: past.length > 0,
-      canRedo: future.length > 0,
+  const value = useMemo<HistoryCtx>(() => {
+    void version;
+    const jumpTarget = (p: number | undefined) => (p === undefined || p === page ? null : p);
+    return {
+      canUndo: stack.canUndo,
+      canRedo: stack.canRedo,
+      undoPage: jumpTarget(stack.undoPage),
+      redoPage: jumpTarget(stack.redoPage),
       record,
       undo,
       redo,
       clear,
-    }),
-    [past.length, future.length, record, undo, redo, clear],
-  );
+    };
+  }, [version, page, stack, record, undo, redo, clear]);
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }

--- a/packages/core/src/app/components/inspector/inspector-provider.tsx
+++ b/packages/core/src/app/components/inspector/inspector-provider.tsx
@@ -291,6 +291,14 @@ export function InspectorProvider({
 
   const pendingRef = useRef<Map<string, Bucket>>(new Map());
   const instanceCounterRef = useRef(0);
+  // Page + document-order position of each stamped instance. A page's DOM
+  // is torn down on navigation, so the stamp attribute is lost; this lets
+  // `resolveInstance` re-stamp the same call site after a remount.
+  const instanceRefsRef = useRef<Map<string, { loc: string; page: number; ordinal: number }>>(
+    new Map(),
+  );
+  const pageIndexRef = useRef(pageIndex);
+  pageIndexRef.current = pageIndex;
   const pendingSeqRef = useRef(0);
   const [pendingCount, setPendingCount] = useState(0);
   const [committing, setCommitting] = useState(false);
@@ -317,7 +325,32 @@ export function InspectorProvider({
     if (existing) return existing;
     const next = `inst-${++instanceCounterRef.current}`;
     el.setAttribute(INSTANCE_ID_ATTR, next);
+    const loc = el.dataset.slideLoc;
+    const layer = el.closest<HTMLElement>('[data-slide-page]');
+    if (loc) {
+      const scope = layer ?? el.closest<HTMLElement>('[data-inspector-root]') ?? document.body;
+      const siblings = Array.from(scope.querySelectorAll<HTMLElement>(`[data-slide-loc="${loc}"]`));
+      instanceRefsRef.current.set(next, {
+        loc,
+        page: layer ? Number(layer.dataset.slidePage) : pageIndexRef.current,
+        ordinal: siblings.indexOf(el),
+      });
+    }
     return next;
+  }, []);
+
+  const resolveInstance = useCallback((instanceId: string): HTMLElement | null => {
+    const root = document.querySelector<HTMLElement>('[data-inspector-root]');
+    if (!root) return null;
+    const stamped = root.querySelector<HTMLElement>(`[${INSTANCE_ID_ATTR}="${instanceId}"]`);
+    if (stamped) return stamped;
+    const ref = instanceRefsRef.current.get(instanceId);
+    if (!ref) return null;
+    const layer = root.querySelector<HTMLElement>(`[data-slide-page="${ref.page}"]`);
+    const el = layer?.querySelectorAll<HTMLElement>(`[data-slide-loc="${ref.loc}"]`)[ref.ordinal];
+    if (!el || el.hasAttribute(INSTANCE_ID_ATTR)) return null;
+    el.setAttribute(INSTANCE_ID_ATTR, instanceId);
+    return el;
   }, []);
 
   const refreshCount = useCallback(() => {
@@ -340,20 +373,38 @@ export function InspectorProvider({
   // since the original `anchor` reference may have unmounted. With an
   // instance id, prefer the matching DOM node so per-instance text edits
   // round-trip onto the right element.
-  const findAnchor = useCallback((line: number, column: number, instanceId?: string) => {
-    const root = document.querySelector<HTMLElement>('[data-inspector-root]');
-    if (!root) return null;
-    if (instanceId) {
-      const byInstance = root.querySelector<HTMLElement>(`[${INSTANCE_ID_ATTR}="${instanceId}"]`);
-      if (byInstance) return byInstance;
-    }
-    return root.querySelector<HTMLElement>(`[data-slide-loc="${line}:${column}"]`);
-  }, []);
+  const findAnchor = useCallback(
+    (line: number, column: number, instanceId?: string) => {
+      const root = document.querySelector<HTMLElement>('[data-inspector-root]');
+      if (!root) return null;
+      if (instanceId) {
+        const byInstance = resolveInstance(instanceId);
+        if (byInstance) return byInstance;
+      }
+      // Both pages are mounted mid-transition; prefer the one being shown.
+      const selector = `[data-slide-loc="${line}:${column}"]`;
+      return (
+        root.querySelector<HTMLElement>(
+          `[data-slide-page="${pageIndexRef.current}"] ${selector}`,
+        ) ?? root.querySelector<HTMLElement>(selector)
+      );
+    },
+    [resolveInstance],
+  );
 
   // Mutate bucket + DOM without recording history. Shared by `bufferOps`
   // (the public, history-recording entry point) and by `redo` closures.
+  // `fallbackInstanceId` routes per-instance text ops when the page holding
+  // the anchor isn't mounted (redo from another page); the DOM catches up
+  // via the remount replay below.
   const applyOpsRaw = useCallback(
-    (line: number, column: number, anchor: HTMLElement | null, ops: EditOp[]) => {
+    (
+      line: number,
+      column: number,
+      anchor: HTMLElement | null,
+      ops: EditOp[],
+      fallbackInstanceId?: string,
+    ) => {
       const key = `${line}:${column}`;
       let bucket = pendingRef.current.get(key);
       if (!bucket) {
@@ -381,20 +432,22 @@ export function InspectorProvider({
           bucket.styleOps.set(op.key, { value: op.value, prevText: op.prevText, seq });
           if (anchor?.isConnected) style[op.key] = op.value ?? '';
         } else if (op.kind === 'set-text-range-style') {
-          if (!anchor) continue;
-          const instanceId = ensureInstanceId(anchor);
-          if (!bucket.origHtmls.has(instanceId)) bucket.origHtmls.set(instanceId, anchor.innerHTML);
+          const instanceId = anchor ? ensureInstanceId(anchor) : fallbackInstanceId;
+          if (!instanceId) continue;
+          if (anchor && !bucket.origHtmls.has(instanceId)) {
+            bucket.origHtmls.set(instanceId, anchor.innerHTML);
+          }
           const nextOp: Sequenced<TextRangeStyleOp> = {
             instanceId,
             start: op.start,
             end: op.end,
             key: op.key,
             value: op.value,
-            prevText: op.prevText ?? readEditableText(anchor),
+            prevText: op.prevText ?? (anchor ? readEditableText(anchor) : undefined),
             seq,
           };
           bucket.rangeStyleOps.set(rangeStyleKey(instanceId, op), nextOp);
-          if (anchor.isConnected) {
+          if (anchor?.isConnected) {
             replayDomTextRangeStyles(
               anchor,
               bucket.origHtmls.get(instanceId) ?? anchor.innerHTML,
@@ -406,14 +459,14 @@ export function InspectorProvider({
         } else if (op.kind === 'set-text') {
           // Reused JSX renders multiple DOM nodes with the same
           // `data-slide-loc` but distinct call-site literals; without an
-          // anchor we can't tell which instance to route to, so skip.
-          if (!anchor) continue;
-          const instanceId = ensureInstanceId(anchor);
-          if (!bucket.origTexts.has(instanceId)) {
+          // instance we can't tell which call site to route to, so skip.
+          const instanceId = anchor ? ensureInstanceId(anchor) : fallbackInstanceId;
+          if (!instanceId) continue;
+          if (anchor && !bucket.origTexts.has(instanceId)) {
             bucket.origTexts.set(instanceId, { value: readEditableText(anchor) });
           }
           bucket.textOps.set(instanceId, { value: op.value, seq });
-          if (anchor.isConnected) setEditableText(anchor, op.value);
+          if (anchor?.isConnected) setEditableText(anchor, op.value);
         } else if (op.kind === 'set-attr-asset') {
           if (anchor && !bucket.origAttrs.has(op.attr)) {
             bucket.origAttrs.set(
@@ -540,8 +593,9 @@ export function InspectorProvider({
     [ensureInstanceId],
   );
 
-  // Restore the snapshotted values to bucket + DOM. Mirrors the bucket-empty
-  // logic of `cancelEdits` so an undo back to the absolute baseline cleans up.
+  // Restore the snapshotted values to bucket + DOM. A bucket emptied by undo
+  // is kept (not deleted) so its pre-edit snapshots survive for a later redo
+  // that may run while the page is unmounted.
   const restoreSnapshot = useCallback(
     (line: number, column: number, snaps: Snap[]) => {
       const key = `${line}:${column}`;
@@ -567,7 +621,7 @@ export function InspectorProvider({
             if (sharedAnchor?.isConnected) sharedStyle[snap.key] = orig ?? '';
           }
         } else if (snap.kind === 'range-style') {
-          const textAnchor = findAnchor(line, column, snap.instanceId);
+          const textAnchor = resolveInstance(snap.instanceId);
           if (snap.existed && snap.value) {
             bucket.rangeStyleOps.set(snap.id, { ...snap.value, seq: ++pendingSeqRef.current });
           } else {
@@ -584,7 +638,7 @@ export function InspectorProvider({
             );
           }
         } else if (snap.kind === 'text') {
-          const textAnchor = findAnchor(line, column, snap.instanceId);
+          const textAnchor = resolveInstance(snap.instanceId);
           if (snap.existed) {
             bucket.textOps.set(snap.instanceId, {
               value: snap.value ?? '',
@@ -611,17 +665,9 @@ export function InspectorProvider({
           }
         }
       }
-      if (
-        bucket.styleOps.size === 0 &&
-        bucket.rangeStyleOps.size === 0 &&
-        bucket.textOps.size === 0 &&
-        bucket.attrOps.size === 0
-      ) {
-        pendingRef.current.delete(key);
-      }
       refreshCount();
     },
-    [findAnchor, refreshCount],
+    [findAnchor, resolveInstance, refreshCount],
   );
 
   const bufferOps = useCallback(
@@ -631,8 +677,16 @@ export function InspectorProvider({
       )
         ? ensureInstanceId(anchor)
         : undefined;
-      const snaps = snapshotForOps(line, column, anchor, ops);
-      applyOpsRaw(line, column, anchor, ops);
+      // Resolve anchor-derived fields now so the redo closure can replay
+      // without the anchor (page unmounted).
+      const resolvedOps = ops.map((op) =>
+        op.kind === 'set-text-range-style' && op.prevText === undefined
+          ? { ...op, prevText: readEditableText(anchor) }
+          : op,
+      );
+      const snaps = snapshotForOps(line, column, anchor, resolvedOps);
+      applyOpsRaw(line, column, anchor, resolvedOps);
+      const page = pageIndexRef.current;
       const first = ops[0];
       const opKey = first
         ? first.kind === 'set-style'
@@ -644,11 +698,27 @@ export function InspectorProvider({
       const coalesceKey = `inspector:${line}:${column}:${first?.kind ?? 'noop'}:${opKey}`;
       history.record({
         coalesceKey,
+        page,
         undo: () => restoreSnapshot(line, column, snaps),
-        redo: () => applyOpsRaw(line, column, findAnchor(line, column, instanceId), ops),
+        redo: () =>
+          applyOpsRaw(
+            line,
+            column,
+            instanceId ? resolveInstance(instanceId) : findAnchor(line, column),
+            resolvedOps,
+            instanceId,
+          ),
       });
     },
-    [applyOpsRaw, snapshotForOps, restoreSnapshot, findAnchor, history, ensureInstanceId],
+    [
+      applyOpsRaw,
+      snapshotForOps,
+      restoreSnapshot,
+      findAnchor,
+      resolveInstance,
+      history,
+      ensureInstanceId,
+    ],
   );
 
   const commitEdits = useCallback(async () => {
@@ -800,20 +870,18 @@ export function InspectorProvider({
       }
       // Each text edit has its own anchor — locate by instance id.
       for (const [instanceId, html] of b.origHtmls) {
-        const textEl =
-          root?.querySelector<HTMLElement>(`[${INSTANCE_ID_ATTR}="${instanceId}"]`) ?? null;
+        const textEl = resolveInstance(instanceId);
         if (textEl?.isConnected) textEl.innerHTML = html;
       }
       for (const [instanceId, orig] of b.origTexts) {
-        const textEl =
-          root?.querySelector<HTMLElement>(`[${INSTANCE_ID_ATTR}="${instanceId}"]`) ?? null;
+        const textEl = resolveInstance(instanceId);
         if (textEl?.isConnected) setEditableText(textEl, orig.value);
       }
     }
     pendingRef.current = new Map();
     setPendingCount(0);
     history.clear();
-  }, [history]);
+  }, [history, resolveInstance]);
 
   // Auto-flush on inspector close and on route unmount so toggling
   // off or navigating away doesn't drop buffered edits. Failures are
@@ -876,6 +944,12 @@ export function InspectorProvider({
     const replayAll = () => {
       if (pendingRef.current.size === 0) return;
       observer?.disconnect();
+      // Freshly mounted nodes carry no instance stamp; re-associate them
+      // first so the per-instance text replay below can find them.
+      for (const bucket of pendingRef.current.values()) {
+        for (const instanceId of bucket.textOps.keys()) resolveInstance(instanceId);
+        for (const op of bucket.rangeStyleOps.values()) resolveInstance(op.instanceId);
+      }
       root.querySelectorAll<HTMLElement>('[data-slide-loc]').forEach(applyBuffered);
       observer?.observe(root, { childList: true, subtree: true });
     };
@@ -884,7 +958,7 @@ export function InspectorProvider({
     observer = new MutationObserver(replayAll);
     observer.observe(root, { childList: true, subtree: true });
     return () => observer?.disconnect();
-  }, []);
+  }, [resolveInstance]);
 
   useEffect(() => {
     void pageIndex;
@@ -964,6 +1038,27 @@ export function InspectorProvider({
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [toggle]);
+
+  const { canUndo, canRedo, undo: historyUndo, redo: historyRedo } = history;
+  useEffect(() => {
+    if (import.meta.env.PROD) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (committing || isTypingTarget(e.target)) return;
+      if (!(e.metaKey || e.ctrlKey) || e.altKey) return;
+      const key = e.key.toLowerCase();
+      const wantsRedo = (key === 'z' && e.shiftKey) || (key === 'y' && !e.shiftKey);
+      const wantsUndo = key === 'z' && !e.shiftKey;
+      if (wantsUndo && canUndo) {
+        e.preventDefault();
+        historyUndo();
+      } else if (wantsRedo && canRedo) {
+        e.preventDefault();
+        historyRedo();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [committing, canUndo, canRedo, historyUndo, historyRedo]);
 
   const openCrop = useCallback((anchor: HTMLImageElement) => {
     const loc = anchor.dataset.slideLoc;

--- a/packages/core/src/app/components/inspector/save-bar.tsx
+++ b/packages/core/src/app/components/inspector/save-bar.tsx
@@ -43,6 +43,16 @@ export function SaveBar() {
       onRedo={history.redo}
       canUndo={history.canUndo}
       canRedo={history.canRedo}
+      undoLabel={
+        history.undoPage === null
+          ? undefined
+          : format(t.common.undoOnPage, { page: history.undoPage + 1 })
+      }
+      redoLabel={
+        history.redoPage === null
+          ? undefined
+          : format(t.common.redoOnPage, { page: history.redoPage + 1 })
+      }
     />
   );
 }

--- a/packages/core/src/app/components/panel/save-card.tsx
+++ b/packages/core/src/app/components/panel/save-card.tsx
@@ -17,6 +17,8 @@ type SaveCardProps = {
   onRedo?: () => void;
   canUndo?: boolean;
   canRedo?: boolean;
+  undoLabel?: string;
+  redoLabel?: string;
 };
 
 // Optimistic DOM updates make the canvas *look* saved, so without this
@@ -34,8 +36,12 @@ export function SaveCard({
   onRedo,
   canUndo = false,
   canRedo = false,
+  undoLabel,
+  redoLabel,
 }: SaveCardProps) {
   const t = useLocale();
+  const resolvedUndoLabel = undoLabel ?? t.common.undo;
+  const resolvedRedoLabel = redoLabel ?? t.common.redo;
   const [justSaved, setJustSaved] = useState(false);
   const resolvedSavedLabel = savedLabel ?? t.common.saved;
 
@@ -78,8 +84,8 @@ export function SaveCard({
               className="text-muted-foreground hover:text-foreground"
               onClick={onUndo}
               disabled={committing || !canUndo}
-              aria-label={t.common.undo}
-              title={t.common.undo}
+              aria-label={resolvedUndoLabel}
+              title={resolvedUndoLabel}
             >
               <Undo2 className="size-3.5" />
             </Button>
@@ -89,8 +95,8 @@ export function SaveCard({
               className="text-muted-foreground hover:text-foreground"
               onClick={onRedo}
               disabled={committing || !canRedo}
-              aria-label={t.common.redo}
-              title={t.common.redo}
+              aria-label={resolvedRedoLabel}
+              title={resolvedRedoLabel}
             >
               <Redo2 className="size-3.5" />
             </Button>

--- a/packages/core/src/app/components/slide-transition-layer.tsx
+++ b/packages/core/src/app/components/slide-transition-layer.tsx
@@ -789,7 +789,7 @@ export function SlideTransitionLayer({
       style={{ background: 'var(--osd-bg)' }}
     >
       {OutgoingPage && outgoing !== null ? (
-        <div ref={outgoingLayerRef} className="absolute inset-0">
+        <div ref={outgoingLayerRef} data-slide-page={outgoing} className="absolute inset-0">
           <SlidePageProvider index={outgoing} total={total}>
             <StepHost
               isActivePage={false}
@@ -802,7 +802,7 @@ export function SlideTransitionLayer({
         </div>
       ) : null}
       {CurrentPage ? (
-        <div ref={incomingLayerRef} className="absolute inset-0">
+        <div ref={incomingLayerRef} data-slide-page={current} className="absolute inset-0">
           <SlidePageProvider index={current} total={total}>
             <StepHost
               isActivePage

--- a/packages/core/src/app/lib/history-stack.test.ts
+++ b/packages/core/src/app/lib/history-stack.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HistoryStack } from './history-stack';
+
+function entry(log: string[], name: string, page?: number, coalesceKey?: string) {
+  return {
+    page,
+    coalesceKey,
+    undo: () => log.push(`undo:${name}`),
+    redo: () => log.push(`redo:${name}`),
+  };
+}
+
+describe('HistoryStack', () => {
+  it('undoes and redoes in stack order', () => {
+    const log: string[] = [];
+    const stack = new HistoryStack();
+    stack.record(entry(log, 'a'));
+    stack.record(entry(log, 'b'));
+    stack.undo();
+    stack.undo();
+    stack.redo();
+    expect(log).toEqual(['undo:b', 'undo:a', 'redo:a']);
+    expect(stack.canUndo).toBe(true);
+    expect(stack.canRedo).toBe(true);
+  });
+
+  it('ignores records made while applying an entry', () => {
+    const log: string[] = [];
+    const stack = new HistoryStack();
+    stack.record({
+      undo: () => stack.record(entry(log, 'nested')),
+      redo: () => {},
+    });
+    stack.undo();
+    expect(stack.canUndo).toBe(false);
+    expect(stack.canRedo).toBe(true);
+  });
+
+  it('coalesces rapid entries with the same key and page', () => {
+    const log: string[] = [];
+    let now = 0;
+    const stack = new HistoryStack({ now: () => now, coalesceWindowMs: 100 });
+    stack.record(entry(log, 'a1', 0, 'k'));
+    now = 50;
+    stack.record(entry(log, 'a2', 0, 'k'));
+    now = 80;
+    stack.record(entry(log, 'b', 1, 'k'));
+    stack.undo();
+    stack.undo();
+    expect(log).toEqual(['undo:b', 'undo:a1']);
+    stack.redo();
+    stack.redo();
+    expect(log).toEqual(['undo:b', 'undo:a1', 'redo:a2', 'redo:b']);
+  });
+
+  it('navigates to the entry page before applying when it differs', () => {
+    const log: string[] = [];
+    let page = 0;
+    const navigate = vi.fn((p: number) => {
+      page = p;
+      log.push(`nav:${p}`);
+    });
+    const stack = new HistoryStack({ currentPage: () => page, navigate });
+    stack.record(entry(log, 'a', 0));
+    page = 2;
+    stack.record(entry(log, 'b', 2));
+    stack.record(entry(log, 'design'));
+    stack.undo();
+    stack.undo();
+    stack.undo();
+    expect(log).toEqual(['undo:design', 'undo:b', 'nav:0', 'undo:a']);
+    expect(stack.redoPage).toBe(0);
+    stack.redo();
+    stack.redo();
+    expect(log.slice(4)).toEqual(['redo:a', 'nav:2', 'redo:b']);
+  });
+
+  it('reports the page of the next undo and redo entries', () => {
+    const log: string[] = [];
+    const stack = new HistoryStack({ currentPage: () => 1 });
+    stack.record(entry(log, 'a', 3));
+    expect(stack.undoPage).toBe(3);
+    expect(stack.redoPage).toBeUndefined();
+    stack.undo();
+    expect(stack.undoPage).toBeUndefined();
+    expect(stack.redoPage).toBe(3);
+  });
+
+  it('notifies on every change and clears both stacks', () => {
+    const onChange = vi.fn();
+    const stack = new HistoryStack({ onChange });
+    stack.record({ undo() {}, redo() {} });
+    stack.undo();
+    stack.clear();
+    stack.clear();
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(stack.canUndo).toBe(false);
+    expect(stack.canRedo).toBe(false);
+  });
+});

--- a/packages/core/src/app/lib/history-stack.ts
+++ b/packages/core/src/app/lib/history-stack.ts
@@ -1,0 +1,99 @@
+export type HistoryEntry = {
+  undo: () => void;
+  redo: () => void;
+  coalesceKey?: string;
+  page?: number;
+  ts: number;
+};
+
+export type HistoryStackOptions = {
+  currentPage?: () => number | undefined;
+  navigate?: (page: number) => void;
+  onChange?: () => void;
+  now?: () => number;
+  coalesceWindowMs?: number;
+};
+
+const DEFAULT_COALESCE_WINDOW_MS = 500;
+
+export class HistoryStack {
+  private past: HistoryEntry[] = [];
+  private future: HistoryEntry[] = [];
+  private applying = false;
+  private readonly opts: HistoryStackOptions;
+
+  constructor(opts: HistoryStackOptions = {}) {
+    this.opts = opts;
+  }
+
+  get canUndo(): boolean {
+    return this.past.length > 0;
+  }
+
+  get canRedo(): boolean {
+    return this.future.length > 0;
+  }
+
+  get undoPage(): number | undefined {
+    return this.past.at(-1)?.page;
+  }
+
+  get redoPage(): number | undefined {
+    return this.future.at(-1)?.page;
+  }
+
+  record(entry: Omit<HistoryEntry, 'ts'>): void {
+    if (this.applying) return;
+    const ts = this.opts.now?.() ?? Date.now();
+    const windowMs = this.opts.coalesceWindowMs ?? DEFAULT_COALESCE_WINDOW_MS;
+    const top = this.past.at(-1);
+    if (
+      top &&
+      entry.coalesceKey !== undefined &&
+      top.coalesceKey === entry.coalesceKey &&
+      top.page === entry.page &&
+      ts - top.ts < windowMs
+    ) {
+      this.past[this.past.length - 1] = { ...top, redo: entry.redo, ts };
+    } else {
+      this.past.push({ ...entry, ts });
+    }
+    this.future = [];
+    this.opts.onChange?.();
+  }
+
+  undo(): void {
+    const top = this.past.pop();
+    if (!top) return;
+    this.apply(top, top.undo);
+    this.future.push(top);
+    this.opts.onChange?.();
+  }
+
+  redo(): void {
+    const top = this.future.pop();
+    if (!top) return;
+    this.apply(top, top.redo);
+    this.past.push(top);
+    this.opts.onChange?.();
+  }
+
+  clear(): void {
+    if (this.past.length === 0 && this.future.length === 0) return;
+    this.past = [];
+    this.future = [];
+    this.opts.onChange?.();
+  }
+
+  private apply(entry: HistoryEntry, fn: () => void): void {
+    if (entry.page !== undefined && entry.page !== this.opts.currentPage?.()) {
+      this.opts.navigate?.(entry.page);
+    }
+    this.applying = true;
+    try {
+      fn();
+    } finally {
+      this.applying = false;
+    }
+  }
+}

--- a/packages/core/src/app/routes/slide.tsx
+++ b/packages/core/src/app/routes/slide.tsx
@@ -599,7 +599,7 @@ export function Slide() {
   );
 
   return (
-    <HistoryProvider>
+    <HistoryProvider page={index} onNavigate={goTo}>
       <InspectorProvider slideId={slideId} pageIndex={index}>
         <SelectionReporter />
         <div className="flex h-dvh flex-col overflow-hidden bg-sidebar text-foreground">

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -22,6 +22,8 @@ export const en: Locale = {
     tryAgain: 'Try again',
     undo: 'Undo',
     redo: 'Redo',
+    undoOnPage: 'Undo · jumps to page {page}',
+    redoOnPage: 'Redo · jumps to page {page}',
     selected: 'Selected',
   },
 

--- a/packages/core/src/locale/ja.ts
+++ b/packages/core/src/locale/ja.ts
@@ -22,6 +22,8 @@ export const ja: Locale = {
     tryAgain: '再試行',
     undo: '元に戻す',
     redo: 'やり直す',
+    undoOnPage: '元に戻す · {page} ページへ移動',
+    redoOnPage: 'やり直す · {page} ページへ移動',
     selected: '選択中',
   },
 

--- a/packages/core/src/locale/types.ts
+++ b/packages/core/src/locale/types.ts
@@ -22,6 +22,8 @@ export type Locale = {
     tryAgain: string;
     undo: string;
     redo: string;
+    undoOnPage: string;
+    redoOnPage: string;
     selected: string;
   };
 

--- a/packages/core/src/locale/zh-cn.ts
+++ b/packages/core/src/locale/zh-cn.ts
@@ -22,6 +22,8 @@ export const zhCN: Locale = {
     tryAgain: '重试',
     undo: '撤销',
     redo: '重做',
+    undoOnPage: '撤销 · 跳转到第 {page} 页',
+    redoOnPage: '重做 · 跳转到第 {page} 页',
     selected: '已选中',
   },
 

--- a/packages/core/src/locale/zh-tw.ts
+++ b/packages/core/src/locale/zh-tw.ts
@@ -22,6 +22,8 @@ export const zhTW: Locale = {
     tryAgain: '重試',
     undo: '復原',
     redo: '重做',
+    undoOnPage: '復原 · 跳至第 {page} 頁',
+    redoOnPage: '重做 · 跳至第 {page} 頁',
     selected: '已選取',
   },
 


### PR DESCRIPTION
## What

- **Cross-page history.** Every inspector history entry records the page it was made on. Undo/redo of an entry from another page navigates there first, then applies the change. Design-panel entries stay page-agnostic.
- **Edits survive navigation.** Per-instance text edits (`data-slide-instance-id`) were lost visually after leaving and returning to a page, because the remounted DOM had no stamp. Instances now record `{loc, page, ordinal}` and are re-stamped on remount via `resolveInstance`. The transition layer's page divs carry `data-slide-page` so lookup is scoped per page (both pages are mounted mid-transition).
- **Redo while the target page is unmounted.** `applyOpsRaw` accepts a fallback instance id so the buffer is updated even without an anchor; the remount replay brings the DOM in line. Buckets emptied by undo are kept (not deleted) so pre-edit snapshots are still available for that redo.
- **Shortcuts.** ⌘Z / Ctrl+Z undo, ⌘⇧Z / Ctrl+Y redo, when not typing and not committing.
- **Page hint.** Undo/redo buttons show "Undo · jumps to page N" in their tooltip when they will navigate (all four locales).
- History stack extracted to `lib/history-stack.ts` with unit tests; `HistoryProvider` wraps it and takes `page` / `onNavigate`.

## Why

The history technically survived page changes already, but two gaps made it feel single-page: text edits vanished after navigating away and back, and undoing a change made on another page did nothing visible.

## Reviewer notes

- Undo applies synchronously right after `goTo()`; the target page isn't mounted yet at that moment. Correctness relies on the existing MutationObserver replay in `InspectorProvider` re-applying the buffer once the page mounts. Fresh mounts render source (baseline), so an undo-to-baseline needs no DOM work.
- Text/range-style restores now go through `resolveInstance` only (no `data-slide-loc` fallback) to avoid touching a same-loc sibling on the current page when the target page is unmounted.
- Manual checks worth doing: edit text on p1 → edit style on p3 → undo twice (should jump to p1 and restore text); edit p1 text, go to p2 and back (text should still show); with a transition enabled, undo right after navigating.

Changeset: `@open-slide/core` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Undo and redo history now works across pages, automatically navigating to the relevant page before applying changes.
  * Undo and redo controls indicate when an action will move to another page.
  * Edit history is preserved more reliably when pages are remounted or content is restored.
  * Keyboard shortcuts for undo and redo are available during development.

* **Localization**
  * Added page-aware undo and redo labels in English, Japanese, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->